### PR TITLE
docs(feature): SDD drafts para agente-00c-artifact-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
 
+### Added (drafts SDD — sem implementacao)
+
+- **Feature SDD `agente-00c-artifact-cache`** drafts iniciais em
+  `docs/specs/agente-00c-artifact-cache/`:
+  - `spec.md` — feature spec completa com 4 User Stories
+    (P1/P1/P2/P2), 17 Functional Requirements (FR-CACHE-001..017),
+    Edge Cases, Constitutional Alignment, 5 Success Criteria,
+    Out of Scope, e 5 Open Questions para `/clarify`.
+  - `plan.md` — plano tecnico provisorio com Constitution Check,
+    Data Model (state.json novo schema), API Contracts da primitiva
+    nova `state-cache.sh` (6 subcomandos), Research (5 decisoes),
+    Project Structure, Phase plan, Risks.
+  - `tasks.md` — 20 tarefas em 5 fases (Clarify → Primitiva+schema →
+    Skills → Orquestrador+report → Integracao+release), matriz de
+    dependencias, coverage matrix Requirements×Tasks.
+- Proposito: reduzir ~5-10k tokens/onda em pipelines longos do
+  agente-00c via cache opcional de briefing.md + constitution.md
+  em `state.json`, com hash-validation TOCTOU-safe e fallback
+  preservado para skills standalone.
+- Implementacao real fica deferida apos `/clarify` resolver as 5
+  Open Questions.
+
 ## [3.13.0] - 2026-05-20
 
 Feature-00C — variante do agente-00C focada em **uma feature

