### PR TITLE
feat(serve): preferir asset de release verificavel ao auto-tarball da API (v5.18.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.18.0] - 2026-07-11
+
+### Added
+
+- **`cstk serve`: asset de release verificável preferido ao auto-tarball da
+  API**: o guard fail-closed do 5.15.0 (enforced-guards) bloqueava todo
+  `cstk serve`/`--update` com `unverifiable-blocked` porque procurava o
+  checksum em `<tarball_url>.sha256` — endpoint de auto-tarball da API do
+  GitHub, que não tem como ter arquivo publicado; o único caminho era
+  `--allow-unverified`. Agora `_serve_download_verify_extract` (modos nativo
+  E `--docker`) prefere um par de assets `<nome>.tar.gz` +
+  `<nome>.tar.gz.sha256` publicado na release (primeiro `.tar.gz` na ordem
+  da API cujo sibling exato exista; pareamento por igualdade de string
+  completa, nunca substring) e instala com outcome `verified`, sem bypass.
+  Sem par completo, fallback ao auto-tarball (fail-closed intacto);
+  mismatch segue bloqueio absoluto; o asset passa pela MESMA allowlist de
+  hosts (`trusted-hosts.sh`). O `package_url` do `enforcement-log.jsonl`
+  registra a URL de fato baixada (asset ou auto-tarball). Lado emissor:
+  workflow `release.yml` adicionado ao repo do cstk-panel publica o par a
+  cada tag (idempotente com release criada manualmente). 4 cenários novos
+  em `tests/cstk/test_serve.sh` (55 no total).
+
 ## [5.17.0] - 2026-07-11
 
 Feature `panel-docker`, via pipeline SDD `feature-00c`. Aditiva/não-breaking:
@@ -3654,6 +3676,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.18.0]: https://github.com/JotJunior/cstk/releases/tag/v5.18.0
 [5.17.0]: https://github.com/JotJunior/cstk/releases/tag/v5.17.0
 [5.16.1]: https://github.com/JotJunior/cstk/releases/tag/v5.16.1
 [5.16.0]: https://github.com/JotJunior/cstk/releases/tag/v5.16.0

--- a/README.md
+++ b/README.md
@@ -434,7 +434,11 @@ passam a ser **enforced** (não dependem mais do orquestrador lembrar):
    ausência de `.sha256` do pacote baixado bloqueia (`unverifiable-blocked`);
    bypass explícito via `--allow-unverified`/`CSTK_SERVE_ALLOW_UNVERIFIED=1`
    com aviso de alta visibilidade; divergência de checksum continua
-   bloqueando sempre (sem bypass possível).
+   bloqueando sempre (sem bypass possível). Quando a release do painel
+   publica o par de assets `cstk-panel-<versão>.tar.gz` + `.tar.gz.sha256`,
+   o serve prefere esse asset verificável ao auto-tarball da API (que não
+   tem como ter `.sha256` publicado) e instala com outcome `verified` —
+   sem precisar de bypass.
 3. **Allowlist de hosts confiáveis** (`CSTK_TRUSTED_RELEASE_HOSTS`, match
    exato case-insensitive, `file://` isento) aplicada em `cstk serve`,
    `cstk install --from` e `cstk self-update --from` — rejeita host fora

--- a/cli/lib/serve.sh
+++ b/cli/lib/serve.sh
@@ -28,6 +28,15 @@
 #   checksum (`.sha256` presente mas nao confere) permanece bloqueio absoluto
 #   (outcome mismatch-blocked) — o bypass NUNCA se aplica a esse caso.
 #
+#   Fonte VERIFICAVEL preferida (complemento ao D2): o auto-tarball da API
+#   (`tarball_url`) NUNCA tem `.sha256` — nao existe como publicar arquivo
+#   nesse endpoint, entao por ele so saem outcomes unverifiable-*. Quando a
+#   release publica um par de assets `<nome>.tar.gz` + `<nome>.tar.gz.sha256`
+#   (mesma convencao do release.yml do proprio cstk),
+#   _serve_download_verify_extract usa o ASSET como package_url — unica fonte
+#   capaz de outcome `verified`. Sem par completo, fallback ao auto-tarball
+#   (comportamento anterior; fail-closed intacto).
+#
 # POSIX sh puro — sem Bash-isms (nao usa [[ ]], arrays, local, source, <<<).
 # Deps opcionais confinadas: npm, node (runtime do painel, nao do cstk).
 # curl e usado via http.sh (nao diretamente). SEM jq (Principio II — jq e um
