### PR TITLE
feat(validate-documentation): perfil de validação de artefatos SDD (spec-profile + plan-profile)

### DIFF
--- a/docs/specs/validate-docs-sdd-profile/checklists/requirements.md
+++ b/docs/specs/validate-docs-sdd-profile/checklists/requirements.md
@@ -1,0 +1,67 @@
+# Requirements Checklist: validate-docs-sdd-profile
+
+**Purpose**: Valida a QUALIDADE dos requisitos (spec.md + plan.md) antes de
+`/create-tasks` — foco em (a) cobertura dos dois perfis spec-profile/
+plan-profile, (b) fronteira de nao-duplicacao com `analyze`/
+`validate-docs-rendered` testavel, (c) completude do contrato CLI para
+implementar, (d) convencao `tests/test_<nome>.sh` refletida, (e) criterios
+derivados de fonte real (Principio VI). "Unit tests for English."
+**Created**: 2026-07-10
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) · [contracts/validate-sdd-cli.md](../contracts/validate-sdd-cli.md)
+
+> Legenda: `{auto}` resolvivel contra artefatos; `{humano}` julgamento de
+> negocio; marcadores `[Gap]`/`[Ambiguity]`/`[Conflict]`.
+
+## (a) Cobertura dos dois perfis (US1 spec-profile / US2 plan-profile)
+
+- [x] CHK001 - Os FRs do spec-profile cobrem as 3 secoes obrigatorias e os 6 anti-padroes estruturalmente detectaveis catalogados em `specify/examples/spec-bad.md`? [Completude, Spec §FR-001..007, SC-002] {auto} — SIM: FR-001 (secoes), FR-002 (impl. detail), FR-003 (SC nao-mensuravel/jargao), FR-004 (>3 NEEDS CLARIFICATION), FR-005 (N/A residual), FR-006 (adjetivo vago), FR-007 (stories acopladas) — 1:1 com os 6 anti-padroes referenciados em SC-002.
+- [x] CHK002 - Os FRs do plan-profile cobrem as 4 secoes obrigatorias, placeholder de template, rotulo real-vs-proposto, `[NEEDS CLARIFICATION]` residual e referencia `FR-`/`SC-` inexistente? [Completude, Spec §FR-008..012] {auto} — SIM: FR-008 (secoes), FR-009 (placeholder), FR-010 (rotulo, aplica Principio VI), FR-011 (clarification residual), FR-012 (dangling ref).
+- [x] CHK003 - Cada Acceptance Scenario de US1 (AS1-4) e US2 (AS1-4) tem um FR correspondente rastreavel? [Traceability, Spec §User Scenarios] {auto} — SIM: US1 AS1→FR-001(zero erros), AS2→FR-001, AS3→FR-004, AS4→FR-002/FR-003; US2 AS1→FR-008, AS2→FR-012, AS3→FR-010, AS4→FR-009.
+- [ ] CHK004 - O finding `duplicate-id` (catalogado no contrato e exercitado no quickstart Cenario 5) tem um FR correspondente na secao Requirements do `spec.md`? [Traceability, contracts/validate-sdd-cli.md §Catalogo, quickstart.md §Cenario 5] {auto} — **[Gap]**: o contrato marca a origem como "Gotcha da skill" (nao um FR novo) e a citacao e legitima — `global/skills/validate-documentation/SKILL.md:267` ja trata "IDs duplicados dentro do mesmo documento" como erro para o perfil UC existente, entao o check REUSA convencao ja estabelecida, nao inventa criterio (Principio VI preservado). Ainda assim, nenhum FR-NNN do `spec.md` desta feature cobre explicitamente esse check para o spec-profile — `create-tasks` deve garantir que a task de implementacao do `duplicate-id` cite `SKILL.md:267` como fonte (nao um FR ausente) para nao ficar orfa de rastreabilidade.
+- [x] CHK005 - As Key Entities (`SddSpecArtifact`, `SddPlanArtifact`, `SddValidationProfile`, `ValidationFinding`) cobrem os conceitos usados pelos FRs sem introduzir vocabulario novo nao explicado? [Consistencia, Spec §Key Entities, data-model.md] {auto} — SIM: `data-model.md` reproduz as 4 entidades como conceituais (sem persistencia) e mapeia cada uma ao artefato/linha de saida correspondente do contrato.
+
+## (b) Fronteira de nao-duplicacao com `analyze`/`validate-docs-rendered`
+
+- [x] CHK006 - FR-018 declara, por categoria de check, qual das tres skills e a dona (nao apenas afirmacao solta de "nao duplica")? [Clareza, Spec §FR-018, plan.md §Fronteira] {auto} — SIM: `plan.md` §"Fronteira de responsabilidade (SC-005)" materializa uma tabela de 8 categorias × dono, reproduzindo `research.md` Decision 4.
+- [x] CHK007 - A fronteira e verificavel por teste, nao apenas declarativa? [Mensurabilidade, quickstart.md §Cenario 9] {auto} — SIM: Cenario 9 tem um "Nao-Expected" explicito ("NENHUM achado sobre link/anchor quebrado no disco") junto do "Expected" (`dangling-fr-sc-ref`), tornando a fronteira FR-012 vs FR-013 um assert negativo executavel, nao so prosa.
+- [x] CHK008 - O formato de saida (`FINDING|severity|code|msg`) evita colisao de namespace com os achados de `validate-docs-rendered` (que usa saida tab-separated com categorias `Link`/`Frontmatter`/`Mermaid`, nao `code` kebab-case)? [Consistencia] {auto} — SIM verificado por leitura direta de `global/skills/validate-docs-rendered/scripts/validate.sh` (linhas 46-52, 167, 193): formato e vocabulario de campo sao inteiramente distintos do contrato desta feature; os dois scripts nunca emitem para o mesmo stream combinado.
+- [x] CHK009 - SC-005 ("zero achados sobrepondo categoria de `analyze`/`validate-docs-rendered`") define um mecanismo de verificacao concreto, nao so aspiracional? [Mensurabilidade, Spec §SC-005] {auto} — SIM (com ressalva): o mecanismo declarado e "checklist documentado de fronteira" (tabela em `plan.md`), nao um teste automatizado de sobreposicao — escolha deliberada registrada em `research.md` Decision 4 (rejeitou deixar a fronteira implicita na prosa). E verificavel por auditoria humana/CI de doc, nao por assert de codigo; suficiente para o escopo desta feature de tooling.
+
+## (c) Completude do contrato CLI (`contracts/validate-sdd-cli.md`)
+
+- [x] CHK010 - A precedencia entre flag explicita (`--sdd-spec`/`--sdd-plan`), deteccao automatica por path e "perfil indeterminado" esta definida sem ambiguidade de ordem? [Clareza, contracts/validate-sdd-cli.md §Selecao de perfil, Spec §FR-014..016] {auto} — SIM: 3 niveis numerados explicitos (flag > auto-path > indeterminado exit 2), com FR-014/FR-015/FR-016 correspondentes.
+- [x] CHK011 - O formato de saida (stdout) documenta TODOS os campos (severity, code, mensagem, linha RESULT final) com exemplo concreto? [Completude, contracts/validate-sdd-cli.md §Saida] {auto} — SIM: secao "Saida (stdout)" define os 3 campos + linha `RESULT` sempre emitida, com 3 exemplos completos (conformante/reprovado/indeterminado) na secao final.
+- [x] CHK012 - Os 3 exit codes (0/1/2) tem semantica e rationale registrados (por que exit-por-Erro, nao exit-por-qualquer-finding)? [Clareza, contracts/validate-sdd-cli.md §Exit codes, research.md Decision 3] {auto} — SIM: tabela de exit codes + link explicito para `research.md` Decision 3, que compara com o precedente divergente de `validate-tasks-template.sh` e justifica a escolha.
+- [ ] CHK013 - Todo finding code do catalogo tem FR de origem definido sem ambiguidade? [Rastreabilidade, contracts/validate-sdd-cli.md §Catalogo] {auto} — **[Gap]** (mesma raiz de CHK004): 12 dos 13 codes tem FR direto; `duplicate-id` cita "(Gotcha da skill: ...)" em vez de um FR-NNN — consistente e rastreavel (ver CHK004), mas quebra o padrao 1:1 code→FR dos demais 12 e merece nota explicita na task de implementacao para nao ser lido como omissao acidental.
+- [ ] CHK014 - O default de resolucao da `spec.md` correspondente (flag `--spec`, usado pelo check FR-012) esta especificado para TODOS os casos de invocacao, inclusive artefatos de teste fora da convencao `docs/specs/<feature>/`? [Clareza, contracts/validate-sdd-cli.md §Argumentos] {auto} — **[Ambiguity]**: o contrato define o default como `<dir-de-FILE-ou-pai>/spec.md resolvido pela convencao docs/specs/<feature>/`, cobrindo os 2 casos reais do pipeline (arquivo direto em `docs/specs/<f>/` e `contracts/*.md` um nivel abaixo). Nao cobre explicitamente o caso de fixture de teste fora dessa convencao (ex.: copia em dir temporario para `tests/test_validate-sdd.sh`) sem `--spec` — o contrato esta marcado `[PROPOSTA]`, entao a resolucao fica para `/execute-task` (baixo risco: `research.md` Decision 5 ja assume fixtures copiadas de `docs/specs/enforced-guards/`, que preserva a convencao de path).
+- [x] CHK015 - O contrato distingue claramente decisao de design `[PROPOSTA — a validar na implementacao]` de fonte real, evitando que a CLI ainda-nao-implementada seja lida como contrato observado (Principio VI)? [Clareza, contracts/validate-sdd-cli.md linhas 9-18] {auto} — SIM: bloco de abertura do contrato e explicito ("Nenhum campo abaixo e extraido de fonte real observada") e cita os precedentes REAIS verificados por leitura (`validate-tasks-template.sh`, `validate.sh`) separadamente das decisoes de design novas.
+
+## (d) Convencao `tests/test_<nome>.sh`
+
+- [x] CHK016 - A obrigatoriedade do teste-irmao para o novo script esta documentada no plano de implementacao? [Completude, plan.md §Technical Context "Testing", §Project Structure] {auto} — SIM: `plan.md` cita `tests/test_validate-sdd.sh` explicitamente com a convencao `global/skills/*/scripts/<n>.sh → tests/test_<n>.sh` e o gate `./tests/run.sh --check-coverage`.
+- [x] CHK017 - O plano identifica a fonte das fixtures de teste (boas/quebradas) como artefato real existente, nao fabricado? [Traceability, plan.md §Project Structure, research.md Decision 5] {auto} — SIM: fixtures "boas" citam `docs/specs/enforced-guards/{spec,plan}.md`, artefato real e verificavel no repo (nao hipotetico).
+- [x] CHK018 - A criacao do teste esta refletida como item de estrutura de source code a criar (nao apenas mencionada em prosa solta)? [Clareza, plan.md §Source Code] {auto} — SIM: bloco "Source Code" lista `tests/test_validate-sdd.sh` com marcador `CRIAR` e descricao do gate, no mesmo nivel do script principal.
+
+## (e) Veracidade de dados — Principio VI
+
+- [x] CHK019 - As decisoes tecnicas do plano (precedentes `validate-tasks-template.sh`, `validate.sh`) citam fonte verificavel por leitura, nao suposicao? [Traceability, research.md Decision 1, Decision 3] {auto} — SIM: research.md registra "foi verificado por leitura direta" para a ausencia de `scripts/` em `validate-documentation` e cita linhas/arquivos concretos para os precedentes.
+- [x] CHK020 - O check `unlabeled-contract` (FR-010) aplica o proprio Principio VI ao artefato validado, em vez de introduzir um vetor de fabricacao na propria feature? [Consistencia, Spec §FR-010, plan.md §Constitution Check linha VI] {auto} — SIM: FR-010 exige rotulagem real-vs-proposto em `contracts/*.md`; a Constitution Check do proprio `plan.md` marca a linha VI como PASS citando que o proprio contrato desta feature segue essa rotulagem (`[PROPOSTA — a validar na implementacao]`).
+- [x] CHK021 - Os valores concretos citados no plano (ex.: numero de secoes obrigatorias, contagem de finding codes) sao derivados de contagem real dos artefatos, nao estimativa solta? [Mensurabilidade, plan.md §Technical Context "Scale/Scope"] {auto} — SIM: "~13 finding codes" e "~2 perfis" batem com a contagem real do catalogo em `contracts/validate-sdd-cli.md` (8 codes spec-profile + 5 codes plan-profile = 13).
+
+## Consistencia e Rastreabilidade
+
+- [x] CHK022 - A terminologia spec-profile/plan-profile e usada de forma consistente entre spec.md, plan.md e o contrato (sem sinonimo divergente)? [Consistencia] {auto} — SIM: os 3 artefatos usam exatamente "spec-profile"/"plan-profile" sem variacao (ex.: nunca "perfil-spec" ou "spec profile").
+- [x] CHK023 - Os Success Criteria SC-001..006 se ligam a cenarios concretos do quickstart? [Traceability, quickstart.md] {auto} — SIM: SC-001→Cenario 1/2, SC-002→Cenarios 3/4/5/6, SC-003→Cenario 7, SC-004→Cenario 10, SC-005→fronteira (CHK009), SC-006→adocao pelos orquestradores (fora do escopo do quickstart, tracked via plan §Proximos Passos).
+- [x] CHK024 - As FRs desta feature nao contradizem a constitution do projeto (v1.2.0, 6 principios)? [Constitution Alignment, plan.md §Constitution Check] {auto} — SIM: tabela de 6 principios no plan.md, todos PASS, com nota especifica de que o Principio VI e REFORCADO (nao apenas nao-violado) pelo FR-010.
+- [x] CHK025 - A premissa de estabilidade da convencao `docs/specs/<feature>/` (base da deteccao automatica US3) esta documentada com contingencia caso mude? [Clareza, Spec §Dependencies & Assumptions] {auto} — SIM: ultima "Assume" da secao declara explicitamente "se essa convencao mudar, a deteccao automatica precisa ser revisada".
+
+## Ambiguidades e decisao de produto
+
+- [ ] CHK026 - A ordem de implementacao proposta em `plan.md` §Proximos Passos (script → SKILL.md → teste, US1 antes de US2/US3) reflete a prioridade real de entrega, ou o dono do produto prefere entregar US1+US3 (ergonomia de deteccao automatica) antes de aprofundar US2? [Risco, Spec §User Scenarios prioridades P1/P2/P3] {humano} — spec ja justifica P1(US1)/P2(US2)/P3(US3) por "MVP mais frequente primeiro"; aguardando confirmacao do dono do produto de que essa ordem serve tambem para `/create-tasks` (nenhum sinal em contrario nos artefatos).
+
+## Notes
+
+- Items `{auto}` resolvidos: 23 (`[x]` com citacao).
+- Items abertos para `/create-tasks`: CHK004/CHK013 `[Gap]` (finding `duplicate-id` sem FR direto — task deve citar `SKILL.md:267` como fonte explicita, nao criar FR fantasma), CHK014 `[Ambiguity]` (default de `--spec` para fixtures fora da convencao — resolver em `/execute-task` do script).
+- Item `{humano}`: CHK026 (confirmar ordem de entrega US1→US2→US3 para o backlog).
+- Nenhum `[Conflict]` encontrado entre spec.md e plan.md nesta rodada.