--- a/docs/specs/agente-00c-artifact-cache/plan.md
+++ b/docs/specs/agente-00c-artifact-cache/plan.md
@@ -1,0 +1,367 @@
+# Implementation Plan: Agente-00C Artifact Cache
+
+**Feature**: `agente-00c-artifact-cache`
+**Spec**: [`spec.md`](./spec.md)
+**Created**: 2026-05-20
+**Status**: Draft (pre-clarify)
+
+> Este plano sera revisado apos `clarify` resolver as 5 Open Questions
+> da spec. Decisoes marcadas com `[NEEDS CLARIFY]` ficam tentativas
+> ate la.
+
+---
+
+## Constitution Check
+
+Verificacao pre-arquitetura contra `docs/constitution.md` do projeto:
+
+| Principio | Decisao arquitetural correspondente |
+|-----------|--------------------------------------|
+| I. Auditabilidade Total | `state-cache.sh` registra Decisao via `state-decisions.sh register` em toda invalidacao. Metricas em `metricas.cache`. |
+| II. Pause-or-Decide | Drift MAJOR → BloqueioHumano; MINOR/PATCH → auto-resolve com Decisao informativa. |
+| III. Idempotencia | Cache eh derivado; source eh canonico. Reconstruivel a qualquer momento. |
+| IV. Autonomia Limitada | Sem novos loops; invalidacoes nao consomem `ciclos_consumidos`. |
+| V. Blast Radius | `state.json` vive em `.claude/agente-00c-state/`; secrets-filter aplicado pre-gravacao; source files read-only. |
+
+**Resultado**: aprovado para `/plan`. Sem violacoes detectadas.
+
+---
+
+## Technical Context
+
+### Linguagem e runtime
+
+- **Primitiva nova `state-cache.sh`**: POSIX shell (sh / bash 3.2+),
+  compativel com macOS default. Dependencias externas: `jq`,
+  `sha256sum` (linux) / `shasum -a 256` (macos). Mesma stack ja
+  usada pelas outras primitivas em `global/skills/agente-00c-runtime/scripts/`.
+- **Modificacoes nas skills**: editar `SKILL.md` de `specify`,
+  `clarify`, `plan`, `execute-task` para adicionar protocolo de
+  leitura FR-CACHE-008 (instrucoes ao LLM em prosa, nao codigo
+  executavel — skills sao prompts).
+
+### Limites operacionais
+
+- **Tamanho do resumo**: alvo 1500-2000 chars (~375-500 tokens
+  pt-br). Configuravel via campo `config.cache.resumo_max_chars`
+  em state.json.
+- **Threshold de passthrough**: default 3000 chars (FR-CACHE-007).
+- **Timeout de geracao do resumo**: N/A se heuristica extractiva;
+  ate 60s se LLM-in-session. Decisao em [NEEDS CLARIFY Q1].
+
+### Compatibilidade
+
+- **Schema bump**: state.json schema_version MINOR (ex: 1.4.0 → 1.5.0).
+  Campos novos sao opcionais (FR-CACHE-001), sem migracao forcada.
+- **Skills standalone**: comportamento preservado (FR-CACHE-014).
+- **Execucoes legadas**: state.json sem campos de cache continua
+  valido; cache fica vazio, populado na proxima onda 1.
+
+---
+
+## Data Model
+
+### state.json — novos campos
+
+```jsonc
+{
+  // ... campos existentes ...
+  "briefing_cache": {
+    "source_path": "/abs/path/to/docs/01-briefing-discovery/briefing.md",
+    "source_sha256": "a1b2c3...64chars",
+    "source_chars": 8420,
+    "resumo": "## Visao\n...\n## Usuarios\n...\n## Restricoes\n...",
+    "resumo_chars": 1480,
+    "estrategia": "resumo",  // ou "passthrough" ou "desabilitado"
+    "gerado_em": "2026-05-20T14:32:11Z",
+    "gerado_na_onda": 1
+  },
+  "constitution_cache": {
+    "source_path": "/abs/path/to/docs/constitution.md",
+    "source_sha256": "d4e5f6...64chars",
+    "source_chars": 11200,
+    "resumo": "## Core Principles\n### I. ...\n### II. ...",
+    "resumo_chars": 1720,
+    "estrategia": "resumo",
+    "gerado_em": "2026-05-20T14:33:02Z",
+    "gerado_na_onda": 1,
+    "version": "1.2.0"  // copia de FR-PRE-004 para audit cross-onda
+  },
+  "metricas": {
+    // ... metricas existentes ...
+    "cache": {
+      "tokens_cache_hits": 0,
+      "tokens_cache_misses_drift": 0,
+      "tokens_cache_misses_disabled": 0,
+      "tokens_economizados_estimados": 0,
+      "ultima_invalidacao": null  // ISO-8601 ou null
+    }
+  },
+  "config": {
+    // novo bloco opcional
+    "cache": {
+      "passthrough_threshold_chars": 3000,
+      "resumo_max_chars": 2000,
+      "tokens_per_char_ratio": 0.25  // pt-br = 4 chars/tok
+    }
+  }
+}
+```
+
+### Decisao auditavel (categoria nova)
+
+```jsonc
+{
+  "id": "dec-NNN",
+  "categoria": "cache-invalidacao",
+  "contexto": "drift detectado em constitution.md entre ondas 3 e 4",
+  "opcoes": ["regenerar-cache", "abortar-feature", "marcar-cache-stale"],
+  "escolha": "regenerar-cache",
+  "justificativa": "politica default FR-CACHE-009 (drift MINOR/PATCH = auto-resolve)",
+  "agente": "agente-00c-orchestrator",
+  "score": 3,
+  "registrada_em": "2026-05-20T14:51:08Z"
+}
+```
+
+---
+
+## API Contracts
+
+### `state-cache.sh` — nova primitiva
+
+Localizacao: `global/skills/agente-00c-runtime/scripts/state-cache.sh`
+
+```bash
+# Sintaxe geral
+state-cache.sh <subcommand> --state-dir <SD> [opcoes]
+
+# Subcomandos
+state-cache.sh ensure --state-dir <SD> --artifact <briefing|constitution> --source-path <PATH>
+  # Popula ou atualiza o cache. Detecta drift, gera resumo, aplica secrets-filter, persiste.
+  # Exit 0 = cache pronto; exit 1 = arquivo source ausente; exit 2 = falha critica.
+
+state-cache.sh get-resumo --state-dir <SD> --artifact <briefing|constitution>
+  # Retorna o resumo via stdout se cache em estado "resumo" + sha256 confirmado.
+  # Exit 0 = hit; exit 1 = miss (campo ausente, estrategia != "resumo", ou drift); exit 2 = erro fatal.
+
+state-cache.sh check-drift --state-dir <SD> --artifact <briefing|constitution>
+  # Compara sha256 registrado vs hash do arquivo em disco AGORA.
+  # Exit 0 = sem drift; exit 1 = drift MINOR/PATCH; exit 2 = drift MAJOR; exit 3 = erro.
+  # Para constitution: exit 2 quando version primeiro digito mudou OU >50% chars diff.
+
+state-cache.sh invalidate --state-dir <SD> --artifact <briefing|constitution> --razao <texto>
+  # Forca invalidacao. Registra Decisao via state-decisions.sh. Cache fica vazio ate proximo ensure.
+
+state-cache.sh metrics-bump --state-dir <SD> --tipo <hit|miss-drift|miss-disabled> [--chars-economizados N]
+  # Incrementa contadores em metricas.cache. Chamado pelas skills apos consumo (ou tentativa).
+
+state-cache.sh status --state-dir <SD> --artifact <briefing|constitution>
+  # Imprime JSON com estado completo do cache (path, sha256, estrategia, chars, idade).
+  # Exit 0 sempre que state.json eh valido.
+```
+
+### Contrato de leitura das skills (FR-CACHE-008)
+
+Skills afetadas (`specify`, `clarify`, `plan`, `execute-task`) terao
+em seu `SKILL.md` um bloco novo `## Leitura de artefatos foundational`:
+
+```markdown
+## Leitura de artefatos foundational
+
+Antes de ler `briefing.md` ou `docs/constitution.md` direto do disco,
+verifique se ha cache valido:
+
+1. Se variavel `AGENTE_00C_STATE_DIR` esta setada OU se
+   `<projeto-alvo>/.claude/agente-00c-state/state.json` existe:
+   - Invoque via Bash: `state-cache.sh get-resumo --state-dir <SD>
+     --artifact <briefing|constitution>`
+   - Exit 0 + stdout nao-vazio = use o resumo retornado.
+   - Exit 1 = caia em leitura direta do disco.
+   - Exit 2 = aborte com diagnostico do stderr (estado corrompido).
+
+2. Caso contrario (rodando standalone): leia direto do disco
+   (comportamento atual, sem mudanca).
+
+3. Apos consumo (hit ou miss): chame
+   `state-cache.sh metrics-bump --tipo <hit|miss-drift|miss-disabled>
+   --chars-economizados N`.
+```
+
+---
+
+## Research
+
+### Decisao 1: Geracao do resumo — heuristica extractiva (provisorio)
+
+`[NEEDS CLARIFY Q1]` — sera decidido em clarify.
+
+Opcoes avaliadas:
+
+**A. LLM in-session**:
+- Pros: resumo de melhor qualidade semantica, preserva nuance.
+- Contras: cada onda 1 paga tokens extras pelo prompt+resposta; nao
+  deterministico (resumo varia entre runs); adiciona dependencia
+  do prompt-cache hit.
+
+**B. Heuristica extractiva**:
+- Pros: deterministico, zero tokens, trivial de testar.
+- Contras: pode perder contexto importante (resumo bobo).
+
+**C. Hibrido (heuristica primeiro, LLM fallback se output >
+threshold)**:
+- Pros: combina vantagens.
+- Contras: 2 caminhos para manter.
+
+**Recomendacao provisoria**: B (heuristica extractiva) para v1.
+Algoritmo:
+1. Extrair todos os `## Heading` e `### Heading` (com numeracao).
+2. Para cada heading, extrair primeira linha de corpo nao-vazia.
+3. Se ainda excede `resumo_max_chars`, dropar `### Heading`s ate
+   caber.
+4. Output formatado como markdown.
+
+Reavaliar para v2 se SC-001 falhar em pipelines reais.
+
+### Decisao 2: Threshold de passthrough
+
+`[NEEDS CLARIFY Q2]` — 3000 chars proposto.
+
+Racional: arquivo pequeno cabe em ~750 tokens. Re-leitura por skill
+gera <1k tokens overhead. Geracao de resumo (mesmo heuristico)
+exige fork+exec de shell por onda, custo nao-zero. Break-even
+estimado em torno de 3-4k chars.
+
+Confirmar em clarify se threshold deve ser proporcional ao numero
+de ondas esperado.
+
+### Decisao 3: Cache da constitution raiz vs feature-delta
+
+`[NEEDS CLARIFY Q3]` — proposto: cachear apenas a "constitution
+ativa" (feature-delta se existe, senao raiz). Path resolvido via
+`pipeline.sh constitution-conflict` (ja existente).
+
+### Decisao 4: Re-geracao em retomada
+
+`[NEEDS CLARIFY Q4]` — proposto: confiar no backup-de-onda quando
+hash bate; regenerar apenas em drift detectado. Aplica logica ja
+existente do `feature-00c-preflight.sh` estendida para o campo de
+cache.
+
+### Decisao 5: Medicao de tokens economizados
+
+`[NEEDS CLARIFY Q5]` — proposto: heuristica `chars / 4` (pt-br) ou
+`chars / 3` (en), ratio configuravel em `config.cache.
+tokens_per_char_ratio`. Sem dependencia de API externa.
+
+---
+
+## Project Structure
+
+```
+docs/specs/agente-00c-artifact-cache/
+├── spec.md              # ESTE arquivo (already done)
+├── plan.md              # ESTE arquivo
+├── checklists/          # gerado por /checklist
+│   ├── ux.md
+│   ├── api.md
+│   ├── security.md
+│   └── performance.md
+├── tasks.md             # gerado por /create-tasks
+├── data-model.md        # detalhes do schema (opcional, se necessario)
+├── contracts/
+│   └── state-cache-sh.md  # contrato da nova primitiva (detalhado)
+└── validation-runs/     # outputs de execucoes de validacao
+```
+
+Source files modificados:
+
+```
+global/skills/agente-00c-runtime/scripts/
+├── state-cache.sh          # NOVO — primitiva do cache
+├── state-validate.sh       # MOD — adicionar validacao FR-CACHE-017
+└── state-rw.sh             # eventualmente MOD se schema_version bump exigir
+
+global/skills/specify/SKILL.md      # MOD — protocolo FR-CACHE-008
+global/skills/clarify/SKILL.md      # MOD — protocolo FR-CACHE-008
+global/skills/plan/SKILL.md         # MOD — protocolo FR-CACHE-008
+global/skills/execute-task/SKILL.md # MOD — protocolo FR-CACHE-008
+
+tests/
+├── test_state-cache.sh                  # NOVO — cobertura da primitiva
+├── test_state-validate.sh               # EXPANDIR — cenarios de FR-CACHE-017
+└── integration_cache-pipeline.sh        # NOVO (opcional) — integracao end-to-end
+
+CHANGELOG.md                            # MOD — entrada nova
+```
+
+---
+
+## Complexity Tracking
+
+| Item | Justificativa |
+|------|---------------|
+| Nova primitiva `state-cache.sh` | Necessaria — nenhuma primitiva existente lida com derivacao de conteudo + filtro de secrets. |
+| Modificacao em 4 skills | Necessaria — FR-CACHE-008 exige protocolo de leitura novo. Modificacao eh aditiva (fallback preservado), nao destrutiva. |
+| Schema bump MINOR | Necessario para auditabilidade. Mas compativel: campos novos sao opcionais. |
+| Sem dependencias novas de runtime | Mantido — usa apenas jq + sha256sum ja exigidos pelas outras primitivas. |
+| Heuristica extractiva sem LLM | Reduz complexidade total ao custo de qualidade de resumo. Reavaliavel em v2. |
+
+**Sem violacoes constitucionais detectadas. Plan apto a clarify.**
+
+---
+
+## Phases
+
+### Phase 0 — Clarify (5 perguntas abertas)
+
+Resolver Q1-Q5 antes de /plan finalizar. Saida: plan atualizado +
+checklist gerado.
+
+### Phase 1 — Primitiva + schema (M)
+
+- `state-cache.sh` com 6 subcomandos (FR-CACHE-008/009/010/015).
+- Schema bump em `state-validate.sh` (FR-CACHE-017).
+- Testes unitarios da primitiva (>= 12 cenarios).
+
+### Phase 2 — Skills modificadas (M)
+
+- Editar `SKILL.md` de specify/clarify/plan/execute-task para
+  adicionar `## Leitura de artefatos foundational`.
+- Testes de regressao standalone (FR-CACHE-014, SC-002).
+
+### Phase 3 — Orquestrador + relatorio (A)
+
+- Modificacoes em `agente-00c-orchestrator.md` e
+  `agente-00c-feature-orchestrator.md`:
+  - Invocar `state-cache.sh ensure` na onda 1 apos validacao de
+    briefing/constitution.
+  - Pre-flight drift check no inicio de cada onda N>1.
+- `report.sh generate`: secao nova `### Cache de Artefatos`.
+
+### Phase 4 — Integracao + validacao (A)
+
+- Test E2E rodando uma pipeline minimal de 3 ondas com cache ativo.
+- Medicao real de `tokens_economizados_estimados` vs baseline.
+- Documentacao em CHANGELOG.md + bump de versao.
+
+---
+
+## Risks
+
+| Risco | Probabilidade | Mitigacao |
+|-------|--------------|-----------|
+| Resumo extractivo perde info critica e degrada decisoes do clarify-answerer | Media | Suite de regressao validando que decisoes em fixture-de-projeto-conhecido nao mudam com cache ativo. |
+| TOCTOU race entre check-drift e get-resumo | Baixa | Double-check no momento do consumo (FR-CACHE-008 step 2); lock global ja existente. |
+| Schema bump quebra execucoes em andamento | Baixa | Campos novos sao opcionais; state.json legado continua valido. Documentar em CHANGELOG. |
+| Filtro de secrets sobre-redacta resumo til | Media | FR-CACHE-007 fallback para passthrough se redacao >50%. |
+| Standalone skill quebra por bug em conditional | Alta sem testes | Test de regressao explicito (FR-CACHE-014). |
+
+---
+
+## Out-of-Plan (deferred to Out of Scope da spec)
+
+- Cache de spec/plan/tasks.
+- Cache global cross-execucao.
+- Configuracao per-skill.
+- Migrador de state.json legado.

