### PR TITLE
fix(state-ondas): reconcile-tasks cura títulos vazios em .tasks[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.14.1] - 2026-06-23
+
+### Fixed
+
+- **`reconcile-tasks` cura títulos vazios em `.tasks[]`** (`state-ondas.sh`): ondas `execute-task` longas que gravavam `record-task` em lote sem `--titulo` deixavam entradas com `title=""` (sintoma: N tasks "sem título" com a mesma contagem de testes da suíte da onda, p.ex. 18× `39/39`). O `reconcile-tasks` agora, além do back-fill de tasks ausentes, **cura** entradas já presentes com título vazio, buscando o título no `tasks.md` em duas granularidades — heading (`### N.M Título`) e checkbox (`- [x] N.M.K texto`), com precedência do heading. A fonte é sempre o backlog (rastreável, nunca inventada — Princípio VI); `tests_run`/`tests_passed` **não** são tocados (sem fonte por task → não fabrica). Só fora de `--dry-run`; a contagem de stdout (tasks back-filled) é preservada. Como `review-task` §4.6 chama `reconcile-tasks`, estados afetados se auto-curam no próximo review. Cobertura: 4 cenários novos em `tests/test_state-ondas.sh`.
+
 ## [5.14.0] - 2026-06-18
 
 ### Added