--- a/docs/specs/validate-docs-sdd-profile/contracts/validate-sdd-cli.md
+++ b/docs/specs/validate-docs-sdd-profile/contracts/validate-sdd-cli.md
@@ -1,0 +1,145 @@
+# Contracts: validate-docs-sdd-profile
+
+Contrato de interface do MOTOR deterministico dos perfis spec-profile e
+plan-profile. A "interface externa" desta feature e a **CLI do script POSIX**
+`global/skills/validate-documentation/scripts/validate-sdd.sh` (args + exit
+codes + formato de saida machine-readable), consumida pelo operador e pelos
+orquestradores `agente-00c`/`feature-00c` como gate pos-artefato.
+
+> **[PROPOSTA — a validar na implementacao]** Este e um contrato NOVO,
+> projetado do zero para uma interface que AINDA NAO EXISTE (a skill
+> `validate-documentation` nao possui `scripts/` hoje). Nenhum campo abaixo e
+> extraido de fonte real observada — sao decisoes de design a serem
+> confirmadas/ajustadas quando o script for implementado em `/execute-task`.
+> Distingue-se, por construcao (Constitution VI), de um contrato de API REAL
+> que exigiria fonte rastreavel. O formato/severidade seguem o precedente REAL
+> de `create-tasks/scripts/validate-tasks-template.sh` e
+> `validate-docs-rendered/scripts/validate.sh` (esses, sim, verificados por
+> leitura).
+
+## Command: `validate-sdd.sh`
+
+**Localizacao**: `global/skills/validate-documentation/scripts/validate-sdd.sh`
+**Tipo**: CLI POSIX sh (Constitution II — sem dependencia externa obrigatoria)
+**Auth**: N/A (ferramenta local, sincrona)
+
+### Invocacao
+
+```
+validate-sdd.sh FILE [--sdd-spec | --sdd-plan] [--spec SPEC_MD]
+```
+
+| Argumento / Flag | Obrigatorio | Descricao |
+|------------------|-------------|-----------|
+| `FILE` (posicional) | sim | Caminho do artefato a validar (ex.: `docs/specs/x/spec.md`). |
+| `--sdd-spec` | nao | Forca o spec-profile, ignorando a deteccao por path (FR-014). |
+| `--sdd-plan` | nao | Forca o plan-profile, ignorando a deteccao por path (FR-014). |
+| `--spec SPEC_MD` | nao | Caminho explicito da `spec.md` correspondente para o check de referencia de IDs `FR-`/`SC-` (FR-012). Default: `<dir-de-FILE-ou-pai>/spec.md` resolvido pela convencao `docs/specs/<feature>/`. |
+
+> **Nota (CHK014 [Ambiguity], resolvido em `/execute-task`)**: a restricao de
+> convencao `docs/specs/<feature>/spec.md` acima aplica-se SOMENTE ao
+> **default automatico** (quando `--spec` nao e informado). A flag
+> **explicita** `--spec SPEC_MD` aceita QUALQUER path, inclusive fixtures de
+> teste fora dessa convencao (`tests/test_validate-sdd.sh` exercita esse
+> caso). O default so tenta resolver `<dir-de-FILE>/spec.md` quando `FILE`
+> segue a convencao reconhecida; fora dela e sem `--spec`, o check
+> `dangling-fr-sc-ref` e silenciosamente pulado (nunca fabrica um path).
+
+**Selecao de perfil** (precedencia):
+1. Flag explicita `--sdd-spec` / `--sdd-plan` (FR-014) vence tudo.
+2. Deteccao automatica por convencao de path (FR-015):
+   - `*/docs/specs/<feature>/spec.md` → spec-profile;
+   - `*/docs/specs/<feature>/{plan,research,data-model,quickstart}.md`
+     ou `*/docs/specs/<feature>/contracts/*.md` → plan-profile.
+3. Nenhuma flag + path fora de convencao reconhecida → **perfil
+   indeterminado** (FR-016): exit 2 com mensagem clara, sem aplicar perfil.
+
+`--sdd-spec` e `--sdd-plan` sao mutuamente exclusivas (passar ambas → exit 2,
+uso incorreto).
+
+### Saida (stdout) — machine-readable
+
+Uma linha por achado, seguida de uma linha de resultado. Formato paralelo ao
+`validate-tasks-template.sh` (`FINDING|severity|code|msg`):
+
+```
+FINDING|<severity>|<code>|<mensagem>
+...
+RESULT|<file>|profile=<spec|plan>|errors=<N>|warnings=<M>
+```
+
+- `severity ∈ {error, warning, info}` — mapeia 1:1 para a taxonomia canonica
+  da skill (Erro / Aviso / Info — FR-017). NAO introduzir taxonomia
+  divergente.
+- `code` — slug kebab-case estavel do tipo de achado (catalogo abaixo).
+- `mensagem` — texto pt-br curto, sem `|` (o pipe e o separador).
+- A linha `RESULT` sempre e emitida (inclusive com 0 achados).
+
+### Exit codes
+
+| Exit | Significado |
+|------|-------------|
+| `0` | Conformante: zero achados de severidade `error` (avisos/infos podem existir e NAO bloqueiam — FR-017). |
+| `1` | Reprovado: >= 1 achado `error`. |
+| `2` | Uso incorreto, arquivo inexistente, flags conflitantes, OU perfil indeterminado (FR-016). |
+
+Racional do exit-por-Erro (nao exit-por-qualquer-finding): ver `research.md`
+Decision 3.
+
+## Catalogo de finding codes
+
+### spec-profile (US1)
+
+| code | severity | FR | Condicao |
+|------|----------|-----|----------|
+| `missing-section` | error | FR-001 | Falta uma das 3 secoes obrigatorias (`User Scenarios & Testing`, `Requirements`, `Success Criteria`). |
+| `impl-detail-in-spec` | error | FR-002 | Termo de stack/linguagem/framework/lib/API especifica detectado no corpo da spec. |
+| `sc-not-measurable` | error | FR-003 | Success Criterion sem metrica quantificavel OU com jargao tecnico de implementacao. |
+| `too-many-clarifications` | error | FR-004 | Mais de 3 marcadores `[NEEDS CLARIFICATION]` no total. |
+| `na-placeholder-section` | warning | FR-005 | Secao deixada com placeholder `N/A` em vez de removida. |
+| `vague-adjective` | warning | FR-006 | Adjetivo vago sem quantificacao em Requirements/Success Criteria. |
+| `coupled-user-story` | warning | FR-007 | User story que depende de outra para ser testada isoladamente. |
+| `duplicate-id` | error | (Gotcha da skill: "IDs duplicados sao erro") | ID `FR-`/`SC-` repetido no mesmo documento. |
+
+### plan-profile (US2)
+
+| code | severity | FR | Condicao |
+|------|----------|-----|----------|
+| `missing-section` | error | FR-008 | Falta uma das 4 secoes obrigatorias de `plan.md` (`Summary`, `Technical Context`, `Constitution Check`, `Project Structure`). |
+| `template-placeholder` | error | FR-009 | Token de template nao preenchido em qualquer artefato `/plan` (ex.: `[FEATURE]`, `[Topico]`, `[Endpoint/Command/Event]`, `[DATE]`, `[short-name]`). |
+| `unlabeled-contract` | error | FR-010 | Entrada em `contracts/*.md` sem rotulo inequivoco real-vs-proposto (`[PROPOSTA — a validar na implementacao]` ou marcacao equivalente de contrato real). |
+| `residual-clarification` | error | FR-011 | `[NEEDS CLARIFICATION]` remanescente em `plan.md`. |
+| `dangling-fr-sc-ref` | error | FR-012 | ID `FR-`/`SC-` citado em `plan.md` que NAO existe na `spec.md` correspondente (checagem semantica; ver FR-013 — NAO e resolucao de path/anchor). |
+
+> **Fora de escopo do script (FR-013/FR-018)**: NENHUM code de resolucao de
+> link/anchor no disco, sintaxe Mermaid, frontmatter YAML ou cobertura
+> cross-artifact. Esses pertencem a `validate-docs-rendered` e `analyze`
+> (ver `research.md` Decision 4).
+
+## Exemplos de saida
+
+Artefato conformante (spec-profile):
+
+```
+$ validate-sdd.sh docs/specs/enforced-guards/spec.md
+RESULT|docs/specs/enforced-guards/spec.md|profile=spec|errors=0|warnings=0
+# exit 0
+```
+
+Artefato reprovado (plan-profile, placeholder + ref pendente):
+
+```
+$ validate-sdd.sh docs/specs/x/plan.md
+FINDING|error|template-placeholder|Token de template nao preenchido: [FEATURE]
+FINDING|error|dangling-fr-sc-ref|plan.md cita FR-099, ausente na spec.md correspondente
+RESULT|docs/specs/x/plan.md|profile=plan|errors=2|warnings=0
+# exit 1
+```
+
+Perfil indeterminado (FR-016):
+
+```
+$ validate-sdd.sh /tmp/qualquer/spec.md
+Perfil nao determinado para '/tmp/qualquer/spec.md': path fora da convencao docs/specs/<feature>/ e nenhuma flag informada. Use --sdd-spec ou --sdd-plan.
+# exit 2
+```

--- a/docs/specs/validate-docs-sdd-profile/data-model.md
+++ b/docs/specs/validate-docs-sdd-profile/data-model.md
@@ -1,0 +1,31 @@
+# Data Model: validate-docs-sdd-profile
+
+## N/A — feature de tooling sem modelo de dados persistente
+
+Esta feature nao introduz nenhuma entidade persistida (sem banco, sem
+schema, sem arquivo de estado novo). E um motor de validacao sincrono e
+stateless: le UM artefato de texto, aplica checks e emite achados em stdout.
+Portanto NAO ha modelo de dados relacional/documental a projetar.
+
+As "Key Entities" listadas na spec sao entidades CONCEITUAIS (tipos de
+artefato e de achado), nao registros persistidos. Documentadas abaixo apenas
+para rastreabilidade spec ↔ plan; sua representacao em runtime e efemera (o
+proprio arquivo de entrada e as linhas `FINDING`/`RESULT` de saida definidas
+em `contracts/validate-sdd-cli.md`).
+
+| Entidade (spec) | Natureza | Representacao em runtime |
+|-----------------|----------|--------------------------|
+| **SddSpecArtifact** | Conceitual — um `spec.md` gerado por `specify` | O arquivo `FILE` passado ao script quando o perfil resolvido e spec-profile. Nao persistido pela feature. |
+| **SddPlanArtifact** | Conceitual — um artefato da familia `/plan` (`plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/*.md`) | O arquivo `FILE` passado ao script quando o perfil resolvido e plan-profile. Nao persistido. |
+| **SddValidationProfile** | Conceitual — conjunto de checks aplicavel a um tipo de artefato | Ramo de codigo do script selecionado por flag/deteccao de path (spec-profile vs plan-profile). Sem estado. |
+| **ValidationFinding** | Conceitual — achado individual com severidade e localizacao | Linha `FINDING|<severity>|<code>|<msg>` em stdout (contrato). Efemero; nao gravado. |
+
+**Transicoes de estado**: N/A — a validacao e uma funcao pura
+`(artefato, perfil) → lista de achados + veredito de exit`. Nao ha ciclo de
+vida, nao ha mutacao de registro.
+
+**Relacionamentos**: a unica relacao entre entidades e a referencia SEMANTICA
+de um `SddPlanArtifact` (`plan.md`) para os IDs `FR-`/`SC-` de um
+`SddSpecArtifact` (`spec.md`) da mesma feature — verificada por FR-012 (o ID
+citado existe na spec) e explicitamente NAO por resolucao de path/anchor no
+disco (FR-013, dono `validate-docs-rendered`).

--- a/docs/specs/validate-docs-sdd-profile/plan.md
+++ b/docs/specs/validate-docs-sdd-profile/plan.md
@@ -1,0 +1,161 @@
+# Implementation Plan: validate-docs-sdd-profile
+
+**Feature**: `validate-docs-sdd-profile` | **Date**: 2026-07-10 | **Spec**: [./spec.md](./spec.md)
+
+## Summary
+
+Adicionar dois perfis de validacao — spec-profile e plan-profile — a skill
+`validate-documentation`, cobrindo os artefatos do proprio pipeline SDD
+(`spec.md` e a familia `/plan`: `plan.md`, `research.md`, `data-model.md`,
+`quickstart.md`, `contracts/*.md`), hoje sem checklist nativo (a skill so
+conhece o perfil UC e o `--runbook`). Abordagem tecnica (Phase 0): um NOVO
+script POSIX deterministico `global/skills/validate-documentation/scripts/validate-sdd.sh`
+como motor, com a prosa do `SKILL.md` documentando acionamento e gotchas —
+espelhando o arranjo ja existente em `create-tasks` e `validate-docs-rendered`
+(script + SKILL.md). Acionamento por deteccao automatica de path
+(`docs/specs/<feature>/...`) + flags explicitas `--sdd-spec`/`--sdd-plan`,
+com fail-safe "perfil indeterminado" (exit 2) fora da convencao. Severidade
+reusa a taxonomia canonica Erro/Aviso/Info da skill (so Erro bloqueia → exit
+1). Os checks derivam dos criterios JA documentados em `specify`
+(`examples/spec-bad.md`) e `plan` (templates + convencao
+`[PROPOSTA — a validar na implementacao]`) — a feature nao inventa criterios,
+so os torna nativamente verificaveis. Fronteira de nao-duplicacao com
+`analyze` (cross-artifact) e `validate-docs-rendered` (renderizacao/links no
+disco) documentada como checklist (SC-005).
+
+## Technical Context
+
+**Language/Version**: POSIX sh (Constitution II — sh puro, sem bashismos)
+**Primary Dependencies**: nenhuma obrigatoria — apenas coreutils/grep/sed ja
+usados pelos scripts existentes do toolkit. `jq` NAO e necessario (o motor
+opera sobre texto Markdown, nao JSON).
+**Storage**: N/A (motor stateless; sem persistencia — ver `data-model.md`)
+**Testing**: harness POSIX do projeto (`tests/run.sh`), novo
+`tests/test_validate-sdd.sh` (convencao `global/skills/*/scripts/<n>.sh` →
+`tests/test_<n>.sh`, gateado por `./tests/run.sh --check-coverage`)
+**Target Platform**: CLI local (macOS/zsh dev + Ubuntu CI), invocado por
+operador e pelos orquestradores `agente-00c`/`feature-00c`
+**Project Type**: extensao de skill (single-layer tooling)
+**Performance Goals**: N/A — validacao de UM arquivo texto, sincrona, sub-segundo
+**Constraints**: POSIX sh puro; zero dependencia externa obrigatoria
+(Constitution II); nao alterar os perfis UC/`--runbook` existentes
+**Scale/Scope**: 1 script novo + prosa no `SKILL.md` + 1 arquivo de teste; ~2
+perfis, ~13 finding codes
+
+Nenhum `[NEEDS CLARIFICATION]` remanescente — FR-013 foi resolvido na fase
+clarify (dec-004); as demais decisoes de implementacao estao em `research.md`.
+
+## Constitution Check
+
+*GATE: Deve passar antes do Phase 0. Re-checar apos Phase 1.*
+
+Constitution v1.2.0 (6 principios; VI = Veracidade de Dados / Zero Fabricacao).
+
+| Principio | Status | Notas |
+|-----------|--------|-------|
+| I. SDD recursivo (NON-NEGOTIABLE) | PASS | A propria feature segue o pipeline SDD (spec → clarify → plan → …); alem disso ENTREGA mais SDD-enforcement (checklist nativo para artefatos SDD). |
+| II. Scripts POSIX sh puros, zero dep externa (NON-NEGOTIABLE) | PASS | Motor e POSIX sh puro; `jq` nao requerido; sem dependencia obrigatoria (nem o carve-out de "optional deps with fallback" e necessario). |
+| III. Formato canonico de skill (progressive disclosure, gotchas, description-trigger) | PASS | Script e o motor; `SKILL.md` continua a interface em prosa com gotchas e triggers, como `create-tasks`/`validate-docs-rendered`. |
+| IV. Zero coleta remota (NON-NEGOTIABLE) | PASS | Validacao 100% local; nenhuma telemetria, nenhuma chamada de rede. |
+| V. Profundidade e reducao de retrabalho | PASS | Substitui grep ad-hoc por gate deterministico reusavel (SC-006), reduzindo retrabalho dos orquestradores. |
+| VI. Veracidade de dados — zero fabricacao (NON-NEGOTIABLE) | PASS | O plan-profile ENFORCA o Principio VI (FR-010: contrato deve ser rotulado real-vs-proposto). Os artefatos deste plano nao afirmam contrato real inventado — a CLU do script e marcada `[PROPOSTA — a validar na implementacao]`; fixtures citam artefato REAL verificado (`enforced-guards`). |
+
+Nenhum FAIL em principio MUST → **gate liberado**. Sem entradas em Complexity
+Tracking (nenhuma violacao a justificar).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+docs/specs/validate-docs-sdd-profile/
+├── spec.md          # WHAT/WHY (pronto; FR-013 resolvido em clarify)
+├── plan.md          # This file
+├── research.md      # Phase 0 output — 6 decisoes de design
+├── data-model.md    # Phase 1 output — N/A persistente (tooling)
+├── quickstart.md    # Phase 1 output — 12 cenarios de aceitacao
+└── contracts/
+    └── validate-sdd-cli.md   # Contrato da CLI do motor [PROPOSTA]
+```
+
+### Source Code (repository root — arvore real, alvos da implementacao)
+
+```
+global/skills/validate-documentation/
+├── SKILL.md                       # EDITAR: documentar spec-profile + plan-profile,
+│                                  #   acionamento (--sdd-spec/--sdd-plan + auto-path),
+│                                  #   catalogo de findings, gotchas, §Fronteira
+├── evals/                         # (existente; possivel eval nova — opcional)
+└── scripts/                       # CRIAR (diretorio ainda nao existe)
+    └── validate-sdd.sh            # CRIAR: motor POSIX (contrato em contracts/)
+
+tests/
+└── test_validate-sdd.sh          # CRIAR: cobre validate-sdd.sh (gate --check-coverage)
+                                   #   fixtures boas = docs/specs/enforced-guards/{spec,plan}.md
+```
+
+Skills de fronteira (NAO alteradas — apenas referenciadas pela §Fronteira):
+`global/skills/analyze/`, `global/skills/validate-docs-rendered/`.
+
+**Structure Decision**: seguir o padrao script+SKILL.md ja usado por
+`create-tasks` e `validate-docs-rendered`. Criar `scripts/` sob
+`validate-documentation` (hoje inexistente) e um teste-irmao em `tests/`,
+satisfazendo a "Regra de ouro" do `CLAUDE.md`. Os perfis UC e `--runbook`
+permanecem prosa-apenas e intocados.
+
+### §Fronteira de responsabilidade (SC-005)
+
+Checklist canonico de quem-faz-o-que (reproduzido no `SKILL.md` na
+implementacao). Detalhe e rationale em `research.md` Decision 4:
+
+- **validate-documentation (spec/plan-profile — esta feature)**: secoes
+  obrigatorias de UM artefato; anti-padroes de conteudo de `spec.md`;
+  placeholder/rotulo/`[NEEDS CLARIFICATION]` residual em `/plan`; existencia
+  SEMANTICA de ID `FR-`/`SC-` citado (FR-012).
+- **validate-docs-rendered**: resolucao de link/anchor no DISCO (arquivo
+  existe, header casa — §2.2), Mermaid, frontmatter YAML, code-block sem
+  linguagem (FR-013/FR-018).
+- **analyze**: cobertura cross-artifact (tasks vs requisitos, duplicacao,
+  gaps, drift de terminologia, alinhamento com constitution), Pass G
+  (convencoes de borda) (FR-018/Out of Scope).
+
+## Convencoes de Borda
+
+**N/A — single-layer.** Feature de tooling POSIX que le um arquivo de texto e
+emite achados em stdout. Nao atravessa fronteira backend↔frontend, DB↔backend
+nem broker↔consumer; nao ha DTO, payload de API, coluna de banco nem
+serializacao cross-camada onde uma convencao de case (snake vs camel)
+pudesse divergir. O unico "contrato de borda" e o formato de saida
+machine-readable (`FINDING|...`/`RESULT|...`), definido em
+`contracts/validate-sdd-cli.md`.
+
+## Complexity Tracking
+
+> Preencher APENAS se Constitution Check tem violacoes que precisam justificativa.
+
+Nenhuma violacao de constitution — tabela vazia.
+
+## Re-check pos-design (ETAPA 7)
+
+Design Phase 1 nao introduziu complexidade nova: continua 1 script POSIX puro
++ prosa + 1 teste, zero dependencia externa, zero rede, zero persistencia. Os
+6 principios MUST/SHOULD permanecem PASS. O plan-profile reforca o Principio
+VI em vez de tensiona-lo. **Re-check: PASS.**
+
+## Artefatos
+
+| Arquivo | Status |
+|---------|--------|
+| docs/specs/validate-docs-sdd-profile/plan.md | Criado |
+| docs/specs/validate-docs-sdd-profile/research.md | Criado |
+| docs/specs/validate-docs-sdd-profile/data-model.md | Criado (N/A documentado) |
+| docs/specs/validate-docs-sdd-profile/quickstart.md | Criado |
+| docs/specs/validate-docs-sdd-profile/contracts/validate-sdd-cli.md | Criado ([PROPOSTA]) |
+
+## Proximos Passos
+
+1. `/checklist` — quality gate dos requisitos antes de decompor.
+2. `/create-tasks` — decompor em backlog (criar `validate-sdd.sh`, editar
+   `SKILL.md`, criar `tests/test_validate-sdd.sh`, afinar wordlist contra
+   `spec-bad.md` ate SC-002).
+3. `/analyze` — apos tasks, validar consistencia spec ↔ plan ↔ tasks.

--- a/docs/specs/validate-docs-sdd-profile/quickstart.md
+++ b/docs/specs/validate-docs-sdd-profile/quickstart.md
@@ -1,0 +1,103 @@
+# Quickstart: validate-docs-sdd-profile
+
+Cenarios de aceitacao executaveis para os perfis spec-profile e plan-profile.
+Cada cenario e o oraculo de um teste em `tests/test_validate-sdd.sh`. O
+formato de saida e os exit codes referenciados vivem em
+`contracts/validate-sdd-cli.md`.
+
+> Comando abreviado: `vsdd` = `global/skills/validate-documentation/scripts/validate-sdd.sh`.
+
+## Cenario 1 — spec.md conformante (spec-profile, 0 erros) [US1, SC-001]
+
+1. Apontar para um `spec.md` real e limpo:
+   `vsdd docs/specs/enforced-guards/spec.md`
+2. Perfil resolvido automaticamente por path → spec-profile.
+3. **Expected**: nenhuma linha `FINDING|error|...`;
+   `RESULT|...|profile=spec|errors=0|warnings=0`; **exit 0**.
+
+## Cenario 2 — spec.md com secao obrigatoria ausente (spec-profile) [US1 AS2, FR-001]
+
+1. Copiar `enforced-guards/spec.md` removendo a secao `## Success Criteria`.
+2. `vsdd <copia-quebrada>.md --sdd-spec`
+3. **Expected**: `FINDING|error|missing-section|...Success Criteria...`;
+   `errors>=1`; **exit 1**.
+
+## Cenario 3 — spec.md com termo de stack em Success Criteria (spec-profile) [US1 AS4, FR-002/FR-003]
+
+1. Copiar um `spec.md` bom e inserir em Success Criteria um criterio com
+   jargao tecnico (ex.: "API response time under 200ms", "React render <50ms")
+   — os anti-padroes 1 e 2 de `specify/examples/spec-bad.md`.
+2. `vsdd <copia>.md`
+3. **Expected**: `FINDING|error|sc-not-measurable|...` e/ou
+   `FINDING|error|impl-detail-in-spec|...`; **exit 1**.
+
+## Cenario 4 — spec.md com > 3 `[NEEDS CLARIFICATION]` (spec-profile) [US1 AS3, FR-004]
+
+1. Copiar um `spec.md` bom e adicionar um QUARTO marcador
+   `[NEEDS CLARIFICATION]`.
+2. `vsdd <copia>.md`
+3. **Expected**: `FINDING|error|too-many-clarifications|...contagem=4...limite=3`;
+   **exit 1**.
+
+## Cenario 5 — spec.md com ID duplicado (spec-profile) [Gotcha da skill]
+
+1. Copiar um `spec.md` bom e duplicar um `FR-001` (dois requisitos com o
+   mesmo ID).
+2. `vsdd <copia>.md`
+3. **Expected**: `FINDING|error|duplicate-id|...FR-001...`; **exit 1**.
+
+## Cenario 6 — avisos nao bloqueiam (spec-profile) [FR-005/006/007, FR-017]
+
+1. Copiar um `spec.md` bom, remover nada obrigatorio, mas deixar uma secao
+   `N/A` residual (FR-005) e um adjetivo vago sem metrica (FR-006).
+2. `vsdd <copia>.md`
+3. **Expected**: linhas `FINDING|warning|na-placeholder-section|...` e
+   `FINDING|warning|vague-adjective|...`; `errors=0`; **exit 0** (Aviso
+   recomenda, nao bloqueia — semantica de severidade da skill).
+
+## Cenario 7 — plan.md conformante (plan-profile, 0 erros) [US2, SC-003]
+
+1. `vsdd docs/specs/enforced-guards/plan.md`
+2. Perfil resolvido automaticamente por path → plan-profile.
+3. **Expected**: nenhuma linha `FINDING|error|...`;
+   `RESULT|...|profile=plan|errors=0|warnings=0`; **exit 0**.
+
+## Cenario 8 — plan.md com placeholder de template residual (plan-profile) [US2 AS4, FR-009]
+
+1. Copiar um `plan.md` bom e deixar um `[FEATURE]` (ou `[DATE]`,
+   `[short-name]`) literal, nao preenchido.
+2. `vsdd <copia>.md`
+3. **Expected**: `FINDING|error|template-placeholder|...[FEATURE]...`;
+   **exit 1**.
+
+## Cenario 9 — plan.md cita FR/SC inexistente na spec (plan-profile) [US2 AS2, FR-012]
+
+1. Copiar um `plan.md` bom e inserir uma citacao a `FR-099` que NAO existe
+   na `spec.md` da mesma feature.
+2. `vsdd <copia>.md --spec docs/specs/enforced-guards/spec.md`
+3. **Expected**: `FINDING|error|dangling-fr-sc-ref|...FR-099...`; **exit 1**.
+4. **Nao-Expected** (fronteira FR-013): NENHUM achado sobre link/anchor
+   quebrado no disco — isso e de `validate-docs-rendered`, nao deste perfil.
+
+## Cenario 10 — contracts/*.md sem rotulo real-vs-proposto (plan-profile) [US2 AS3, FR-010/SC-004]
+
+1. Copiar um `contracts/*.md` bom e remover o rotulo
+   `[PROPOSTA — a validar na implementacao]` de uma entrada que documenta um
+   endpoint/evento.
+2. `vsdd <copia>.md --sdd-plan`
+3. **Expected**: `FINDING|error|unlabeled-contract|...`; **exit 1**.
+
+## Cenario 11 — perfil indeterminado fora da convencao (US3 AS3) [FR-016]
+
+1. `vsdd /tmp/fora-da-convencao/spec.md` (arquivo chamado `spec.md` mas fora
+   de `docs/specs/<feature>/`, sem flag).
+2. **Expected**: mensagem em stderr "Perfil nao determinado ... use
+   --sdd-spec ou --sdd-plan"; **exit 2**; NENHUM perfil aplicado
+   silenciosamente.
+
+## Cenario 12 — deteccao automatica por path (US3 AS1/AS2) [FR-015]
+
+1. `vsdd docs/specs/enforced-guards/research.md` (sem flag).
+2. **Expected**: perfil plan-profile aplicado automaticamente (research.md e
+   da familia `/plan`); `RESULT|...|profile=plan|...`.
+3. Repetir com `docs/specs/enforced-guards/spec.md` → `profile=spec`.