--- a/docs/specs/agente-00c-artifact-cache/spec.md
+++ b/docs/specs/agente-00c-artifact-cache/spec.md
@@ -1,0 +1,524 @@
+# Feature Specification: Agente-00C Artifact Cache
+
+**Feature**: `agente-00c-artifact-cache`
+**Created**: 2026-05-20
+**Status**: Draft
+
+## Clarifications
+
+_(esta secao sera populada pela skill `clarify` apos draft inicial)_
+
+---
+
+> **Contexto**: o orquestrador agente-00c (e sua variante feature-00c)
+> executa a pipeline SDD em multiplas ondas (waves). Cada onda e uma
+> invocacao fresca do Claude Code, com cold-start de contexto. As
+> skills do pipeline (`specify`, `clarify`, `plan`, `execute-task`)
+> leem `briefing.md` e `docs/constitution.md` em disco completos a
+> cada invocacao. Em pipelines longas (10+ ondas), isso representa
+> overhead estimado de **5-10k tokens por onda** (50-100k tokens por
+> execucao completa) somente para re-carregar artefatos foundational
+> que mudam raramente.
+>
+> Esta feature introduz um cache opcional de artefatos foundational
+> em `state.json`, com hash-validation TOCTOU-safe para invalidacao
+> automatica. O cache e populado na onda 1 (resumo executivo de
+> briefing + constitution gerado pelo orquestrador) e consultado
+> pelas skills nas ondas N>1 quando rodando dentro do agente-00c.
+> Comportamento standalone das skills (invocacao manual fora do
+> orquestrador) e preservado integralmente.
+
+---
+
+## User Scenarios & Testing
+
+### User Story 1 — Reducao mensuravel de tokens em pipelines longos (Priority: P1)
+
+Joao roda `/agente-00c "<descricao de POC>"` em um projeto de medio
+porte. A execucao atravessa 10 ondas (briefing → constitution →
+specify → clarify → plan → checklist → create-tasks → execute-task
+× N tasks → review-task → review-features). A partir da onda 2,
+sempre que uma skill do pipeline precisa do conteudo de
+`briefing.md` ou `docs/constitution.md`, em vez de ler o arquivo
+completo (5-15k tokens cada), consulta o resumo executivo cacheado
+em `state.json` (1-2k tokens cada). Ao final da execucao, o
+relatorio inclui metrica `tokens_economizados_por_cache` mostrando
+o ganho real comparado a baseline historica.
+
+**Why this priority**: este e o produto da feature. Sem reducao
+mensuravel de tokens, a feature nao tem razao de existir. P1 garante
+end-to-end: cache populado, consumido, e medicao registrada.
+
+**Independent Test**: rodar `/agente-00c` em projeto pequeno (3-5
+ondas) e em projeto medio (10+ ondas); comparar `state.json.metricas.
+tokens_cache_hits` e `state.json.metricas.tokens_economizados_por_cache`
+contra baseline pre-feature (capturada em research.md de `/plan`).
+Esperado: economia >= 70% do conteudo de briefing+constitution em
+ondas N>1.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma execucao do agente-00c com briefing+constitution
+   pre-existentes e cache populado na onda 1, **When** uma skill do
+   pipeline na onda 2 (ou posterior) precisa do conteudo de
+   `briefing.md`, **Then** a skill consulta o resumo cacheado em
+   `state.json.briefing_cache.resumo` em vez de ler o arquivo
+   completo em disco, e a metrica `tokens_cache_hits` incrementa.
+2. **Given** uma execucao concluida com cache ativo, **When** Joao
+   abre o relatorio final, **Then** encontra a secao
+   `### Cache de Artefatos` com: tamanho original vs resumo
+   (chars + tokens estimados), numero de hits por skill,
+   numero de invalidacoes detectadas, e economia liquida em
+   tokens.
+3. **Given** uma execucao em projeto pequeno onde briefing tem
+   <3k chars, **When** o orquestrador avalia custo-beneficio na
+   onda 1, **Then** marca `briefing_cache.estrategia = "passthrough"`
+   (cache desabilitado para esse artefato; arquivo eh pequeno o
+   bastante para nao justificar resumo), e skills leem direto do
+   disco como hoje. Decisao auditavel registrada em
+   `state.json.decisoes[]`.
+
+---
+
+### User Story 2 — Standalone behavior das skills preservado (Priority: P1)
+
+Maria invoca a skill `plan` manualmente via `/plan <descricao>` em
+um projeto que NAO tem agente-00c rodando. A skill detecta ausencia
+de `state.json` (ou ausencia de `briefing_cache`/`constitution_cache`)
+e cai no comportamento atual: le `briefing.md` e
+`docs/constitution.md` diretamente do disco. Maria nao percebe
+diferenca operacional alguma — a skill funciona identicamente ao
+pre-feature.
+
+**Why this priority**: as skills SDD sao user-facing e usadas tanto
+standalone quanto dentro do orquestrador. Quebrar o caminho
+standalone em nome da otimizacao orquestrada eh inaceitavel — viola
+o principio de menor surpresa e quebra docs publicas que ensinam
+uso manual. P1 = mesma prioridade do ganho, porque sem essa
+garantia o ganho vem com regressao.
+
+**Independent Test**: invocar `/plan`, `/specify`, `/clarify`,
+`/execute-task` em um projeto sem `state.json` (ou com state.json
+sem campos de cache); validar que cada skill produz o mesmo output
+que produziria pre-feature, e que ler os arquivos foundational do
+disco continua sendo o comportamento default.
+
+**Acceptance Scenarios**:
+
+1. **Given** projeto SEM `.claude/agente-00c-state/state.json`,
+   **When** usuario invoca `/plan <feature>`, **Then** a skill le
+   `docs/constitution.md` direto do disco, gera plan.md, e nao
+   tenta acessar campos de cache.
+2. **Given** projeto COM `state.json` mas sem campos
+   `briefing_cache`/`constitution_cache` (execucao legada
+   pre-feature), **When** usuario invoca uma skill afetada, **Then**
+   a skill detecta ausencia dos campos e cai no fallback de leitura
+   direta, sem erro.
+3. **Given** invocacao de skill via tool `Skill` dentro de teste
+   automatizado, **When** o teste roda em ambiente sem agente-00c,
+   **Then** o teste passa identicamente ao baseline pre-feature.
+
+---
+
+### User Story 3 — Invalidacao automatica via hash mismatch (Priority: P2)
+
+Durante uma execucao do agente-00c que dura varias horas, Joao
+edita `docs/constitution.md` em outra janela (corrige um typo num
+principio). Na proxima onda, antes de qualquer skill consultar o
+cache, o orquestrador (ou a primeira skill que tenta consumir o
+cache) detecta que o `sha256` registrado em
+`state.json.constitution_cache.source_sha256` nao bate com o hash
+do arquivo em disco. O cache eh invalidado, o orquestrador regenera
+o resumo a partir do arquivo atual, atualiza o sha256, registra uma
+`Decisao` auditavel descrevendo o evento, e a pipeline prossegue
+sem perda de informacao.
+
+**Why this priority**: drift entre cache e source-of-truth eh o
+modo de falha classico de qualquer cache. Sem deteccao automatica,
+decisoes da pipeline ficariam baseadas em conteudo obsoleto — o que
+violaria o Principio I (Auditabilidade Total) silenciosamente. P2
+porque eh defensivo, nao produtivo — sem ele a feature ainda funciona
+no caso default (sem edicao concorrente), mas com risco residual
+importante.
+
+**Independent Test**: rodar uma execucao do agente-00c ate a onda 3
+ou maior; editar `docs/constitution.md` (alterar uma linha do corpo
+de um principio); aguardar proxima onda; verificar logs/relatorio
+para confirmar que a invalidacao foi detectada, registrada como
+Decisao, e cache regenerado.
+
+**Acceptance Scenarios**:
+
+1. **Given** cache populado e arquivo `docs/constitution.md`
+   modificado em disco apos a populacao, **When** o orquestrador
+   inicia a proxima onda, **Then** detecta hash mismatch (via
+   primitiva nova `state-cache.sh check-drift`), invalida o cache,
+   regenera o resumo, atualiza sha256, e registra uma `Decisao`
+   informativa com 5 campos preenchidos (contexto: "drift de
+   constitution detectado entre ondas N e N+1"; opcoes:
+   ["regenerar-cache", "abortar-feature", "marcar-cache-stale"];
+   escolha: "regenerar-cache"; justificativa: politica default
+   FR-CACHE-009; agente: "agente-00c-orchestrator").
+2. **Given** mismatch de hash detectado durante consumo do cache
+   pela skill (TOCTOU possivel entre check-drift inicial e
+   consumo posterior), **When** a skill detecta mismatch via
+   double-check antes de usar o resumo, **Then** invoca leitura
+   direta do disco como fallback (sem abortar a execucao) e
+   registra metrica `cache_toctou_miss` para auditoria.
+3. **Given** uma mudanca MAJOR em `docs/constitution.md` (numero
+   de principios alterado, ou rodape `**Version**` bumped no
+   primeiro digito), **When** o orquestrador detecta o drift,
+   **Then** alem de regenerar cache, emite um `BloqueioHumano`
+   obrigatorio com pergunta "constitution evoluiu MAJOR durante
+   execucao — re-validar decisoes anteriores ou abortar?",
+   espelhando o tratamento ja existente para drift em retomadas
+   (FR-PRE-004 do feature-00c).
+
+---
+
+### User Story 4 — Filtro de secrets aplicado ao conteudo cacheado (Priority: P2)
+
+A constitution de um projeto pode conter texto que mencione tokens
+de exemplo (`AKIA[...]`), URLs com credenciais embutidas, ou
+fragmentos sensitivos em exemplos. Antes de gravar o resumo de
+briefing/constitution em `state.json`, o filtro de secrets
+(`secrets-filter.sh scrub`) eh aplicado ao texto — exatamente como
+ja eh aplicado a backups por onda (FR-029 §extensao). Conteudo
+sensitivo eh redacted antes da gravacao; o source-of-truth (arquivo
+em disco) permanece intocado.
+
+**Why this priority**: o `state.json` eh commitado localmente (via
+`state-ondas.sh git-commit`) e backupeado a cada onda. Vazar
+secrets via cache seria um regressao de seguranca. P2 porque eh
+defesa em profundidade — o filtro ja existe no toolkit, so precisa
+ser estendido ao novo campo.
+
+**Independent Test**: criar `docs/constitution.md` contendo um token
+de exemplo (`AKIA0000000000000000`); rodar agente-00c; verificar
+que `state.json.constitution_cache.resumo` nao contem o token
+literal (foi substituido por `[REDACTED-AWS-KEY]` ou equivalente).
+
+**Acceptance Scenarios**:
+
+1. **Given** `briefing.md` ou `docs/constitution.md` contendo
+   patterns reconhecidos como secrets (regex de
+   `secrets-filter.sh`), **When** o orquestrador gera o resumo
+   cacheado, **Then** aplica `secrets-filter.sh scrub` ao texto
+   ANTES de gravar em `state.json.briefing_cache.resumo` ou
+   `state.json.constitution_cache.resumo`.
+2. **Given** cache populado com conteudo filtrado, **When** uma
+   skill consome o resumo, **Then** recebe a versao filtrada (com
+   redactions visiveis); decisoes baseadas em segredos especificos
+   ficam impossiveis (esperado — segredos nao deveriam estar em
+   documentos de governanca).
+3. **Given** uma execucao concluida, **When** Joao audita o
+   `state.json`, **Then** confirma que nenhum campo do cache
+   contem patterns que `secrets-filter.sh check` reconheceria.
+
+---
+
+### Edge Cases
+
+- **Briefing/constitution ausentes no projeto-alvo**: o cache fica
+  marcado como `desabilitado` (nao tenta gerar resumo de algo que
+  nao existe). Skills caem no fallback default (que tambem falha
+  graciosamente quando os arquivos faltam — comportamento atual).
+- **Arquivos foundational gigantes (>50k chars)**: o orquestrador
+  pode falhar em produzir um resumo util em uma so onda. Politica
+  inicial: `briefing_cache.estrategia = "passthrough"` para arquivos
+  acima de threshold configuravel (default 30k chars); skills caem
+  no fallback de leitura direta. Decisao auditavel registrada
+  explicando a estrategia escolhida.
+- **Resumo gerado for maior que o arquivo original**: bug de
+  qualidade no gerador — registrar como Decisao + sugestao + cair
+  em `passthrough`.
+- **state.json sem schema bumpado**: validacao em
+  `state-validate.sh` detecta schema_version desalinhada e bloqueia
+  a execucao com diagnostico (sem auto-migracao silenciosa).
+- **Cache populado, mas arquivo source deletado**: drift maximo —
+  trata como `BloqueioHumano` obrigatorio ("arquivo source
+  desaparecido entre ondas — abortar ou continuar com cache
+  stale?").
+- **Race entre invalidacao automatica e consumo em paralelo**: o
+  cache eh lido sob o lock ja existente (`state-lock.sh acquire`),
+  garantindo serializacao por onda. Skills que rodam DENTRO de uma
+  onda compartilham snapshot do cache lido no inicio da onda.
+- **Filtro de secrets renderiza resumo inutil**: se >50% do conteudo
+  cacheado foi redacted, registrar Decisao + cair em `passthrough`
+  para esse artefato (skill le direto do disco, onde filtro de
+  secrets NAO eh aplicado — mas leitura direta nao persiste em
+  state.json, entao seguranca eh preservada).
+- **Execucao retomada (resume) com cache do disco diferente do
+  cache em backup**: a primitiva `feature-00c-preflight.sh` ja
+  detecta isso para briefing/constitution diretamente — estender
+  para cache opcional, com o mesmo tratamento (MAJOR drift =
+  bloqueio compulsorio; MINOR/PATCH = aviso).
+- **Skill consome cache mas Decisao referencia versao errada**:
+  campo `constitution.version` registrado em FR-PRE-004 do
+  feature-00c continua sendo o source-of-truth para auditoria;
+  cache eh apenas otimizacao de leitura, nao substitui o
+  registro de versao consumida.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+**Estrutura do cache em state.json**
+
+- **FR-CACHE-001**: `state.json` MUST aceitar dois novos campos
+  top-level opcionais: `briefing_cache` e `constitution_cache`. A
+  ausencia dos campos eh estado valido (execucoes legadas e skills
+  standalone continuam funcionando).
+- **FR-CACHE-002**: Cada campo de cache MUST conter, quando
+  presente, no minimo:
+  - `source_path`: caminho absoluto do arquivo source.
+  - `source_sha256`: hash do conteudo no momento da populacao.
+  - `source_chars`: tamanho do conteudo original em chars.
+  - `resumo`: texto do resumo executivo (apos filtro de secrets).
+  - `resumo_chars`: tamanho do resumo em chars.
+  - `estrategia`: enum `"resumo"`, `"passthrough"`, `"desabilitado"`.
+  - `gerado_em`: ISO-8601 timestamp.
+  - `gerado_na_onda`: integer (numero da onda que gerou/atualizou).
+- **FR-CACHE-003**: Schema_version do `state.json` MUST ser
+  bumpada (MINOR) com fallback graceful: state.json legado sem
+  os novos campos eh upgrade-compatible (campos opcionais).
+  Migracao automatica explicita NAO eh necessaria — cache eh
+  populado na proxima onda 1 (ou primeira onda que invocar
+  `state-cache.sh ensure`).
+
+**Populacao e atualizacao do cache**
+
+- **FR-CACHE-004**: Sistema MUST popular o cache no momento em que
+  briefing/constitution sao validados pela primeira vez na pipeline
+  (etapa `briefing` para `briefing_cache`; etapa `constitution`
+  para `constitution_cache`). Para `feature-00c`, populacao ocorre
+  durante FR-PRE-004 do feature-00c (validacao + registro de hashes).
+- **FR-CACHE-005**: A geracao do resumo MUST seguir politica
+  configuravel (decisao para `/plan`):
+  - Default proposto: usar LLM (mesma sessao do orquestrador) com
+    prompt deterministico — "Resuma X em ate 1500 chars preservando
+    estrutura semantica (secoes, principios, prioridades) e
+    descartando exemplos verbosos e justificativas historicas."
+  - Alternativa avaliavel em /plan: extracao heuristica (manter
+    so headers + 1a linha de cada secao) sem LLM call.
+- **FR-CACHE-006**: O resumo gerado MUST ser submetido a
+  `secrets-filter.sh scrub` ANTES de ser persistido em
+  `state.json`. O resultado filtrado eh o que vai para o campo
+  `resumo`.
+- **FR-CACHE-007**: Sistema MUST avaliar custo-beneficio na
+  populacao: se `source_chars < threshold` (default 3000), marcar
+  `estrategia = "passthrough"` e nao gerar resumo (cache desabilitado
+  para esse artefato; skills leem direto do disco). Threshold
+  configuravel via campo opcional no state.json
+  (`config.cache.passthrough_threshold_chars`, default 3000).
+
+**Consumo do cache**
+
+- **FR-CACHE-008**: Cada skill afetada (`specify`, `clarify`,
+  `plan`, `execute-task`, e quaisquer outras que leiam
+  briefing/constitution) MUST adotar o seguinte protocolo de
+  leitura:
+  1. Detectar se esta rodando dentro do agente-00c (presenca de
+     `state.json` no `.claude/agente-00c-state/` ou variant) E se
+     o cache aplicavel esta populado com `estrategia = "resumo"`.
+  2. Em caso positivo: chamar `state-cache.sh get-resumo --artifact
+     <briefing|constitution>` para obter o resumo. Antes de usar,
+     fazer double-check de drift (`state-cache.sh check-drift
+     --artifact <name>`) — TOCTOU-safe.
+  3. Em caso negativo OU drift detectado: ler o arquivo source
+     direto do disco (comportamento atual).
+- **FR-CACHE-009**: Politica default de invalidacao: hash mismatch
+  detectado durante consumo OU entre ondas DEVE invalidar e
+  regenerar automaticamente (sem bloqueio humano), exceto quando
+  drift eh classificado como MAJOR (FR-CACHE-010). Toda invalidacao
+  automatica registra `Decisao` informativa.
+- **FR-CACHE-010**: Drift MAJOR (mudanca do primeiro digito de
+  `constitution.version`, ou mudanca de >50% nos chars do source
+  entre ondas) MUST escalar para `BloqueioHumano` obrigatorio
+  ANTES de qualquer skill consumir o cache. Pergunta padrao:
+  "<arquivo> evoluiu MAJOR durante execucao — re-validar decisoes
+  anteriores ou abortar?".
+
+**Auditabilidade e telemetria**
+
+- **FR-CACHE-011**: Toda invalidacao de cache MUST gerar `Decisao`
+  com 5 campos preenchidos (contexto, opcoes, escolha,
+  justificativa, agente), registrada via `state-decisions.sh
+  register`. Categoria sugerida: `cache-invalidacao`.
+- **FR-CACHE-012**: `state.json` MUST conter contadores acumulados
+  em `metricas.cache`:
+  - `tokens_cache_hits`: numero de invocacoes que consumiram
+    cache em vez de disco.
+  - `tokens_cache_misses_drift`: invocacoes que detectaram drift
+    e regeneraram.
+  - `tokens_cache_misses_disabled`: invocacoes que cairam em
+    fallback porque cache estava `desabilitado` ou `passthrough`.
+  - `tokens_economizados_estimados`: soma de `source_chars -
+    resumo_chars` por hit, convertida para tokens (chars / 4 para
+    portugues, chars / 3 para ingles — heuristica configuravel).
+- **FR-CACHE-013**: Relatorio final do agente-00c (`report.sh
+  generate`) MUST incluir secao nova `### Cache de Artefatos`
+  reportando as 4 metricas + breakdown por artefato + listagem
+  das invalidacoes detectadas.
+
+**Compatibilidade com skills standalone**
+
+- **FR-CACHE-014**: Cada skill afetada MUST permanecer funcional
+  quando invocada FORA do contexto agente-00c (sem state.json
+  acessivel). Testes de regressao MUST cobrir invocacao standalone.
+- **FR-CACHE-015**: A nova primitiva `state-cache.sh` MUST
+  retornar exit-codes distintos para os casos:
+  - `0`: cache hit; resumo retornado via stdout.
+  - `1`: cache miss (campo ausente, estrategia != "resumo", ou
+    drift detectado); skill DEVE cair em leitura direta.
+  - `2`: erro fatal (state.json corrompido, lock indisponivel); skill
+    DEVE abortar com diagnostico — NAO assumir fallback silencioso.
+
+**Pre-flight e seguranca**
+
+- **FR-CACHE-016**: A primitiva `state-cache.sh` MUST ser
+  invocavel SOMENTE quando o `state-lock.sh` esta acquired (mesmo
+  contrato das outras primitivas de estado). Tentativa de invocar
+  sem lock = exit 2.
+- **FR-CACHE-017**: `state-validate.sh` MUST validar invariantes
+  do cache quando os campos estao presentes:
+  - `source_sha256` eh hex de 64 chars.
+  - `estrategia` esta no enum permitido.
+  - `resumo_chars <= source_chars` (resumo nunca pode ser maior
+    que original).
+  - `gerado_em` eh ISO-8601 valido.
+  - `gerado_na_onda` >= 1 e <= numero da onda corrente.
+
+---
+
+## Constitutional Alignment
+
+Verificacao contra os 5 principios MUST da constitution
+(`docs/constitution.md`):
+
+| Principio | Como esta feature alinha |
+|-----------|--------------------------|
+| **I. Auditabilidade Total** | Toda invalidacao de cache gera `Decisao` com 5 campos. Metricas de cache em `metricas.cache`. Secao dedicada no relatorio final. |
+| **II. Pause-or-Decide** | Drift MAJOR escala para `BloqueioHumano`; outros tipos de drift sao auto-resolvidos via politica default explicita (FR-CACHE-009). |
+| **III. Idempotencia de Retomada** | Cache pode ser reconstruido a qualquer momento do source. Source eh canonico; cache eh derivado. Pre-flight em retomada detecta drift entre cache+backup vs disco. |
+| **IV. Autonomia Limitada com Aborto** | Cache nao introduz nova classe de loop — invalidacoes contam para metrica de saude mas nao para ciclos consumidos. |
+| **V. Blast Radius Confinado** | Cache vive em `state.json` (dentro de `.claude/agente-00c-state/` do projeto-alvo). Filtro de secrets aplicado antes de gravar. Source files (`briefing.md`, `constitution.md`) sao read-only para esta feature. |
+
+---
+
+## Success Criteria
+
+- **SC-001**: Em pipeline de 10 ondas com briefing+constitution
+  totalizando >= 10k chars combinados, o overhead total de
+  re-leitura de artefatos foundational fica >= 70% MENOR que
+  baseline pre-feature. Medido via `metricas.cache.
+  tokens_economizados_estimados` no relatorio final.
+- **SC-002**: Skills standalone (invocadas fora do agente-00c)
+  produzem output identico ao baseline pre-feature em suite de
+  regressao com >= 5 fixtures conhecidas (1 por skill afetada).
+  Identico = diff = 0 em arquivos gerados.
+- **SC-003**: Drift detectado entre ondas (briefing ou
+  constitution modificados em disco) eh detectado em 100% dos
+  casos, com Decisao auditavel registrada, em <= 100ms de overhead
+  por check (medido em test fixture).
+- **SC-004**: Zero secrets vazados via cache em suite de teste com
+  briefing/constitution contendo patterns sensitivos plantados.
+- **SC-005**: Nenhuma regressao em `./tests/run.sh` apos
+  implementacao. Novos testes adicionados: >= 15 cenarios cobrindo
+  cache-hit, cache-miss-drift, cache-disabled-threshold,
+  toctou-safe-double-check, secrets-filter-applied,
+  standalone-skill-fallback, schema-validation.
+
+---
+
+## Out of Scope
+
+- **Cache de outros artefatos SDD** (spec.md, plan.md, tasks.md):
+  estes mudam com mais frequencia entre ondas e ja sao consumidos
+  por skills especificas com leitura full justificavel. Avaliacao
+  futura em feature separada.
+- **Cache compartilhado entre execucoes** (cache global em
+  `~/.claude/cache/`): cada execucao mantem cache proprio em seu
+  state.json. Compartilhamento cross-execucao introduz invalidacao
+  cross-process complexa, fora de escopo.
+- **Cache distribuido / multi-maquina**: agente-00c roda em uma so
+  maquina por execucao. Sem necessidade de coordinacao distribuida.
+- **Migracao automatica de state.json legado**: state.json sem
+  campos de cache eh upgrade-compatible (cache fica vazio,
+  populado na proxima onda). Sem migrador.
+- **Cache de prompts/responses do LLM**: o prompt-cache do
+  Anthropic API ja cobre isso em outra camada (system prompt,
+  tools). Esta feature otimiza apenas conteudo de arquivos de
+  projeto.
+- **Configuracao por skill da estrategia de cache**: politica
+  global (definida no orquestrador) eh suficiente para v1.
+  Customizacao por-skill avaliada se demanda surgir.
+
+---
+
+## Dependencies
+
+**Pre-requisitos internos do toolkit**:
+- `agente-00c-runtime` skill (state-rw.sh, state-lock.sh,
+  state-decisions.sh, state-validate.sh, secrets-filter.sh,
+  state-ondas.sh) — sera estendida com `state-cache.sh`.
+- Schema `state.json` versao corrente (a ser bumped MINOR).
+- Pipeline SDD existente (skills: specify, clarify, plan,
+  execute-task) — sera modificada para protocolo de leitura
+  FR-CACHE-008.
+
+**Pre-requisitos externos**:
+- Nenhuma dependencia nova de runtime (continua POSIX shell +
+  jq + sha256sum).
+
+**Features paralelas**:
+- `feature-00c` (PR #6 merged) — cache aplica automaticamente
+  quando `agente-00c-feature-orchestrator` invoca skills
+  afetadas (mesma primitiva `state-cache.sh`, mesmo state.json
+  com escopo per-short-name).
+
+---
+
+## Validation Plan
+
+1. **Spec review** (esta fase): garantir cobertura de cenarios
+   end-to-end, edge cases, e alinhamento constitucional.
+2. **Clarify** (proxima): resolver `[NEEDS CLARIFICATION]`
+   gerados, especialmente em torno de:
+   - Threshold default de `passthrough` (3000 chars eh defensavel?)
+   - Politica de geracao de resumo (LLM in-session vs heuristica
+     extractiva)
+   - Como medir "tokens economizados" sem instrumentacao do LLM
+     (estimativa por chars/4 eh aceitavel?)
+3. **Plan**: arquitetura detalhada, contracts da nova primitiva
+   `state-cache.sh`, modificacoes em cada skill afetada,
+   schema_version bump strategy, plano de migracao.
+4. **Checklist**: quality gate dos requisitos por dominio
+   (performance, security, compatibility).
+5. **Tasks**: decomposicao em fases com criticidade
+   ([C]/[A]/[M]).
+6. **Execute**: implementacao seguindo SDD pipeline padrao.
+
+---
+
+## Open Questions for /clarify
+
+- **Q1**: Geracao do resumo — LLM in-session ou heuristica extractiva?
+  Trade-off custo (tokens da chamada de resumo) vs qualidade
+  (LLM produz resumo semantico melhor; heuristica eh deterministica
+  e gratuita).
+- **Q2**: Threshold `passthrough` — 3000 chars eh o ponto de
+  equilibrio entre overhead de geracao e ganho? Talvez deva ser
+  proporcional ao numero esperado de ondas (curto = passthrough,
+  longo = cache).
+- **Q3**: Cache de constitution.md raiz vs feature-delta — quando
+  ambos existem, cachear separadamente ou consolidar? Implica em
+  N campos vs 1 campo consolidado em state.json.
+- **Q4**: Re-geracao em retomada (resume) — sempre regenerar do
+  zero, ou confiar no backup-de-onda se hash bate? Trade-off
+  seguranca vs custo.
+- **Q5**: Quem mede "tokens economizados" — orquestrador (proxy
+  via chars / 4) ou plug-in que conta tokens reais via API
+  Anthropic? Plug-in eh mais preciso mas adiciona dependencia.

--- a/docs/specs/agente-00c-artifact-cache/tasks.md
+++ b/docs/specs/agente-00c-artifact-cache/tasks.md
@@ -1,0 +1,306 @@
+# Tasks: Agente-00C Artifact Cache
+
+**Feature**: `agente-00c-artifact-cache`
+**Spec**: [`spec.md`](./spec.md)
+**Plan**: [`plan.md`](./plan.md)
+**Created**: 2026-05-20
+**Status**: Draft (pre-clarify — pode mudar quando Q1-Q5 forem resolvidas)
+
+> Criticidade: `[C]` = Critical (bloqueia release), `[A]` = Alto
+> (defeito perceptivel ao usuario), `[M]` = Medio (qualidade /
+> manutencao).
+
+---
+
+## Resumo quantitativo
+
+| Fase | Tarefas | Tempo estimado |
+|------|---------|----------------|
+| Fase 0 — Clarify + Plan refinado | 1 (operacional) | 1 onda |
+| Fase 1 — Primitiva + schema | 6 | 3-4 ondas |
+| Fase 2 — Skills modificadas | 5 | 2-3 ondas |
+| Fase 3 — Orquestrador + relatorio | 4 | 2 ondas |
+| Fase 4 — Integracao + release | 4 | 2 ondas |
+| **Total** | **20** | **~10-12 ondas** |
+
+---
+
+## Escopo coberto
+
+- Nova primitiva `state-cache.sh` com 6 subcomandos.
+- Schema bump em `state.json` (MINOR) + validacoes.
+- Protocolo de leitura aditivo em 4 skills (specify, clarify,
+  plan, execute-task).
+- Integracao com agente-00c-orchestrator + feature-orchestrator.
+- Secao nova no relatorio final.
+- Testes unitarios e de regressao (>= 15 cenarios).
+
+## Escopo excluido
+
+- Cache de spec/plan/tasks (fora de escopo da spec).
+- Cache cross-execucao em `~/.claude/cache/` (fora de escopo).
+- Migrador automatico de state.json legado (campos opcionais).
+- Configuracao per-skill (apenas global).
+- Plug-in de medicao precisa de tokens via API Anthropic (heuristica chars/4).
+
+---
+
+## Fase 0 — Clarify + Plan refinado
+
+### T0.1 [C] Resolver Open Questions Q1-Q5 da spec via `/clarify`
+
+**Dependencias**: spec.md draftada (concluido).
+**Saida**: spec.md atualizada com bloco `## Clarifications` populado +
+plan.md atualizado removendo todos os `[NEEDS CLARIFY Qn]`.
+**Bloqueia**: T1.1 (primitiva nao pode ser implementada com
+geracao-de-resumo indefinida).
+
+---
+
+## Fase 1 — Primitiva + schema
+
+### T1.1 [C] Implementar `state-cache.sh` subcomando `ensure`
+
+**Path**: `global/skills/agente-00c-runtime/scripts/state-cache.sh`
+**Spec ref**: FR-CACHE-004, FR-CACHE-005, FR-CACHE-006, FR-CACHE-007.
+**Detalhes**:
+- Receber `--state-dir`, `--artifact`, `--source-path`.
+- Calcular `source_sha256` via `sha256sum` (linux) / `shasum -a 256` (macos).
+- Decidir `estrategia`: se `source_chars < passthrough_threshold` → "passthrough"; senao "resumo".
+- Para "resumo": invocar heuristica extractiva (T1.2) OU LLM-in-session (decidido em T0.1).
+- Aplicar `secrets-filter.sh scrub` ao resumo.
+- Atualizar state.json via `state-rw.sh set` (atomico).
+- Registrar `Decisao` informativa via `state-decisions.sh register`.
+**Testes**: cenarios em T1.5.
+
+### T1.2 [C] Implementar gerador de resumo (heuristica extractiva v1)
+
+**Path**: funcao interna em `state-cache.sh` OU script separado em
+`scripts/_summarize.sh`.
+**Detalhes**:
+- Input: texto markdown + max-chars.
+- Output: markdown reduzido (preserva `## Heading`, drops body
+  prolixo, mantem 1a linha de cada heading).
+- Determinista (mesma entrada = mesma saida).
+**Bloqueio**: aguarda T0.1 (heuristica vs LLM).
+
+### T1.3 [C] Implementar subcomandos `get-resumo`, `check-drift`, `invalidate`
+
+**Spec ref**: FR-CACHE-008, FR-CACHE-009, FR-CACHE-010, FR-CACHE-015.
+**Detalhes**:
+- `get-resumo`: le `state.json`, valida `estrategia == "resumo"`, double-check sha256.
+- `check-drift`: compara sha256 registrado vs disco. Distingue MAJOR (version primeiro digito mudou OU >50% chars diff) de MINOR/PATCH.
+- `invalidate`: zera campo de cache, registra Decisao com justificativa fornecida via `--razao`.
+
+### T1.4 [A] Implementar subcomandos `metrics-bump` e `status`
+
+**Spec ref**: FR-CACHE-012.
+**Detalhes**:
+- `metrics-bump`: incrementa contador em `metricas.cache.*` (atomico).
+- `status`: imprime JSON com estado completo do cache (debug/audit).
+
+### T1.5 [C] Suite de testes `tests/test_state-cache.sh`
+
+**Spec ref**: SC-005 (>= 15 cenarios).
+**Cenarios obrigatorios**:
+1. `scenario_ensure_popula_cache_em_state_vazio`
+2. `scenario_ensure_arquivo_pequeno_marca_passthrough`
+3. `scenario_ensure_aplica_secrets_filter`
+4. `scenario_ensure_registra_decisao_auditavel`
+5. `scenario_get_resumo_hit_retorna_resumo`
+6. `scenario_get_resumo_miss_estrategia_passthrough_exit_1`
+7. `scenario_get_resumo_drift_detectado_exit_1`
+8. `scenario_check_drift_sem_mudanca_exit_0`
+9. `scenario_check_drift_minor_exit_1`
+10. `scenario_check_drift_major_exit_2`
+11. `scenario_invalidate_zera_cache_e_registra_decisao`
+12. `scenario_metrics_bump_incrementa_atomicamente`
+13. `scenario_invocacao_sem_lock_exit_2`
+14. `scenario_state_json_corrompido_exit_2`
+15. `scenario_artifact_invalido_exit_1`
+
+### T1.6 [A] Estender `state-validate.sh` com validacoes FR-CACHE-017
+
+**Path**: `global/skills/agente-00c-runtime/scripts/state-validate.sh`
+**Spec ref**: FR-CACHE-017.
+**Detalhes**:
+- Validar `source_sha256` eh hex de 64 chars.
+- Validar `estrategia` no enum permitido.
+- Validar `resumo_chars <= source_chars`.
+- Validar `gerado_em` ISO-8601.
+- Validar `gerado_na_onda >= 1 && <= onda_corrente`.
+**Tests**: expandir `tests/test_state-validate.sh` com >= 5 cenarios.
+
+---
+
+## Fase 2 — Skills modificadas
+
+### T2.1 [C] Adicionar bloco `## Leitura de artefatos foundational` em `specify/SKILL.md`
+
+**Spec ref**: FR-CACHE-008.
+**Detalhes**: inserir bloco padrao do plan.md (secao "Contrato de
+leitura das skills"). Modificacao aditiva — fluxo atual preservado
+no fallback.
+
+### T2.2 [C] Idem para `clarify/SKILL.md`
+
+### T2.3 [C] Idem para `plan/SKILL.md`
+
+### T2.4 [C] Idem para `execute-task/SKILL.md`
+
+### T2.5 [C] Suite de regressao standalone
+
+**Spec ref**: FR-CACHE-014, SC-002.
+**Path**: `tests/test_skills-standalone-regression.sh` (NOVO).
+**Detalhes**:
+- 5 fixtures (1 por skill afetada + 1 cross-skill).
+- Cada fixture: input conhecido + output esperado capturado pre-feature.
+- Test invoca skill SEM state.json → output deve ser identico (diff = 0).
+- Test invoca skill COM state.json mas sem cache → output identico.
+
+---
+
+## Fase 3 — Orquestrador + relatorio
+
+### T3.1 [C] Integrar `state-cache.sh ensure` no `agente-00c-orchestrator.md`
+
+**Path**: `global/agents/agente-00c-orchestrator.md`
+**Spec ref**: FR-CACHE-004.
+**Detalhes**:
+- No fim da etapa `briefing` (apos `pipeline.sh detect-completion`),
+  invocar `state-cache.sh ensure --artifact briefing
+  --source-path <briefing.md>`.
+- No fim da etapa `constitution`, idem para constitution.
+- Registrar Decisao auditavel via `state-decisions.sh register`.
+
+### T3.2 [C] Pre-flight drift check no inicio de cada onda N>1
+
+**Path**: `agente-00c-orchestrator.md` (Loop principal step 1.5)
+**Spec ref**: FR-CACHE-009, FR-CACHE-010.
+**Detalhes**:
+- Apos `state-lock.sh acquire` + `state-validate.sh` + `sha256-verify`,
+  invocar `state-cache.sh check-drift` para briefing e constitution.
+- MAJOR drift → registrar `BloqueioHumano` antes de prosseguir.
+- MINOR/PATCH drift → invocar `state-cache.sh ensure` para regenerar.
+
+### T3.3 [C] Espelhar T3.1 e T3.2 em `agente-00c-feature-orchestrator.md`
+
+**Path**: `global/agents/agente-00c-feature-orchestrator.md`
+**Spec ref**: cobertura da feature-00c (mesma primitiva, mesmo state.json).
+
+### T3.4 [A] Secao `### Cache de Artefatos` em `report.sh generate`
+
+**Path**: `global/skills/agente-00c-runtime/scripts/report.sh`
+**Spec ref**: FR-CACHE-013.
+**Detalhes**:
+- Adicionar secao apos `### Decisoes` (ou apos `### Bloqueios`).
+- Conteudo: tabela 2 colunas (briefing + constitution) com source_chars,
+  resumo_chars, estrategia, hits, drift detectado.
+- Subsecao "Economia liquida": `tokens_economizados_estimados`.
+
+---
+
+## Fase 4 — Integracao + release
+
+### T4.1 [C] Test E2E em projeto fixture
+
+**Path**: `tests/cstk/test_cache-pipeline-e2e.sh` (NOVO).
+**Detalhes**:
+- Criar fixture mini-projeto com briefing+constitution conhecidos
+  (>= 5k chars cada).
+- Rodar simulacao de 3 ondas via primitivas (sem precisar invocar
+  Claude — tests sao para o runtime POSIX).
+- Validar: cache populado na onda 1, hits nas ondas 2 e 3,
+  drift detectado quando arquivo alterado.
+
+### T4.2 [A] Medicao real de SC-001 em projeto piloto
+
+**Detalhes**:
+- Selecionar 1 projeto real (ex: `cstk-cli` ou um existente).
+- Rodar `/agente-00c` BASELINE (sem cache) — capturar baseline de tokens.
+- Mergear PR → rodar `/agente-00c` COM cache em ramo separado.
+- Comparar `metricas.cache.tokens_economizados_estimados` real vs
+  estimativa em spec (5-10k tok/onda).
+- Documentar resultado em `validation-runs/sc-001-piloto.md`.
+
+### T4.3 [M] Atualizar CHANGELOG.md + bump de versao MINOR
+
+**Path**: `CHANGELOG.md`
+**Detalhes**:
+- Entrada nova em `[Unreleased]` descrevendo Added/Changed.
+- Schema_version bump documentado (X.Y.0 → X.(Y+1).0).
+- Bump da versao do toolkit (MINOR — feature nova, nao breaking).
+
+### T4.4 [A] Atualizar doc em CLAUDE.md (per-user) com nota sobre o cache
+
+**Detalhes**: nao versionado, mas Joao adiciona uma linha em
+`CLAUDE.md` local explicando que o cache existe + como inspecionar
+(`state-cache.sh status`).
+
+---
+
+## Matriz de dependencias
+
+```
+T0.1 (clarify)
+  │
+  ├─→ T1.1 (ensure) ──→ T1.3 (get-resumo, check-drift, invalidate)
+  │      │                    │
+  │      └─→ T1.2 (resumo)    └─→ T1.4 (metrics, status)
+  │                                    │
+  │                                    └─→ T1.5 (tests) ──→ T1.6 (validate)
+  │
+  ├─→ T2.1, T2.2, T2.3, T2.4 (skills) ──→ T2.5 (regressao)
+  │      [dependem de T1.3 estar disponivel]
+  │
+  ├─→ T3.1, T3.2, T3.3 (orquestrador) ──→ T3.4 (relatorio)
+  │      [dependem de T1.1 + T1.3 estaveis]
+  │
+  └─→ T4.1 (e2e) ──→ T4.2 (piloto) ──→ T4.3 (changelog) ──→ T4.4 (docs)
+         [depende de TUDO acima merged]
+```
+
+Caminho critico: T0.1 → T1.1 → T1.3 → T1.5 → T3.1/T3.2 → T4.1 → T4.2 → T4.3.
+
+---
+
+## Coverage matrix (Requisitos × Tarefas)
+
+| FR-CACHE | Tarefa(s) cobrindo |
+|----------|---------------------|
+| FR-CACHE-001 (campos opcionais) | T1.1, T1.6 |
+| FR-CACHE-002 (estrutura do campo) | T1.1, T1.6 |
+| FR-CACHE-003 (schema_version bump) | T1.6, T4.3 |
+| FR-CACHE-004 (populacao na onda 1) | T1.1, T3.1, T3.3 |
+| FR-CACHE-005 (politica de geracao) | T0.1, T1.2 |
+| FR-CACHE-006 (secrets-filter) | T1.1, T1.5 (cenario 3) |
+| FR-CACHE-007 (threshold passthrough) | T1.1, T1.5 (cenario 2) |
+| FR-CACHE-008 (protocolo de leitura) | T2.1-T2.4 |
+| FR-CACHE-009 (invalidacao auto) | T1.3, T3.2 |
+| FR-CACHE-010 (drift MAJOR → bloqueio) | T1.3, T3.2 |
+| FR-CACHE-011 (Decisao em invalidacao) | T1.1, T1.3 |
+| FR-CACHE-012 (contadores metricas) | T1.4 |
+| FR-CACHE-013 (secao no relatorio) | T3.4 |
+| FR-CACHE-014 (standalone preservado) | T2.5 |
+| FR-CACHE-015 (exit-codes get-resumo) | T1.3, T1.5 |
+| FR-CACHE-016 (exige lock) | T1.1-T1.4 (validar em T1.5 cenario 13) |
+| FR-CACHE-017 (state-validate) | T1.6 |
+| SC-001 (>= 70% economia) | T4.2 |
+| SC-002 (regressao = 0) | T2.5 |
+| SC-003 (100% drift detectado) | T1.5 |
+| SC-004 (zero secrets vazados) | T1.5 (cenario 3) |
+| SC-005 (suite 15+ cenarios) | T1.5, T2.5 |
+
+---
+
+## Pontos de validacao (gates entre fases)
+
+- **Apos Fase 0**: spec atualizada + plan sem `[NEEDS CLARIFY]`.
+- **Apos Fase 1**: `state-cache.sh` 6 subcomandos passando >= 15
+  cenarios. `./tests/run.sh` sem regressao.
+- **Apos Fase 2**: skills modificadas; suite de regressao
+  standalone passa com diff=0. `./tests/run.sh` sem regressao.
+- **Apos Fase 3**: orquestrador integrado; pipeline simulada local
+  registra hits.
+- **Apos Fase 4**: piloto real mostrou SC-001 atendido (>=70%
+  economia). CHANGELOG atualizado. Versao bumped.


### PR DESCRIPTION
## Summary

Abertura formal da feature SDD `agente-00c-artifact-cache`. Esta PR contem APENAS os artefatos SDD (spec + plan + tasks), sem mudancas de codigo. Implementacao real fica deferida ate `/clarify` resolver as 5 Open Questions.

## Contexto

Discutindo otimizacao de boot tax do toolkit, PR #8 e PR #9 ja entregaram ~2k tok/boot economizados. O salto maior prometido para PR3 — cache de briefing/constitution no agente-00c (5-10k tok/onda em pipelines longos) — investigacao mostrou que e refactor multi-arquivo tocando agente + 4 skills + runtime + schema. Exige pipeline SDD formal antes da implementacao para nao quebrar Auditabilidade Total (Principio I da constitution).

## Drafts incluidos

| Arquivo | Linhas | Cobertura |
|---|---|---|
| [`spec.md`](./docs/specs/agente-00c-artifact-cache/spec.md) | 524 | 4 User Stories (P1/P1/P2/P2), 17 FRs, Edge Cases, Constitutional Alignment, 5 SCs, 5 Open Questions |
| [`plan.md`](./docs/specs/agente-00c-artifact-cache/plan.md) | 367 | Constitution Check, Data Model, API Contracts (`state-cache.sh` × 6 subcomandos), Research (5 decisoes), Phases, Risks |
| [`tasks.md`](./docs/specs/agente-00c-artifact-cache/tasks.md) | 306 | 20 tarefas em 5 fases, matriz de dependencias, coverage matrix |

## Estrategia tecnica (resumo do plan)

- **Novo:** primitiva `state-cache.sh` em `agente-00c-runtime/scripts/` (6 subcomandos: `ensure`, `get-resumo`, `check-drift`, `invalidate`, `metrics-bump`, `status`).
- **Schema:** state.json ganha campos opcionais `briefing_cache`, `constitution_cache`, `metricas.cache`. MINOR bump, backwards-compatible.
- **Skills modificadas:** specify, clarify, plan, execute-task ganham bloco \"Leitura de artefatos foundational\" — aditivo, com fallback preservado.
- **Orquestrador:** integra `ensure` na onda 1 + `check-drift` no inicio de N>1.
- **Relatorio:** secao nova \"Cache de Artefatos\" com metricas.
- **Standalone preservado:** FR-CACHE-014 + teste de regressao explicito (SC-002 = diff=0 vs baseline).

## Open Questions para /clarify

1. **Q1**: Geracao do resumo — LLM in-session vs heuristica extractiva?
2. **Q2**: Threshold `passthrough` — 3000 chars eh o ponto de equilibrio?
3. **Q3**: Cache de constitution.md raiz vs feature-delta — separados ou consolidados?
4. **Q4**: Re-geracao em retomada — sempre regenerar ou confiar no backup-de-onda?
5. **Q5**: Quem mede tokens economizados — heuristica chars/4 ou API Anthropic?

## Test plan

- [ ] Spec review humano antes de `/clarify`
- [ ] `/clarify` para resolver Q1-Q5
- [ ] Refinar `plan.md` removendo todos `[NEEDS CLARIFY Qn]`
- [ ] `/checklist` para quality gate dos requisitos
- [ ] Iniciar implementacao via `/execute-task` Fase 1 (T1.1)

## Sequencia da otimizacao de boot tax

| PR | Alvo | Tokens/boot |
|---|---|---|
| #8 (merged?) | Skills descriptions | ~1.354 |
| #9 (open) | Commands + Agents descriptions | ~669 |
| **#10 (esta PR)** | **Drafts SDD do cache** | **0 (sem codigo)** |
| futuro | Implementacao do cache (~10 ondas via SDD) | ~5-10k/onda em pipelines longos |

🤖 Generated with [Claude Code](https://claude.com/claude-code)