### PR TITLE
fix: hardening derivado de sugestões da knowledge.db (v5.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.16.1] - 2026-07-10
+
+Bugfixes derivados de uma varredura da `knowledge.db` (sugestões acumuladas por
+execuções 00c passadas), validados contra o código atual antes de aplicar.
+
+### Fixed
+
+- **`state-ondas.sh git-commit` quebrava em git worktree** (afeta `cstk session`):
+  o check de repositório usava `[ -d "$_pap/.git" ]`, mas em worktree o `.git` é
+  um ARQUIVO (`gitdir: ...`), não diretório → falso-negativo "não é repositório
+  git". Trocado por `git -C "$_pap" rev-parse --is-inside-work-tree` (worktree/
+  submódulo-safe, alinhado ao `commit-mode.sh`). Regressão coberta por
+  `scenario_git_commit_worktree`.
+- **`report.sh` afirmava "execução abortada" em feature-00c concluída**: o campo
+  "Stack final" do Resumo Executivo imprimia *"não aplicável — execução abortada
+  antes de definir"* sempre que `suggested_stack` era null (sempre, em feature-00c,
+  que herda a stack do projeto), contradizendo o `Status=concluida` na mesma
+  tabela. O fallback agora é condicional ao status: mensagem de "abortada" só para
+  `status=abortada`; caso contrário, *"não aplicável (herdada do projeto / não
+  definida)"*. Regressão coberta por `scenario_stack_final_condicional_ao_status`.
+- **`review-task/SKILL.md` referenciava subcomandos inexistentes**: a §4.5
+  (half-records) mandava `state-decisions-reconcile.sh detect` e `repair
+  --dry-run/--apply`, mas o script só expõe `check` (detect-only) — rodar `detect`
+  saía com exit 2. Corrigido para `check` e reescrito para refletir que não há
+  subcomando de repair (resolução de half-record é manual na retomada).
+- **`validate-documentation` (perfil `--runbook`): falso-positivo de placeholder
+  em corpus pt-br**. O check de placeholder residual casava o token solto `TODO`,
+  colidindo com "TODO/TODA" em ênfase CAIXA-ALTA (ex.: "para TODO comando"),
+  legítimo em prosa pt-br. Passa a exigir o marcador delimitado (`TODO:` ou
+  `TODO(`). (O motor `validate-sdd.sh` introduzido em 5.16.0 já era imune — usa
+  delimitadores `[...]`.)
+
 ## [5.16.0] - 2026-07-10
 
 Origem: 4 sugestões geradas por IA em outra máquina, validadas contra o código
@@ -3567,6 +3599,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.16.1]: https://github.com/JotJunior/cstk/releases/tag/v5.16.1
 [5.16.0]: https://github.com/JotJunior/cstk/releases/tag/v5.16.0
 [5.15.0]: https://github.com/JotJunior/cstk/releases/tag/v5.15.0
 [5.14.1]: https://github.com/JotJunior/cstk/releases/tag/v5.14.1