@@ -3362,6 +3368,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.14.1]: https://github.com/JotJunior/cstk/releases/tag/v5.14.1
 [5.14.0]: https://github.com/JotJunior/cstk/releases/tag/v5.14.0
 [5.13.0]: https://github.com/JotJunior/cstk/releases/tag/v5.13.0
 [5.12.0]: https://github.com/JotJunior/cstk/releases/tag/v5.12.0

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -489,6 +489,12 @@ _so_cmd_record_task() {
 # evita fabricar pass/fail). Back-fill via record-task --if-absent: NUNCA
 # clobbera entrada real ja gravada pelo execute-task. Idempotente.
 #
+# Tambem CURA titulos vazios: entradas ja presentes em .tasks[] com
+# title=="" (sintoma de onda execute-task longa gravada em lote sem
+# --titulo) recebem o titulo do heading em tasks.md (fonte rastreavel,
+# nunca inventada). Nao toca tests_run/tests_passed (sem fonte por task ->
+# nao fabrica). So fora de --dry-run; nao afeta a contagem de stdout.
+#
 # Stdout (default): numero de tasks back-filled nesta chamada.
 # --dry-run: NAO escreve; imprime os task_id que SERIAM back-filled (um por
 #   linha) — usado pelo gate de completude do review-task.
@@ -512,6 +518,70 @@ _so_cmd_reconcile_tasks() {
 
   if [ -z "$_rc_wid" ]; then
     _rc_wid=$(jq -r '((.waves // .ondas) // []) as $w | if ($w | length) > 0 then ($w[-1].id // "") else "" end' "$_rc_sf" 2>/dev/null) || _rc_wid=""
+  fi
+
+  # --- Cura de titulos vazios -------------------------------------------
+  # Entradas ja presentes em .tasks[] com title vazio/null (sintoma de onda
+  # execute-task longa que gravou record-task em lote sem --titulo) recebem
+  # o titulo do heading correspondente em tasks.md. A FONTE e rastreavel
+  # (heading do backlog) — nunca inventada (Principio VI). Roda so fora de
+  # --dry-run e NAO altera a contagem de back-fill (contrato de stdout
+  # preservado: continua sendo o nº de tasks AUSENTES back-filled abaixo).
+  if [ "$_rc_dry" != "yes" ]; then
+    # Mapa id->titulo a partir de tasks.md em DUAS granularidades, porque
+    # as ondas gravam tasks ora no nivel do heading (### N.M Titulo), ora no
+    # nivel do checkbox (- [x] N.M.K texto). Heading tem precedencia sobre
+    # checkbox para o mesmo id (na pratica nao colidem: heading e N.M,
+    # checkbox e N.M.K). Em ambos os casos a FONTE e o backlog — rastreavel,
+    # nunca inventado (Principio VI).
+    _rc_titlemap=$(awk '
+      { sub(/\r$/, "") }
+      /^### / {
+        line = $0; sub(/^### +/, "", line)
+        split(line, a, /[ \t]+/); id = a[1]
+        if (id ~ /^[0-9]+(\.[0-9]+)+(-bis(\.[0-9]+)*)?$/) {
+          t = line; sub(/^[^ \t]+[ \t]+/, "", t)
+          gsub(/`/, "", t); sub(/[ \t]*\[[CAM]\][ \t]*$/, "", t)
+          gsub(/\t/, " ", t); gsub(/  +/, " ", t)
+          sub(/^ +/, "", t); sub(/ +$/, "", t)
+          if (t != "") heading[id] = t
+        }
+        next
+      }
+      /^- \[.\] / {
+        line = $0; sub(/^- \[.\][ \t]+/, "", line)
+        split(line, a, /[ \t]+/); id = a[1]
+        if (id ~ /^[0-9]+(\.[0-9]+)+(-bis(\.[0-9]+)*)?$/) {
+          t = line; sub(/^[^ \t]+[ \t]+/, "", t)
+          gsub(/`/, "", t); gsub(/\t/, " ", t); gsub(/  +/, " ", t)
+          sub(/^ +/, "", t); sub(/ +$/, "", t)
+          if (t != "" && !(id in checkbox)) checkbox[id] = t
+        }
+        next
+      }
+      END {
+        for (k in checkbox) if (!(k in heading)) print k "\t" checkbox[k]
+        for (k in heading) print k "\t" heading[k]
+      }
+    ' "$_rc_md")
+    if [ -n "$_rc_titlemap" ]; then
+      _rc_mapjson=$(printf '%s\n' "$_rc_titlemap" \
+        | jq -R 'split("\t") | {(.[0]): .[1]}' 2>/dev/null \
+        | jq -s 'add' 2>/dev/null) || _rc_mapjson=""
+      if [ -n "$_rc_mapjson" ]; then
+        _rc_heal=$(mktemp) || _so_die "mktemp falhou" 1
+        if jq --argjson m "$_rc_mapjson" '
+              .tasks = ((.tasks // []) | map(
+                if ((.title // "") == "") and (($m[.task_id] // null) != null)
+                then .title = $m[.task_id] else . end))
+            ' "$_rc_sf" > "$_rc_heal" 2>/dev/null \
+            && ! cmp -s "$_rc_heal" "$_rc_sf"; then
+          _so_atomic_write "$_rc_sf" "$_rc_heal"
+          _so_update_sha "$_rc_sdir"
+        fi
+        rm -f -- "$_rc_heal" 2>/dev/null || :
+      fi
+    fi
   fi
 
   # task_ids ja presentes em .tasks[] (snapshot)

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -458,6 +458,75 @@ scenario_reconcile_tasks_obriga_flags() {
   assert_exit 2 "$SCRIPT" reconcile-tasks --state-dir "$_sd" || return 1
 }
 
+# ---- cura de titulos vazios (onda execute-task longa gravada em lote) ----
+scenario_reconcile_tasks_cura_titulo_vazio() {
+  _sd="$TMPDIR_TEST/state"
+  _md="$TMPDIR_TEST/tasks.md"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  # entrada real previa SEM --titulo (title="") com tests 39/39 — replica o
+  # sintoma do lote de onda-009.
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id 1.1 \
+    --outcome pass --testes-rodados 39 --testes-passados 39 --origem execute-task
+  _write_tasks_md "$_md"
+  capture "$SCRIPT" reconcile-tasks --state-dir "$_sd" --tasks-md "$_md"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "reconcile cura" "$_CAPTURED_STDERR"; return 1; }
+  # titulo curado a partir do heading em tasks.md
+  capture "$RW" get --state-dir "$_sd" --field '.tasks[] | select(.task_id=="1.1") | .title'
+  assert_stdout_contains "Setup do Projeto" || return 1
+  # NAO carrega a tag de criticidade
+  if printf '%s' "$_CAPTURED_STDOUT" | grep -q '\['; then
+    _fail "cura titulo" "titulo curado carregou tag: $_CAPTURED_STDOUT"; return 1
+  fi
+  # tests_run/passed PRESERVADOS (39/39) — cura nunca fabrica/zera contagem
+  capture "$RW" get --state-dir "$_sd" --field '.tasks[] | select(.task_id=="1.1") | .tests_run'
+  assert_stdout_contains "39" || return 1
+}
+
+scenario_reconcile_tasks_cura_titulo_nivel_checkbox() {
+  # onda execute-task longa grava no nivel do CHECKBOX (N.M.K), nao do heading;
+  # o titulo deve ser curado a partir do texto do checkbox em tasks.md.
+  _sd="$TMPDIR_TEST/state"
+  _md="$TMPDIR_TEST/tasks.md"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id 1.1.1 \
+    --outcome pass --testes-rodados 39 --testes-passados 39 --origem execute-task
+  _write_tasks_md "$_md"
+  capture "$SCRIPT" reconcile-tasks --state-dir "$_sd" --tasks-md "$_md"
+  capture "$RW" get --state-dir "$_sd" --field '.tasks[] | select(.task_id=="1.1.1") | .title'
+  assert_stdout_contains "Criar repo" || return 1
+}
+
+scenario_reconcile_tasks_cura_nao_clobbera_titulo_existente() {
+  _sd="$TMPDIR_TEST/state"
+  _md="$TMPDIR_TEST/tasks.md"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id 1.1 --titulo "REAL" \
+    --outcome pass --origem execute-task
+  _write_tasks_md "$_md"
+  capture "$SCRIPT" reconcile-tasks --state-dir "$_sd" --tasks-md "$_md"
+  capture "$RW" get --state-dir "$_sd" --field '.tasks[] | select(.task_id=="1.1") | .title'
+  assert_stdout_contains "REAL" || return 1
+}
+
+scenario_reconcile_tasks_dry_run_nao_cura() {
+  _sd="$TMPDIR_TEST/state"
+  _md="$TMPDIR_TEST/tasks.md"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id 1.1 \
+    --outcome pass --origem execute-task
+  _write_tasks_md "$_md"
+  capture "$SCRIPT" reconcile-tasks --state-dir "$_sd" --tasks-md "$_md" --dry-run
+  # dry-run nao escreve: title de 1.1 permanece vazio
+  capture "$RW" get --state-dir "$_sd" --field '.tasks[] | select(.task_id=="1.1") | .title'
+  if [ -n "$_CAPTURED_STDOUT" ] && [ "$_CAPTURED_STDOUT" != "" ]; then
+    _fail "dry-run cura" "dry-run alterou o titulo: [$_CAPTURED_STDOUT]"; return 1
+  fi
+}
+
 # ==== back-compat pt-BR (schema-en-migration §6: readers leem state legado) ====
 # Os writers do state-ondas assumem EN-on-disk (garantido pelo migrate
 # defensivo do command-pai), igual ao exemplar drift.sh mark-touched. O que


### PR DESCRIPTION
## Problema

Ondas `execute-task` longas gravavam `record-task` em lote **sem `--titulo`**, deixando entradas em `.tasks[]` com `title=""` e a contagem de testes da suíte da onda replicada em todas (sintoma observado na feature `external-process`: 18 tasks "sem título" com `39/39` idênticos). A `knowledge.db` apenas espelhava fielmente o `state.json` — a origem era o lote, não a ingestão.

As ondas gravam em granularidades distintas: heading (`### N.M`) nas bem-formadas, checkbox (`- [x] N.M.K`) no lote problemático.

## Correção

`reconcile-tasks` (`state-ondas.sh`) agora, além do back-fill de tasks ausentes, **cura** entradas já presentes com título vazio:

- Busca o título no `tasks.md` em **duas granularidades** — heading e checkbox — com precedência do heading.
- Fonte sempre rastreável (backlog), **nunca inventada** — Princípio VI.
- `tests_run`/`tests_passed` **não** são tocados (sem fonte por task → não fabrica).
- Só fora de `--dry-run`; contrato de stdout (contagem de back-fill) preservado; idempotente.
- `review-task` §4.6 já chama `reconcile-tasks` → estados afetados **se auto-curam** no próximo review.

## Testes

- 4 cenários novos em `tests/test_state-ondas.sh` (heal heading, heal checkbox, no-clobber de título real, dry-run no-write).
- Suite completa verde: **1398/0**.
- Verificado contra cópia read-only do state real `external-process`: os 18 títulos curados a partir do texto real do checkbox; contagens de teste preservadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)