### PR TITLE
feat(trigger-eval): harness de eval de disparo de skills + fix da description do plan

### DIFF
--- a/global/skills/advisor/evals/triggers.jsonl
+++ b/global/skills/advisor/evals/triggers.jsonl
@@ -1,0 +1,4 @@
+{"query": "critica meu plano de migracao pra microsservicos, quero feedback estrategico honesto", "expect": "advisor"}
+{"query": "avalia se minha ideia de cache distribuido faz sentido", "expect": "advisor"}
+{"query": "vale a pena reescrever esse modulo em Rust ou e over-engineering? quero um parecer franco", "expect": "advisor", "tier": "hard"}
+{"query":"o cache de sessão tá expirando antes do esperado e eu suspeito que é culpa do design atual — TTL configurado no lugar errado. você acha que vale mudar a arquitetura ou é melhor corrigir o TTL pontualmente?","expect":"advisor","tier":"gen"}

--- a/global/skills/analyze/evals/triggers.jsonl
+++ b/global/skills/analyze/evals/triggers.jsonl
@@ -1,0 +1,8 @@
+{"query": "verifica se a spec, o plan e as tasks dessa feature estao consistentes entre si", "expect": "analyze"}
+{"query": "faz um cross-check dos artefatos SDD: a spec promete coisas que o backlog nao cobre?", "expect": "analyze"}
+{"query": "audita a coerencia entre o plano tecnico e a constituicao do projeto", "expect": "analyze"}
+{"query": "sera que o que a gente prometeu na spec realmente aparece no plano e nas tarefas?", "expect": "analyze", "tier": "hard"}
+{"query":"tenho a spec.md, o plano tecnico e o backlog de tarefas — quero saber se os tres estao contando a mesma historia ou se tem coisa desencontrada entre eles","expect":"analyze","tier":"gen"}
+{"query":"a constituicao do projeto diz uma coisa e as tarefas que criamos dizem outra — quero entender onde os dois divergem","expect":"analyze","tier":"gen"}
+{"query":"o plano de implementacao que gerei bate com o que esta na spec? ou ficou coisa sobrando sem cobertura nos dois lados?","expect":"analyze","tier":"gen"}
+{"query":"consegue olhar se as tarefas que criei estao alinhadas com a spec e com o plano? quero saber se tem gap ou contradicao entre eles","expect":"analyze","tier":"gen"}

--- a/global/skills/apply-insights/evals/triggers.jsonl
+++ b/global/skills/apply-insights/evals/triggers.jsonl
@@ -1,0 +1,3 @@
+{"query":"Acabei de rodar /insights e ele mostrou vários padrões de uso. Como eu aplico isso no projeto pra melhorar o fluxo?","expect":"apply-insights","tier":"gen"}
+{"query":"Tenho percebido que o Claude repete as mesmas perguntas de permissão toda hora e perde contexto entre sessões. Tem alguma forma de ajustar o projeto pra corrigir isso com base no que ele mesmo usa?","expect":"apply-insights","tier":"gen"}
+{"query":"Vi que nos últimos sprints o agente sempre pede as mesmas coisas antes de começar. Quero incorporar isso no CLAUDE.md pra não precisar repetir","expect":"apply-insights","tier":"gen"}

--- a/global/skills/briefing/evals/triggers.jsonl
+++ b/global/skills/briefing/evals/triggers.jsonl
@@ -1,0 +1,3 @@
+{"query": "vamos iniciar um projeto novo do zero, faz o discovery de visao, usuarios e stack", "expect": "briefing"}
+{"query":"quero construir um sistema de agendamento de consultas medicas. nao sei por onde comecar, tenho algumas ideias mas preciso organizar tudo — quem vai usar, quais as restricoes tecnicas, o que e obrigatorio na versao 1","expect":"briefing","tier":"gen"}
+{"query":"to come cando um projeto novo do zero pra um cliente. ainda nao escrevi nada, nao sei nem qual stack usar, quero fazer as perguntas certas primeiro pra entender o negocio dele","expect":"briefing","tier":"gen"}

--- a/global/skills/bugfix/evals/triggers.jsonl
+++ b/global/skills/bugfix/evals/triggers.jsonl
@@ -1,0 +1,8 @@
+{"query": "tem um bug: o calculo de frete retorna negativo as vezes, investiga e corrige", "expect": "bugfix"}
+{"query": "o fluxo de checkout esta quebrando em producao, investiga a causa", "expect": "bugfix"}
+{"query": "as vezes o saldo fica negativo sem motivo e nao consigo reproduzir; rastreia de onde vem", "expect": "bugfix", "tier": "hard"}
+{"query":"o fluxo de checkout ta quebrando quando o usuario clica em confirmar pedido — o botao some e a tela trava, mas nao sei se e no frontend ou na api. preciso rastrear de onde vem o problema","expect":"bugfix","tier":"gen"}
+{"query":"quando o usuario completa o cadastro, o email de boas-vindas nao esta chegando — ja vi que a fila RabbitMQ parece estar recebendo a mensagem, mas o consumer nao processa","expect":"bugfix","tier":"gen"}
+{"query":"o endpoint de login tá retornando 500 quando mando a senha com caracteres especiais tipo & e <, parece que tem algo escapando errado lá no handler de autenticação","expect":"bugfix","tier":"gen"}
+{"query":"tô vendo no log que às vezes o refresh token não é invalidado quando o usuário faz logout — como eu rastreio de onde vem esse comportamento?","expect":"bugfix","tier":"gen"}
+{"query":"nosso fluxo de pagamento as vezes falha silenciosamente — a transacao some do banco mas a confirmacao nunca chega pro usuario. ja olhei os logs e o erro nao aparece em lugar nenhum obvio. preciso entender de onde isso pode estar vindo","expect":"bugfix","tier":"gen"}

--- a/global/skills/checklist/evals/triggers.jsonl
+++ b/global/skills/checklist/evals/triggers.jsonl
@@ -1,0 +1,1 @@
+{"query":"esses requisitos que escrevi sao bons o suficiente pra virar historia de usuario decente? tem algum criterio que eu esqueci de cobrir?","expect":"checklist","tier":"gen"}