--- a/global/skills/agente-00c-runtime/scripts/report.sh
+++ b/global/skills/agente-00c-runtime/scripts/report.sh
@@ -84,7 +84,7 @@ _rp_render_secao_1() {
     "| ID Execucao | \($exec.id) |",
     "| Projeto-Alvo | \($exec.target_project_path // $exec.projeto_alvo_path) |",
     "| Descricao | \($exec.target_project_description // $exec.projeto_alvo_descricao) |",
-    "| Stack final | \(($exec.suggested_stack // $exec.stack_sugerida) // "nao aplicavel — execucao abortada antes de definir") |",
+    "| Stack final | \(($exec.suggested_stack // $exec.stack_sugerida) // (if (($exec.status // "") == "abortada") then "nao aplicavel — execucao abortada antes de definir" else "nao aplicavel (herdada do projeto / nao definida)" end)) |",
     "| Status | \($exec.status) |",
     "| Motivo termino | \(($exec.termination_reason // $exec.motivo_termino) // "(em andamento)") |",
     "| Iniciada em | \($exec.started_at // $exec.iniciada_em) |",

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -709,7 +709,11 @@ _so_cmd_git_commit() {
   [ -n "$_motivo" ] || _so_die_usage "git-commit: --motivo obrigatorio"
   command -v git >/dev/null 2>&1 || _so_die "git-commit: git nao encontrado no PATH" 1
   [ -d "$_pap" ] || _so_die "git-commit: projeto-alvo-path nao existe: $_pap" 1
-  if [ ! -d "$_pap/.git" ]; then
+  # Worktree-safe: em git worktree o `.git` e um ARQUIVO (`gitdir: ...`), nao
+  # diretorio — `[ -d .git ]` daria falso-negativo e quebraria `cstk session`.
+  # `rev-parse` cobre repo normal, worktree e submodulo (mesma checagem de
+  # commit-mode.sh).
+  if ! git -C "$_pap" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     _so_die "git-commit: $_pap nao e repositorio git (init manual antes)" 1
   fi
   if [ -z "$_onda" ]; then

--- a/global/skills/review-task/SKILL.md
+++ b/global/skills/review-task/SKILL.md
@@ -212,16 +212,19 @@ reusa o `state-decisions-reconcile.sh` ja existente. Para auditar:
 
 ```bash
 ~/.claude/skills/agente-00c-runtime/scripts/state-decisions-reconcile.sh \
-  detect --state-dir "$STATE_DIR"
+  check --state-dir "$STATE_DIR"
 # exit 0 + stdout vazio -> 0 half-records pendentes (estado saudavel).
 # exit 1 + TSV (dec-id, onda-id, subagent-type) -> half-records a sanar.
 ```
 
-O numero de half-records pendentes DEVE ser **0**. Se `detect` lista
-entradas, reporte finding `model-routing-half-record` em "Recomendacoes"
-e instrua a rodar `state-decisions-reconcile.sh repair --dry-run` (depois
-`--apply`) na retomada via `/feature-00c-resume`. Read-only e idempotente
-— seguro de rodar dentro do review-task.
+O numero de half-records pendentes DEVE ser **0**. O subcomando real e
+`check` (DETECT-ONLY — o script apenas audita; NAO existe subcomando
+`repair`/`detect`). Se `check` lista entradas, reporte finding
+`model-routing-half-record` em "Recomendacoes" e sinalize a meia-gravacao
+para resolucao manual na retomada (`/feature-00c-resume`): inspecionar o
+`state.json` e completar o `record-skill` faltante ou remover a Decisao
+orfa correspondente. Read-only e idempotente — seguro de rodar dentro do
+review-task.
 
 **Path canonico do relatorio**: salvar em
 `docs/specs/<feature>/review-<onda-id>.md` (onde `<onda-id>` e a string

--- a/global/skills/validate-documentation/SKILL.md
+++ b/global/skills/validate-documentation/SKILL.md
@@ -238,9 +238,13 @@ Ausencia de qualquer secao acima e Erro (nao Aviso). Para
 ### Checks adicionais
 
 - **Sem placeholders residuais**: rejeitar se conteudo contem
-  `TODO`, `XXX`, `FIXME`, `<placeholder>`, `lorem ipsum`,
-  `TBD`, `[FILL ME]`. Runbook e operacional — placeholder e
-  dividida tecnica que vira incidente.
+  `TODO:`/`TODO(`, `XXX`, `FIXME`, `<placeholder>`, `lorem ipsum`,
+  `TBD`, `[FILL ME]`. Runbook e operacional — placeholder e divida
+  tecnica que vira incidente. NOTA (corpus pt-br): exigir o marcador
+  DELIMITADO — `TODO:` (dois-pontos) ou `TODO(` (estilo comentario de
+  codigo) — e NAO o token solto `TODO`. Em prosa pt-br, "TODO/TODA" em
+  enfase CAIXA-ALTA (ex: "para TODO comando") e legitimo e NAO deve
+  disparar falso-positivo.
 - **Cross-refs validos**: paths relativos em links Markdown
   (`[texto](../path)`) devem existir no disco. Reportar
   link quebrado como Erro.

--- a/tests/test_report.sh
+++ b/tests/test_report.sh
@@ -335,4 +335,17 @@ scenario_emit_aborta_sem_secrets_filter() {
   assert_stderr_contains "secrets-filter" || return 1
 }
 
+scenario_stack_final_condicional_ao_status() {
+  # Regressao: 'Stack final' nao pode afirmar 'abortada' numa execucao
+  # concluida sem suggested_stack (caso feature-00c, herda stack do projeto).
+  _sd="$TMPDIR_TEST/state"
+  _init "$_sd"
+  _run_wave_with_decision "$_sd"
+  capture "$RW" set --state-dir "$_sd" --field '.execution.status' --value '"concluida"'
+  capture "$SCRIPT" generate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "generate" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_not_contains "abortada antes de definir" || return 1
+  assert_stdout_contains "herdada do projeto" || return 1
+}
+
 run_all_scenarios

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -844,4 +844,29 @@ scenario_reconcile_wave_phase_override() {
   assert_stdout_contains "next=checklist" || return 1
 }
 
+scenario_git_commit_worktree() {
+  # Regressao: em git worktree o `.git` e ARQUIVO (`gitdir: ...`), nao diretorio.
+  # O check antigo `[ -d "$_pap/.git" ]` dava falso-negativo e quebrava commit
+  # dentro de `cstk session` (que usa worktrees).
+  _sd="$TMPDIR_TEST/state"
+  _main="$TMPDIR_TEST/mainrepo"
+  _wt="$TMPDIR_TEST/wt"
+  _init_state "$_sd"
+  mkdir -p "$_main"
+  ( cd "$_main" && git init -q -b main \
+    && git config user.email t@t && git config user.name t \
+    && touch base.txt && git add . && git commit -q -m initial \
+    && git worktree add -b feat "$_wt" ) >/dev/null 2>&1
+  [ -f "$_wt/.git" ] || { _fail "worktree setup" ".git deveria ser ARQUIVO em $_wt"; return 1; }
+  ( cd "$_wt" && touch novo.txt )
+  capture "$SCRIPT" git-commit --state-dir "$_sd" --projeto-alvo-path "$_wt" \
+    --motivo "commit em worktree"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "worktree commit" "exit=$_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"; return 1; }
+  _msg=$(git -C "$_wt" log -1 --pretty=%s)
+  case "$_msg" in
+    *"chore(agente-00c):"*"commit em worktree"*) ;;
+    *) _fail "worktree commit msg" "obtido: $_msg"; return 1 ;;
+  esac
+}
+
 run_all_scenarios