@@ -182,7 +191,9 @@ _serve_write_integrity_log() {
 }
 
 # _serve_download_verify_extract DEST_DIR [ALLOW_UNVERIFIED] [BYPASS_METHOD]
-# Baixa a release mais recente do painel via API GitHub, aplica a mesma
+# Baixa a release mais recente do painel via API GitHub (asset de release
+# verificavel preferido; fallback ao auto-tarball — ver "Fonte VERIFICAVEL
+# preferida" no cabecalho), aplica a mesma
 # allowlist de hosts confiaveis + integridade FAIL-CLOSED ja em producao
 # (enforced-guards US2 — FR-008/009/010/011), e extrai o tarball em
 # DEST_DIR (sempre recriado do zero — qualquer conteudo pre-existente em
@@ -272,15 +283,43 @@ _serve_download_verify_extract() {
 
   printf 'cstk serve: instalando versao %s...\n' "$_sdve_tag"
 
-  # S2/CHK-S03/CHK-S04: validar host e schema da tarball_url
-  if ! _serve_check_host_allowlist "$_sdve_tarball"; then
+  # Fonte verificavel preferida (fecha o gap do research.md D2): o
+  # auto-tarball da API nao tem como ter `.sha256` publicado; um par de
+  # assets `<nome>.tar.gz` + `<nome>.tar.gz.sha256` na release e a UNICA
+  # fonte capaz de outcome `verified`. Selecao: primeiro asset `.tar.gz`
+  # (ordem da API) cujo sibling EXATO `.sha256` tambem exista na MESMA
+  # release; sem par completo, fallback ao auto-tarball (comportamento
+  # anterior, fail-closed intacto). Pareamento por igualdade de string
+  # completa (lookup associativo do awk), nunca substring — mesma
+  # disciplina anti-spoofing de trusted-hosts.sh.
+  _sdve_assets=$(grep -o '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*"' "$_sdve_api_file" \
+    | sed 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+  _sdve_asset_pkg=$(printf '%s\n' "$_sdve_assets" | awk '
+    { seen[$0] = 1; url[NR] = $0 }
+    END {
+      for (i = 1; i <= NR; i++)
+        if (url[i] ~ /\.tar\.gz$/ && (url[i] ".sha256") in seen) { print url[i]; exit }
+    }')
+
+  if [ -n "$_sdve_asset_pkg" ]; then
+    _sdve_pkg_url="$_sdve_asset_pkg"
+    _sdve_sha256_url="${_sdve_asset_pkg}.sha256"
+    printf 'cstk serve: release publica asset verificavel; baixando %s\n' "$_sdve_pkg_url"
+  else
+    _sdve_pkg_url="$_sdve_tarball"
+    _sdve_sha256_url="${_sdve_tarball}.sha256"
+  fi
+
+  # S2/CHK-S03/CHK-S04: validar host e schema da URL do pacote (asset ou
+  # auto-tarball — ambas vem do JSON da API e passam pela MESMA allowlist)
+  if ! _serve_check_host_allowlist "$_sdve_pkg_url"; then
     rm -rf -- "$_sdve_tmp"
     return 1
   fi
 
-  # Download do tarball (CHK-R03: timeouts via http.sh)
+  # Download do pacote (CHK-R03: timeouts via http.sh)
   _sdve_archive="$_sdve_tmp/archive.tar.gz"
-  if ! http_download "$_sdve_tarball" "$_sdve_archive"; then
+  if ! http_download "$_sdve_pkg_url" "$_sdve_archive"; then
     printf 'cstk serve: erro: falha ao baixar tarball do painel\n' >&2
     rm -rf -- "$_sdve_tmp"
     return 1
@@ -302,7 +341,8 @@ _serve_download_verify_extract() {
   # prosseguir sem .sha256 (task 3.2) — NUNCA aplicavel quando o .sha256
   # EXISTE mas diverge (mismatch permanece bloqueio absoluto, regressao
   # FR-010/task 3.4). Mesma semantica no modo alternativo (FR-007).
-  _sdve_sha256_url="${_sdve_tarball}.sha256"
+  # _sdve_sha256_url ja resolvida acima, em par com _sdve_pkg_url (asset
+  # sibling ou `<tarball_url>.sha256` no fallback).
   _sdve_sha256_file="$_sdve_tmp/archive.tar.gz.sha256"
   _sdve_expected=""
   _sdve_actual=""
@@ -317,7 +357,7 @@ _serve_download_verify_extract() {
     # .sha256 obtido e ambos os hashes sao calculaveis -> comparacao definitiva.
     if [ "$_sdve_expected" != "$_sdve_actual" ]; then
       printf 'cstk serve: erro: checksum SHA-256 nao confere (integridade comprometida)\n' >&2
-      _serve_write_integrity_log "mismatch-blocked" "$_sdve_tarball" "$_sdve_expected" "$_sdve_actual" ""
+      _serve_write_integrity_log "mismatch-blocked" "$_sdve_pkg_url" "$_sdve_expected" "$_sdve_actual" ""
       rm -rf -- "$_sdve_tmp"
       return 1
     fi
@@ -330,11 +370,11 @@ _serve_download_verify_extract() {
     if [ "$_sdve_allow_unverified" = "1" ]; then
       printf 'cstk serve: AVISO -- prosseguindo SEM verificacao de integridade (bypass=%s); o pacote baixado NAO foi confirmado\n' \
         "${_sdve_bypass_method:-desconhecido}" >&2
-      _serve_write_integrity_log "unverifiable-bypassed" "$_sdve_tarball" "" "" "$_sdve_bypass_method"
+      _serve_write_integrity_log "unverifiable-bypassed" "$_sdve_pkg_url" "" "" "$_sdve_bypass_method"
     else
       printf 'cstk serve: erro: integridade do pacote nao pode ser confirmada (.sha256 indisponivel)\n' >&2
       printf 'cstk serve: use --allow-unverified ou defina CSTK_SERVE_ALLOW_UNVERIFIED=1 para prosseguir conscientemente (risco: pacote nao verificado)\n' >&2
-      _serve_write_integrity_log "unverifiable-blocked" "$_sdve_tarball" "" "" ""
+      _serve_write_integrity_log "unverifiable-blocked" "$_sdve_pkg_url" "" "" ""
       rm -rf -- "$_sdve_tmp"
       return 1
     fi
@@ -477,7 +517,10 @@ Usage: cstk serve [--port PORT] [--host HOST] [--update] [--reinstall]
 
 Start the cstk panel web interface. On first run, downloads the latest
 release from GitHub and installs it locally. Subsequent runs reuse the
-cached installation.
+cached installation. When the release publishes a <name>.tar.gz asset
+with a matching <name>.tar.gz.sha256, that verifiable asset is preferred
+and its SHA-256 is enforced; otherwise the API auto-tarball is used,
+whose integrity cannot be confirmed (see --allow-unverified).
 
 The panel compiles the workspace packages (npm run build) and then runs
 `npm run start`: a single Fastify process (requires cstk-panel >= 0.2.0)

--- a/tests/cstk/test_serve.sh
+++ b/tests/cstk/test_serve.sh
@@ -1574,4 +1574,221 @@ scenario_docker_flag_host_nao_loopback_aviso_ainda_aplica() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# Asset de release verificavel preferido — fecha o gap do research.md D2:
+# o auto-tarball da API (`tarball_url`) NUNCA tem `.sha256` publicavel, entao
+# so um par de assets `<nome>.tar.gz` + `<nome>.tar.gz.sha256` na release
+# produz outcome `verified`. Sem par completo, fallback ao auto-tarball
+# (fail-closed intacto). Ver cabecalho de cli/lib/serve.sh.
+# ---------------------------------------------------------------------------
+
+# _stub_curl_release_assets BIN_DIR MODE
+# Stub de curl para o caminho asset-preferred de _serve_download_verify_extract:
+# a resposta da API inclui `assets[].browser_download_url` (forma real
+# confirmada contra api.github.com/repos/JotJunior/cstk/releases/latest).
+# Toda URL requisitada e logada em $TMPDIR_TEST/curl-urls.log (baked, mesmo
+# padrao de _stub_npm_logging) para assertar QUAL fonte foi baixada.
+# O `.sha256` do AUTO-TARBALL sempre 404a (estado real do endpoint da API).
+# Modos:
+#   ok          par completo; .sha256 do asset CONFERE -> verified via asset
+#   no-sibling  asset .tar.gz sem sibling .sha256 -> fallback ao auto-tarball
+#   bad-sha     par completo; .sha256 do asset NAO confere -> mismatch
+#   evil-host   par completo hospedado fora da allowlist -> rejeicao de host
+_stub_curl_release_assets() {
+  _scra_bin="$1"
+  _scra_mode="$2"
+  _scra_tarball="$SERVE_FIXTURE_DIR/panel-fixture.tar.gz"
+  _scra_sha256=$(_serve_fixture_sha256 "$_scra_tarball")
+
+  _scra_asset_base="https://github.com/JotJunior/cstk-panel/releases/download/v0.0.1/cstk-panel-0.0.1.tar.gz"
+  if [ "$_scra_mode" = "evil-host" ]; then
+    _scra_asset_base="https://evil.com/releases/download/v0.0.1/cstk-panel-0.0.1.tar.gz"
+  fi
+
+  if [ "$_scra_mode" = "no-sibling" ]; then
+    _scra_assets_json="{\"name\":\"cstk-panel-0.0.1.tar.gz\",\"browser_download_url\":\"${_scra_asset_base}\"}"
+  else
+    _scra_assets_json="{\"name\":\"cstk-panel-0.0.1.tar.gz\",\"browser_download_url\":\"${_scra_asset_base}\"},{\"name\":\"cstk-panel-0.0.1.tar.gz.sha256\",\"browser_download_url\":\"${_scra_asset_base}.sha256\"}"
+  fi
+
+  # Hash servido no .sha256 do ASSET: correto em ok, adulterado em bad-sha
+  # (64 zeros hex — mesmo artificio de _stub_curl_bad_sha256).
+  if [ "$_scra_mode" = "bad-sha" ]; then
+    _scra_served_sha=$(printf '0%.0s' $(seq 1 64))
+  else
+    _scra_served_sha="$_scra_sha256"
+  fi
+
+  cat > "$_scra_bin/curl" <<STUB
+#!/bin/sh
+_url=""
+_output=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in
+    -o) shift; _output="\$1" ;;
+    --) shift; _url="\$1" ;;
+    https://*|http://*) _url="\$1" ;;
+    *) ;;
+  esac
+  shift
+done
+printf '%s\n' "\$_url" >> "$TMPDIR_TEST/curl-urls.log"
+case "\$_url" in
+  *releases/latest*)
+    _resp='{"tag_name":"v0.0.1","tarball_url":"https://github.com/JotJunior/cstk-panel/archive/v0.0.1.tar.gz","prerelease":false,"draft":false,"assets":[${_scra_assets_json}]}'
+    if [ -n "\$_output" ]; then printf '%s\n' "\$_resp" > "\$_output"; else printf '%s\n' "\$_resp"; fi
+    ;;
+  */releases/download/*.sha256)
+    # .sha256 do ASSET de release
+    if [ -n "\$_output" ]; then
+      printf '%s  cstk-panel-0.0.1.tar.gz\n' "${_scra_served_sha}" > "\$_output"
+    else
+      printf '%s  cstk-panel-0.0.1.tar.gz\n' "${_scra_served_sha}"
+    fi
+    ;;
+  *.sha256)
+    # .sha256 do AUTO-TARBALL da API: nunca existe -> 404
+    exit 1
+    ;;
+  */releases/download/*.tar.gz|*archive*.tar.gz)
+    if [ -n "\$_output" ]; then
+      cp "${_scra_tarball}" "\$_output"
+    else
+      cat "${_scra_tarball}"
+    fi
+    ;;
+  *)
+    printf 'stub-curl: URL inesperada: %s\n' "\$_url" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$_scra_bin/curl"
+}
+
+# Caminho feliz da feature: par de assets verificavel -> instala VERIFICADO
+# sem nenhum bypass, baixando o asset (nao o auto-tarball), sem linha no
+# enforcement-log (verified e silencioso, task 3.3.3).
+scenario_asset_par_verificavel_instala_sem_bypass() {
+  _setup_serve_env
+  _make_bin_dir
+  _snapshot_repo_root_log
+  _stub_curl_release_assets "$_STUB_BIN" ok
+  _stub_npm_ok "$_STUB_BIN"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "asset_par_exit" "esperado exit 0 (asset verificado, sem bypass), obtido $_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if [ ! -f "$CSTK_PANEL_DIR/package.json" ]; then
+    _fail "asset_par_instalou" "package.json esperado apos install verificado via asset"
+    return 1
+  fi
+  if ! printf '%s' "$_CAPTURED_STDOUT" | grep -qi 'integridade verificada'; then
+    _fail "asset_par_msg" "stdout nao confirma integridade verificada; stdout=$_CAPTURED_STDOUT"
+    return 1
+  fi
+  if ! grep -q 'releases/download/v0.0.1/cstk-panel-0.0.1.tar.gz' "$TMPDIR_TEST/curl-urls.log" 2>/dev/null; then
+    _fail "asset_par_baixou_asset" "curl-urls.log nao mostra download do asset; log=$(cat "$TMPDIR_TEST/curl-urls.log" 2>/dev/null)"
+    return 1
+  fi
+  if grep -q 'archive/v0.0.1.tar.gz' "$TMPDIR_TEST/curl-urls.log" 2>/dev/null; then
+    _fail "asset_par_nao_baixou_tarball_api" "auto-tarball da API foi requisitado mesmo com par de assets disponivel; log=$(cat "$TMPDIR_TEST/curl-urls.log")"
+    return 1
+  fi
+  _log=$(_serve_enforcement_log)
+  if [ -n "$_log" ]; then
+    _fail "asset_par_sem_log" "outcome verified NAO deve gravar linha no enforcement-log; log=$_log"
+    return 1
+  fi
+  _assert_no_repo_root_leak || return 1
+}
+
+# Regressao do fallback: asset .tar.gz SEM sibling .sha256 nao forma par ->
+# serve ignora o asset, cai no auto-tarball e o fail-closed default bloqueia
+# (exatamente o comportamento pre-feature).
+scenario_asset_sem_sibling_sha256_cai_no_fallback() {
+  _setup_serve_env
+  _make_bin_dir
+  _snapshot_repo_root_log
+  _stub_curl_release_assets "$_STUB_BIN" no-sibling
+  _stub_npm_ok "$_STUB_BIN"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "asset_no_sibling_exit" "esperado exit 1 (fallback unverifiable-blocked), obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  if grep -q 'releases/download/' "$TMPDIR_TEST/curl-urls.log" 2>/dev/null; then
+    _fail "asset_no_sibling_nao_baixa_asset" "asset sem sibling .sha256 NAO deveria ser baixado; log=$(cat "$TMPDIR_TEST/curl-urls.log")"
+    return 1
+  fi
+  if ! grep -q 'archive/v0.0.1.tar.gz' "$TMPDIR_TEST/curl-urls.log" 2>/dev/null; then
+    _fail "asset_no_sibling_fallback" "fallback ao auto-tarball nao aconteceu; log=$(cat "$TMPDIR_TEST/curl-urls.log" 2>/dev/null)"
+    return 1
+  fi
+  _log=$(_serve_enforcement_log)
+  case "$_log" in
+    *'"outcome":"unverifiable-blocked"'*) : ;;
+    *) _fail "asset_no_sibling_log" "esperado outcome=unverifiable-blocked; log=$_log"; return 1 ;;
+  esac
+  case "$_log" in
+    *'archive/v0.0.1.tar.gz'*) : ;;
+    *) _fail "asset_no_sibling_log_pkg_url" "package_url do log deveria ser o auto-tarball (fonte realmente usada); log=$_log"; return 1 ;;
+  esac
+  _assert_no_repo_root_leak || return 1
+}
+
+# Regressao FR-010 no caminho novo: mismatch de checksum do ASSET bloqueia
+# mesmo com --allow-unverified (bypass NUNCA se aplica a mismatch), e o
+# package_url auditado e o asset realmente baixado.
+scenario_asset_mismatch_bloqueia_mesmo_com_allow_unverified() {
+  _setup_serve_env
+  _make_bin_dir
+  _snapshot_repo_root_log
+  _stub_curl_release_assets "$_STUB_BIN" bad-sha
+  _stub_npm_ok "$_STUB_BIN"
+  _run_serve --allow-unverified
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "asset_mismatch_exit" "mismatch de asset MUST bloquear mesmo com --allow-unverified; obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  if [ -f "$CSTK_PANEL_DIR/package.json" ]; then
+    _fail "asset_mismatch_sem_instalacao" "package.json NAO deveria existir apos mismatch"
+    return 1
+  fi
+  _log=$(_serve_enforcement_log)
+  case "$_log" in
+    *'"outcome":"mismatch-blocked"'*) : ;;
+    *) _fail "asset_mismatch_log" "esperado outcome=mismatch-blocked; log=$_log"; return 1 ;;
+  esac
+  case "$_log" in
+    *'releases/download/v0.0.1/cstk-panel-0.0.1.tar.gz'*) : ;;
+    *) _fail "asset_mismatch_log_pkg_url" "package_url do log deveria ser o asset baixado; log=$_log"; return 1 ;;
+  esac
+  _assert_no_repo_root_leak || return 1
+}
+
+# Asset selecionado passa pela MESMA allowlist de hosts do auto-tarball:
+# par hospedado fora dela e rejeitado ANTES de qualquer download (loud,
+# exit 1) — nao ha downgrade silencioso para fonte nao confiavel.
+scenario_asset_host_fora_da_allowlist_exit1() {
+  _setup_serve_env
+  _make_bin_dir
+  _stub_curl_release_assets "$_STUB_BIN" evil-host
+  _stub_npm_ok "$_STUB_BIN"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "asset_evil_host_exit" "asset em host fora da allowlist deve ser rejeitado; obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  if ! printf '%s' "$_CAPTURED_STDERR" | grep -qi 'evil\|fora da lista\|rejeitad'; then
+    _fail "asset_evil_host_msg" "stderr nao menciona rejeicao de host; stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if [ -f "$CSTK_PANEL_DIR/package.json" ]; then
+    _fail "asset_evil_host_sem_instalacao" "nada deveria ter sido instalado apos rejeicao de host"
+    return 1
+  fi
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Problema

O guard fail-closed do enforced-guards (5.15.0) bloqueava **todo** `cstk serve`/`--update` com `unverifiable-blocked`: o checksum era procurado em `<tarball_url>.sha256`, mas `tarball_url` é o endpoint de auto-tarball da API do GitHub — não existe como publicar arquivo ali, então **nenhuma** release do cstk-panel podia ser verificada e o único caminho era `--allow-unverified` (caso real: update v0.12.1 → v0.13.0 bloqueado).

## Solução

`_serve_download_verify_extract` (caminho único dos modos nativo e `--docker`) agora prefere um **asset de release verificável**:

- Seleciona o primeiro asset `.tar.gz` (ordem da API) cujo sibling **exato** `.tar.gz.sha256` exista na mesma release (pareamento por igualdade de string completa via lookup associativo do awk — nunca substring, mesma disciplina anti-spoofing do `trusted-hosts.sh`).
- Par encontrado → baixa o asset, verifica SHA-256 e instala com outcome `verified`, sem bypass.
- Sem par completo → fallback ao auto-tarball (comportamento anterior, fail-closed intacto).
- Mismatch segue **bloqueio absoluto** (bypass nunca se aplica); asset passa pela **mesma allowlist de hosts**; `package_url` do `enforcement-log.jsonl` registra a URL de fato baixada.

Forma real de `assets[].browser_download_url` confirmada contra `api.github.com/repos/JotJunior/cstk/releases/latest` (host `github.com`, já na allowlist; redirect para `objects.githubusercontent.com` também allowlisted; `http_download` usa `curl -L`).

Lado emissor: workflow `release.yml` adicionado ao repo do **cstk-panel** (fora deste PR) publica o par `cstk-panel-<versão>.tar.gz` + `.sha256` a cada tag.

## Testes

- 4 cenários novos em `tests/cstk/test_serve.sh` (55 no total): verified via asset sem bypass + fonte assertada via log de URLs do stub; fallback quando falta o sibling; mismatch de asset bloqueando mesmo com `--allow-unverified`; host fora da allowlist rejeitado antes de qualquer download.
- Suíte completa local verde; `shellcheck` limpo em `cli/lib/serve.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