--- a/global/skills/clarify/evals/triggers.jsonl
+++ b/global/skills/clarify/evals/triggers.jsonl
@@ -1,0 +1,5 @@
+{"query": "a spec dessa feature tem ambiguidades, me ajuda a resolver com perguntas estruturadas", "expect": "clarify"}
+{"query": "a feature ja esta especificada mas faltou detalhar o formato de saida; refina a spec existente", "expect": "clarify"}
+{"query": "a spec dessa feature ja existe, mas o time nao concorda no que significa 'pedido concluido'; alinha isso comigo", "expect": "clarify", "tier": "hard"}
+{"query":"o documento de spec que temos ja tem os requisitos funcionais, mas ficou vago na parte de autenticacao — precisamos resolver essas ambiguidades antes de partir pra implementacao","expect":"clarify","tier":"gen"}
+{"query":"nossa spec de pagamentos ficou pronta mas o time ta com duvida se o fluxo de reembolso cobre o caso de estorno parcial — da pra passar por ela e fechar esses pontos abertos antes de planejar?","expect":"clarify","tier":"gen"}

--- a/global/skills/constitution/evals/triggers.jsonl
+++ b/global/skills/constitution/evals/triggers.jsonl
@@ -1,0 +1,3 @@
+{"query": "define os principios de governanca imutaveis do projeto", "expect": "constitution"}
+{"query":"quero documentar que nesse projeto TDD e inegociavel, sem cobertura de teste nao mergeia, e que qualidade vem antes de velocidade — como registro isso de forma oficial?","expect":"constitution","tier":"gen"}
+{"query":"o projeto cresceu e o time novo nao sabe o que e intocavel: quais sao as regras que nao podem mudar, quem pode mudar o que, e como a gente faz amendment quando precisar","expect":"constitution","tier":"gen"}

--- a/global/skills/create-tasks/evals/triggers.jsonl
+++ b/global/skills/create-tasks/evals/triggers.jsonl
@@ -1,0 +1,4 @@
+{"query": "quebra esse escopo num backlog de tarefas com fases e dependencias", "expect": "create-tasks"}
+{"query": "decompoe a implementacao dessa feature numa lista de tarefas", "expect": "create-tasks"}
+{"query": "essa feature ainda nao tem nenhum item planejado; preciso transformar o escopo em pedacos executaveis com a ordem certa e o que depende do que", "expect": "create-tasks", "tier": "hard"}
+{"query":"baseado no que a gente ja escreveu sobre a feature de onboarding, queria quebrar isso em pedacos menores para o time conseguir trabalhar em paralelo — com fases e prioridades","expect":"create-tasks","tier":"gen"}

--- a/global/skills/e2e-integration-flow/evals/triggers.jsonl
+++ b/global/skills/e2e-integration-flow/evals/triggers.jsonl
@@ -1,0 +1,3 @@
+{"query": "escreve um teste e2e com playwright validando o fluxo de checkout em todas as camadas", "expect": "e2e-integration-flow"}
+{"query":"quero rodar um fluxo completo de cadastro de usuário e verificar se o token JWT salvo no banco bate com o que chega no header das requisições seguintes","expect":"e2e-integration-flow","tier":"gen"}
+{"query":"preciso validar o fluxo de pagamento inteiro: usuário adiciona cartão, aprova compra, e quero checar se o webhook de confirmação realmente atualiza o status do pedido no banco sem deixar janela de inconsistência","expect":"e2e-integration-flow","tier":"gen"}

--- a/global/skills/execute-task/evals/triggers.jsonl
+++ b/global/skills/execute-task/evals/triggers.jsonl
@@ -1,0 +1,6 @@
+{"query": "implementa a tarefa T-014 seguindo o workflow de execucao", "expect": "execute-task"}
+{"query": "executa a proxima tarefa do backlog", "expect": "execute-task"}
+{"query":"a spec esta aprovada, o plano tecnico esta fechado — agora so falta colocar a mao na massa na tarefa NOTIF-003 que e adicionar o handler de webhook","expect":"execute-task","tier":"gen"}
+{"query":"o backlog esta montado e a proxima tarefa e criar a migracao do banco para adicionar a coluna de status — como eu executo isso dentro do fluxo do projeto?","expect":"execute-task","tier":"gen"}
+{"query":"implementar a tarefa TASK-042 do backlog: persistir o evento de pagamento aprovado no banco depois que o webhook do gateway chega","expect":"execute-task","tier":"gen"}
+{"query":"executar a task de integracao com o servico de notificacoes: precisa disparar o push quando o pedido mudar de status, salvar o log no postgres e marcar como enviado na tabela","expect":"execute-task","tier":"gen"}

--- a/global/skills/initialize-docs/evals/triggers.jsonl
+++ b/global/skills/initialize-docs/evals/triggers.jsonl
@@ -1,0 +1,3 @@
+{"query":"vou comecar um projeto novo do zero. preciso organizar tudo: onde vou guardar os requisitos, casos de uso, modelos de dados, decisoes de arquitetura, planos de teste... como monto isso?","expect":"initialize-docs","tier":"gen"}
+{"query":"antes de comecar a codar quero deixar arrumado o espaco de trabalho da documentacao. o que precisa existir? pastas, templates, readme de cada secao... me ajuda a preparar esse esqueleto","expect":"initialize-docs","tier":"gen"}
+{"query":"o time novo vai entrar semana que vem e quero que o repositorio ja tenha um lugar definido pra cada tipo de documento — specs, DERs, ADRs, runbooks, tudo. como estruturo isso de forma padrao?","expect":"initialize-docs","tier":"gen"}

--- a/global/skills/owasp-security/evals/triggers.jsonl
+++ b/global/skills/owasp-security/evals/triggers.jsonl
@@ -1,0 +1,2 @@
+{"query": "faz um security review desse endpoint de login seguindo OWASP", "expect": "owasp-security"}
+{"query": "acho que da pra burlar o login mandando um header forjado; confere se isso e exploravel", "expect": "owasp-security", "tier": "hard"}

--- a/global/skills/plan/SKILL.md
+++ b/global/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: 'Technical implementation plan from a spec — architecture, data model, API contracts, research, test scenarios. Triggers: "plan", "criar plano", "planejar implementacao", "implementation plan". Skip for spec creation (specify) or task decomposition (create-tasks).'
+description: 'Technical implementation plan — the technical HOW: architecture, data model, API contracts, research, test scenarios. Use when the user wants the technical design of a feature (how to structure/build it, define contracts/schema), whether or not a formal spec.md exists yet. Triggers: "plan", "criar plano", "planejar implementacao", "desenho tecnico", "definir arquitetura/contratos/modelo de dados". Skip when defining WHAT/for-whom in natural language (use specify) or breaking work into tasks (create-tasks).'
 argument-hint: "[caminho para spec ou descricao da feature]"
 allowed-tools:
   - Read