### PR DESCRIPTION
Varredura da `knowledge.db` (sugestões acumuladas por execuções 00c passadas), cada candidato **verificado contra o código atual** antes de aplicar (filtrados os já-corrigidos e os já entregues na v5.16.0).

## Fixes

- **`state-ondas.sh git-commit` quebrava em git worktree** (afeta `cstk session`): check `[ -d "$_pap/.git" ]` dá falso-negativo em worktree (`.git` é arquivo) → `git -C rev-parse --is-inside-work-tree`. Regressão: `scenario_git_commit_worktree`.
- **`report.sh` afirmava "execução abortada" em feature-00c concluída**: campo "Stack final" imprimia "abortada antes de definir" sempre que `suggested_stack` era null (sempre em feature-00c) → fallback condicional ao status. Regressão: `scenario_stack_final_condicional_ao_status`.
- **`review-task/SKILL.md` §4.5 referenciava `detect`/`repair` inexistentes**: o script só tem `check` (detect-only) → corrigido + reescrito (sem repair automático).
- **`validate-documentation --runbook`: falso-positivo de placeholder** com "TODO/TODA" em ênfase pt-br → exige marcador delimitado (`TODO:`/`TODO(`).

## Testes
Suíte completa: **PASS 1500 / FAIL 1** — a única falha é o flaky conhecido `test_00c-bootstrap :: scenario_issue_2_sigint_propaga_exit_130` (SIGINT/timing, sem relação com estas mudanças; passa 2/2 isolado). Shellcheck limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)