### PR TITLE
perf(commands+agents): trim YAML descriptions (~669 tok/boot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Slash commands + custom agents descriptions**: trim YAML `description:`
+  em todos os 6 slash commands (`global/commands/`) e 6 custom agents
+  (`global/agents/`). Reducao de ~5.245 chars para ~2.569 chars (~669 tokens
+  economizados por boot, -51%). Triggers e discriminadores chave preservados
+  (clarify-asker vs answerer, orchestrator vs feature-orchestrator, etc).
+  Detalhes operacionais e flags permanecem no body de cada arquivo (so
+  carrega quando o comando/agente e efetivamente invocado). Continuacao da
+  otimizacao iniciada em PR #8 (skills); combinada, total ~2k tokens/boot.
+  PR #9.
+
 ## [3.13.0] - 2026-05-20
 
 Feature-00C — variante do agente-00C focada em **uma feature

--- a/global/agents/agente-00c-clarify-answerer.md
+++ b/global/agents/agente-00c-clarify-answerer.md
@@ -1,13 +1,6 @@
 ---
 name: agente-00c-clarify-answerer
-description: |
-  Subagente que aplica heuristica de score 0..3 para responder
-  autonomamente perguntas geradas pelo clarify-asker. Recebe perguntas +
-  briefing + constitution_projeto + constitution_toolkit + stack_sugerida
-  + decisoes_anteriores; para cada pergunta atribui score baseado em
-  quantas das 3 fontes (briefing, constitution, stack-sugerida) suportam
-  cada opcao. Score >=2 decide; score 1 decide so se opcao restante
-  violar constitution; score 0 marca como pause-humano.
+description: 'Subagente: aplica heuristica score 0..3 sobre 3 fontes (briefing, constitution_projeto, stack_sugerida) para responder perguntas do clarify-asker autonomamente. Score >=2 decide; score 0 pausa humano.'
 allowed-tools:
   - Read
   - Bash

--- a/global/agents/agente-00c-clarify-asker.md
+++ b/global/agents/agente-00c-clarify-asker.md
@@ -1,12 +1,6 @@
 ---
 name: agente-00c-clarify-asker
-description: |
-  Subagente especializado em gerar perguntas estruturadas para a etapa
-  clarify do SDD. Recebe spec_corrente + briefing + etapa_corrente,
-  invoca a skill clarify do toolkit e devolve entre 1 e 5 perguntas
-  com opcoes recomendadas. NAO toma decisoes — apenas gera perguntas.
-  O orquestrador-pai (agente-00c-orchestrator) media a comunicacao
-  entre asker e answerer.
+description: 'Subagente: gera 1-5 perguntas estruturadas para etapa clarify do SDD via skill clarify. Nao toma decisoes — orquestrador-pai (agente-00c-orchestrator) media comunicacao com answerer.'
 allowed-tools:
   - Skill
   - Read

--- a/global/agents/agente-00c-feature-orchestrator.md
+++ b/global/agents/agente-00c-feature-orchestrator.md
@@ -1,17 +1,6 @@
 ---
 name: agente-00c-feature-orchestrator
-description: |
-  Orquestrador autonomo da pipeline SDD `specify → clarify → plan →
-  checklist → create-tasks → execute-task → review-task` no escopo de
-  UMA feature individual dentro de projeto com briefing+constitution
-  pre-existentes. Paralelo ao `agente-00c-orchestrator` (que opera no
-  escopo de projeto inteiro). Reusa o mesmo runtime POSIX
-  (agente-00c-runtime) via `AGENTE_00C_STATE_DIR` apontando para
-  `feature-00c-state/<short-name>/`. Registra decisoes auditaveis,
-  gerencia orcamento de onda, retorna intent de schedule da proxima
-  onda (executado pelo slash command pai via ScheduleWakeup) e gera
-  relatorio cross-onda. Invocado pelos slash commands /feature-00c e
-  /feature-00c-resume.
+description: 'Orquestrador autonomo da pipeline SDD (specify→clarify→plan→checklist→create-tasks→execute-task→review-task) para UMA feature individual. Reusa runtime POSIX agente-00c-runtime via AGENTE_00C_STATE_DIR=feature-00c-state/<short-name>/. Invocado por /feature-00c e /feature-00c-resume.'
 allowed-tools:
   - Agent
   - Skill

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -1,15 +1,6 @@
 ---
 name: agente-00c-orchestrator
-description: |
-  Orquestrador raiz do agente-00C. Conduz a pipeline SDD (briefing →
-  constitution → specify → clarify → plan → checklist → create-tasks →
-  execute-task → review-task → review-features) sobre um projeto-alvo,
-  registrando decisoes auditaveis, gerenciando orcamento de onda
-  (proxies de tool calls / wallclock / tamanho de estado), retornando
-  intent de schedule da proxima onda (executado pelo slash command pai
-  via ScheduleWakeup, que sub-agentes nao podem invocar de forma
-  sobrevivente) e gerando relatorio cross-onda. Invocado pelos slash
-  commands /agente-00c e /agente-00c-resume.
+description: 'Orquestrador raiz da pipeline SDD (briefing→constitution→specify→clarify→plan→checklist→create-tasks→execute-task→review-task→review-features) sobre projeto-alvo. Gerencia orcamento de onda, ScheduleWakeup, decisoes auditaveis. Invocado por /agente-00c e /agente-00c-resume.'
 allowed-tools:
   - Agent
   - Skill

--- a/global/agents/feature-00c-clarify-answerer.md
+++ b/global/agents/feature-00c-clarify-answerer.md
@@ -1,13 +1,6 @@
 ---
 name: feature-00c-clarify-answerer
-description: |
-  Subagente que aplica heuristica de score 0..3 para responder
-  autonomamente perguntas geradas pelo feature-00c-clarify-asker.
-  Recebe perguntas + briefing + constitution_projeto + spec_corrente
-  + decisoes_anteriores; para cada pergunta atribui score baseado em
-  quantas das 3 fontes (briefing, constitution, spec_corrente)
-  suportam cada opcao. Score >=2 decide; score 1 decide so se opcao
-  restante violar constitution; score 0 marca como pause-humano.
+description: 'Subagente: aplica heuristica score 0..3 sobre 3 fontes (briefing, constitution_projeto, spec_corrente) para responder perguntas do feature-00c-clarify-asker autonomamente. Score >=2 decide; score 0 pausa humano.'
 allowed-tools:
   - Read
   - Bash

--- a/global/agents/feature-00c-clarify-asker.md
+++ b/global/agents/feature-00c-clarify-asker.md
@@ -1,14 +1,6 @@
 ---
 name: feature-00c-clarify-asker
-description: |
-  Subagente especializado em gerar perguntas estruturadas para a etapa
-  clarify do SDD, no escopo do feature-00c (uma feature individual
-  dentro de projeto com briefing+constitution pre-existentes). Recebe
-  spec_corrente + briefing + decisoes_anteriores, invoca a skill
-  clarify do toolkit e devolve entre 1 e 5 perguntas com opcoes
-  recomendadas. NAO toma decisoes — apenas gera perguntas. O
-  orquestrador-pai (agente-00c-feature-orchestrator) media a comunicacao
-  entre asker e answerer.
+description: 'Subagente: gera 1-5 perguntas estruturadas para etapa clarify do SDD no escopo feature-00c. Nao toma decisoes — orquestrador-pai (agente-00c-feature-orchestrator) media comunicacao com answerer.'
 allowed-tools:
   - Skill
   - Read

--- a/global/commands/agente-00c-abort.md
+++ b/global/commands/agente-00c-abort.md
@@ -1,9 +1,5 @@
 ---
-description: |
-  Aborta manualmente a execucao corrente do agente-00C no projeto-alvo.
-  Marca status como `abortada`, atualiza `terminada_em`, gera relatorio
-  final e faz commit local. Idempotente — se a execucao ja esta em status
-  terminal, apenas reporta.
+description: 'Aborta manualmente a execucao corrente do agente-00C no projeto-alvo. Marca status como abortada, gera relatorio final, commit local. Idempotente.'
 argument-hint: "[--projeto-alvo-path <path>]"
 allowed-tools:
   - Agent

--- a/global/commands/agente-00c-resume.md
+++ b/global/commands/agente-00c-resume.md
@@ -1,9 +1,5 @@
 ---
-description: |
-  Retoma execucao 00C apos pausa por bloqueio humano (com `--resposta-bloqueio`)
-  ou apos schedule entre ondas. Le o estado, valida hash de integridade
-  (FR-029), aplica resposta a bloqueios pendentes (se aplicavel) e delega
-  proxima onda ao agente-00c-orchestrator.
+description: 'Retoma execucao 00C apos pausa por bloqueio humano ou schedule entre ondas. Valida hash de integridade (FR-029), aplica resposta a bloqueios pendentes, delega proxima onda ao agente-00c-orchestrator.'
 argument-hint: "[--projeto-alvo-path <path>] [--resposta-bloqueio <id>:<resposta>] [--init-aspectos <json-array>] [--init-aspectos-tecnicos <json-array>] [--init-aspectos-operacionais <json-array>]"
 allowed-tools:
   - Agent

--- a/global/commands/agente-00c.md
+++ b/global/commands/agente-00c.md
@@ -1,11 +1,5 @@
 ---
-description: |
-  Inicia uma nova execucao do orquestrador autonomo agente-00C sobre um
-  projeto-alvo. Recebe uma descricao curta do POC/MVP e (opcionalmente) uma
-  stack-sugerida em JSON, uma whitelist de URLs externas e o caminho do
-  projeto-alvo. Cria estado em <projeto-alvo>/.claude/agente-00c-state/ e
-  delega a execucao da pipeline SDD ao agente custom
-  agente-00c-orchestrator.
+description: 'Inicia execucao do orquestrador autonomo agente-00C sobre um projeto-alvo. Cria state em <projeto-alvo>/.claude/agente-00c-state/ e delega pipeline SDD ao agente-00c-orchestrator.'
 argument-hint: "<descricao-curta> [--stack <stack-json>] [--whitelist <path>] [--projeto-alvo-path <path>]"
 allowed-tools:
   - Agent

--- a/global/commands/feature-00c-abort.md
+++ b/global/commands/feature-00c-abort.md
@@ -1,12 +1,5 @@
 ---
-description: |
-  Aborta manualmente a execucao corrente do feature-00c para uma feature
-  especifica (short-name). Implementa SIGTERM + grace period de 60s
-  para a onda corrente persistir state graciosamente, depois
-  force-acquire do lock como fallback (FR-025 atualizado). Marca status
-  como `abortada`, atualiza `terminada_em`, gera relatorio parcial e
-  faz commit local. Idempotente — se ja em status terminal, apenas
-  reporta.
+description: 'Aborta manualmente feature-00c para um short-name. SIGTERM + grace period 60s para persistir state; force-acquire do lock como fallback (FR-025). Marca abortada, gera relatorio parcial, commit local. Idempotente.'
 argument-hint: "<short-name> [--motivo <texto>] [--purge-backups]"
 allowed-tools:
   - Bash

--- a/global/commands/feature-00c-resume.md
+++ b/global/commands/feature-00c-resume.md
@@ -1,10 +1,5 @@
 ---
-description: |
-  Retoma execucao feature-00c pausada por bloqueio humano (com
-  --resposta-bloqueio) ou apos schedule entre ondas. Le o estado,
-  valida hash de integridade (FR-014 + FR-PRE-004), aplica resposta a
-  bloqueios pendentes (se aplicavel) e delega proxima onda ao agente
-  custom agente-00c-feature-orchestrator.
+description: 'Retoma execucao feature-00c pausada por bloqueio humano ou schedule entre ondas. Valida hash (FR-014 + FR-PRE-004), aplica resposta a bloqueios, delega proxima onda ao agente-00c-feature-orchestrator.'
 argument-hint: "<short-name> [--resposta-bloqueio <texto>]"
 allowed-tools:
   - Agent

--- a/global/commands/feature-00c.md
+++ b/global/commands/feature-00c.md
@@ -1,14 +1,5 @@
 ---
-description: |
-  Inicia uma nova execucao do orquestrador autonomo feature-00c sobre
-  UMA feature individual dentro de projeto que JA tem briefing +
-  constitution ratificados. Recebe descricao-curta + (opcional)
-  short-name + (opcional) path do projeto + (opcional) whitelist.
-  Cria estado em
-  <projeto-alvo>/.claude/feature-00c-state/<short-name>/ e delega
-  a execucao da pipeline SDD (specify→clarify→plan→checklist→
-  create-tasks→execute-task→review-task) ao agente custom
-  agente-00c-feature-orchestrator.
+description: 'Inicia execucao feature-00c sobre UMA feature individual em projeto com briefing+constitution ratificados. Cria state em .claude/feature-00c-state/<short-name>/ e delega pipeline SDD (specify→clarify→plan→checklist→create-tasks→execute-task→review-task) ao agente-00c-feature-orchestrator.'
 argument-hint: '"<descricao-curta>" [<short-name>] [--projeto <path>] [--whitelist <urls>]'
 allowed-tools:
   - Agent


### PR DESCRIPTION
## Summary

Continuacao de PR #8 (skills). Cortando descriptions YAML eager-loaded em **6 slash commands** e **6 custom agents**:

- **Antes**: ~5.245 chars / ~1.310 tok
- **Depois**: ~2.569 chars / ~640 tok
- **Economia**: ~2.676 chars / **~669 tokens por boot** (-51%)

**Combinado com PR #8: ~2.000 tokens/boot economizados no toolkit shipped.** Em pipeline tipico de 10 ondas: ~20k tok; sobre 100 execucoes: ~2M tokens.

## Estrategia

Mesma do PR #8: cada `description:` reduzida ao essencial, com triggers e discriminadores chave preservados para nao quebrar auto-routing. Detalhes operacionais (flags, descricao de FRs, ordem completa da pipeline) permanecem no **body** do arquivo — so carrega quando o comando/agente e efetivamente invocado.

### Slash commands (`global/commands/`)

| Comando | Antes | Depois |
|---|---|---|
| `feature-00c` | 505 | 289 |
| `feature-00c-abort` | 423 | 212 |
| `agente-00c` | 376 | 179 |
| `feature-00c-resume` | 312 | 200 |
| `agente-00c-resume` | 272 | 199 |
| `agente-00c-abort` | 248 | 146 |

### Custom agents (`global/agents/`)

| Agente | Antes | Depois |
|---|---|---|
| `agente-00c-feature-orchestrator` | 697 | 283 |
| `agente-00c-orchestrator` | 598 | 274 |
| `feature-00c-clarify-asker` | 499 | 194 |
| `agente-00c-clarify-answerer` | 478 | 200 |
| `feature-00c-clarify-answerer` | 465 | 211 |
| `agente-00c-clarify-asker` | 372 | 182 |

## Test plan

- [x] `./tests/run.sh` — **672 PASS / 0 FAIL** (mesmos 2 orphan warnings pre-existentes do PR #8)
- [x] Verificacao manual de YAML em `agente-00c-orchestrator.md` e `feature-00c.md` — frontmatter valido, `allowed-tools`/`argument-hint` preservados
- [ ] Smoke test pos-merge: invocar `/agente-00c` e disparar Agent com `subagent_type: agente-00c-orchestrator` para confirmar routing

## Sobre CLAUDE.md (escopo original do PR2)

Descoberta durante implementacao: `CLAUDE.md` esta em `.gitignore` (nunca foi versionado) — e per-usuario, nao shipa via repo. Por isso o foco pivotou para commands+agents, que sao o equivalente "shipped" do mesmo padrao eager-load. PR3 (cache de briefing/constitution no agente-00c) segue sendo o proximo passo de maior impacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)