--- a/global/skills/plan/evals/triggers.jsonl
+++ b/global/skills/plan/evals/triggers.jsonl
@@ -1,0 +1,5 @@
+{"query": "monta o plano tecnico de implementacao dessa spec: arquitetura, contratos de API e modelo de dados", "expect": "plan"}
+{"query": "como construir isso na pratica? quero o desenho tecnico — camadas, contratos, dados — antes de codar", "expect": "plan", "tier": "hard"}
+{"query":"ja tenho a spec da feature de pagamentos pronta, agora quero entender como isso vai ser estruturado tecnicamente — arquitetura, tabelas do banco, contratos de API","expect":"plan","tier":"gen"}
+{"query":"me ajuda a pensar no design da solucao para a feature de exportacao de relatorios — quero entender as opcoes de armazenamento, como a API vai funcionar e o que precisa ser testado","expect":"plan","tier":"gen"}
+{"query":"preciso estruturar como o serviço de notificações vai conversar com o de pedidos. tem race condition hoje que a gente resolve com retry, mas quero definir os contratos e o modelo de dados antes de continuar remendando","expect":"plan","tier":"gen"}

--- a/global/skills/review-features/evals/triggers.jsonl
+++ b/global/skills/review-features/evals/triggers.jsonl
@@ -1,0 +1,3 @@
+{"query": "me da um dashboard comparando o progresso de todas as features do portfolio", "expect": "review-features"}
+{"query":"quero entender onde cada feature ta agora — qual ta mais adiantada, qual ta parada faz tempo, se tem alguma que nao vale mais a pena continuar","expect":"review-features","tier":"gen"}
+{"query":"tem tres features rodando em paralelo e preciso decidir qual priorizar no proximo sprint — me da um quadro geral de cada uma","expect":"review-features","tier":"gen"}

--- a/global/skills/review-task/evals/triggers.jsonl
+++ b/global/skills/review-task/evals/triggers.jsonl
@@ -1,0 +1,4 @@
+{"query": "qual o status das tarefas? o que esta pronto pra comecar?", "expect": "review-task"}
+{"query": "o que falta pra fechar essa entrega e o que eu ja posso pegar agora?", "expect": "review-task", "tier": "hard"}
+{"query":"o backlog ta uma bagunica, quero saber o que ja foi feito, o que ta em aberto e o que depende de quem antes de continuarmos","expect":"review-task","tier":"gen"}
+{"query":"me fala quais tarefas ja posso comecar a implementar agora, quais ainda tem prerequisito em aberto e quantas foram concluidas ate agora","expect":"review-task","tier":"gen"}

--- a/global/skills/specify/evals/triggers.jsonl
+++ b/global/skills/specify/evals/triggers.jsonl
@@ -1,0 +1,7 @@
+{"query": "quero comecar uma feature nova de exportacao de relatorios em CSV, cria a spec", "expect": "specify"}
+{"query": "transforma essa descricao em linguagem natural numa spec SDD com user stories e FRs", "expect": "specify"}
+{"query": "ainda nao tem nada escrito sobre a funcionalidade de cupons; bota no papel o que ela precisa fazer e pra quem", "expect": "specify", "tier": "hard"}
+{"query":"tenho uma ideia de feature de exportacao de relatorios em PDF, mas ela ainda nao ta escrita em nenhum lugar — preciso transformar isso num documento formal com user stories e criterios de aceite","expect":"specify","tier":"gen"}
+{"query":"quero documentar essa nova feature de notificacoes push que o PO descreveu numa call hoje — ele falou os cenarios principais mas nao existe nada escrito ainda","expect":"specify","tier":"gen"}
+{"query":"vou adicionar uma feature de multi-tenant no sistema — ainda nao tem spec nenhuma, mas sei os atores, os fluxos e as restricoes principais. como transformo isso num artefato utilizavel pelo time?","expect":"specify","tier":"gen"}
+{"query":"tenho uma ideia de feature: quando o usuario finalizar o checkout, ele recebe um email de confirmacao com PDF do pedido anexado. como eu converto isso numa spec formal com criterios de aceite?","expect":"specify","tier":"gen"}

--- a/global/skills/validate-docs-rendered/evals/triggers.jsonl
+++ b/global/skills/validate-docs-rendered/evals/triggers.jsonl
@@ -1,0 +1,4 @@
+{"query": "confere se os diagramas mermaid desse doc renderizam e se os links internos resolvem", "expect": "validate-docs-rendered"}
+{"query": "sera que esse markdown vai renderizar certo? checa frontmatter e blocos de codigo sem linguagem", "expect": "validate-docs-rendered"}
+{"query":"meus diagramas de sequencia no docs/02-requisitos estao abrindo brancos no GitHub, quero checar se o Mermaid ta correto antes de mandar o PR","expect":"validate-docs-rendered","tier":"gen"}
+{"query":"os links internos do nosso README de arquitetura nao estao resolvendo, e acho que tem um code block sem linguagem la tambem — da pra validar isso?","expect":"validate-docs-rendered","tier":"gen"}

--- a/global/skills/validate-documentation/evals/triggers.jsonl
+++ b/global/skills/validate-documentation/evals/triggers.jsonl
@@ -1,0 +1,4 @@
+{"query": "audita a qualidade e completude do UC-CAD-001.md contra o padrao estrutural", "expect": "validate-documentation"}
+{"query": "esse documento de caso de uso esta bem estruturado e completo?", "expect": "validate-documentation"}
+{"query":"o nosso UC-CAD-003 tem todos os campos que precisa? quero saber se ta faltando alguma seção obrigatoria no documento","expect":"validate-documentation","tier":"gen"}
+{"query":"antes de apresentar a spec pro time eu quero garantir que ela ta bem escrita e completa, sem secoes faltando ou mal preenchidas","expect":"validate-documentation","tier":"gen"}

