### PR TITLE
docs(cstk-session): documentar limitacao com git submodules

### DIFF
--- a/cli/lib/session.sh
+++ b/cli/lib/session.sh
@@ -98,6 +98,18 @@ SUBCOMANDOS:
            se PR existe, retorna URL existente. Flags --draft/--title/
            --body/--reviewer sao repassadas ao `gh pr create`.
 
+LIMITACOES:
+  Git submodules NAO sao isolados pela sessao. `cstk session start`
+  chama `git worktree add` puro; submodules ficam vazios na sessao
+  (so com gitlink `.git`). Se rodar `git submodule update --init`
+  dentro da sessao, o `.git` de cada submodule e compartilhado com
+  o checkout principal via `.git/modules/<nome>` — branch HEAD do
+  submodule e SHARED entre main e sessao. Mudancas no submodule
+  feitas na sessao afetam o checkout principal silenciosamente.
+  Workaround: edite codigo de submodule pelo checkout principal,
+  OU abra session SEPARADA dentro do submodule
+  (`cd path/to/submodule && cstk session start ...`).
+
 ENVIRONMENT:
   CSTK_LIB              caminho da biblioteca (setado pelo cstk)
 

--- a/docs/specs/cstk-session/spec.md
+++ b/docs/specs/cstk-session/spec.md
@@ -289,6 +289,21 @@ checa (branch nao tracked, sem commits a frente).
 - Sessao chamada com mesmo nome de branch ja remota (`gh pr create`
   vai pushear): comportamento aceitavel — usuario assume que sabe o
   que faz; `start` ja avisou "branch existente reutilizada".
+- **Repo com git submodules (monorepo)**: `start` chama `git worktree
+  add` puro, sem `git submodule update --init`. Submodules ficam
+  vazios na sessao (so o gitlink `.git` em cada subdir). Se operador
+  inicializar manualmente na sessao, o `.git/modules/<nome>` e
+  compartilhado com o checkout principal — branch HEAD do submodule
+  fica SHARED entre as duas worktrees, quebrando a promessa de
+  isolamento para edits dentro do submodule. **Workaround atual**:
+  editar codigo de submodule pelo checkout principal, OU abrir
+  session SEPARADA dentro do submodule (`cd path/to/submodule &&
+  cstk session start ...`). Limitacao documentada no help do
+  `cstk session` + issue de tracking aberta no repositorio. **Nao
+  e bug do cstk**: limitacao fundamental de como git trata
+  submodules em worktrees — para isolamento real seria necessario
+  criar worktree do submodule tambem, o que extrapola escopo desta
+  feature.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Documenta limitacao conhecida do `cstk session` em monorepos com git submodules. Em vez de mudar comportamento, deixa explicito o gap e o workaround — fix real exigiria criar worktree do submodule tambem, o que extrapola escopo.

## Mudancas

- **`cli/lib/session.sh`** — bloco novo `LIMITACOES` no `cstk session --help` (entre SUBCOMANDOS e ENVIRONMENT). 10 linhas.
- **`docs/specs/cstk-session/spec.md`** — edge case novo no bloco Edge Cases, com diagnostico, workarounds e justificativa de porque NAO eh bug do cstk.

## Cenarios cobertos

1. **Sem `git submodule update --init`**: submodules vazios no worktree (so gitlink). Build quebra; IDE perde refs.
2. **Com init**: `.git/modules/<nome>` compartilhado entre worktrees — branch HEAD do submodule fica shared. Edicao na sessao afeta main silenciosamente.

## Workaround documentado

Edite codigo de submodule pelo checkout principal, OU abra session SEPARADA dentro do submodule (`cd path/to/submodule && cstk session start ...`).

## Issue de tracking

Aberta em paralelo descrevendo o problema e possiveis caminhos para fix real (multi-worktree de submodules).

## Test plan

- [x] `./tests/run.sh cstk/test_session` — **60 PASS / 0 FAIL**
- [x] `cstk session start --help` exibe bloco LIMITACOES novo
- [x] Spec atualizada com edge case visivel na renderizacao

🤖 Generated with [Claude Code](https://claude.com/claude-code)