--- a/docs/specs/validate-docs-sdd-profile/research.md
+++ b/docs/specs/validate-docs-sdd-profile/research.md
@@ -1,0 +1,202 @@
+# Research: validate-docs-sdd-profile
+
+Documento produzido no Phase 0 do `/plan`. Resolve as decisoes tecnicas em
+aberto ANTES do design. A spec ja passou por `/clarify` (FR-013 resolvido,
+zero `[NEEDS CLARIFICATION]` residuais), portanto nao ha unknowns herdados da
+spec — as decisoes abaixo sao escolhas de implementacao que a propria spec
+deixou explicitamente para o `/plan` (secao Out of Scope: "Escolha de
+implementacao … decisao de /plan" e "Nomeacao exata de flags … decisao de
+/plan").
+
+## Decision 1: Motor deterministico via NOVO script POSIX (nao prosa-apenas)
+
+**Decision**: Implementar os dois perfis como um NOVO script POSIX sh
+`global/skills/validate-documentation/scripts/validate-sdd.sh` (a skill
+`validate-documentation` hoje NAO possui diretorio `scripts/` — foi
+verificado por leitura direta: `global/skills/validate-documentation/`
+contem apenas `evals/` e `SKILL.md`), com a prosa do `SKILL.md` documentando
+o acionamento, os perfis e os gotchas. Os perfis UC e `--runbook` existentes
+permanecem prosa-apenas e INALTERADOS (spec, Out of Scope).
+
+**Rationale**:
+1. **Determinismo e testabilidade** — os checks desta feature (secoes
+   obrigatorias presentes, contagem de `[NEEDS CLARIFICATION]`, IDs
+   duplicados, referencia `FR-`/`SC-` inexistente na spec) sao
+   estruturalmente decidiveis; um script produz o MESMO veredito toda vez,
+   ao contrario de um checklist guiado por prosa que depende do LLM
+   "lembrar" de cada criterio.
+2. **Convencao ja imposta pelo projeto** — o `CLAUDE.md` (secao "Como testar
+   scripts shell") e `tests/README.md` estabelecem: todo `.sh` novo em
+   `global/skills/*/scripts/` EXIGE `tests/test_<nome>.sh`, e
+   `./tests/run.sh --check-coverage` falha (exit 1) na ausencia. Um motor
+   deterministico entra nessa malha de cobertura; prosa nao.
+3. **Precedente direto** — `global/skills/create-tasks/scripts/validate-tasks-template.sh`
+   e `global/skills/validate-docs-rendered/scripts/validate.sh` sao skills
+   que combinam script POSIX determinista + `SKILL.md` em prosa; o padrao
+   ja existe no toolkit e este perfil o segue.
+4. **Reuso pelos orquestradores como gate** — `agente-00c`/`feature-00c`
+   podem invocar o script diretamente como gate pos-artefato (hoje aplicam
+   os criterios ad-hoc com grep — gap confirmado pelo read-back loop:
+   sugestao de `cstk/enforced-guards` registrada na knowledge.db aponta
+   exatamente "validate-documentation nao tem perfil dedicado para
+   artefatos de /plan").
+
+**Alternatives considered**:
+- **Prosa-apenas (como UC/`--runbook` fazem hoje)** — rejeitado: sem
+  cobertura de teste (`--check-coverage` nao alcanca prosa), sem
+  determinismo, e mantem os orquestradores presos ao grep ad-hoc que a
+  feature existe para eliminar (SC-006).
+- **Estender o `validate.sh` de `validate-docs-rendered`** — rejeitado:
+  violaria a fronteira de responsabilidade (FR-018); aquele script e o dono
+  da validacao de RENDERIZACAO, nao de qualidade estrutural de artefato SDD.
+
+**Nota de conformidade com o Principio III (skill = prosa + progressive
+disclosure)**: o script e o MOTOR; o `SKILL.md` continua sendo a interface
+em prosa (quando usar, gotchas, exemplos). Isso e exatamente o arranjo de
+`create-tasks` e `validate-docs-rendered` — nao ha conflito com o Principio
+III.
+
+## Decision 2: Acionamento = deteccao automatica por path + flags explicitas
+
+**Decision**: Suportar AMBOS os mecanismos, espelhando o que a skill ja faz
+para os perfis existentes:
+- **Deteccao automatica por convencao de path** (FR-015):
+  - `docs/specs/<feature>/spec.md` → spec-profile;
+  - `docs/specs/<feature>/plan.md`, `.../research.md`, `.../data-model.md`,
+    `.../quickstart.md`, `.../contracts/*.md` → plan-profile.
+- **Selecao explicita por flag** (FR-014): `--sdd-spec` e `--sdd-plan`,
+  aditivas as flags/perfis ja existentes (`--runbook`, perfil UC default).
+- **Perfil indeterminado** (FR-016): quando o path nao casa nenhuma
+  convencao reconhecida (nem UC `UC-*.md`, nem runbook `RB-\d{3}-*.md`, nem
+  spec-profile, nem plan-profile) e nenhuma flag foi passada, reportar erro
+  claro "perfil nao determinado" e sair — NUNCA aplicar o perfil UC default
+  silenciosamente aos artefatos desta feature.
+
+**Rationale**: e o padrao ESTABELECIDO da propria skill — o perfil UC casa
+por glob `UC-*.md`, o `--runbook` casa por filename `RB-\d{3}-*.md` OU pela
+flag `--runbook` (verificado no `SKILL.md`, secao "Perfil `--runbook`").
+Duplicar esse mecanismo dual (auto por path + flag explicita) mantem
+consistencia e satisfaz FR-014 (explicito), FR-015 (auto) e FR-016
+(fail-safe) sem inventar convencao nova.
+
+**Alternatives considered**:
+- **Somente flag explicita** — rejeitado: falha FR-015 (auto-deteccao) e
+  reintroduz atrito de adocao (US3).
+- **Somente auto-deteccao por path** — rejeitado: falha FR-014 (override
+  explicito) e nao resolve validar um artefato fora da convencao de
+  diretorio.
+- **Estender o default implicito do perfil UC para spec/plan** — rejeitado
+  explicitamente pela spec (US3 Acceptance Scenario 3): aplicar perfil por
+  engano e pior que pedir desambiguacao.
+
+## Decision 3: Reuso da taxonomia de severidade + semantica dos exit codes
+
+**Decision**: Reutilizar a taxonomia de severidade JA existente na skill —
+**Erro** (bloqueia aprovacao) / **Aviso** (recomenda correcao) / **Info**
+(sugestao opcional) — sem introduzir taxonomia divergente (FR-017). No
+contrato do script (ver `contracts/validate-sdd-cli.md`):
+- stdout: uma linha por achado `FINDING|<severity>|<code>|<msg>` com
+  `severity ∈ {error, warning, info}` (mapeando 1:1 para Erro/Aviso/Info) +
+  uma linha final `RESULT|<file>|profile=<p>|errors=<N>|warnings=<M>`.
+- **exit codes**: `0` = zero achados de severidade `error` (avisos/infos
+  podem existir e NAO bloqueiam); `1` = >=1 achado `error`; `2` = uso
+  incorreto / arquivo inexistente / perfil indeterminado (FR-016).
+
+**Rationale**: alinhar o exit code a SEMANTICA da severidade da skill — so
+**Erro** bloqueia aprovacao, logo so **Erro** deve produzir exit != 0 de
+"reprovado". Isso segue a convencao do `validate.sh` de `validate-docs-rendered`
+("exit 0 se zero ERROs, 1 se houver ERROs"), e NAO a do
+`validate-tasks-template.sh` (que sai 1 em QUALQUER finding, inclusive
+warning). A divergencia e deliberada: a taxonomia canonica de
+`validate-documentation` distingue Aviso de Erro (Aviso "recomenda", nao
+"bloqueia"), enquanto o modelo critical/warning de `validate-tasks-template`
+trata ambos como reprovacao. Adotar o exit-por-Erro preserva FR-017.
+
+**Alternatives considered**:
+- **exit 1 em qualquer finding (estilo `validate-tasks-template.sh`)** —
+  rejeitado: conflitaria Aviso com Erro e violaria a semantica "Aviso nao
+  bloqueia" do modelo de severidade que FR-017 manda preservar.
+
+## Decision 4: Fronteira de responsabilidade documentada (nao-duplicacao)
+
+**Decision**: Materializar SC-005 como um **checklist de fronteira**
+documentado (neste plano, secao Project Structure/§Fronteira, e reproduzido
+no `SKILL.md` na implementacao) declarando, por categoria de check, qual das
+tres skills e a dona:
+
+| Categoria de check | Dono | spec/plan-profile faz? |
+|--------------------|------|------------------------|
+| Secoes obrigatorias presentes num UNICO artefato | validate-documentation (novos perfis) | SIM (FR-001, FR-008) |
+| Anti-padroes de conteudo da spec (impl. vazando, SC nao-mensuravel, `[NEEDS CLARIFICATION]` > 3, stories acopladas, adjetivos vagos, N/A residual) | validate-documentation (spec-profile) | SIM (FR-002..FR-007) |
+| Placeholder de template residual / rotulo real-vs-proposto / `[NEEDS CLARIFICATION]` residual no plan | validate-documentation (plan-profile) | SIM (FR-009, FR-010, FR-011) |
+| ID `FR-`/`SC-` citado em plan.md EXISTE na spec.md (checagem SEMANTICA) | validate-documentation (plan-profile) | SIM (FR-012) |
+| Link/anchor entre arquivos RESOLVE no disco (arquivo existe, header casa) | validate-docs-rendered (§2.2) | NAO (FR-013, FR-018) |
+| Sintaxe Mermaid, frontmatter YAML, code-block sem linguagem | validate-docs-rendered | NAO (FR-018) |
+| Cobertura cross-artifact (tasks vs requisitos, duplicacao, gaps, drift de terminologia, alinhamento com constitution) | analyze | NAO (FR-018) |
+| Drift de case-convention entre camadas (snake vs camel) | analyze (Pass G) | NAO (Out of Scope) |
+
+**Rationale**: SC-005 exige "checklist documentado de fronteira de
+responsabilidade entre as tres skills". A linha divisoria mais sutil
+(referencia cruzada de IDs) foi resolvida na fase clarify (dec-004,
+2026-07-10): o plan-profile faz apenas a checagem SEMANTICA (o ID existe na
+spec?), NUNCA a resolucao de path/anchor no disco — essa fica 100% com
+`validate-docs-rendered` §2.2, verificado por leitura real daquele
+`SKILL.md`.
+
+**Alternatives considered**:
+- **Deixar a fronteira implicita na prosa dos FRs** — rejeitado: SC-005
+  pede um artefato de fronteira explicito e verificavel; prosa dispersa nao
+  e auditavel como checklist.
+
+## Decision 5: Estrategia de fixtures e cobertura de teste
+
+**Decision**: O teste `tests/test_validate-sdd.sh` (nome derivado da
+convencao `global/skills/<X>/scripts/<n>.sh` → `tests/test_<n>.sh`) usa como
+fixture "boa" os artefatos REAIS ja versionados em
+`docs/specs/enforced-guards/` — verificado por leitura direta que
+`spec.md` contem as 3 secoes obrigatorias (`User Scenarios & Testing`,
+`Requirements`, `Success Criteria`) e `plan.md` as 4 (`Summary`,
+`Technical Context`, `Constitution Check`, `Project Structure`) — e como
+fixtures "ruins" copias deliberadamente quebradas (heredoc ou arquivos sob
+`tests/fixtures/`), uma quebra por cenario (secao removida, stack-term
+injetado em SC, 4o `[NEEDS CLARIFICATION]`, ID duplicado, placeholder
+`[FEATURE]` residual, citacao `FR-099` inexistente, entrada de contrato sem
+rotulo real-vs-proposto).
+
+**Rationale**: satisfaz a "Regra de ouro" do `CLAUDE.md` (todo `.sh` novo
+tem `test_<nome>.sh`, gateada por `--check-coverage`), reusa artefatos reais
+como oraculo de verdade-positiva (0 erros) e isola cada verdade-negativa num
+unico defeito para assercao precisa da severidade (SC-001..SC-004).
+
+**Alternatives considered**:
+- **Somente fixtures inline (heredoc), sem apontar para artefato real** —
+  aceitavel para os casos "ruins", mas para o caso "bom" o artefato real de
+  `enforced-guards` da maior confianca de que o perfil nao produz
+  falso-positivo contra um artefato de producao. Usar ambos.
+
+## Decision 6: Deteccao heuristica de conteudo — limites e severidade
+
+**Decision**: Os checks de CONTEUDO derivados dos anti-padroes catalogados
+em `specify/examples/spec-bad.md` (impl. vazando FR-002, SC nao-mensuravel
+FR-003, adjetivos vagos FR-006, stories acopladas FR-007) sao heuristicos
+(lista de termos de stack + ausencia de padrao numerico de metrica). Os
+puramente estruturais e de baixo risco de falso-positivo sao **Erro**
+(FR-002, FR-003, FR-004); os semanticos com risco de falso-positivo sao
+**Aviso** (FR-005, FR-006, FR-007, ja assim classificados na spec). A lista
+concreta de termos de stack e o conjunto de regex de metrica sao detalhe de
+implementacao (marcado `[PROPOSTA — a validar na implementacao]` no
+contrato), a ser afinado contra os 6 exemplos de `spec-bad.md` ate atingir
+SC-002 (100% dos 6 anti-padroes estruturalmente detectaveis).
+
+**Rationale**: casa exatamente a classificacao de severidade que a spec ja
+fixou (FR-002/003/004 = erro; FR-005/006/007 = aviso), e reconhece
+honestamente que deteccao semantica tem limite — por isso story-coupling
+(FR-007) e aviso, nao erro. A calibragem da wordlist contra `spec-bad.md`
+evita afirmar cobertura que ainda nao foi medida (SC-002 e verificado no
+teste, nao presumido).
+
+**Alternatives considered**:
+- **Tornar todos os checks de conteudo Erro** — rejeitado: falso-positivo
+  em check semantico (ex.: "robusto" num contexto legitimo) bloquearia
+  aprovacao indevidamente; a spec ja separa erro de aviso justamente por
+  isso.

--- a/docs/specs/validate-docs-sdd-profile/spec.md
+++ b/docs/specs/validate-docs-sdd-profile/spec.md
@@ -1,0 +1,407 @@
+# Feature Specification: validate-docs-sdd-profile
+
+**Feature**: `validate-docs-sdd-profile`
+**Created**: 2026-07-10
+**Status**: Draft
+
+## Visao geral
+
+A skill `validate-documentation` hoje conhece apenas dois perfis de artefato:
+o perfil UC (default, casos de uso `UC-*.md`) e o perfil `--runbook`
+(`RB-\d{3}-*.md`). Nenhum dos dois cobre os artefatos gerados pelo proprio
+pipeline SDD deste toolkit — `spec.md` (gerado por `specify`) nem a familia de
+artefatos gerados por `plan` (`plan.md`, `research.md`, `data-model.md`,
+`quickstart.md`, `contracts/*.md`). Como resultado, quando um orquestrador
+(`agente-00c`/`feature-00c`) ou um operador precisa checar a qualidade
+estrutural de um `spec.md` ou de um `plan.md` isolado, a unica opcao hoje e
+grep ad-hoc — sem checklist nativo, sem relatorio consistente com o resto da
+skill, sem reuso dos criterios de qualidade que ja estao documentados na
+prosa de `specify` e `plan`.
+
+Esta feature adiciona dois novos perfis a `validate-documentation` —
+spec-profile e plan-profile — que aplicam, de forma nativa e reusavel, os
+criterios de qualidade que `specify` e `plan` ja definem para seus proprios
+artefatos (ausencia de detalhes de implementacao, success criteria
+mensuraveis, limite de `[NEEDS CLARIFICATION]`, rotulagem de contrato
+real-vs-proposto, ausencia de placeholders de template). Os dois perfis
+novos NAO substituem nem duplicam `analyze` (consistencia cross-artifact
+profunda) nem `validate-docs-rendered` (validacao de renderizacao) — cobrem
+exclusivamente a qualidade estrutural de UM artefato isolado, no mesmo
+espirito dos perfis UC e `--runbook` ja existentes.
+
+> Decisoes de infraestrutura: **N/A** — a feature nao introduz scheduling,
+> sessao persistente, refresh de token externo, rotacao de chaves ou mutex
+> multi-processo. E uma extensao de checklist de validacao textual, sincrona
+> e local.
+
+## Clarifications
+
+### Session 2026-07-10
+
+- Q: O plan-profile deve incluir uma checagem de que links internos entre
+  artefatos da familia `/plan` (ex.: `plan.md` referenciando
+  `contracts/algo.md`) apontam para arquivos existentes, ou essa
+  responsabilidade fica 100% com `validate-docs-rendered`? → A: fica 100%
+  delegada a `validate-docs-rendered` (secao 2.2 "Links internos" do seu
+  SKILL.md ja verifica que o arquivo apontado existe e que o anchor
+  corresponde a um header valido, com severidade erro para quebrados). O
+  plan-profile NAO faz resolucao de link/anchor no disco; sua unica
+  checagem de referencia cruzada e semantica — validar que IDs `FR-`/`SC-`
+  citados em `plan.md` existem de fato na `spec.md` correspondente
+  (ja coberto por FR-012), nao que um path aponta para um arquivo real.
+
+## User Scenarios & Testing
+
+### User Story 1 - Validar um spec.md isolado contra checklist nativo (Priority: P1)
+
+Como orquestrador (`agente-00c`/`feature-00c`) ou operador, eu quero validar
+um `spec.md` recem-gerado contra um checklist nativo da skill
+`validate-documentation` — que reaproveita os criterios ja documentados em
+`specify` (zero detalhes de implementacao, success criteria mensuraveis e
+tech-agnostic, no maximo 3 `[NEEDS CLARIFICATION]`, secoes obrigatorias
+presentes) — em vez de depender de grep ad-hoc escrito na hora, para que a
+qualidade estrutural de um `spec.md` seja checada de forma consistente e
+auditavel antes de avancar para `clarify`/`plan`.
+
+**Why this priority**: e o artefato mais cedo no pipeline SDD (gerado por
+`specify`, primeira etapa apos briefing/constitution) e o que hoje sofre mais
+com a ausencia de checklist nativo — o gap descrito na Visao Geral. Sem esta
+story, as demais nao tem MVP: e o caso de uso mais frequente.
+
+**Independent Test**: rodar a validacao contra um `spec.md` conhecido (ex.:
+`docs/specs/enforced-guards/spec.md`, ja existente no projeto) e confirmar
+que o relatorio gerado aponta zero erros estruturais; em seguida rodar contra
+uma copia deliberadamente quebrada (uma secao obrigatoria removida, um jargao
+tecnico inserido em Success Criteria, um quarto marcador
+`[NEEDS CLARIFICATION]` adicionado) e confirmar que cada quebra e detectada e
+classificada com a severidade correta. Testavel isoladamente de US2 e US3.
+
+**Acceptance Scenarios**:
+
+1. **Given** um `spec.md` com as tres secoes obrigatorias presentes
+   (`User Scenarios & Testing`, `Requirements`, `Success Criteria`) e
+   conteudo consistente com os criterios de `specify`, **When** a validacao
+   roda com o spec-profile, **Then** o relatorio reporta zero erros.
+2. **Given** um `spec.md` faltando uma secao obrigatoria, **When** a
+   validacao roda, **Then** o relatorio reporta um erro (bloqueante)
+   identificando a secao ausente.
+3. **Given** um `spec.md` com mais de 3 marcadores
+   `[NEEDS CLARIFICATION]`, **When** a validacao roda, **Then** o relatorio
+   reporta um erro citando a contagem encontrada e o limite excedido.
+4. **Given** um `spec.md` com uma Success Criteria redigida em termos
+   tecnicos (ex.: menciona um framework ou tempo de resposta de API em vez
+   de uma metrica orientada ao usuario), **When** a validacao roda,
+   **Then** o relatorio reporta um erro apontando o anti-padrao.
+
+---
+
+### User Story 2 - Validar artefatos da familia /plan contra checklist nativo (Priority: P2)
+
+Como orquestrador ou operador, eu quero validar `plan.md` e os artefatos
+associados (`research.md`, `data-model.md`, `quickstart.md`,
+`contracts/*.md`) contra um checklist nativo que reaproveita os criterios ja
+documentados em `plan` (secoes obrigatorias presentes, rotulagem explicita
+de contrato real-vs-proposto, referencias a FR/SC que de fato existem na
+spec correspondente, ausencia de placeholder de template residual), para que
+a qualidade estrutural de um plano tecnico seja checada de forma consistente
+antes de avancar para `create-tasks`.
+
+**Why this priority**: depende do mesmo mecanismo de perfil que US1
+introduz, mas atua na etapa seguinte do pipeline (`plan`) — tem valor
+proprio e independente (um operador pode rodar `/plan` sem nunca ter usado
+o novo perfil de US1), mas naturalmente vem depois porque `plan.md` so
+existe apos `spec.md`.
+
+**Independent Test**: rodar a validacao contra os artefatos de
+`docs/specs/enforced-guards/` (`plan.md`, `research.md`, `data-model.md`,
+`quickstart.md`, `contracts/`), ja existentes no projeto, e confirmar
+relatorio limpo; em seguida rodar contra copias deliberadamente quebradas
+(um placeholder de template `[FEATURE]` esquecido, uma citacao a `FR-099`
+inexistente na spec, uma entrada de contrato sem rotulo real-vs-proposto) e
+confirmar deteccao com severidade correta. Testavel isoladamente de US1 e
+US3 (basta apontar a validacao diretamente para os artefatos, sem depender
+do mecanismo de deteccao automatica de US3).
+
+**Acceptance Scenarios**:
+
+1. **Given** um `plan.md` com as secoes obrigatorias presentes (`Summary`,
+   `Technical Context`, `Constitution Check`, `Project Structure`) e sem
+   placeholders de template residuais, **When** a validacao roda com o
+   plan-profile, **Then** o relatorio reporta zero erros.
+2. **Given** um `plan.md` que cita um `FR-NNN` ou `SC-NNN` inexistente na
+   `spec.md` correspondente, **When** a validacao roda, **Then** o
+   relatorio reporta um erro identificando a citacao invalida.
+3. **Given** uma entrada em `contracts/*.md` que documenta um
+   endpoint/evento sem indicar claramente se e um contrato real (extraido
+   de fonte verificavel) ou uma proposta ainda nao validada, **When** a
+   validacao roda, **Then** o relatorio reporta um erro apontando a
+   ambiguidade.
+4. **Given** qualquer artefato da familia `/plan` contendo um placeholder de
+   template nao preenchido (ex.: `[FEATURE]`, `[Topico]`,
+   `[Endpoint/Command/Event]` copiados literalmente do template), **When**
+   a validacao roda, **Then** o relatorio reporta um erro.
+
+---
+
+### User Story 3 - Deteccao automatica de perfil por convencao de path (Priority: P3)
+
+Como orquestrador ou operador, eu quero que a skill reconheca
+automaticamente qual perfil aplicar (spec-profile ou plan-profile) quando o
+caminho do artefato segue a convencao padrao do pipeline SDD
+(`docs/specs/<feature>/spec.md`, `docs/specs/<feature>/plan.md`, etc.), para
+nao precisar informar explicitamente qual perfil usar toda vez que valido um
+artefato gerado pelo proprio pipeline.
+
+**Why this priority**: e uma melhoria de ergonomia sobre US1/US2 — reduz
+atrito de adocao (nenhum orquestrador precisa "lembrar" de passar uma opcao
+extra), mas o valor central (checklist nativo existir) ja esta entregue por
+US1/US2 mesmo sem deteccao automatica. Por isso vem depois.
+
+**Independent Test**: apontar a validacao para um caminho que segue a
+convencao padrao (ex.: `docs/specs/qualquer-feature/spec.md`) sem informar
+qual perfil usar, e confirmar que o spec-profile e aplicado automaticamente;
+repetir para `plan.md` e confirmar plan-profile. Em seguida, apontar para um
+caminho fora da convencao (ex.: um arquivo chamado `spec.md` fora de
+`docs/specs/`) e confirmar que o sistema nao aplica um perfil por engano —
+pede desambiguacao explicita em vez de adivinhar. Testavel isoladamente de
+US1/US2 (assume que os perfis ja existem; testa apenas o mecanismo de
+selecao).
+
+**Acceptance Scenarios**:
+
+1. **Given** um caminho de artefato que segue a convencao padrao do
+   pipeline SDD para `spec.md`, **When** a validacao roda sem selecao
+   explicita de perfil, **Then** o spec-profile e aplicado
+   automaticamente.
+2. **Given** um caminho de artefato que segue a convencao padrao do
+   pipeline SDD para qualquer arquivo da familia `/plan` (`plan.md`,
+   `research.md`, `data-model.md`, `quickstart.md`, `contracts/*.md`),
+   **When** a validacao roda sem selecao explicita de perfil, **Then** o
+   plan-profile e aplicado automaticamente.
+3. **Given** um arquivo cujo caminho nao segue nenhuma convencao
+   reconhecida (nem UC, nem runbook, nem spec/plan), **When** a validacao
+   roda sem selecao explicita de perfil, **Then** o sistema reporta que o
+   perfil nao pode ser determinado automaticamente e pede selecao
+   explicita, em vez de aplicar silenciosamente um perfil incorreto
+   (comportamento atual do perfil UC como default implicito NAO se estende
+   aos artefatos desta feature).
+
+### Edge Cases
+
+- O que acontece quando um artefato nao casa nenhum perfil conhecido (nem
+  UC, nem runbook, nem spec-profile, nem plan-profile)? O sistema reporta
+  erro claro de "perfil nao determinado" — ver Acceptance Scenario 3 de
+  US3.
+- O que acontece com `tasks.md`, que vive no mesmo diretorio
+  `docs/specs/<feature>/` mas nao e nem spec nem artefato de `/plan`? Fica
+  fora do escopo dos dois novos perfis — nenhum perfil "tasks" e definido
+  por esta feature.
+- O que acontece quando `spec.md` tem mais de 3 `[NEEDS CLARIFICATION]`?
+  Erro bloqueante — mesma regra hard-limit ja aplicada por `specify` (ver
+  Acceptance Scenario 3 de US1).
+- O que acontece quando `plan.md` referencia um `FR-`/`SC-` inexistente na
+  `spec.md` correspondente? Erro — ver Acceptance Scenario 2 de US2. Este
+  check e de integridade referencial de UM documento (o `plan.md` citando
+  IDs que devem existir alhures), no mesmo espirito do que o perfil UC ja
+  faz hoje ao exigir que `Dependencias` referenciem UCs existentes — nao e
+  a analise de cobertura cross-artifact profunda que `analyze` ja realiza
+  (duplicacao, gaps, drift de terminologia entre spec/tasks/constitution).
+- O que acontece com um `contracts/*.md` que documenta um endpoint de
+  sistema externo sem indicar claramente se e real ou proposto? Erro — a
+  ambiguidade entre contrato real e hipotese e exatamente o risco que o
+  Principio VI (Veracidade de Dados) do toolkit existe para evitar.
+
+## Requirements
+
+### Functional Requirements
+
+#### Perfil spec-profile (US1)
+
+- **FR-001**: O sistema MUST validar a presenca das tres secoes obrigatorias
+  de um `spec.md` (`User Scenarios & Testing`, `Requirements`,
+  `Success Criteria`); ausencia de qualquer uma delas MUST ser reportada com
+  severidade erro.
+- **FR-002**: O sistema MUST detectar linguagem de detalhe de implementacao
+  (nomes de linguagem, framework, biblioteca ou API especifica) dentro de um
+  `spec.md`, reportando com severidade erro — espelha o anti-padrao "Detalhes
+  de implementacao na spec" catalogado em `specify` (`examples/spec-bad.md`).
+- **FR-003**: O sistema MUST detectar Success Criteria que nao sejam
+  mensuraveis (sem metrica quantificavel: tempo, percentual, contagem, taxa)
+  ou que usem jargao tecnico especifico de implementacao, reportando com
+  severidade erro — espelha o anti-padrao "Success criteria com jargao
+  tecnico".
+- **FR-004**: O sistema MUST detectar mais de 3 marcadores
+  `[NEEDS CLARIFICATION]` no total de um `spec.md`, reportando com
+  severidade erro — mesma regra hard-limit ja imposta por `specify`.
+- **FR-005**: O sistema SHOULD detectar secoes deixadas com placeholder
+  "N/A" em vez de removidas, reportando com severidade aviso — espelha o
+  anti-padrao "Secoes vazias com N/A".
+- **FR-006**: O sistema SHOULD detectar adjetivos vagos sem quantificacao em
+  Requirements/Success Criteria (ex.: "rapido", "simples", "robusto" sem
+  metrica associada), reportando com severidade aviso — espelha o
+  anti-padrao "Adjetivos vagos sem quantificacao".
+- **FR-007**: O sistema SHOULD detectar user stories que dependem umas das
+  outras para serem testadas isoladamente (nao independentemente
+  testaveis), reportando com severidade aviso — espelha o anti-padrao "User
+  stories que dependem umas das outras". Classificado como aviso (nao erro)
+  porque a deteccao de acoplamento entre stories e uma checagem semantica,
+  nao puramente estrutural.
+
+#### Perfil plan-profile (US2)
+
+- **FR-008**: O sistema MUST validar a presenca das secoes obrigatorias de
+  `plan.md` (`Summary`, `Technical Context`, `Constitution Check`,
+  `Project Structure`); ausencia de qualquer uma delas MUST ser reportada
+  com severidade erro.
+- **FR-009**: O sistema MUST detectar, em qualquer artefato da familia
+  `/plan` (`plan.md`, `research.md`, `data-model.md`, `quickstart.md`,
+  `contracts/*.md`), placeholders de template nao preenchidos (tokens entre
+  colchetes copiados literalmente dos templates da skill `plan`, ex.:
+  `[FEATURE]`, `[Topico]`, `[Endpoint/Command/Event]`), reportando com
+  severidade erro.
+- **FR-010**: O sistema MUST validar que toda entrada em `contracts/*.md`
+  esta rotulada de forma inequivoca como contrato real (extraido de fonte
+  verificavel) ou como proposta ainda nao validada (convencao
+  `[PROPOSTA — a validar na implementacao]` ja usada por `plan`); ausencia
+  de rotulagem clara MUST ser reportada com severidade erro — aplica o
+  Principio VI (Veracidade de Dados) do toolkit ao artefato de contrato.
+- **FR-011**: O sistema MUST validar que `plan.md` nao contem marcadores
+  `[NEEDS CLARIFICATION]` residuais (devem ter sido resolvidos no Phase 0,
+  conforme `plan`); presenca MUST ser reportada com severidade erro.
+- **FR-012**: O sistema MUST validar que referencias a `FR-`/`SC-` citadas
+  em `plan.md` correspondem a IDs de fato presentes na `spec.md` da mesma
+  feature; citacao de um ID inexistente MUST ser reportada com severidade
+  erro. Este check e de integridade referencial de UM documento (mesmo
+  espirito da checagem "Dependencias devem referenciar UCs existentes" que
+  o perfil UC ja aplica hoje) — nao substitui a analise de cobertura
+  cross-artifact que `analyze` realiza.
+- **FR-013**: O sistema MUST NOT verificar, no plan-profile, se um link
+  interno entre artefatos da familia `/plan` resolve no disco (arquivo
+  apontado existe, anchor corresponde a um header) — essa checagem
+  permanece 100% de responsabilidade de `validate-docs-rendered` (secao
+  2.2 "Links internos" do seu SKILL.md). A unica checagem de referencia
+  cruzada do plan-profile e semantica: validar que IDs `FR-`/`SC-` citados
+  em `plan.md` existem na `spec.md` correspondente (ver FR-012) — nao
+  resolucao de path/anchor no disco (ver Clarifications, 2026-07-10).
+
+#### Acionamento e deteccao de perfil (US3)
+
+- **FR-014**: O sistema MUST oferecer uma forma de o operador/orquestrador
+  selecionar explicitamente qual perfil aplicar (spec-profile ou
+  plan-profile), adicionalmente aos perfis UC e `--runbook` ja existentes.
+- **FR-015**: O sistema MUST reconhecer automaticamente o perfil aplicavel
+  quando o caminho do artefato segue a convencao padrao do pipeline SDD
+  deste toolkit (`docs/specs/<feature>/spec.md` para spec-profile;
+  `docs/specs/<feature>/{plan,research,data-model,quickstart}.md` ou
+  `docs/specs/<feature>/contracts/*.md` para plan-profile), sem exigir
+  selecao explicita nesses casos.
+- **FR-016**: Quando um artefato nao casa nenhuma convencao reconhecida
+  (nem UC, nem runbook, nem spec-profile, nem plan-profile) e nenhuma
+  selecao explicita de perfil foi informada, o sistema MUST reportar que o
+  perfil nao pode ser determinado, em vez de aplicar silenciosamente um
+  perfil default incorreto.
+
+#### Severidade e nao-duplicacao (transversal)
+
+- **FR-017**: Todo achado dos perfis spec-profile e plan-profile MUST ser
+  classificado usando o mesmo modelo de severidade ja existente na skill
+  (Erro bloqueia aprovacao / Aviso recomenda correcao / Info e sugestao
+  opcional) — o sistema MUST NOT introduzir uma taxonomia de severidade
+  divergente.
+- **FR-018**: Os perfis spec-profile e plan-profile MUST NOT reimplementar
+  checagens ja de responsabilidade de `analyze` (consistencia cross-artifact
+  profunda: duplicacao de requisitos, gaps de cobertura entre spec/tasks,
+  drift de terminologia, alinhamento com constitution) nem de
+  `validate-docs-rendered` (validacao de renderizacao: sintaxe Mermaid,
+  parse de frontmatter YAML, resolucao de links internos no disco —
+  arquivo apontado existe e anchor corresponde a header — e validade de
+  anchors) — o escopo dos dois novos perfis MUST se limitar a qualidade
+  estrutural de UM artefato isolado, no mesmo espirito dos perfis UC e
+  `--runbook` ja existentes. Fronteira explicita para o caso de referencia
+  cruzada de IDs: FR-012/FR-013 cobrem apenas se um ID `FR-`/`SC-` citado
+  existe na spec (checagem semantica, dono: plan-profile); se um path de
+  arquivo/anchor citado resolve no disco e checagem de renderizacao (dono:
+  `validate-docs-rendered`, secao 2.2).
+
+### Key Entities
+
+- **SddSpecArtifact**: um `spec.md` gerado pela skill `specify`, validado
+  pelo spec-profile — extensao do escopo hoje limitado a UC/runbook.
+- **SddPlanArtifact**: qualquer artefato da familia gerada pela skill
+  `plan` (`plan.md`, `research.md`, `data-model.md`, `quickstart.md`,
+  `contracts/*.md`), validado pelo plan-profile.
+- **SddValidationProfile**: o conjunto de checks aplicavel a um tipo de
+  artefato — extensao do modelo ja existente (perfil UC e perfil
+  `--runbook`) para incluir spec-profile e plan-profile.
+- **ValidationFinding**: um achado individual produzido por um check,
+  com severidade (erro/aviso/info) e localizacao — reaproveita o formato de
+  relatorio ja existente na skill.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: O spec-profile cobre as 3 secoes obrigatorias de um `spec.md`
+  em 100% das execucoes, sem falso-negativo para artefato com secao
+  obrigatoria ausente, em um conjunto de teste controlado.
+- **SC-002**: O spec-profile detecta 100% dos 6 anti-padroes catalogados em
+  `specify` (`examples/spec-bad.md`) que sao estruturalmente detectaveis
+  (implementacao vazando na spec, success criteria com jargao tecnico,
+  stories acopladas, adjetivos vagos, excesso de
+  `[NEEDS CLARIFICATION]`, secoes vazias com N/A), em um conjunto de teste
+  controlado construido a partir desses exemplos.
+- **SC-003**: O plan-profile cobre as 4 secoes obrigatorias de um `plan.md`
+  em 100% das execucoes, sem falso-negativo, em um conjunto de teste
+  controlado.
+- **SC-004**: O plan-profile detecta 100% das entradas de `contracts/*.md`
+  sem rotulagem explicita real-vs-proposto, em um conjunto de teste
+  controlado.
+- **SC-005**: Para qualquer execucao dos dois novos perfis, zero achados tem
+  categoria que se sobreponha a uma categoria ja coberta por `analyze` ou
+  `validate-docs-rendered` — verificado por checklist documentado de
+  fronteira de responsabilidade entre as tres skills.
+- **SC-006**: Apos a adocao desta feature, os orquestradores
+  `agente-00c`/`feature-00c` deixam de depender de grep ad-hoc para checar
+  a qualidade estrutural de `spec.md`/artefatos de `plan` — 100% dos pontos
+  onde essa checagem ad-hoc ocorre hoje passam a invocar um dos dois novos
+  perfis dentro de um ciclo de release do toolkit.
+
+## Out of Scope
+
+- Deteccao de drift de convencao de case (`snake_case` vs `camelCase`)
+  entre camadas — ja coberta pelo Pass G ("Convencoes de Borda") de
+  `analyze`.
+- Validacao de sintaxe Mermaid, parse de frontmatter YAML, resolucao de
+  links internos no disco (arquivo apontado existe) ou validade de anchors
+  de renderizacao — permanece 100% com `validate-docs-rendered` (ver
+  Clarifications, 2026-07-10, para a resolucao de FR-013).
+- Analise de cobertura cross-artifact profunda (mapeamento tasks vs
+  requisitos, duplicacao de requisitos, gaps, drift de terminologia entre
+  spec/tasks/constitution) — permanece 100% com `analyze`.
+- Escolha de implementacao (script dedicado em `scripts/` vs. checklist
+  guiado por prosa, como os perfis UC/`--runbook` ja fazem hoje) — decisao
+  de `/plan`.
+- Nomeacao exata de flags/opcoes de acionamento explicito — decisao de
+  `/plan`.
+- Mudanca nos perfis UC e `--runbook` ja existentes — permanecem
+  inalterados; esta feature apenas adiciona dois perfis novos.
+
+## Dependencies & Assumptions
+
+- **Depende de** a infraestrutura de relatorio e o modelo de severidade
+  (Erro/Aviso/Info) ja existentes em `validate-documentation` — os dois
+  perfis novos reutilizam esse formato, nao criam um paralelo.
+- **Depende de** os criterios de qualidade ja documentados na prosa de
+  `specify` (`SKILL.md` + `examples/spec-bad.md`) e `plan` (`SKILL.md` +
+  `templates/*.md`) como fonte dos checks — esta feature nao inventa novos
+  criterios de qualidade, apenas os torna nativamente verificaveis via
+  `validate-documentation`.
+- **Assume** que `analyze` permanece responsavel por consistencia
+  cross-artifact profunda e `validate-docs-rendered` permanece responsavel
+  por checks de renderizacao — os dois perfis novos NAO assumem nenhuma
+  dessas responsabilidades (ver FR-018 e Out of Scope).
+- **Assume** que a convencao de diretorio `docs/specs/<feature>/{spec.md,
+  plan.md,research.md,data-model.md,quickstart.md,contracts/}` (ja em uso
+  neste projeto, ex.: `docs/specs/enforced-guards/`) e estavel o bastante
+  para servir de base a deteccao automatica de perfil (US3/FR-015). Se essa
+  convencao mudar, a deteccao automatica precisa ser revisada.

--- a/docs/specs/validate-docs-sdd-profile/tasks.md
+++ b/docs/specs/validate-docs-sdd-profile/tasks.md
@@ -1,0 +1,209 @@
+# Tarefas cstk - validate-docs-sdd-profile
+
+Escopo: Adicionar dois novos perfis nativos a skill `validate-documentation`
+— **spec-profile** (valida `spec.md` contra os criterios ja documentados em
+`specify`) e **plan-profile** (valida `plan.md`/`research.md`/`data-model.md`/
+`quickstart.md`/`contracts/*.md` contra os criterios ja documentados em
+`plan`) — via um novo motor POSIX `scripts/validate-sdd.sh` + prosa no
+`SKILL.md`, acionados por flags explicitas (`--sdd-spec`/`--sdd-plan`) ou por
+deteccao automatica de path (`docs/specs/<feature>/...`). Deriva de
+[spec.md](./spec.md) + [plan.md](./plan.md) + [contracts/validate-sdd-cli.md](./contracts/validate-sdd-cli.md);
+consome gaps de [checklists/requirements.md](./checklists/requirements.md).
+
+**Ordem de entrega** (decisao, nao bloqueio — Ref: checklists/requirements.md
+CHK026): FASE 1 (US1/spec-profile, P1) → FASE 2 (US2/plan-profile, P2) →
+FASE 3 (prosa SKILL.md + fronteira, transversal) → FASE 4 (testes). A spec
+justifica P1 antes de P2 por "MVP mais frequente primeiro" (spec.md §User
+Story 1 "Why this priority"); nenhum sinal em contrario nos artefatos.
+
+**Legenda de status:**
+- `[ ]` Pendente
+- `[~]` Em andamento
+- `[x]` Concluido
+- `[!]` Bloqueado
+
+**Legenda de criticidade:**
+- `[C]` Critico - Impacto financeiro direto, regulatorio ou de seguranca
+- `[A]` Alto - Funcionalidade essencial (sem ela o perfil nao opera)
+- `[M]` Medio - Necessario mas sem urgencia imediata (prosa/documentacao/afinamento)
+
+---
+
+## FASE 1 - Motor spec-profile (US1, P1)
+
+### 1.1 Scaffolding do motor CLI (arg parsing, selecao de perfil, formato de saida) `[A]`
+
+Ref: contracts/validate-sdd-cli.md (Command `validate-sdd.sh`, Invocacao,
+Saida, Exit codes); plan.md §Project Structure; research.md Decision 1/2/3.
+
+- [x] 1.1.1 Criar `global/skills/validate-documentation/scripts/validate-sdd.sh` (shebang `#!/bin/sh`, `set -eu`; skill ainda nao tem diretorio `scripts/` — verificado em research.md Decision 1)
+- [x] 1.1.2 Implementar parsing de argumentos: `FILE` posicional obrigatorio, `--sdd-spec`, `--sdd-plan`, `--spec SPEC_MD`; `--sdd-spec`/`--sdd-plan` mutuamente exclusivas → exit 2 (uso incorreto)
+- [x] 1.1.3 Implementar precedencia de selecao de perfil (FR-014/FR-015/FR-016): (1) flag explicita vence tudo; (2) deteccao automatica por convencao `docs/specs/<feature>/spec.md` → spec-profile; (3) sem flag e fora da convencao → perfil indeterminado, mensagem clara em stderr, exit 2
+- [x] 1.1.4 Implementar emissor de saida machine-readable: uma linha `FINDING|<severity>|<code>|<mensagem>` por achado + linha `RESULT|<file>|profile=<spec|plan>|errors=<N>|warnings=<M>` sempre emitida (mesmo com 0 achados) — contracts/validate-sdd-cli.md §Saida
+- [x] 1.1.5 Implementar exit codes conforme severidade (FR-017, research.md Decision 3): `0` = zero achados `error` (avisos/infos nao bloqueiam); `1` = >=1 achado `error`; `2` = uso incorreto/arquivo inexistente/flags conflitantes/perfil indeterminado
+- [x] 1.1.6 Subtarefa de teste (placeholder ate FASE 4 consolidar o arquivo): cobrir Cenario 11 (perfil indeterminado, exit 2) e Cenario 12 (deteccao automatica sem flag) do quickstart.md em `tests/test_validate-sdd.sh`
+
+### 1.2 Checks estruturais do spec-profile `[A]`
+
+Ref: spec.md FR-001/FR-004; contracts/validate-sdd-cli.md §Catalogo spec-profile.
+
+- [x] 1.2.1 `missing-section` (error, FR-001): validar presenca das 3 secoes obrigatorias de `spec.md` (`User Scenarios & Testing`, `Requirements`, `Success Criteria`)
+- [x] 1.2.2 `too-many-clarifications` (error, FR-004): contar marcadores `[NEEDS CLARIFICATION]` no documento; > 3 reporta erro citando contagem e limite
+- [x] 1.2.3 `duplicate-id` (error): detectar ID `FR-`/`SC-` repetido no mesmo documento — **Ref: checklists/requirements.md CHK004/CHK013 [Gap] resolvido**: nao ha FR proprio no spec.md desta feature; a origem e legitima e reusa a convencao ja aplicada ao perfil UC existente, documentada em `global/skills/validate-documentation/SKILL.md:267` ("IDs duplicados dentro do mesmo documento sao erro, nao aviso") — citar essa linha como fonte no comentario do check, nao criar FR fantasma
+- [x] 1.2.4 Subtarefa de teste: Cenarios 1 (conformante), 2 (secao ausente), 4 (>3 clarifications), 5 (ID duplicado) do quickstart.md em `tests/test_validate-sdd.sh`
+
+### 1.3 Checks de conteudo heuristicos do spec-profile `[M]`
+
+Ref: spec.md FR-002/FR-003/FR-005/FR-006/FR-007; research.md Decision 6.
+
+- [x] 1.3.1 `impl-detail-in-spec` (error, FR-002): wordlist de termos de linguagem/framework/biblioteca/API especifica no corpo da spec
+- [x] 1.3.2 `sc-not-measurable` (error, FR-003): Success Criterion sem metrica quantificavel (regex de percentual/tempo/contagem/taxa) OU com jargao tecnico de implementacao
+- [x] 1.3.3 `na-placeholder-section` (warning, FR-005): secao deixada com placeholder `N/A` em vez de removida
+- [x] 1.3.4 `vague-adjective` (warning, FR-006): adjetivo vago sem quantificacao em Requirements/Success Criteria (ex.: "rapido", "simples", "robusto")
+- [x] 1.3.5 `coupled-user-story` (warning, FR-007): user story que depende de outra para ser testada isoladamente
+- [x] 1.3.6 Calibrar a wordlist/regex dos checks 1.3.1-1.3.5 contra os 6 exemplos de `specify/examples/spec-bad.md` ate atingir SC-002 (100% dos 6 anti-padroes estruturalmente detectaveis)
+- [x] 1.3.7 Subtarefa de teste: Cenario 3 (termo de stack em SC) e Cenario 6 (avisos nao bloqueiam — `errors=0`, exit 0) do quickstart.md em `tests/test_validate-sdd.sh`
+
+---
+
+## FASE 2 - Motor plan-profile (US2, P2)
+
+### 2.1 Selecao de perfil e checks estruturais do plan-profile `[A]`
+
+Ref: spec.md FR-008/FR-009/FR-011/FR-015; contracts/validate-sdd-cli.md §Catalogo plan-profile.
+
+- [x] 2.1.1 Estender a deteccao automatica de path (1.1.3) para a familia `/plan`: `plan.md`, `research.md`, `data-model.md`, `quickstart.md`, `contracts/*.md` → plan-profile (FR-015)
+- [x] 2.1.2 `missing-section` (error, FR-008): validar presenca das 4 secoes obrigatorias de `plan.md` (`Summary`, `Technical Context`, `Constitution Check`, `Project Structure`)
+- [x] 2.1.3 `template-placeholder` (error, FR-009): detectar tokens de template nao preenchidos em qualquer artefato `/plan` (ex.: `[FEATURE]`, `[Topico]`, `[Endpoint/Command/Event]`, `[DATE]`, `[short-name]`)
+- [x] 2.1.4 `residual-clarification` (error, FR-011): `[NEEDS CLARIFICATION]` remanescente em `plan.md`
+- [x] 2.1.5 Subtarefa de teste: Cenario 7 (plan.md conformante) e Cenario 8 (placeholder residual) do quickstart.md em `tests/test_validate-sdd.sh`
+
+### 2.2 Rotulagem real-vs-proposto e referencia cruzada semantica `[A]`
+
+Ref: spec.md FR-010/FR-012/FR-013 (resolvido em clarify, dec-004); Principio VI.
+
+- [x] 2.2.1 `unlabeled-contract` (error, FR-010): exigir rotulo inequivoco real-vs-proposto em toda entrada de `contracts/*.md` (`[PROPOSTA — a validar na implementacao]` ou marcacao equivalente de contrato real) — aplica o Principio VI ao artefato de contrato
+- [x] 2.2.2 `dangling-fr-sc-ref` (error, FR-012): extrair IDs `FR-`/`SC-` citados em `plan.md` e validar que existem na `spec.md` correspondente (resolvida via `--spec` explicito ou default de convencao — ver 2.3)
+- [x] 2.2.3 Garantir explicitamente (assert negativo) que NENHUM check do plan-profile resolve path/anchor no disco — fronteira FR-013 com `validate-docs-rendered` §2.2, ja resolvida na fase clarify (dec-004): a unica checagem de referencia cruzada e semantica (existencia do ID na spec), nunca resolucao de link/anchor
+- [x] 2.2.4 Subtarefa de teste: Cenario 9 (FR-099 inexistente, incluindo o "Nao-Expected" — nenhum achado de link/anchor quebrado) e Cenario 10 (contrato sem rotulo) do quickstart.md em `tests/test_validate-sdd.sh`
+
+### 2.3 Resolucao do default de `--spec` fora da convencao `docs/specs/<feature>/` `[M]`
+
+Ref: checklists/requirements.md CHK014 [Ambiguity]; contracts/validate-sdd-cli.md §Argumentos.
+
+- [x] 2.3.1 Confirmar/implementar que a flag EXPLICITA `--spec SPEC_MD` aceita qualquer path (inclusive fixtures de teste fora de `docs/specs/`) — a restricao a convencao `docs/specs/<feature>/spec.md` se aplica SOMENTE ao default automatico (quando `--spec` nao e informado), nunca a flag explicita
+- [x] 2.3.2 Documentar essa distincao (flag explicita vs default automatico) em `contracts/validate-sdd-cli.md` (nota inline na tabela de argumentos) e no `SKILL.md`
+- [x] 2.3.3 Subtarefa de teste: fixture local em `tests/fixtures/validate-sdd/` (fora de `docs/specs/`) exercitada via `--spec` explicito, confirmando que `dangling-fr-sc-ref` funciona sem depender da convencao de diretorio
+
+---
+
+## FASE 3 - Prosa SKILL.md e fronteira de nao-duplicacao (transversal)
+
+### 3.1 Documentar spec-profile e plan-profile no SKILL.md `[M]`
+
+Ref: plan.md §Summary; global/skills/validate-documentation/SKILL.md (secoes existentes de perfil UC e `--runbook`).
+
+- [x] 3.1.1 Adicionar secao "Perfil `spec-profile`" (mesmo padrao da secao `--runbook` existente): quando usar, acionamento (`--sdd-spec` + auto-deteccao), catalogo de findings com severidade
+- [x] 3.1.2 Adicionar secao "Perfil `plan-profile`": idem, cobrindo `--sdd-plan` + auto-deteccao + `--spec`
+- [x] 3.1.3 Documentar a precedencia de selecao de perfil (flag explicita > auto-deteccao por path > indeterminado) com exemplos de invocacao (espelhando os 3 exemplos de `contracts/validate-sdd-cli.md` §Exemplos de saida)
+- [x] 3.1.4 Rodar o gate `docs-render` (skill `validate-docs-rendered`) sobre o `SKILL.md` atualizado, confirmando frontmatter/links/code-blocks sem regressao de render
+
+### 3.2 Documentar §Fronteira explicita com `analyze` e `validate-docs-rendered` `[M]`
+
+Ref: plan.md §Fronteira de responsabilidade (SC-005); research.md Decision 4; spec.md FR-018/Out of Scope.
+
+- [x] 3.2.1 Reproduzir no `SKILL.md` a tabela de fronteira "categoria de check → dono" de `plan.md` (8 categorias: secoes obrigatorias, anti-padroes de conteudo, placeholder/rotulo/clarification residual, referencia semantica de ID, link/anchor no disco, Mermaid/frontmatter/code-block, cobertura cross-artifact, drift de case-convention)
+- [x] 3.2.2 Adicionar Gotcha explicito no `SKILL.md`: "o check `duplicate-id` do spec-profile reusa a convencao de ID duplicado ja aplicada ao perfil UC (`SKILL.md:267`), nao introduz um FR novo" — fecha CHK004/CHK013 na documentacao publicada da skill
+- [x] 3.2.3 Cross-check textual (grep) confirmando que nenhum termo/categoria documentado como responsabilidade dos novos perfis se sobrepõe as categorias listadas como dono `analyze`/`validate-docs-rendered` na mesma tabela (SC-005)
+
+---
+
+## FASE 4 - Testes (`tests/test_validate-sdd.sh`)
+
+### 4.1 Fixtures de teste `[A]`
+
+Ref: research.md Decision 5; plan.md §Project Structure ("Testing").
+
+- [x] 4.1.1 Fixture "boa" spec-profile: apontar diretamente para `docs/specs/enforced-guards/spec.md` (artefato real e versionado, ja verificado por leitura conter as 3 secoes obrigatorias — research.md Decision 5)
+- [x] 4.1.2 Fixture "boa" plan-profile: apontar para `docs/specs/enforced-guards/{plan.md,research.md,data-model.md,quickstart.md,contracts/}` (ja verificado conter as 4 secoes obrigatorias)
+- [x] 4.1.3 Fixtures "ruins" (heredoc inline ou arquivos sob `tests/fixtures/validate-sdd/`), uma quebra por cenario: secao obrigatoria removida, termo de stack injetado em SC, 4o `[NEEDS CLARIFICATION]`, ID `FR-001` duplicado, `N/A` residual + adjetivo vago, placeholder `[FEATURE]` residual, citacao `FR-099` inexistente, entrada de contrato sem rotulo real-vs-proposto
+- [x] 4.1.4 Fixture fora da convencao `docs/specs/` para exercitar CHK014/`--spec` explicito (consumida por 2.3.3) e o Cenario 11 (perfil indeterminado)
+
+### 4.2 Criar `tests/test_validate-sdd.sh` cobrindo os 12 cenarios do quickstart `[A]`
+
+Ref: quickstart.md Cenarios 1-12; CLAUDE.md "Como testar scripts shell" ("Regra de
+ouro": todo `.sh` novo em `global/skills/*/scripts/` exige `tests/test_<nome>.sh`);
+`./tests/run.sh --check-coverage`.
+
+- [x] 4.2.1 Cenario 1 — spec.md conformante: zero `FINDING|error`, `RESULT|...|profile=spec|errors=0|warnings=0`, exit 0
+- [x] 4.2.2 Cenario 2 — secao obrigatoria ausente: `FINDING|error|missing-section|...`, exit 1
+- [x] 4.2.3 Cenario 3 — termo de stack em Success Criteria: `sc-not-measurable` e/ou `impl-detail-in-spec`, exit 1
+- [x] 4.2.4 Cenario 4 — 4o `[NEEDS CLARIFICATION]`: `too-many-clarifications` citando contagem=4/limite=3, exit 1
+- [x] 4.2.5 Cenario 5 — ID duplicado: `duplicate-id` citando o ID repetido, exit 1
+- [x] 4.2.6 Cenario 6 — avisos nao bloqueiam: `na-placeholder-section` + `vague-adjective` como `warning`, `errors=0`, exit 0
+- [x] 4.2.7 Cenario 7 — plan.md conformante: zero `FINDING|error`, `RESULT|...|profile=plan|errors=0|warnings=0`, exit 0
+- [x] 4.2.8 Cenario 8 — placeholder de template residual: `template-placeholder`, exit 1
+- [x] 4.2.9 Cenario 9 — `FR-099` inexistente na spec: `dangling-fr-sc-ref` + assert negativo (nenhum achado de link/anchor quebrado), exit 1
+- [x] 4.2.10 Cenario 10 — contrato sem rotulo real-vs-proposto: `unlabeled-contract`, exit 1
+- [x] 4.2.11 Cenario 11 — perfil indeterminado fora da convencao: mensagem clara em stderr, exit 2, nenhum perfil aplicado
+- [x] 4.2.12 Cenario 12 — deteccao automatica por path (spec e plan, sem flag): `profile=spec`/`profile=plan` corretos
+- [x] 4.2.13 Rodar `./tests/run.sh --check-coverage` confirmando que `test_validate-sdd.sh` cobre `validate-sdd.sh` (gate de cobertura da convencao)
+
+### 4.3 Gate de validacao cruzada `[M]`
+
+Ref: CLAUDE.md "Como testar scripts shell"; tests/README.md.
+
+- [x] 4.3.1 Rodar `./tests/run.sh validate-sdd` (filtro isolado) confirmando a suite nova 100% verde
+- [x] 4.3.2 Rodar `./tests/run.sh` completo (suite ~1100 cenarios) confirmando zero regressao introduzida <!-- PASS 1495/0/0 validado pelo command pai -->
+
+- [x] 4.3.3 Rodar `shellcheck` (advisory, `.shellcheckrc` do projeto) sobre `validate-sdd.sh` e corrigir achados nao-suprimidos
+
+---
+
+## Matriz de Dependencias
+
+```mermaid
+flowchart TD
+    F1[FASE 1 - Motor spec-profile]
+    F2[FASE 2 - Motor plan-profile]
+    F3[FASE 3 - Prosa SKILL.md + fronteira]
+    F4[FASE 4 - Testes]
+
+    F1 --> F2
+    F1 --> F3
+    F2 --> F3
+    F2 --> F4
+    F3 --> F4
+```
+
+## Resumo Quantitativo
+
+| Fase | Tarefas | Subtarefas | Criticidade |
+|------|---------|------------|-------------|
+| 1 - Motor spec-profile | 3 | 17 | A/A/M |
+| 2 - Motor plan-profile | 3 | 12 | A/A/M |
+| 3 - Prosa SKILL.md + fronteira | 2 | 7 | M/M |
+| 4 - Testes | 3 | 20 | A/A/M |
+| **Total** | **11** | **56** | - |
+
+## Escopo Coberto
+
+| Item | Descricao | Fase |
+|------|-----------|------|
+| US1 | spec-profile: 3 secoes obrigatorias + 6 anti-padroes de `spec-bad.md` + `duplicate-id` (SKILL.md:267) | FASE 1 |
+| US2 | plan-profile: 4 secoes obrigatorias + placeholder de template + rotulo real-vs-proposto + `[NEEDS CLARIFICATION]` residual + `dangling-fr-sc-ref` | FASE 2 |
+| US3 | Deteccao automatica de perfil por convencao de path + flags explicitas `--sdd-spec`/`--sdd-plan` (com fail-safe "indeterminado") | FASE 1 + FASE 2 |
+| CHK004/CHK013 | `duplicate-id` sem FR proprio, rastreado a `SKILL.md:267` | FASE 1 (1.2.3) |
+| CHK014 | Default de `--spec` para fixtures fora da convencao `docs/specs/` | FASE 2 (2.3) |
+| SC-005 | Fronteira de nao-duplicacao com `analyze`/`validate-docs-rendered` documentada e testavel | FASE 3 + FASE 2 (2.2.3/2.2.4) |
+| SC-001..004 | Cobertura, deteccao de anti-padroes, secoes de plan e rotulagem de contrato — verificadas empiricamente | FASE 4 |
+
+## Escopo Excluido
+
+| Item | Descricao | Motivo |
+|------|-----------|--------|
+| Resolucao de link/anchor no disco | Arquivo apontado existe / anchor casa header | Permanece 100% de `validate-docs-rendered` §2.2 (FR-013/FR-018) |
+| Sintaxe Mermaid / frontmatter YAML / code-block sem linguagem | Validacao de renderizacao | Permanece 100% de `validate-docs-rendered` (FR-018) |
+| Cobertura cross-artifact profunda (tasks vs requisitos, duplicacao, gaps, drift de terminologia) | Consistencia entre multiplos artefatos | Permanece 100% de `analyze` (FR-018/Out of Scope) |
+| Drift de convencao de case (`snake_case` vs `camelCase`) entre camadas | Convencoes de borda | Coberto pelo Pass G de `analyze` (Out of Scope) |
+| Alteracao dos perfis UC e `--runbook` existentes | Perfis ja em producao na skill | Permanecem inalterados — esta feature so adiciona 2 perfis novos (Out of Scope) |

--- a/global/skills/validate-documentation/SKILL.md
+++ b/global/skills/validate-documentation/SKILL.md
@@ -180,6 +180,16 @@ Valide e corrija os problemas encontrados em UC-CAD-001.md
 Valide o runbook RB-001-restore-drill.md com perfil --runbook
 ```
 
+**Validar spec.md de uma feature SDD (perfil spec-profile):**
+```
+global/skills/validate-documentation/scripts/validate-sdd.sh docs/specs/minha-feature/spec.md
+```
+
+**Validar plan.md de uma feature SDD (perfil plan-profile, com referencia cruzada de IDs):**
+```
+global/skills/validate-documentation/scripts/validate-sdd.sh docs/specs/minha-feature/plan.md --spec docs/specs/minha-feature/spec.md
+```
+
 ---
 
 ## Perfil `--runbook` (RB-NNN)
@@ -254,6 +264,121 @@ sob pressao. Placeholder = pessoa errada lendo o passo errado em
 
 ---
 
+## Perfil `spec-profile` (SDD)
+
+Valida `spec.md` de uma feature SDD (`docs/specs/<feature>/spec.md`)
+contra os criterios ja documentados na skill `specify`. Motor
+deterministico: `global/skills/validate-documentation/scripts/validate-sdd.sh`
+(POSIX sh, mesmo padrao de `create-tasks/scripts/validate-tasks-template.sh`
+e `validate-docs-rendered/scripts/validate.sh`).
+
+**Quando usar**: apos `specify` (ou apos `clarify`), antes de avancar para
+`plan` — gate de qualidade da spec antes de investir em desenho tecnico.
+
+**Acionamento**: flag `--sdd-spec` (forca o perfil, ignora deteccao por
+path) OU deteccao automatica quando `FILE` casa a convencao
+`docs/specs/<feature>/spec.md`.
+
+### Catalogo de findings (spec-profile)
+
+| code | severidade | Condicao |
+|------|------------|----------|
+| `missing-section` | Erro | Falta uma das 3 secoes obrigatorias (`User Scenarios & Testing`, `Requirements`, `Success Criteria`). |
+| `impl-detail-in-spec` | Erro | Termo de stack/linguagem/framework/lib especifica no corpo da spec (ex.: `bcrypt`, `PostgreSQL`, `React`). |
+| `sc-not-measurable` | Erro | Success Criterion sem metrica quantificavel OU com jargao tecnico (ex.: `API`, `TPS`, `paint time`). |
+| `too-many-clarifications` | Erro | Mais de 3 marcadores `[NEEDS CLARIFICATION]` no total. |
+| `duplicate-id` | Erro | ID `FR-`/`SC-` repetido no mesmo documento (reusa a convencao do Gotcha abaixo). |
+| `na-placeholder-section` | Aviso | Secao deixada com placeholder `N/A` em vez de removida. |
+| `vague-adjective` | Aviso | Adjetivo vago sem quantificacao em Requirements/Success Criteria (ex.: "MUST be fast", "deve ser robusto"). |
+| `coupled-user-story` | Aviso | User story que depende de outra para ser testada isoladamente. |
+
+Wordlists/regex de `impl-detail-in-spec`/`sc-not-measurable`/`vague-adjective`
+sao calibradas contra os 6 anti-padroes de `specify/examples/spec-bad.md`
+(deliberadamente restritas a termos concretos de stack — nao termos
+genericos de dominio como "API"/"CLI"/"JSON" que aparecem legitimamente em
+specs de ferramentas de dev, o que geraria falso-positivo).
+
+## Perfil `plan-profile` (SDD)
+
+Valida os artefatos de `/plan` de uma feature SDD — `plan.md`,
+`research.md`, `data-model.md`, `quickstart.md`, `contracts/*.md` — contra
+os criterios ja documentados na skill `plan`. Mesmo motor
+`scripts/validate-sdd.sh`.
+
+**Quando usar**: apos `plan`, antes de `checklist`/`create-tasks` — gate de
+qualidade do desenho tecnico.
+
+**Acionamento**: flag `--sdd-plan` OU deteccao automatica quando `FILE`
+casa `docs/specs/<feature>/{plan,research,data-model,quickstart}.md` ou
+`docs/specs/<feature>/contracts/*.md`.
+
+**Flag `--spec SPEC_MD`**: caminho explicito da `spec.md` correspondente,
+usado pelo check `dangling-fr-sc-ref`. Default: `<dir-de-FILE>/spec.md`
+resolvido pela convencao `docs/specs/<feature>/` — **so quando `FILE`
+segue essa convencao**. A flag explicita `--spec` aceita QUALQUER path
+(inclusive fixtures de teste fora de `docs/specs/`); a restricao de
+convencao se aplica somente ao default automatico.
+
+### Catalogo de findings (plan-profile)
+
+| code | severidade | Escopo | Condicao |
+|------|------------|--------|----------|
+| `missing-section` | Erro | `plan.md` | Falta uma das 4 secoes obrigatorias (`Summary`, `Technical Context`, `Constitution Check`, `Project Structure`). |
+| `template-placeholder` | Erro | qualquer artefato `/plan` | Token de template nao preenchido (`[FEATURE]`, `[DATE]`, `[short-name]`, `[Topico]`, `[Endpoint/Command/Event]`). |
+| `unlabeled-contract` | Erro | `contracts/*.md` | Entrada que documenta um Command/Endpoint/Event sem rotulo inequivoco real-vs-proposto (`[PROPOSTA — a validar na implementacao]` ou `[EXISTENTE]`). |
+| `residual-clarification` | Erro | `plan.md` | `[NEEDS CLARIFICATION]` remanescente. |
+| `dangling-fr-sc-ref` | Erro | `plan.md` | ID `FR-`/`SC-` citado que NAO existe na `spec.md` correspondente — checagem SEMANTICA apenas, nunca resolucao de link/anchor no disco. |
+
+### Precedencia de selecao de perfil
+
+1. **Flag explicita** (`--sdd-spec`/`--sdd-plan`/`--runbook`) vence tudo.
+2. **Deteccao automatica por path**: `UC-*.md` → perfil UC; `RB-\d{3}-*.md`
+   → `--runbook`; `docs/specs/<feature>/spec.md` → spec-profile;
+   `docs/specs/<feature>/{plan,research,data-model,quickstart}.md` ou
+   `docs/specs/<feature>/contracts/*.md` → plan-profile.
+3. **Nem flag nem convencao reconhecida** → perfil indeterminado, mensagem
+   clara em stderr, exit 2 — NUNCA aplica um perfil por engano.
+
+Exemplos (espelham `contracts/validate-sdd-cli.md` §Exemplos de saida):
+
+```console
+$ validate-sdd.sh docs/specs/enforced-guards/spec.md
+RESULT|docs/specs/enforced-guards/spec.md|profile=spec|errors=0|warnings=0
+# exit 0
+
+$ validate-sdd.sh docs/specs/x/plan.md
+FINDING|error|template-placeholder|Token de template nao preenchido: [FEATURE]
+FINDING|error|dangling-fr-sc-ref|plan.md cita FR-099, ausente na spec.md correspondente
+RESULT|docs/specs/x/plan.md|profile=plan|errors=2|warnings=0
+# exit 1
+
+$ validate-sdd.sh /tmp/qualquer/spec.md
+Perfil nao determinado para '/tmp/qualquer/spec.md': path fora da convencao docs/specs/<feature>/ e nenhuma flag informada. Use --sdd-spec ou --sdd-plan.
+# exit 2
+```
+
+## Fronteira de nao-duplicacao (`spec-profile`/`plan-profile` vs `analyze` vs `validate-docs-rendered`)
+
+Tres skills tocam artefatos SDD; cada categoria de check tem UM dono, sem
+sobreposicao (SC-005 da feature `validate-docs-sdd-profile`):
+
+| Categoria de check | Dono | spec/plan-profile faz? |
+|--------------------|------|------------------------|
+| Secoes obrigatorias presentes num UNICO artefato | `validate-documentation` (spec/plan-profile) | SIM |
+| Anti-padroes de conteudo da spec (impl. vazando, SC nao-mensuravel, `[NEEDS CLARIFICATION]` > 3, stories acopladas, adjetivos vagos, N/A residual) | `validate-documentation` (spec-profile) | SIM |
+| Placeholder de template residual / rotulo real-vs-proposto / `[NEEDS CLARIFICATION]` residual no plan | `validate-documentation` (plan-profile) | SIM |
+| ID `FR-`/`SC-` citado em `plan.md` EXISTE na `spec.md` (checagem SEMANTICA) | `validate-documentation` (plan-profile) | SIM |
+| Link/anchor entre arquivos RESOLVE no disco (arquivo existe, header casa) | `validate-docs-rendered` | NAO |
+| Sintaxe Mermaid, frontmatter YAML, code-block sem linguagem | `validate-docs-rendered` | NAO |
+| Cobertura cross-artifact (tasks vs requisitos, duplicacao, gaps, drift de terminologia, alinhamento com constitution) | `analyze` | NAO |
+| Drift de case-convention entre camadas (snake vs camel) | `analyze` (Pass G) | NAO |
+
+A linha mais sutil e a de referencia cruzada de IDs: `plan-profile` faz
+APENAS a checagem semantica (o ID existe na spec?), NUNCA a resolucao de
+path/anchor no disco — essa fica 100% com `validate-docs-rendered`.
+
+---
+
 ## Gotchas
 
 ### Valida DOCUMENTO INDIVIDUAL, nao relacionamento entre artefatos
@@ -267,6 +392,15 @@ Um `sequenceDiagram` sem `participant` declarado, ou setas fora do padrao (`-->`
 ### IDs duplicados dentro do mesmo documento sao erro, nao aviso
 
 RN01 aparecendo duas vezes, ou CT03 com dois cenarios distintos, quebra rastreabilidade. Detectar e reportar como Erro, nao Aviso.
+
+### `duplicate-id` do spec-profile reusa esta convencao, nao inventa criterio novo
+
+O check `duplicate-id` de `spec-profile` (perfil SDD, acima) aplica a MESMA
+regra deste Gotcha a `FR-`/`SC-` em `spec.md` — nao ha FR proprio na spec
+da feature `validate-docs-sdd-profile` cobrindo esse check porque ele reusa
+uma convencao ja estabelecida aqui, e nao introduz criterio novo. Fecha
+CHK004/CHK013 (checklist da feature): a citacao a este Gotcha, e nao a um
+FR-NNN inexistente, e a rastreabilidade correta.
 
 ### Minimo 5 casos de teste (sucesso + erro + edge) — abaixo disso reprova
 

--- a/global/skills/validate-documentation/scripts/validate-sdd.sh
+++ b/global/skills/validate-documentation/scripts/validate-sdd.sh
@@ -1,0 +1,373 @@
+#!/bin/sh
+# validate-sdd.sh — motor deterministico dos perfis spec-profile e
+# plan-profile da skill validate-documentation.
+#
+# Ref: docs/specs/validate-docs-sdd-profile/contracts/validate-sdd-cli.md
+#      docs/specs/validate-docs-sdd-profile/quickstart.md (12 cenarios)
+#      docs/specs/validate-docs-sdd-profile/spec.md FR-001..FR-018
+#
+# Uso:
+#   validate-sdd.sh FILE [--sdd-spec | --sdd-plan] [--spec SPEC_MD]
+#
+#   --sdd-spec        Forca o spec-profile (ignora deteccao por path).
+#   --sdd-plan        Forca o plan-profile (ignora deteccao por path).
+#   --spec SPEC_MD    spec.md explicita para o check dangling-fr-sc-ref.
+#                      Default: <dir-de-FILE>/spec.md (convencao
+#                      docs/specs/<feature>/), so quando FILE segue essa
+#                      convencao.
+#
+# Selecao de perfil (precedencia — FR-014/FR-015/FR-016):
+#   1. Flag explicita --sdd-spec/--sdd-plan vence tudo.
+#   2. Deteccao automatica por convencao de path:
+#        */docs/specs/<feature>/spec.md                    -> spec-profile
+#        */docs/specs/<feature>/{plan,research,data-model,
+#          quickstart}.md ou .../contracts/*.md             -> plan-profile
+#   3. Nem flag nem convencao -> perfil indeterminado, exit 2.
+#
+# Saida (stdout), uma linha por achado + linha de resultado final:
+#   FINDING|<severity>|<code>|<mensagem>
+#   RESULT|<file>|profile=<spec|plan>|errors=<N>|warnings=<M>
+#   severity in {error, warning, info}
+#
+# Exit codes:
+#   0  zero achados de severidade error (avisos/infos nao bloqueiam)
+#   1  >=1 achado error
+#   2  uso incorreto / arquivo inexistente / flags conflitantes / perfil
+#      indeterminado
+#
+# POSIX sh puro (Constitution II) — sem bash-ismos, sem GNU-only.
+
+set -eu
+
+_VSDD_NAME="validate-sdd"
+
+usage() {
+  cat <<'USAGE' >&2
+Uso: validate-sdd.sh FILE [--sdd-spec | --sdd-plan] [--spec SPEC_MD]
+
+Valida FILE contra o spec-profile ou plan-profile da skill
+validate-documentation. Perfil resolvido por flag explicita ou por
+deteccao automatica de path (docs/specs/<feature>/...).
+
+Emite linhas FINDING|severity|code|msg e uma linha RESULT final.
+Exit: 0 conformante (so avisos/infos); 1 reprovado (>=1 erro);
+2 uso incorreto / arquivo ausente / perfil indeterminado.
+USAGE
+}
+
+FILE=""
+FORCE_SPEC=0
+FORCE_PLAN=0
+SPEC_MD_ARG=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sdd-spec)
+      FORCE_SPEC=1; shift ;;
+    --sdd-plan)
+      FORCE_PLAN=1; shift ;;
+    --spec)
+      [ $# -ge 2 ] || { usage; exit 2; }
+      SPEC_MD_ARG="$2"; shift 2 ;;
+    --spec=*)
+      SPEC_MD_ARG="${1#--spec=}"; shift ;;
+    -h|--help)
+      usage; exit 2 ;;
+    --*)
+      printf '%s: opcao desconhecida: %s\n' "$_VSDD_NAME" "$1" >&2
+      usage; exit 2 ;;
+    *)
+      if [ -z "$FILE" ]; then FILE="$1"; shift
+      else
+        printf '%s: argumento extra: %s\n' "$_VSDD_NAME" "$1" >&2
+        usage; exit 2
+      fi ;;
+  esac
+done
+
+if [ -z "$FILE" ]; then
+  usage; exit 2
+fi
+
+if [ "$FORCE_SPEC" -eq 1 ] && [ "$FORCE_PLAN" -eq 1 ]; then
+  printf '%s: --sdd-spec e --sdd-plan sao mutuamente exclusivas\n' "$_VSDD_NAME" >&2
+  exit 2
+fi
+
+if [ ! -f "$FILE" ]; then
+  printf '%s: arquivo nao encontrado: %s\n' "$_VSDD_NAME" "$FILE" >&2
+  exit 2
+fi
+
+# --- Selecao de perfil ---------------------------------------------------
+
+PROFILE=""
+
+# Prefixa com "./" quando FILE e relativo e ja comeca literalmente com
+# "docs/specs/..." — assim UM SO padrao ("*/docs/specs/...") cobre tanto o
+# path absoluto (/repo/docs/specs/...) quanto o relativo (que sem esse
+# prefixo nao teria "/" antes de "docs" e o glob "*/" nao bateria). Sempre
+# calculado (mesmo com flag explicita) porque a resolucao do --spec default
+# mais abaixo tambem depende dele.
+case "$FILE" in
+  docs/specs/*) _detect_path="./$FILE" ;;
+  *) _detect_path="$FILE" ;;
+esac
+
+if [ "$FORCE_SPEC" -eq 1 ]; then
+  PROFILE="spec"
+elif [ "$FORCE_PLAN" -eq 1 ]; then
+  PROFILE="plan"
+else
+  case "$_detect_path" in
+    */docs/specs/*/spec.md)
+      PROFILE="spec" ;;
+    */docs/specs/*/plan.md|*/docs/specs/*/research.md|*/docs/specs/*/data-model.md|*/docs/specs/*/quickstart.md)
+      PROFILE="plan" ;;
+    */docs/specs/*/contracts/*.md)
+      PROFILE="plan" ;;
+    *)
+      PROFILE="" ;;
+  esac
+fi
+
+if [ -z "$PROFILE" ]; then
+  printf "Perfil nao determinado para '%s': path fora da convencao docs/specs/<feature>/ e nenhuma flag informada. Use --sdd-spec ou --sdd-plan.\n" "$FILE" >&2
+  exit 2
+fi
+
+# --- Resolucao do --spec default (so quando FILE segue a convencao) -----
+# A flag explicita --spec aceita QUALQUER path (inclusive fixtures de
+# teste fora de docs/specs/) — a restricao de convencao aplica-se SOMENTE
+# ao default automatico (CHK014).
+
+SPEC_MD="$SPEC_MD_ARG"
+if [ -z "$SPEC_MD" ]; then
+  case "$_detect_path" in
+    */docs/specs/*/contracts/*.md)
+      _dir=$(dirname "$FILE")
+      _parent=$(dirname "$_dir")
+      SPEC_MD="$_parent/spec.md" ;;
+    */docs/specs/*/*.md)
+      _dir=$(dirname "$FILE")
+      SPEC_MD="$_dir/spec.md" ;;
+    *)
+      SPEC_MD="" ;;
+  esac
+fi
+
+# Buffer de findings em arquivo temporario, nao em contador de variavel de
+# shell. Alguns checks abaixo iteram matches via `printf ... | while read`,
+# e esse padrao roda o corpo do loop em SUBSHELL no POSIX sh — incrementos
+# em variavel global feitos de dentro do subshell somem quando ele termina
+# (mesma classe de bug documentada em validate-docs-rendered/validate.sh:
+# "padrao defeituoso HISTORICO"). Escrever em arquivo via `>>` e seguro
+# porque e I/O real, nao estado de variavel — sobrevive ao fim do subshell.
+FINDINGS_TMP=$(mktemp)
+trap 'rm -f "$FINDINGS_TMP"' EXIT
+
+emit() { # emit SEVERITY CODE MSG
+  printf 'FINDING|%s|%s|%s\n' "$1" "$2" "$3" >> "$FINDINGS_TMP"
+}
+
+has_section() { # has_section HEADER_TEXT
+  grep -qE "^##[[:space:]]+${1}[[:space:]]*\$" "$FILE" 2>/dev/null
+}
+
+count_matches() { # count_matches REGEX -> stdout N (0 se nenhuma)
+  _n=$(grep -cE "$1" "$FILE" 2>/dev/null) || _n=0
+  printf '%s' "$_n"
+}
+
+# ==========================================================================
+# spec-profile (US1) — FR-001..FR-007 + duplicate-id (Gotcha "IDs
+# duplicados dentro do mesmo documento sao erro, nao aviso" do SKILL.md)
+# ==========================================================================
+
+validate_spec_profile() {
+  # FR-001 — 3 secoes obrigatorias
+  for _sec in "User Scenarios & Testing" "Requirements" "Success Criteria"; do
+    has_section "$_sec" \
+      || emit error missing-section "Secao obrigatoria ausente: ${_sec}"
+  done
+
+  # FR-004 — no maximo 3 [NEEDS CLARIFICATION]. Casa so o prefixo (nao
+  # exige "]" imediato) porque o formato real usado por /specify inclui a
+  # pergunta inline: "[NEEDS CLARIFICATION: pergunta especifica]"
+  # (specify/SKILL.md:230) — nao apenas o marcador bare.
+  _nc=$(count_matches '\[NEEDS CLARIFICATION')
+  if [ "$_nc" -gt 3 ]; then
+    emit error too-many-clarifications "contagem=${_nc} excede limite=3 de marcadores [NEEDS CLARIFICATION]"
+  fi
+
+  # duplicate-id — ID FR-/SC- definido (formato **FR-NNN**) mais de uma vez.
+  # Reusa a convencao ja aplicada ao perfil UC existente (SKILL.md, Gotcha
+  # "IDs duplicados dentro do mesmo documento sao erro, nao aviso") — nao
+  # introduz FR novo (CHK004/CHK013 [Gap] resolvido em create-tasks).
+  _dup_ids=$(grep -oE '\*\*(FR|SC)-[0-9]+\*\*' "$FILE" 2>/dev/null \
+    | tr -d '*' | sort | uniq -d) || _dup_ids=""
+  if [ -n "$_dup_ids" ]; then
+    for _id in $_dup_ids; do
+      emit error duplicate-id "ID duplicado dentro do documento: ${_id}"
+    done
+  fi
+
+  # FR-002 — termo de stack/framework/lib especifica no corpo da spec.
+  # Wordlist calibrada contra specify/examples/spec-bad.md anti-padrao 1
+  # (bcrypt, PostgreSQL) — deliberadamente restrita a nomes concretos de
+  # linguagem/framework/lib/DB, nao termos genericos de dominio (API, CLI,
+  # JSON, Bash) que aparecem legitimamente em specs de ferramentas de dev.
+  _impl_regex='\<(bcrypt|argon2|postgresql|postgres|mysql|mongodb|redis|kafka|rabbitmq|react|vue\.js|angular|django|flask|fastapi|spring|rails|laravel|express\.js|node\.js|typescript|javascript|graphql|grpc)\>'
+  _impl_hits=$(grep -inE "$_impl_regex" "$FILE" 2>/dev/null) || _impl_hits=""
+  if [ -n "$_impl_hits" ]; then
+    printf '%s\n' "$_impl_hits" | while IFS=: read -r _ln _rest; do
+      _term=$(printf '%s' "$_rest" | grep -oiE "$_impl_regex" | head -n 1)
+      emit error impl-detail-in-spec "Termo de implementacao/stack na linha ${_ln}: ${_term}"
+    done
+  fi
+
+  # FR-003 — Success Criterion sem metrica quantificavel OU com jargao
+  # tecnico. Escopo: linhas de item de lista dentro de Success Criteria
+  # (**SC-NNN**: ...).
+  _sc_lines=$(grep -nE '^\s*-\s+\*\*SC-[0-9]+\*\*' "$FILE" 2>/dev/null) || _sc_lines=""
+  if [ -n "$_sc_lines" ]; then
+    printf '%s\n' "$_sc_lines" | while IFS=: read -r _ln _rest; do
+      _sc_id=$(printf '%s' "$_rest" | grep -oE 'SC-[0-9]+' | head -n 1)
+      if printf '%s' "$_rest" | grep -qiE '\<(API|TPS|paint time|render time)\>'; then
+        emit error sc-not-measurable "${_sc_id} usa jargao tecnico de implementacao (linha ${_ln})"
+      elif ! printf '%s' "$_rest" | grep -qE '[0-9]'; then
+        emit error sc-not-measurable "${_sc_id} sem metrica quantificavel (linha ${_ln})"
+      fi
+    done
+  fi
+
+  # FR-005 — secao deixada com placeholder N/A residual (aviso).
+  _na_lines=$(count_matches '^[[:space:]]*N/A[[:space:]]*$')
+  if [ "$_na_lines" -gt 0 ]; then
+    emit warning na-placeholder-section "Secao com placeholder 'N/A' residual em vez de removida (${_na_lines} ocorrencia(s))"
+  fi
+
+  # FR-006 — adjetivo vago sem quantificacao em Requirements/Success
+  # Criteria. Escopo restrito ao padrao "MUST (be) <adj>" / "deve ser
+  # <adj>" para minimizar falso-positivo contra prosa legitima (ex.:
+  # "diagnostico rapido" fora desse padrao NAO dispara).
+  _vague_en='MUST[[:space:]]+(be[[:space:]]+)?(fast|secure|robust|intuitive|simple|responsive|efficient|reliable|scalable|user-friendly|easy)\>'
+  _vague_pt='deve[[:space:]]+ser[[:space:]]+(rapido|simples|robusto|seguro|intuitivo|eficiente|responsivo|confiavel|escalavel)\>'
+  _vague_hits=$(grep -inE "${_vague_en}|${_vague_pt}" "$FILE" 2>/dev/null) || _vague_hits=""
+  if [ -n "$_vague_hits" ]; then
+    printf '%s\n' "$_vague_hits" | while IFS=: read -r _ln _rest; do
+      emit warning vague-adjective "Adjetivo vago sem quantificacao na linha ${_ln}"
+    done
+  fi
+
+  # FR-007 — user story acoplada a outra (nao testavel isoladamente).
+  if grep -qiE '\(requer[[:space:]].*(story|completa)' "$FILE" 2>/dev/null; then
+    emit warning coupled-user-story "User story parece depender de outra para ser testada isoladamente (padrao '(requer ...')"
+  fi
+}
+
+# ==========================================================================
+# plan-profile (US2) — FR-008..FR-012
+# ==========================================================================
+
+validate_plan_profile() {
+  _base=$(basename "$FILE")
+  _is_plan_md=0
+  [ "$_base" = "plan.md" ] && _is_plan_md=1
+  _is_contract=0
+  case "$FILE" in
+    */contracts/*.md) _is_contract=1 ;;
+  esac
+
+  # FR-008 — 4 secoes obrigatorias, so em plan.md
+  if [ "$_is_plan_md" -eq 1 ]; then
+    for _sec in "Summary" "Technical Context" "Constitution Check" "Project Structure"; do
+      has_section "$_sec" \
+        || emit error missing-section "Secao obrigatoria ausente: ${_sec}"
+    done
+  fi
+
+  # FR-009 — placeholder de template nao preenchido, em qualquer artefato
+  # /plan (plan.md, research.md, data-model.md, quickstart.md, contracts).
+  # Listas paralelas (regex ERE escapada / texto literal para a mensagem) em
+  # vez de derivar o texto via tr -d — mais simples que desescapar em runtime.
+  _tok_idx=0
+  for _tok_regex in '\[FEATURE\]' '\[DATE\]' '\[short-name\]' '\[Topico\]' '\[Endpoint/Command/Event\]'; do
+    _tok_idx=$((_tok_idx + 1))
+    case "$_tok_idx" in
+      1) _tok_display='[FEATURE]' ;;
+      2) _tok_display='[DATE]' ;;
+      3) _tok_display='[short-name]' ;;
+      4) _tok_display='[Topico]' ;;
+      5) _tok_display='[Endpoint/Command/Event]' ;;
+    esac
+    _hits=$(count_matches "$_tok_regex")
+    if [ "$_hits" -gt 0 ]; then
+      emit error template-placeholder "Token de template nao preenchido: ${_tok_display} (${_hits} ocorrencia(s))"
+    fi
+  done
+
+  # FR-011 — [NEEDS CLARIFICATION] remanescente, so em plan.md
+  if [ "$_is_plan_md" -eq 1 ]; then
+    _nc=$(count_matches '\[NEEDS CLARIFICATION')
+    if [ "$_nc" -gt 0 ]; then
+      emit error residual-clarification "plan.md contem ${_nc} marcador(es) [NEEDS CLARIFICATION] remanescente(s)"
+    fi
+  fi
+
+  # FR-010 — entrada de contracts/*.md sem rotulo real-vs-proposto.
+  # Heuristico documento-nivel (research.md Decision 6/CHK015): se o
+  # arquivo documenta um Command/Endpoint/Event (heading dedicado) e NAO
+  # contem NENHUM rotulo real-vs-proposto reconhecido em todo o
+  # documento, reporta erro. Fronteira: nao resolve link/anchor (FR-013).
+  if [ "$_is_contract" -eq 1 ]; then
+    _entry_hits=$(count_matches '^#{1,3}[[:space:]].*\<(Command|Endpoint|Event)\>')
+    if [ "$_entry_hits" -gt 0 ]; then
+      _label_hits=$(count_matches '\[PROPOSTA|\[EXISTENTE')
+      if [ "$_label_hits" -eq 0 ]; then
+        emit error unlabeled-contract "Entrada de contrato sem rotulo inequivoco real-vs-proposto ([PROPOSTA ...] ou equivalente)"
+      fi
+    fi
+  fi
+
+  # FR-012 — ID FR-/SC- citado em plan.md que nao existe na spec.md
+  # correspondente. Checagem SEMANTICA apenas (FR-013): nunca resolve
+  # path/anchor no disco.
+  if [ "$_is_plan_md" -eq 1 ]; then
+    if [ -n "$SPEC_MD" ] && [ -f "$SPEC_MD" ]; then
+      _cited=$(grep -oE '\<(FR|SC)-[0-9]+\>' "$FILE" 2>/dev/null | sort -u) || _cited=""
+      if [ -n "$_cited" ]; then
+        for _id in $_cited; do
+          if ! grep -qE "\*\*${_id}\*\*" "$SPEC_MD" 2>/dev/null; then
+            emit error dangling-fr-sc-ref "plan.md cita ${_id}, ausente na spec.md correspondente (${SPEC_MD})"
+          fi
+        done
+      fi
+    fi
+  fi
+}
+
+# ==========================================================================
+
+if [ "$PROFILE" = "spec" ]; then
+  validate_spec_profile
+else
+  validate_plan_profile
+fi
+
+# Recalcula contadores a partir do arquivo (nao de variavel incrementada em
+# subshell — ver comentario acima de FINDINGS_TMP). VAR=$(grep -c ...) || VAR=0
+# e o padrao seguro (grep -c sai 1 sem match, imprimindo "0"; o || so
+# dispara no exit code, nunca duplica a saida).
+ERRORS=$(grep -c '^FINDING|error|' "$FINDINGS_TMP" 2>/dev/null) || ERRORS=0
+WARNINGS=$(grep -c '^FINDING|warning|' "$FINDINGS_TMP" 2>/dev/null) || WARNINGS=0
+ERRORS=${ERRORS:-0}
+WARNINGS=${WARNINGS:-0}
+
+cat "$FINDINGS_TMP"
+printf 'RESULT|%s|profile=%s|errors=%d|warnings=%d\n' "$FILE" "$PROFILE" "$ERRORS" "$WARNINGS"
+
+if [ "$ERRORS" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/test_validate-sdd.sh
+++ b/tests/test_validate-sdd.sh
@@ -1,0 +1,281 @@
+#!/bin/sh
+# test_validate-sdd.sh — cobre global/skills/validate-documentation/scripts/validate-sdd.sh
+#
+# Os 12 cenarios de docs/specs/validate-docs-sdd-profile/quickstart.md sao o
+# oraculo. Fixtures "boas" apontam para os artefatos REAIS e versionados de
+# docs/specs/enforced-guards/ (spec.md com as 3 secoes obrigatorias, plan.md
+# com as 4 — verificado por leitura, research.md Decision 5). Fixtures
+# "ruins" sao copias mutadas no $TMPDIR_TEST (fixtures reais permanecem
+# read-only, convencao do harness).
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/validate-documentation/scripts/validate-sdd.sh"
+EG="$REPO_ROOT/docs/specs/enforced-guards"
+
+# ==== Cenario 1 — spec.md conformante (spec-profile, 0 erros) ====
+
+scenario_c01_spec_conformante() {
+  assert_exit 0 sh "$SCRIPT" "$EG/spec.md" || return 1
+  assert_stdout_not_contains 'FINDING|error|' || return 1
+  assert_stdout_contains 'RESULT|' || return 1
+  assert_stdout_contains 'profile=spec|errors=0|warnings=0' || return 1
+}
+
+# ==== Cenario 2 — spec.md com secao obrigatoria ausente ====
+
+scenario_c02_spec_secao_ausente() {
+  grep -v '^## Success Criteria$' "$EG/spec.md" > "$TMPDIR_TEST/broken.md"
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/broken.md" --sdd-spec || return 1
+  assert_stdout_contains 'FINDING|error|missing-section|' || return 1
+  assert_stdout_contains 'Success Criteria' || return 1
+}
+
+# ==== Cenario 3 — spec.md com termo de stack em Success Criteria ====
+
+scenario_c03_spec_termo_stack_em_sc() {
+  cp "$EG/spec.md" "$TMPDIR_TEST/broken.md"
+  printf -- '- **SC-099**: API response time under 200ms\n' >> "$TMPDIR_TEST/broken.md"
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/broken.md" --sdd-spec || return 1
+  case "${_CAPTURED_STDOUT:-}" in
+    *'FINDING|error|sc-not-measurable|'*|*'FINDING|error|impl-detail-in-spec|'*) : ;;
+    *) _fail "assert_stdout_contains" "esperado sc-not-measurable ou impl-detail-in-spec"; return 1 ;;
+  esac
+}
+
+# ==== Cenario 4 — spec.md com > 3 [NEEDS CLARIFICATION] ====
+
+scenario_c04_spec_excesso_clarifications() {
+  cp "$EG/spec.md" "$TMPDIR_TEST/broken.md"
+  printf '[NEEDS CLARIFICATION: um]\n[NEEDS CLARIFICATION: dois]\n[NEEDS CLARIFICATION: tres]\n[NEEDS CLARIFICATION: quatro]\n' >> "$TMPDIR_TEST/broken.md"
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/broken.md" --sdd-spec || return 1
+  assert_stdout_contains 'FINDING|error|too-many-clarifications|' || return 1
+  assert_stdout_contains 'contagem=4' || return 1
+  assert_stdout_contains 'limite=3' || return 1
+}
+
+# ==== Cenario 5 — spec.md com ID duplicado ====
+
+scenario_c05_spec_id_duplicado() {
+  cp "$EG/spec.md" "$TMPDIR_TEST/broken.md"
+  printf -- '- **FR-001**: Duplicado deliberadamente para o teste.\n' >> "$TMPDIR_TEST/broken.md"
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/broken.md" --sdd-spec || return 1
+  assert_stdout_contains 'FINDING|error|duplicate-id|' || return 1
+  assert_stdout_contains 'FR-001' || return 1
+}
+
+# ==== Cenario 6 — avisos nao bloqueiam ====
+
+scenario_c06_spec_avisos_nao_bloqueiam() {
+  cp "$EG/spec.md" "$TMPDIR_TEST/broken.md"
+  printf '\nN/A\n' >> "$TMPDIR_TEST/broken.md"
+  printf -- '- **FR-098**: O sistema MUST be robust em todos os cenarios.\n' >> "$TMPDIR_TEST/broken.md"
+  assert_exit 0 sh "$SCRIPT" "$TMPDIR_TEST/broken.md" --sdd-spec || return 1
+  assert_stdout_not_contains 'FINDING|error|' || return 1
+  assert_stdout_contains 'FINDING|warning|na-placeholder-section|' || return 1
+  assert_stdout_contains 'FINDING|warning|vague-adjective|' || return 1
+  assert_stdout_contains 'errors=0' || return 1
+}
+
+# ==== Cenario 7 — plan.md conformante (plan-profile, 0 erros) ====
+
+scenario_c07_plan_conformante() {
+  assert_exit 0 sh "$SCRIPT" "$EG/plan.md" || return 1
+  assert_stdout_not_contains 'FINDING|error|' || return 1
+  assert_stdout_contains 'profile=plan|errors=0|warnings=0' || return 1
+}
+
+# ==== Cenario 8 — plan.md com placeholder de template residual ====
+
+scenario_c08_plan_placeholder_residual() {
+  cp "$EG/plan.md" "$TMPDIR_TEST/broken.md"
+  printf '\nTexto com [FEATURE] literal nao preenchido.\n' >> "$TMPDIR_TEST/broken.md"
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/broken.md" --sdd-plan || return 1
+  assert_stdout_contains 'FINDING|error|template-placeholder|' || return 1
+  assert_stdout_contains '[FEATURE]' || return 1
+}
+
+# ==== Cenario 9 — plan.md cita FR/SC inexistente na spec ====
+
+scenario_c09_plan_ref_inexistente() {
+  mkdir -p "$TMPDIR_TEST/c9"
+  cp "$EG/plan.md" "$TMPDIR_TEST/c9/plan.md"
+  printf '\nVer FR-099 para detalhes (nao existe na spec).\n' >> "$TMPDIR_TEST/c9/plan.md"
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/c9/plan.md" --sdd-plan --spec "$EG/spec.md" || return 1
+  assert_stdout_contains 'FINDING|error|dangling-fr-sc-ref|' || return 1
+  assert_stdout_contains 'FR-099' || return 1
+  # Nao-Expected (fronteira FR-013): nenhum achado de link/anchor quebrado.
+  assert_stdout_not_contains 'Link' || return 1
+  assert_stdout_not_contains 'anchor' || return 1
+}
+
+# ==== Cenario 10 — contracts/*.md sem rotulo real-vs-proposto ====
+
+scenario_c10_contrato_sem_rotulo() {
+  mkdir -p "$TMPDIR_TEST/c10/contracts"
+  cat > "$TMPDIR_TEST/c10/contracts/foo.md" <<'EOF'
+# Contract: Foo
+
+## Command: `foo.sh`
+
+Descricao do comando foo, sem rotulo real-vs-proposto.
+EOF
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/c10/contracts/foo.md" --sdd-plan || return 1
+  assert_stdout_contains 'FINDING|error|unlabeled-contract|' || return 1
+}
+
+scenario_c10b_contrato_com_rotulo_passa() {
+  mkdir -p "$TMPDIR_TEST/c10b/contracts"
+  cat > "$TMPDIR_TEST/c10b/contracts/foo.md" <<'EOF'
+# Contract: Foo
+
+> [PROPOSTA — a validar na implementacao] Contrato novo.
+
+## Command: `foo.sh`
+
+Descricao do comando foo.
+EOF
+  assert_exit 0 sh "$SCRIPT" "$TMPDIR_TEST/c10b/contracts/foo.md" --sdd-plan || return 1
+  assert_stdout_not_contains 'FINDING|error|' || return 1
+}
+
+# ==== Cenario 11 — perfil indeterminado fora da convencao ====
+
+scenario_c11_perfil_indeterminado() {
+  mkdir -p "$TMPDIR_TEST/fora-da-convencao"
+  printf '# spec\n' > "$TMPDIR_TEST/fora-da-convencao/spec.md"
+  assert_exit 2 sh "$SCRIPT" "$TMPDIR_TEST/fora-da-convencao/spec.md" || return 1
+  assert_stderr_contains 'Perfil nao determinado' || return 1
+  assert_stderr_contains '--sdd-spec' || return 1
+}
+
+# ==== Cenario 12 — deteccao automatica por path (sem flag) ====
+
+scenario_c12_auto_deteccao_spec() {
+  assert_exit 0 sh "$SCRIPT" "$EG/spec.md" || return 1
+  assert_stdout_contains 'profile=spec' || return 1
+}
+
+scenario_c12_auto_deteccao_plan() {
+  assert_exit 0 sh "$SCRIPT" "$EG/research.md" || return 1
+  assert_stdout_contains 'profile=plan' || return 1
+}
+
+# ==== Cobertura adicional: uso incorreto (exit 2) ====
+
+scenario_sem_argumento() {
+  assert_exit 2 sh "$SCRIPT" || return 1
+  assert_stderr_contains 'Uso:' || return 1
+}
+
+scenario_arquivo_inexistente() {
+  assert_exit 2 sh "$SCRIPT" "$TMPDIR_TEST/nao-existe.md" --sdd-spec || return 1
+  assert_stderr_contains 'nao encontrado' || return 1
+}
+
+scenario_flags_conflitantes() {
+  assert_exit 2 sh "$SCRIPT" "$EG/spec.md" --sdd-spec --sdd-plan || return 1
+  assert_stderr_contains 'mutuamente exclusivas' || return 1
+}
+
+# ==== CHK014 — --spec explicito aceita path fora da convencao docs/specs/ ====
+
+scenario_spec_explicito_fora_da_convencao() {
+  mkdir -p "$TMPDIR_TEST/outside"
+  cat > "$TMPDIR_TEST/outside/spec.md" <<'EOF'
+# Feature Specification: outside
+
+## User Scenarios & Testing
+
+Texto.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: O sistema MUST fazer algo.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 100% dos casos passam.
+EOF
+  cat > "$TMPDIR_TEST/outside/plan.md" <<'EOF'
+# Implementation Plan: outside
+
+## Summary
+
+Cita FR-001 (existe) e FR-777 (nao existe).
+
+## Technical Context
+
+Texto.
+
+## Constitution Check
+
+OK.
+
+## Project Structure
+
+Texto.
+EOF
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/outside/plan.md" --sdd-plan --spec "$TMPDIR_TEST/outside/spec.md" || return 1
+  assert_stdout_contains 'FINDING|error|dangling-fr-sc-ref|' || return 1
+  assert_stdout_contains 'FR-777' || return 1
+}
+
+# ==== Calibragem SC-002: 6 anti-padroes de specify/examples/spec-bad.md ====
+
+scenario_calibragem_spec_bad_100pc() {
+  cat > "$TMPDIR_TEST/calib.md" <<'EOF'
+# Feature Specification: calib
+
+## User Scenarios & Testing
+
+### User Story P1 - Usuario cria conta (Priority: P1)
+
+Texto.
+
+### User Story P2 - Usuario configura perfil (requer Story P1 completa) (Priority: P2)
+
+Texto.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST hash passwords with bcrypt (cost factor 12) and store in PostgreSQL `users.password_hash` column.
+- **FR-005**: System MUST be fast and responsive
+- **FR-006**: System MUST be secure
+- **FR-007**: UI MUST be intuitive
+
+## Key Entities
+
+N/A
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: API response time under 200ms
+- **SC-002**: Database handles 1000 TPS
+- **SC-003**: React components render efficiently with <50ms paint time
+EOF
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/calib.md" --sdd-spec || return 1
+  # Anti-padrao 1: detalhe de implementacao
+  assert_stdout_contains 'FINDING|error|impl-detail-in-spec|' || return 1
+  # Anti-padrao 2: SC com jargao tecnico
+  assert_stdout_contains 'FINDING|error|sc-not-measurable|' || return 1
+  # Anti-padrao 3: stories acopladas
+  assert_stdout_contains 'FINDING|warning|coupled-user-story|' || return 1
+  # Anti-padrao 4: adjetivos vagos
+  assert_stdout_contains 'FINDING|warning|vague-adjective|' || return 1
+  # Anti-padrao 6: N/A residual
+  assert_stdout_contains 'FINDING|warning|na-placeholder-section|' || return 1
+}
+
+run_all_scenarios


### PR DESCRIPTION
## Origem
Sugestões geradas por IA em outra máquina (sug-001 + sug-003), validadas contra o código antes de implementar. Pipeline SDD via `feature-00c` (`docs/specs/validate-docs-sdd-profile/`).

## Problema
A skill `validate-documentation` só tinha perfis UC (default) e `--runbook`; artefatos SDD (`spec.md` e artefatos de `/plan`) não tinham checklist nativo, forçando os orquestradores a validar via `grep` ad-hoc. Gap confirmado não-redundante: `analyze` é cross-artifact (exige `tasks.md`); `validate-docs-rendered` só cobre render/links.

## Solução
- **Novo motor POSIX** `global/skills/validate-documentation/scripts/validate-sdd.sh`: `spec-profile` (sem termos de stack, FR/SC sem ID duplicado, success criteria mensuráveis+tech-agnostic, seções obrigatórias, `[NEEDS CLARIFICATION]`≤3) e `plan-profile` (rótulo `[EXISTENTE]`/`[PROPOSTA]`, FR/SC citados existem na spec, zero placeholder de template). Acionamento por flag `--sdd-spec`/`--sdd-plan` ou auto-detecção por path. Formato `FINDING|<severity>|<code>|<msg>`, exit 0/1/2.
- **SKILL.md**: seções dos dois perfis + tabela de fronteira de não-duplicação vs `analyze`/`validate-docs-rendered`.
- **`tests/test_validate-sdd.sh`**: 19 cenários (12 oráculos do quickstart + anti-patterns + fixtures reais de `docs/specs/enforced-guards/`).

3 bugs reais corrigidos durante a implementação (subshell var-loss, case glob, regex NEEDS CLARIFICATION).

## Testes
Suíte completa **PASS 1495/0/0**, shellcheck limpo, `--check-coverage` zero órfãos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)