--- a/tests/trigger-eval/README.md
+++ b/tests/trigger-eval/README.md
@@ -1,0 +1,67 @@
+# trigger-eval — harness de disparo de skills
+
+Mede **se a `description` de cada skill dispara na hora certa** — e, mais
+importante, **quando uma skill é confundida com outra** (matriz de confusão
+entre clusters de overlap). Complementa o `tests/run.sh`, que cobre os
+**scripts** POSIX mas nunca o *triggering* das skills.
+
+Inspirado no loop de disparo do `skill-creator` da Anthropic (queries
+should-trigger / should-not, melhor `description` escolhida por score em
+held-out). Ver análise em CLAUDE.md / memória `reference_superpowers_benchmark`.
+
+## Natureza: periódico, NÃO é gate de CI
+
+Decidir disparo é **comportamento de modelo**, não script — então o runner
+precisa de um LLM no loop (um Workflow). Roda **sob demanda / pré-release**,
+não a cada push. O `tests/run.sh` continua sendo o gate determinístico.
+
+## Como rodar
+
+```sh
+# 1. monta o payload (descriptions vivas + queries) — requer jq
+sh tests/trigger-eval/collect.sh > /tmp/trigger-payload.json
+
+# 2. roda o juiz (via Claude Code, tool Workflow):
+#    Workflow({ scriptPath: "tests/trigger-eval/run.workflow.js",
+#               args: <conteúdo de /tmp/trigger-payload.json> })
+```
+
+O runner devolve `{accuracy, byExpect, confusionPairs, misfires}`. O sinal
+mais útil é `confusionPairs` (`esperado → escolhido`) e `misfires` (com a
+justificativa do juiz) — é onde mora o problema de description.
+
+## Formato do dado
+
+Cada skill é dona das suas queries em `global/skills/<nome>/evals/triggers.jsonl`
+(espelha a convenção `tests/test_<n>.sh`). Casos que **não** devem disparar
+nada ficam em `tests/trigger-eval/negatives.jsonl`. Uma query por linha:
+
+```json
+{"query": "texto que o usuário digitaria", "expect": "<slug-da-skill|none>"}
+```
+
+`expect` é o ground-truth: o slug que **deveria** disparar, ou `none`.
+
+## Princípio anti-circular (importante)
+
+Não gere as queries parafraseando a `description` e depois teste a
+`description` contra elas — isso mede a skill contra ela mesma e infla o
+score. Regras:
+
+- **Queries fundadas no PROPÓSITO** (o que um usuário real digitaria), com
+  near-misses propositais nas fronteiras entre skills irmãs.
+- O **juiz vê só as descriptions**; quem escreve a query conhece o propósito.
+- O seed atual é **hand-authored** nos clusters de overlap conhecidos
+  (`specify↔clarify`, `plan↔create-tasks↔execute-task`,
+  `validate-documentation↔validate-docs-rendered↔analyze`, `bugfix↔e2e`,
+  `advisor↔bugfix`, `review-task↔review-features`) + negativos. Cobertura das
+  23 skills é incremental.
+
+## Próximos passos
+
+- Geração assistida de drafts para as skills ainda sem `evals/` (com revisão
+  humana antes de confiar nos números — passo `eval_review` do skill-creator).
+- Sweep multi-modelo (haiku/sonnet/opus): a Anthropic recomenda testar
+  disparo nos três tiers. O runner aceita `model` por fase.
+- Loop de otimização de `description`: quando um cluster tiver acurácia baixa,
+  gerar variantes da description e escolher a melhor por score held-out.

--- a/tests/trigger-eval/ab.workflow.js
+++ b/tests/trigger-eval/ab.workflow.js
@@ -1,0 +1,77 @@
+export const meta = {
+  name: 'trigger-eval-ab',
+  description: 'A/B causal de UMA description: julga cada query com o catalogo usando a description ANTIGA vs a NOVA de um slug (resto do catalogo identico), por modelo. Mede fixed (antigo erra/novo acerta), regressed (antigo acerta/novo erra), bothOk, bothBad. args = {catalog (com a desc NOVA), targetSlug, descOld, queries, models?}.',
+  phases: [{ title: 'A/B' }],
+}
+
+let A = args
+if (typeof A === 'string') { try { A = JSON.parse(A) } catch (_) { A = {} } }
+const catalogNew = (A && A.catalog) || []
+const targetSlug = (A && A.targetSlug) || 'plan'
+const descOld = A && A.descOld
+const queries = (A && A.queries) || []
+const models = (A && Array.isArray(A.models) && A.models.length) ? A.models : ['sonnet', 'haiku']
+if (!catalogNew.length || !queries.length || !descOld) {
+  return { error: 'args precisa de {catalog, targetSlug, descOld, queries, models?}', _debug: { argsType: typeof args, keys: (A && typeof A === 'object') ? Object.keys(A) : null } }
+}
+
+const norm = (s) => String(s == null ? '' : s).trim().toLowerCase().replace(/[^a-z0-9-]/g, '')
+const NAMES = new Set(catalogNew.map((c) => norm(c.name)))
+const validChoice = (raw) => (norm(raw) === 'none' || NAMES.has(norm(raw))) ? raw : ('OUT:' + raw)
+const catalogOld = catalogNew.map((c) => norm(c.name) === norm(targetSlug) ? { ...c, description: descOld } : c)
+const textOf = (cat) => cat.map((c) => `- ${c.name}: ${c.description}`).join('\n')
+const textOld = textOf(catalogOld)
+const textNew = textOf(catalogNew)
+
+const SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['chosen', 'confidence', 'reason'],
+  properties: { chosen: { type: 'string' }, confidence: { type: 'number' }, reason: { type: 'string' } },
+}
+const prompt = (catText, q) => [
+  'Voce SIMULA o seletor de skills do Claude Code.',
+  'Catalogo (slug: description):', '', catText, '',
+  `Mensagem do usuario: "${q}"`,
+  'Baseando-se SOMENTE nas descriptions acima (ignore conhecimento previo das skills), qual UNICA skill dispararia?',
+  'Se nenhuma se aplica, "none". O slug DEVE estar no catalogo; NUNCA invente nome fora dele — nesse caso "none".',
+  'Responda o slug exato ou "none".',
+].join('\n')
+
+const rows = await parallel(
+  queries.map((q, i) => async () => {
+    const verds = await parallel(
+      models.map((m) => async () => {
+        const [vo, vn] = await Promise.all([
+          agent(prompt(textOld, q.query), { label: `${m}/old:q${i}→${q.expect}`, phase: 'A/B', schema: SCHEMA, model: m }).catch(() => null),
+          agent(prompt(textNew, q.query), { label: `${m}/new:q${i}→${q.expect}`, phase: 'A/B', schema: SCHEMA, model: m }).catch(() => null),
+        ])
+        const co = vo ? validChoice(vo.chosen) : 'ERROR'
+        const cn = vn ? validChoice(vn.chosen) : 'ERROR'
+        return { m, old: { chosen: co, ok: norm(co) === norm(q.expect) }, new: { chosen: cn, ok: norm(cn) === norm(q.expect) } }
+      })
+    )
+    const perModel = {}
+    for (const v of verds) if (v) perModel[v.m] = v
+    return { query: q.query, expect: q.expect, perModel }
+  })
+)
+
+const byModel = {}
+for (const m of models) {
+  const fixed = []
+  const regressed = []
+  let bothOk = 0
+  let bothBad = 0
+  for (const r of rows) {
+    const c = r.perModel[m]
+    if (!c) continue
+    if (!c.old.ok && c.new.ok) fixed.push({ query: r.query, expect: r.expect, old: c.old.chosen, new: c.new.chosen })
+    else if (c.old.ok && !c.new.ok) regressed.push({ query: r.query, expect: r.expect, old: c.old.chosen, new: c.new.chosen })
+    else if (c.old.ok && c.new.ok) bothOk++
+    else bothBad++
+  }
+  const accOld = rows.filter((r) => r.perModel[m] && r.perModel[m].old.ok).length
+  const accNew = rows.filter((r) => r.perModel[m] && r.perModel[m].new.ok).length
+  byModel[m] = { total: rows.length, accOld, accNew, fixed, regressed, bothOk, bothBad }
+}
+
+return { models, targetSlug, total: rows.length, byModel }

