### PR TITLE
fix(commit-mode): guard-branch reconhece master como default sem remote (CI release v5.13.0)

### DIFF
--- a/global/skills/agente-00c-runtime/scripts/commit-mode.sh
+++ b/global/skills/agente-00c-runtime/scripts/commit-mode.sh
@@ -171,17 +171,28 @@ _cm_cmd_guard_branch() {
     return 1
   }
 
-  # Resolver branch default: mesmo algoritmo de _session_default_branch
-  # (remote HEAD => fallback "main")
+  # Resolver branch default: origin/HEAD e autoritativo quando ha remote.
+  # Sem remote (repo local / origin/HEAD nao setado), o nome do branch
+  # default de `git init` VARIA por ambiente (macOS default "main", muitos
+  # Linux/CI default "master"), entao tratamos AMBOS como default — bloquear
+  # commit/push tanto em "main" quanto em "master".
   _default=$(git -C "$_pap" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
     | sed 's@^refs/remotes/origin/@@') || _default=""
-  [ -n "$_default" ] || _default="main"
 
   printf '%s\n' "$_head"
 
-  if [ "$_head" = "$_default" ]; then
-    _cm_err "guard-branch: HEAD esta na branch default '$_default' — commit/push bloqueado (FR-005)"
-    return 3
+  if [ -n "$_default" ]; then
+    # Remote resolvel: o default e unico e autoritativo.
+    if [ "$_head" = "$_default" ]; then
+      _cm_err "guard-branch: HEAD esta na branch default '$_default' — commit/push bloqueado (FR-005)"
+      return 3
+    fi
+  else
+    # Sem remote: bloquear a convencao default (main OU master).
+    if [ "$_head" = "main" ] || [ "$_head" = "master" ]; then
+      _cm_err "guard-branch: HEAD esta na branch default '$_head' — commit/push bloqueado (FR-005)"
+      return 3
+    fi
   fi
 
   return 0

--- a/tests/test_commit-mode.sh
+++ b/tests/test_commit-mode.sh
@@ -63,8 +63,12 @@ _init_git_repo() {
   printf 'init\n' > "$_gdir/README.md"
   git -C "$_gdir" add README.md 2>/dev/null
   git -C "$_gdir" commit -q -m "init" 2>/dev/null
-  # Criar branch nao-default
-  if [ "$_branch" != "main" ] && [ "$_branch" != "master" ]; then
+  # Branch determinista, independente do default do `git init` (que varia:
+  # macOS default "main", Linux/CI default "master"). Renomeia o branch
+  # inicial para o nome pedido em vez de assumir o default do ambiente.
+  if [ "$_branch" = "main" ] || [ "$_branch" = "master" ]; then
+    git -C "$_gdir" branch -m "$_branch" 2>/dev/null || :
+  else
     git -C "$_gdir" checkout -q -b "$_branch" 2>/dev/null
   fi
 }
@@ -376,16 +380,14 @@ scenario_fr015c_guard_branch_default_master() {
   _sd="$TMPDIR_TEST/guard-master"
   _init_state "$_sd" true
 
-  # Criar repo com branch "main" como default e commit na main
-  _init_git_repo "$_gdir" "main"
-  git -C "$_gdir" checkout -q main 2>/dev/null || :
+  # Repo na branch "master" SEM remote. guard-branch sem origin/HEAD trata
+  # tanto "main" quanto "master" como default => bloqueado exit 3. Cobre o
+  # ambiente CI/Linux onde `git init` default e "master".
+  _init_git_repo "$_gdir" "master"
+  git -C "$_gdir" checkout -q master 2>/dev/null || :
 
-  # Simular remote origin/HEAD apontando para "master" via ref simbolica
-  # (guard-branch usa symbolic-ref refs/remotes/origin/HEAD => sem remote, fallback e "main")
-  # Aqui: HEAD=main e fallback default=main => exit 3 (mesmo algoritmo, origem "main")
   capture "$SCRIPT" guard-branch --state-dir "$_sd" --projeto-alvo-path "$_gdir"
-  # main sem remote: fallback="main"; HEAD="main" => bloqueado exit 3
-  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "main sem remote: exit esperado 3" "obtido $_CAPTURED_EXIT"; return 1; }
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "master sem remote: exit esperado 3" "obtido $_CAPTURED_EXIT"; return 1; }
 }
 
 scenario_fr015c_guard_branch_nao_default_nao_bloqueia() {


### PR DESCRIPTION
Hotfix do release **v5.13.0** (a primeira tag falhou no gate de testes do CI).

## Causa
`guard-branch` resolvia o branch default via `origin/HEAD` com fallback fixo `"main"`. Nos fixtures de teste (repos locais sem remote), o branch default de `git init` varia por ambiente — macOS → `main`, Linux/CI → `master`. Um repo em `master` não era reconhecido como default → não bloqueava (exit 0 onde se esperava 3). 3 cenários falhavam só no CI.

## Fix (duas camadas)
- **helper** `commit-mode.sh`: sem `origin/HEAD`, trata **`main` e `master`** como default. Com remote, `origin/HEAD` continua autoritativo (default único, comportamento de produção inalterado).
- **teste** `_init_git_repo`: renomeia o branch inicial deterministicamente (`git branch -m`) em vez de assumir o default do ambiente; o cenário `default_master` passa a exercitar de fato `master`.

## Verificação
- `test_commit-mode`: **23 PASS / 0 FAIL** em ambiente normal **E** simulando CI (`init.defaultBranch=master`).
- `sh -n` POSIX OK.

Após merge, a tag `v5.13.0` será reapontada para o novo HEAD da main e re-empurrada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)