--- a/tests/trigger-eval/collect.sh
+++ b/tests/trigger-eval/collect.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# collect.sh — monta o payload {catalog, queries} para o runner trigger-eval.
+#
+#   catalog : descriptions VIVAS de cada global/skills/<n>/SKILL.md (o artefato sob teste)
+#   queries : uniao de global/skills/*/evals/triggers.jsonl + tests/trigger-eval/negatives.jsonl
+#
+# Saida: JSON compacto (uma linha) em stdout, pronto para virar o `args` do Workflow.
+# Requer jq. Uso:
+#   sh tests/trigger-eval/collect.sh > /tmp/trigger-payload.json
+#
+# Nao roda evals (isso e o Workflow run.workflow.js); so agrega o dado de disco.
+set -eu
+
+ROOT=${CSTK_ROOT:-$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)}
+cd "$ROOT"
+
+command -v jq >/dev/null 2>&1 || { printf 'collect.sh: jq e obrigatorio\n' >&2; exit 2; }
+
+cat_tmp=$(mktemp)
+q_tmp=$(mktemp)
+trap 'rm -f "$cat_tmp" "$q_tmp"' EXIT INT TERM
+
+# --- catalog: name + description de cada SKILL.md ---
+for f in global/skills/*/SKILL.md; do
+  [ -f "$f" ] || continue
+  name=$(basename "$(dirname "$f")")
+  # primeira linha `description:` dentro do bloco de frontmatter (entre o 1o e o 2o '---')
+  desc=$(awk '
+    /^---[[:space:]]*$/ { d++; if (d==2) exit; next }
+    d==1 && /^description:/ { sub(/^description:[[:space:]]*/, ""); print; exit }
+  ' "$f")
+  # remove aspas YAML externas (simples/duplas) e desescapa '' -> '
+  desc=$(printf '%s' "$desc" | sed -e "s/^'//" -e "s/'[[:space:]]*\$//" -e "s/''/'/g" -e 's/^"//' -e 's/"[[:space:]]*$//')
+  jq -n --arg n "$name" --arg d "$desc" '{name:$n, description:$d}'
+done | jq -s '.' > "$cat_tmp"
+
+# --- queries: todas as triggers.jsonl + negatives.jsonl ---
+{
+  for f in global/skills/*/evals/triggers.jsonl tests/trigger-eval/negatives.jsonl; do
+    [ -f "$f" ] || continue
+    grep -v '^[[:space:]]*$' "$f" || true
+  done
+} | jq -c 'select(.query and .expect)' | jq -s '.' > "$q_tmp"
+
+jq -c -n --slurpfile c "$cat_tmp" --slurpfile q "$q_tmp" \
+  '{catalog: $c[0], queries: $q[0]}'

--- a/tests/trigger-eval/harden.workflow.js
+++ b/tests/trigger-eval/harden.workflow.js
@@ -1,0 +1,125 @@
+export const meta = {
+  name: 'trigger-eval-harden',
+  description: 'Endurece o seed de trigger-eval: gera queries adversariais por cluster de overlap (sem trigger-keywords), faz ground-check cetico (descarta mal-fundadas) e julga (juiz ve SO as descriptions). Devolve acuracia + misfires REAIS + keep-set defensavel para persistir. args = {catalog, clusters}.',
+  phases: [
+    { title: 'Generate', model: 'sonnet' },
+    { title: 'Ground-check', model: 'sonnet' },
+    { title: 'Judge', model: 'sonnet' },
+  ],
+}
+
+let A = args
+if (typeof A === 'string') { try { A = JSON.parse(A) } catch (_) { A = {} } }
+const catalog = (A && A.catalog) || []
+const clusters = (A && A.clusters) || []
+if (!catalog.length || !clusters.length) {
+  return { error: 'args precisa de {catalog:[...], clusters:[...]}', _debug: { argsType: typeof args, keys: A && typeof A === 'object' ? Object.keys(A) : null } }
+}
+
+const norm = (s) => String(s == null ? '' : s).trim().toLowerCase().replace(/[^a-z0-9-]/g, '')
+const catalogText = catalog.map((c) => `- ${c.name}: ${c.description}`).join('\n')
+const NAMES = new Set(catalog.map((c) => norm(c.name)))
+// Anti-confabulacao: escolha do juiz fora do catalogo vira "OUT:<x>" visivel (conta como erro), nunca skill real.
+const validChoice = (raw) => (norm(raw) === 'none' || NAMES.has(norm(raw))) ? raw : ('OUT:' + raw)
+
+const GEN_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['queries'],
+  properties: {
+    queries: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: false, required: ['query', 'expect', 'flirts_with', 'rationale'],
+        properties: {
+          query: { type: 'string' }, expect: { type: 'string' },
+          flirts_with: { type: 'string' }, rationale: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+const CHECK_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['verdict', 'why'],
+  properties: { verdict: { type: 'string', enum: ['clear', 'ambiguous', 'wrong'] }, better: { type: 'string' }, why: { type: 'string' } },
+}
+const JUDGE_SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['chosen', 'confidence', 'reason'],
+  properties: { chosen: { type: 'string' }, confidence: { type: 'number' }, reason: { type: 'string' } },
+}
+
+const genPrompt = (cl) => [
+  'Voce gera queries ADVERSARIAIS para testar o disparo (triggering) de skills do Claude Code.',
+  'Catalogo completo (slug: description):', '', catalogText, '',
+  `Tarefa: gere ${cl.n} mensagens de usuario REALISTAS cuja skill correta seja UMA de: [${cl.focus.join(', ')}].`,
+  (cl.confusers && cl.confusers.length) ? `Faca cada query FLERTAR com a fronteira de: [${cl.confusers.join(', ')}] — perto de confundir, mas com resposta correta ainda defensavel.` : '',
+  cl.hint ? `Dica do cluster: ${cl.hint}` : '',
+  'REGRAS CRITICAS:',
+  '- NAO use as trigger-keywords literais da description da skill correta (nao copie "cross-check", "OWASP", "backlog", "dashboard de features" etc.). Expresse a INTENCAO em linguagem natural de usuario (pt-br, pode ser informal/baguncado).',
+  '- Cada query deve ter UMA resposta defensavel no campo expect. Se a resposta correta for "nenhuma skill se aplica", use expect="none".',
+  '- Realista, como um dev pediria de verdade — nao um gotcha artificial.',
+  'Devolva para cada uma: query, expect (slug exato ou "none"), flirts_with (a skill que quase dispara), rationale (1 frase: por que expect e defensavelmente a certa).',
+].filter(Boolean).join('\n')
+
+const checkPrompt = (cand) => [
+  'Voce e um revisor CETICO de evals de disparo de skill. Seu trabalho e barrar queries mal-fundadas.',
+  'Catalogo (slug: description):', '', catalogText, '',
+  `Query: "${cand.query}"`,
+  `Resposta proposta (expect): "${cand.expect}"`,
+  'Lendo SOMENTE as descriptions, um leitor cuidadoso escolheria INEQUIVOCAMENTE a resposta proposta?',
+  '- verdict="clear": expect e claramente a unica melhor opcao.',
+  '- verdict="ambiguous": 2 ou mais skills cabem de verdade (entao a query nao serve para medir description).',
+  '- verdict="wrong": outra skill e claramente melhor (informe qual em "better").',
+  'Seja rigoroso: na duvida entre clear e ambiguous, escolha ambiguous.',
+].join('\n')
+
+const judgePrompt = (q) => [
+  'Voce SIMULA o seletor de skills do Claude Code.',
+  'Catalogo (slug: description):', '', catalogText, '',
+  `Mensagem do usuario: "${q}"`,
+  'Baseando-se SOMENTE nas descriptions (ignore conhecimento previo das skills), qual UNICA skill dispararia?',
+  'O slug DEVE estar no catalogo acima. NUNCA invente um nome fora do catalogo (mesmo que conheca outra skill/plugin); nesse caso responda "none".',
+  'Se nenhuma description se aplica, responda "none". Responda o slug exato ou "none".',
+].join('\n')
+
+const perCluster = await parallel(
+  clusters.map((cl) => async () => {
+    const gen = await agent(genPrompt(cl), { label: `gen:${cl.focus.join('/')}`, phase: 'Generate', schema: GEN_SCHEMA, model: 'sonnet' }).catch(() => null)
+    if (!gen || !Array.isArray(gen.queries)) return []
+    return await parallel(
+      gen.queries.map((cand) => async () => {
+        const chk = await agent(checkPrompt(cand), { label: `chk:${cand.expect}`, phase: 'Ground-check', schema: CHECK_SCHEMA, model: 'sonnet' }).catch(() => null)
+        const grounding = chk ? chk.verdict : 'error'
+        const base = {
+          cluster: cl.focus.join('/'), query: cand.query, expect: cand.expect,
+          flirts_with: cand.flirts_with, grounding, check_why: chk ? chk.why : '', better: chk ? chk.better : '',
+        }
+        if (grounding !== 'clear') return { ...base, skipped: true }
+        const j = await agent(judgePrompt(cand.query), { label: `judge:${cand.expect}`, phase: 'Judge', schema: JUDGE_SCHEMA, model: 'sonnet' }).catch(() => null)
+        const chosen = j ? validChoice(j.chosen) : 'ERROR'
+        return { ...base, chosen, ok: norm(chosen) === norm(cand.expect), confidence: j ? j.confidence : null, reason: j ? j.reason : '' }
+      })
+    )
+  })
+)
+
+const all = perCluster.filter(Boolean).flat().filter(Boolean)
+const judged = all.filter((r) => !r.skipped)
+const skipped = all.filter((r) => r.skipped)
+const correct = judged.filter((r) => r.ok)
+const misfires = judged.filter((r) => !r.ok)
+
+const confusionPairs = {}
+for (const r of misfires) {
+  const k = `${r.expect} → ${norm(r.chosen) || 'EMPTY'}`
+  confusionPairs[k] = (confusionPairs[k] || 0) + 1
+}
+
+return {
+  generated: all.length,
+  judged: judged.length,
+  skipped_misgrounded: skipped.length,
+  accuracy: judged.length ? Number((correct.length / judged.length).toFixed(3)) : 0,
+  confusionPairs,
+  misfires: misfires.map((r) => ({ cluster: r.cluster, query: r.query, expect: r.expect, chosen: r.chosen, confidence: r.confidence, flirts_with: r.flirts_with, reason: r.reason })),
+  keep: judged.map((r) => ({ query: r.query, expect: r.expect, ok: r.ok, cluster: r.cluster })),
+  dropped: skipped.map((r) => ({ query: r.query, expect: r.expect, grounding: r.grounding, better: r.better, why: r.check_why })),
+}

--- a/tests/trigger-eval/negatives.jsonl
+++ b/tests/trigger-eval/negatives.jsonl
@@ -1,0 +1,12 @@
+{"query": "qual e a capital da Franca?", "expect": "none"}
+{"query": "explica o que esse trecho de codigo faz", "expect": "none"}
+{"query": "commita as mudancas e abre um PR", "expect": "none"}
+{"query": "registra a decisao arquitetural de usar Postgres em vez de Mongo num ADR", "expect": "none"}
+{"query": "renomeia a variavel foo pra bar nesse arquivo", "expect": "none"}
+{"query": "roda a suite de testes e me diz se passou", "expect": "none", "tier": "hard"}
+{"query":"renomeia a variavel `state_dir` para `stateDir` no arquivo cli/lib/recall.sh","expect":"none","tier":"gen"}
+{"query":"roda os testes do recall pra ver se ainda passam depois da minha ultima mudanca","expect":"none","tier":"gen"}
+{"query":"o que esse bloco faz exatamente?\n\n```bash\nfts_query=$(printf '%s' \"$@\" | tr -s ' ' '\\n' | awk '{print $1 \"*\"}' | paste -sd' ')\n```","expect":"none","tier":"gen"}
+{"query":"faz um commit so com o recall.sh e o test_recall.sh, mensagem algo tipo 'fix recall fts query escaping'","expect":"none","tier":"gen"}
+{"query":"formata o arquivo phase-model-map.txt com colunas alinhadas, tipo tabela, sem mudar o conteudo","expect":"none","tier":"gen"}
+{"query":"quantas skills globais tem listadas no README agora?","expect":"none","tier":"gen"}

--- a/tests/trigger-eval/run.workflow.js
+++ b/tests/trigger-eval/run.workflow.js
@@ -1,0 +1,93 @@
+export const meta = {
+  name: 'trigger-eval',
+  description: 'Mede acuracia de disparo das skills do cstk: para cada query, um juiz ve SO as descriptions do catalogo e escolhe qual skill o Claude Code dispararia; compara com o ground-truth e devolve acuracia + matriz de confusao + misfires. Periodico (nao-CI). args = {catalog, queries} vindos de collect.sh.',
+  phases: [{ title: 'Judge', model: 'sonnet' }],
+}
+
+// args = { catalog: [{name, description}], queries: [{query, expect, note?}] }
+// Robusto: alguns transportes entregam `args` como STRING JSON em vez de objeto.
+let A = args
+if (typeof A === 'string') { try { A = JSON.parse(A) } catch (_) { A = {} } }
+const catalog = (A && A.catalog) || []
+const queries = (A && A.queries) || []
+if (!catalog.length || !queries.length) {
+  return {
+    error: 'args precisa de {catalog:[...], queries:[...]} nao-vazios. Rode collect.sh e passe a saida como args.',
+    _debug: { argsType: typeof args, parsedType: typeof A, keys: (A && typeof A === 'object') ? Object.keys(A) : null },
+  }
+}
+
+const norm = (s) => String(s == null ? '' : s).trim().toLowerCase().replace(/[^a-z0-9-]/g, '')
+const catalogText = catalog.map((c) => `- ${c.name}: ${c.description}`).join('\n')
+const NAMES = new Set(catalog.map((c) => norm(c.name)))
+// Anti-confabulacao: escolha fora do catalogo (ex.: juiz inventa um plugin que conhece do treino) vira
+// "OUT:<x>" VISIVEL — conta como erro e nunca e aceita como skill real. Nao coerce para "none" (isso esconderia o sintoma).
+const validChoice = (raw) => (norm(raw) === 'none' || NAMES.has(norm(raw))) ? raw : ('OUT:' + raw)
+
+const SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['chosen', 'confidence', 'reason'],
+  properties: {
+    chosen: { type: 'string', description: 'slug exato da skill escolhida, ou "none"' },
+    confidence: { type: 'number', description: 'confianca 0..1' },
+    reason: { type: 'string', description: 'uma frase curta justificando' },
+  },
+}
+
+const prompt = (q) => [
+  'Voce SIMULA o seletor de skills do Claude Code.',
+  'Abaixo o catalogo de skills no formato "slug: description" (a description e o gatilho oficial — diz o que faz e quando usar):',
+  '',
+  catalogText,
+  '',
+  `Mensagem do usuario: "${q}"`,
+  '',
+  'Baseando-se SOMENTE nas descriptions acima (ignore qualquer conhecimento previo que voce tenha das skills),',
+  'decida qual UNICA skill o Claude Code dispararia para essa mensagem.',
+  'Se NENHUMA description se aplica, responda exatamente "none".',
+  'IMPORTANTE: o slug DEVE ser um dos listados no catalogo acima. NUNCA invente um nome fora do catalogo, mesmo que voce conheca outra skill/plugin do Claude Code de outro lugar; nesse caso responda "none".',
+  'Responda com o slug exato (ex.: "specify", "bugfix", "analyze") ou "none".',
+].join('\n')
+
+const verdicts = await parallel(
+  queries.map((q, i) => () =>
+    agent(prompt(q.query), { label: `q${i}→${q.expect}`, phase: 'Judge', schema: SCHEMA, model: 'sonnet' })
+      .then((v) => ({
+        query: q.query,
+        expect: q.expect,
+        chosen: v ? validChoice(v.chosen) : 'ERROR',
+        confidence: v ? v.confidence : null,
+        reason: v ? v.reason : '',
+      }))
+      .catch(() => ({ query: q.query, expect: q.expect, chosen: 'ERROR', confidence: null, reason: 'agent error' }))
+  )
+)
+
+const scored = verdicts.filter(Boolean).map((r) => ({ ...r, ok: norm(r.chosen) === norm(r.expect) }))
+const wrong = scored.filter((r) => !r.ok)
+
+// acuracia por skill esperada (recall por skill)
+const byExpect = {}
+for (const r of scored) {
+  byExpect[r.expect] = byExpect[r.expect] || { n: 0, hit: 0 }
+  byExpect[r.expect].n++
+  if (r.ok) byExpect[r.expect].hit++
+}
+
+// pares de confusao "expect -> chosen" (so os erros)
+const confusionPairs = {}
+for (const r of wrong) {
+  const k = `${r.expect} → ${norm(r.chosen) || 'EMPTY'}`
+  confusionPairs[k] = (confusionPairs[k] || 0) + 1
+}
+
+const correct = scored.filter((r) => r.ok).length
+return {
+  total: scored.length,
+  correct,
+  accuracy: scored.length ? Number((correct / scored.length).toFixed(3)) : 0,
+  byExpect,
+  confusionPairs,
+  misfires: wrong.map((r) => ({ query: r.query, expect: r.expect, chosen: r.chosen, confidence: r.confidence, reason: r.reason })),
+}

--- a/tests/trigger-eval/sweep.workflow.js
+++ b/tests/trigger-eval/sweep.workflow.js
@@ -1,0 +1,95 @@
+export const meta = {
+  name: 'trigger-eval-sweep',
+  description: 'Sweep multi-modelo do trigger-eval: julga CADA query com N modelos (default sonnet vs haiku) e compara acuracia por modelo + divergencias. O sinal-ouro e "modelo fraco erra mas o forte acerta" = description fragil sob modelo menor. args = {catalog, queries, models?}.',
+  phases: [{ title: 'Sweep' }],
+}
+
+let A = args
+if (typeof A === 'string') { try { A = JSON.parse(A) } catch (_) { A = {} } }
+const catalog = (A && A.catalog) || []
+const queries = (A && A.queries) || []
+const models = (A && Array.isArray(A.models) && A.models.length) ? A.models : ['sonnet', 'haiku']
+if (!catalog.length || !queries.length) {
+  return { error: 'args precisa de {catalog:[...], queries:[...], models?}', _debug: { argsType: typeof args, keys: (A && typeof A === 'object') ? Object.keys(A) : null } }
+}
+
+const norm = (s) => String(s == null ? '' : s).trim().toLowerCase().replace(/[^a-z0-9-]/g, '')
+const catalogText = catalog.map((c) => `- ${c.name}: ${c.description}`).join('\n')
+const NAMES = new Set(catalog.map((c) => norm(c.name)))
+const validChoice = (raw) => (norm(raw) === 'none' || NAMES.has(norm(raw))) ? raw : ('OUT:' + raw)
+
+const SCHEMA = {
+  type: 'object', additionalProperties: false, required: ['chosen', 'confidence', 'reason'],
+  properties: {
+    chosen: { type: 'string', description: 'slug exato do catalogo, ou "none"' },
+    confidence: { type: 'number' }, reason: { type: 'string' },
+  },
+}
+
+const prompt = (q) => [
+  'Voce SIMULA o seletor de skills do Claude Code.',
+  'Catalogo (slug: description — a description e o gatilho oficial):', '', catalogText, '',
+  `Mensagem do usuario: "${q}"`,
+  'Baseando-se SOMENTE nas descriptions acima (ignore conhecimento previo das skills), qual UNICA skill dispararia?',
+  'Se nenhuma se aplica, responda "none". O slug DEVE estar no catalogo; NUNCA invente um nome fora dele (mesmo que conheca outra skill/plugin) — nesse caso "none".',
+  'Responda o slug exato ou "none".',
+].join('\n')
+
+const rows = await parallel(
+  queries.map((q, i) => async () => {
+    const verdicts = await parallel(
+      models.map((m) => () =>
+        agent(prompt(q.query), { label: `${m}:q${i}→${q.expect}`, phase: 'Sweep', schema: SCHEMA, model: m })
+          .then((v) => ({ m, chosen: v ? validChoice(v.chosen) : 'ERROR', confidence: v ? v.confidence : null, reason: v ? v.reason : '' }))
+          .catch(() => ({ m, chosen: 'ERROR', confidence: null, reason: 'agent error' }))
+      )
+    )
+    const perModel = {}
+    for (const r of verdicts) if (r) perModel[r.m] = { chosen: r.chosen, ok: norm(r.chosen) === norm(q.expect), confidence: r.confidence, reason: r.reason }
+    return { query: q.query, expect: q.expect, perModel }
+  })
+)
+
+// acuracia + matriz de confusao por modelo
+const byModel = {}
+for (const m of models) {
+  const judged = rows.map((r) => r.perModel[m]).filter(Boolean)
+  const correct = judged.filter((x) => x.ok).length
+  const confusionPairs = {}
+  for (const r of rows) {
+    const x = r.perModel[m]
+    if (x && !x.ok) {
+      const k = `${r.expect} → ${norm(x.chosen) || 'EMPTY'}`
+      confusionPairs[k] = (confusionPairs[k] || 0) + 1
+    }
+  }
+  byModel[m] = { total: judged.length, correct, accuracy: judged.length ? Number((correct / judged.length).toFixed(3)) : 0, confusionPairs }
+}
+
+// divergencias: ref = models[0] (forte), alt = models[ultimo] (fraco)
+const ref = models[0]
+const alt = models[models.length - 1]
+const pick = (r) => ({ query: r.query, expect: r.expect, [ref]: r.perModel[ref], [alt]: r.perModel[alt] })
+const weak_misses_strong_hits = []
+const strong_misses_weak_hits = []
+const both_miss = []
+if (ref !== alt) {
+  for (const r of rows) {
+    const a = r.perModel[ref]
+    const b = r.perModel[alt]
+    if (!a || !b) continue
+    if (a.ok && !b.ok) weak_misses_strong_hits.push(pick(r))
+    else if (!a.ok && b.ok) strong_misses_weak_hits.push(pick(r))
+    else if (!a.ok && !b.ok) both_miss.push(pick(r))
+  }
+}
+
+return {
+  models,
+  total: rows.length,
+  byModel,
+  divergence_ref_vs_alt: { ref, alt },
+  weak_misses_strong_hits, // <- description fragil sob o modelo fraco (o sinal-ouro)
+  strong_misses_weak_hits,
+  both_miss,
+}


### PR DESCRIPTION
## O que

Absorve o loop de disparo (trigger eval) do `skill-creator` da Anthropic: um harness que mede se a `description` de cada skill **dispara na hora certa** — e qual skill é confundida com qual — via juiz LLM que vê **só as descriptions**.

Periódico / **não-CI** (precisa de modelo no loop); `tests/run.sh` segue sendo o gate determinístico.

## Conteúdo

- **Seed**: 92 queries em `global/skills/<n>/evals/triggers.jsonl` (cada skill dona das suas, espelha a convenção `test_<n>.sh`) + `tests/trigger-eval/negatives.jsonl` (`expect=none`). Tiers: `base` (keyword-aligned) / `hard` (keyword-stripped) / `gen` (gerado + ground-checked).
- **Runners** (tool Workflow): `run` (juiz single-model), `harden` (gera→ground-check→julga), `sweep` (multi-modelo), `ab` (A/B causal de uma description). Coletor `collect.sh` (POSIX+jq).
- **Anti-confabulação**: escolha do juiz fora do catálogo vira `OUT:<x>` visível, nunca aceita como skill real (o Haiku confabulou o plugin `commit-commands`, inexistente no catálogo).

## fix(plan)

A description do `plan` exigia spec formal ("from a spec"), o que virava um gate que desviava queries de design técnico para `specify`/`advisor`. Removido o gate, reforçado o *HOW* (arquitetura/contratos/modelo de dados).

**Validado por A/B causal** (desc antiga vs nova, mesmas queries, mesmos modelos):

| Modelo | Antes | Depois | Regressões |
|---|---|---|---|
| Sonnet | 12/14 | 14/14 | 0 |
| Haiku  | 13/14 | 14/14 | 0 |

## Robustez entre tiers

Sweep 92 queries × {Sonnet, Haiku}: **Sonnet 98,9% / Haiku 97,8%** — descriptions robustas, sem campo minado de descriptions fracas.

## Testes

- `./tests/run.sh` (suíte completa): **PASS 1330 / FAIL 0 / ERROR 0 / ORPHANS 0**.
- `--check-coverage`: zero órfãos. `doc-counts`: contagem de skills intacta (nenhuma skill nova).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
