### PR TITLE
feat: gaps de execucao autonoma — triagem specify + metrica tool_calls real

### DIFF
--- a/cli/lib/hooks.sh
+++ b/cli/lib/hooks.sh
@@ -159,10 +159,14 @@ print_paste_block() {
 
 # apply_guard_hooks <src_dir> <dest_claude_root> <dry_run>
 #
-# Provisiona o hook PreToolUse/Bash de enforced-guards (US1 — FR-004,
-# research.md Decision 9) num projeto-alvo:
+# Provisiona os hooks de execucao 00c num projeto-alvo:
 #   1. Copia <src_dir>/pretooluse-bash-guard.sh para
-#      <dest_claude_root>/hooks/pretooluse-bash-guard.sh (chmod +x).
+#      <dest_claude_root>/hooks/pretooluse-bash-guard.sh (chmod +x) —
+#      enforced-guards US1, FR-004, research.md Decision 9.
+#   1b. Copia <src_dir>/posttooluse-tool-call-tick.sh (metrica de tool
+#      calls por onda, sidecar tool-call-ticks.log) quando presente no
+#      catalogo. BEST-EFFORT: ausencia (catalogo antigo) ou falha de cp
+#      NAO muda a palavra de estado nem aborta — e metrica, nao guarda.
 #   2. Mescla <src_dir>/settings.snippet.json em
 #      <dest_claude_root>/settings.json via merge_settings (jq) ou
 #      print_paste_block (fallback sem jq) — mesma mecanica ja testada dos
@@ -213,8 +217,13 @@ apply_guard_hooks() {
     return 0
   fi
 
+  _agh_tick_script="$_agh_src/posttooluse-tool-call-tick.sh"
+
   if [ "$_agh_dry_run" = 1 ]; then
     log_info "[dry-run] guard-hooks: copiaria $_agh_hook_script -> $_agh_hooks_dst/pretooluse-bash-guard.sh"
+    if [ -f "$_agh_tick_script" ]; then
+      log_info "[dry-run] guard-hooks: copiaria $_agh_tick_script -> $_agh_hooks_dst/posttooluse-tool-call-tick.sh"
+    fi
     if [ -f "$_agh_snippet" ]; then
       if detect_jq; then
         log_info "[dry-run] guard-hooks: mesclaria $_agh_snippet -> $_agh_settings_dst (jq)"
@@ -241,6 +250,17 @@ apply_guard_hooks() {
   fi
   chmod +x -- "$_agh_hooks_dst/pretooluse-bash-guard.sh" 2>/dev/null || :
   log_info "hooks: pretooluse-bash-guard.sh provisionado em $_agh_hooks_dst"
+
+  # Hook de metrica (best-effort): falha aqui nunca degrada o provisionamento
+  # do guard — subcontagem de tool_calls e aceitavel, guard ausente nao.
+  if [ -f "$_agh_tick_script" ]; then
+    if cp -- "$_agh_tick_script" "$_agh_hooks_dst/posttooluse-tool-call-tick.sh" 2>/dev/null; then
+      chmod +x -- "$_agh_hooks_dst/posttooluse-tool-call-tick.sh" 2>/dev/null || :
+      log_info "hooks: posttooluse-tool-call-tick.sh provisionado em $_agh_hooks_dst"
+    else
+      log_warn "hooks: cp de posttooluse-tool-call-tick.sh falhou — metrica de tool calls indisponivel (guard intacto)"
+    fi
+  fi
 
   if [ ! -f "$_agh_snippet" ]; then
     log_info "hooks: settings.snippet.json ausente em $_agh_src — so hook copiado"

--- a/global/agents/agente-00c-feature-orchestrator.md
+++ b/global/agents/agente-00c-feature-orchestrator.md
@@ -272,6 +272,13 @@ Sequencia da onda corrente. Cada iteracao:
     inicio real da onda corrente.
 4. budget.sh check
    - se threshold atingido → encerrar onda + Schedule intent
+   - a dimensao tool_calls e alimentada AUTOMATICAMENTE pelo hook
+     PostToolUse posttooluse-tool-call-tick.sh (sidecar tool-call-ticks.log
+     no state dir, somado ao campo do state por budget.sh check e por
+     state-ondas.sh end). NAO chamar state-ondas.sh tool-call-tick
+     manualmente com o hook ativo (contagem dobrada). Sem o hook
+     provisionado a metrica degrada para 0 — best-effort, nunca gateia;
+     wallclock/state_size seguem cobrindo o orcamento.
 4.ter (best-effort, ADITIVO — dica de onda, US4 — FR-006):
     Exibir dica da skill correspondente a fase corrente. Fail-silent absoluto:
     nao bloqueia nem falha se cstk/show-tip.sh ausentes ou catalogo indisponivel.

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -280,8 +280,15 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
    `state-rw.sh sha256-verify --state-dir <SD>` (FR-029). Falha = bloqueio
    humano sem auto-correcao.
 
-2. **Onda nova**: `state-ondas.sh start --state-dir <SD>`. Toda Bash
-   call subsequente registra metrica via `state-ondas.sh tool-call-tick`.
+2. **Onda nova**: `state-ondas.sh start --state-dir <SD>`. A metrica de
+   tool calls da onda e registrada AUTOMATICAMENTE pelo hook PostToolUse
+   `posttooluse-tool-call-tick.sh` (provisionado por `cstk install`/`update`
+   no projeto-alvo), que appenda no sidecar `tool-call-ticks.log` do state
+   dir; `budget.sh check` e `state-ondas.sh end` agregam o sidecar. NAO
+   chame `state-ondas.sh tool-call-tick` manualmente quando o hook esta
+   ativo — cada call contaria em dobro. Sem o hook provisionado a metrica
+   degrada para 0 (best-effort; os proxies wallclock/state_size continuam
+   gateando a onda normalmente).
 
 2.bis **Dica de onda** (fail-silent, US4 — FR-006): exibir dica da skill
    correspondente a fase corrente, se disponivel. Nao bloqueia nem falha:

--- a/global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh
+++ b/global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# posttooluse-tool-call-tick.sh — hook PostToolUse (todas as tools): registra
+# 1 tick de metrica de tool call por invocacao durante execucoes ativas
+# agente-00c/feature-00c.
+#
+# Gap que fecha: `.budgets.tool_calls_current_wave` so avancava via
+# `state-ondas.sh tool-call-tick`, que nenhum mecanismo automatico invocava —
+# ondas fechavam com `tool_calls=0` apesar de dezenas de calls reais, e o
+# proxy de custo do budget.sh (threshold tool_calls_threshold_wave) nunca
+# tinha numero real para comparar. Prosa mandando o orquestrador tickar
+# manualmente e mecanismo advisory — mesma classe de falha que motivou o
+# pretooluse-bash-guard.sh (enforced-guards).
+#
+# POLITICA INVERSA ao pretooluse-bash-guard.sh: isto e METRICA, nao guarda.
+# Fail-OPEN absoluto — qualquer falha (jq ausente, stdin invalido/vazio,
+# state ilegivel, append negado) = exit 0 silencioso, stdout vazio. Este
+# hook NUNCA bloqueia, atrasa ou interfere numa tool call. Por isso NAO usa
+# `set -e` (um erro nao tratado viraria exit != 0 e o harness exporia stderr
+# ao usuario); cada passo trata a propria falha com no-op.
+#
+# REGRA DURA — NAO tocar o state.json: PostToolUse dispara CONCORRENTE as
+# tool calls do orquestrador (batches paralelos do harness). Um
+# read-modify-write do state.json aqui (como faz `tool-call-tick`) poderia
+# clobberar um write transacional (Decisao/bloqueio/onda) gravado entre o
+# read e o `mv` do tick. O state.json e a fonte de verdade transacional;
+# a metrica e derivada. O tick vai num SIDECAR append-only:
+#
+#   <state-dir>/tool-call-ticks.log   — 1 linha (timestamp ISO) por tick
+#
+# Append com O_APPEND e atomico para linhas curtas (< PIPE_BUF). Agregacao:
+# `state-ondas.sh end` soma `wc -l` do sidecar ao campo do state no
+# fechamento da onda; `budget.sh check|status` soma mid-onda. `start` e
+# `end` resetam o sidecar (janela de contagem = start→end). Ticks na
+# fronteira start/end podem se perder — aceitavel para proxy de custo.
+#
+# Deteccao de execucao ativa: mesmo algoritmo e precedencia do
+# pretooluse-bash-guard.sh (agente-00c vence; entre feature-00c, menor
+# short-name lexicografico byte-wise; status em_andamento|aguardando_humano).
+# Fora de execucao ativa: exit 0, zero interferencia na sessao manual.
+#
+# jq: mesma dependencia OPCIONAL confinada dos hooks (Constitution 1.1.0
+# Principio II carve-out). Sem jq nao ha parsing seguro do stdin -> no-op
+# (fail-open; no guard e fail-closed — la a falta de validacao bloqueia,
+# aqui a falta de metrica so subconta).
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+_PTT_INPUT=$(cat 2>/dev/null) || exit 0
+[ -n "$_PTT_INPUT" ] || exit 0
+
+_PTT_CWD=$(printf '%s' "$_PTT_INPUT" | jq -r '.cwd // ""' 2>/dev/null) || exit 0
+_PTT_TOOL_NAME=$(printf '%s' "$_PTT_INPUT" | jq -r '.tool_name // ""' 2>/dev/null) || exit 0
+
+[ -n "$_PTT_CWD" ] || exit 0
+# tool_name vazio = payload anomalo do harness; nao inventa tick.
+[ -n "$_PTT_TOOL_NAME" ] || exit 0
+
+_ptt_is_active_status() {
+  case "$1" in
+    em_andamento | aguardando_humano) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Deteccao de execucao ativa (precedencia identica ao pretooluse-bash-guard.sh).
+_PTT_STATE_DIR=""
+
+_ptt_agente_state="$_PTT_CWD/.claude/agente-00c-state/state.json"
+if [ -f "$_ptt_agente_state" ]; then
+  _ptt_status=$(jq -r '.execution.status // ""' "$_ptt_agente_state" 2>/dev/null) || _ptt_status=""
+  if _ptt_is_active_status "$_ptt_status"; then
+    _PTT_STATE_DIR="$_PTT_CWD/.claude/agente-00c-state"
+  fi
+fi
+
+if [ -z "$_PTT_STATE_DIR" ]; then
+  _ptt_feat_root="$_PTT_CWD/.claude/feature-00c-state"
+  if [ -d "$_ptt_feat_root" ]; then
+    _ptt_active_shorts=""
+    for _ptt_d in "$_ptt_feat_root"/*/; do
+      [ -d "$_ptt_d" ] || continue
+      [ -f "${_ptt_d}state.json" ] || continue
+      _ptt_status=$(jq -r '.execution.status // ""' "${_ptt_d}state.json" 2>/dev/null) || continue
+      _ptt_is_active_status "$_ptt_status" || continue
+      _ptt_active_shorts="${_ptt_active_shorts}$(basename "$_ptt_d")
+"
+    done
+    if [ -n "$_ptt_active_shorts" ]; then
+      # Ordem lexicografica byte-wise (C locale), deterministica — mesma
+      # regra do guard (CHK007/enforced-guards data-model.md).
+      _ptt_first=$(printf '%s' "$_ptt_active_shorts" | LC_ALL=C sort | sed -n '1p')
+      _PTT_STATE_DIR="$_ptt_feat_root/$_ptt_first"
+    fi
+  fi
+fi
+
+# Fora de escopo: nenhuma execucao ativa -> zero interferencia.
+[ -n "$_PTT_STATE_DIR" ] || exit 0
+
+_ptt_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || _ptt_ts="tick"
+printf '%s\n' "$_ptt_ts" >> "$_PTT_STATE_DIR/tool-call-ticks.log" 2>/dev/null || :
+
+exit 0

--- a/global/skills/agente-00c-runtime/hooks/settings.snippet.json
+++ b/global/skills/agente-00c-runtime/hooks/settings.snippet.json
@@ -11,6 +11,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/posttooluse-tool-call-tick.sh",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/global/skills/agente-00c-runtime/scripts/budget.sh
+++ b/global/skills/agente-00c-runtime/scripts/budget.sh
@@ -7,6 +7,9 @@
 #
 # Os proxies cobrem 3 dimensoes (chaves EN do schema; fallback pt-BR no read):
 #   1. tool_calls_current_wave >= tool_calls_threshold_wave (default 80)
+#      (valor corrente = campo do state + linhas do sidecar
+#      <state-dir>/tool-call-ticks.log appendado pelo hook PostToolUse
+#      posttooluse-tool-call-tick.sh — mesma agregacao do state-ondas.sh end)
 #   2. wallclock (now - current_wave_start) >= wallclock_threshold_seconds (5400 = 90min)
 #   3. file size de state.json >= state_size_threshold_bytes (1MB)
 #
@@ -82,7 +85,15 @@ _bd_collect() {
   # Readers diretos sobre o arquivo (schema-en-migration): path EN + fallback
   # (.en // .pt) para back-compat com states pt-BR vivos e com direct-writers
   # ainda nao migrados (ex: state-ondas.sh grava .orcamentos.inicio_onda_corrente).
-  _bd_tc=$(jq -r '(.budgets.tool_calls_current_wave // .orcamentos.tool_calls_onda_corrente) // 0' "$_sf")
+  _bd_tc_field=$(jq -r '(.budgets.tool_calls_current_wave // .orcamentos.tool_calls_onda_corrente) // 0' "$_sf")
+  # Sidecar do hook PostToolUse (ticks automaticos); ausente/ilegivel = 0.
+  _bd_tc_side=0
+  _bd_ticks="$1/tool-call-ticks.log"
+  if [ -f "$_bd_ticks" ]; then
+    _bd_tc_side=$(wc -l < "$_bd_ticks" 2>/dev/null | tr -d '[:space:]') || _bd_tc_side=0
+    case "$_bd_tc_side" in '' | *[!0-9]*) _bd_tc_side=0 ;; esac
+  fi
+  _bd_tc=$((_bd_tc_field + _bd_tc_side))
   _bd_tc_max=$(jq -r '(.budgets.tool_calls_threshold_wave // .orcamentos.tool_calls_threshold_onda) // 80' "$_sf")
   _bd_wc_max=$(jq -r '(.budgets.wallclock_threshold_seconds // .orcamentos.wallclock_threshold_segundos) // 5400' "$_sf")
   _bd_sz_max=$(jq -r '(.budgets.state_size_threshold_bytes // .orcamentos.estado_size_threshold_bytes) // 1048576' "$_sf")

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -24,11 +24,18 @@
 #         tool_calls/termination_reason/next_wave_scheduled_for. Atualiza
 #         accumulated_metrics (waves_total += 1, tool_calls_total +=
 #         tool_calls da onda, wallclock_total_seconds += wallclock).
+#         tool_calls da onda = .budgets.tool_calls_current_wave (ticks
+#         manuais) + linhas do sidecar tool-call-ticks.log (ticks do hook
+#         PostToolUse) — sidecar resetado apos o fechamento.
 #         --add-etapa pode ser passada N vezes para append em executed_stages.
 #
 #   state-ondas.sh tool-call-tick --state-dir DIR
 #       — Incrementa .budgets.tool_calls_current_wave (1 unidade).
-#         Stdout: novo total da onda.
+#         Stdout: novo total da onda (SO o campo do state; nao inclui o
+#         sidecar do hook). Caminho MANUAL/legado: o mecanismo primario de
+#         contagem e o hook posttooluse-tool-call-tick.sh (sidecar
+#         append-only) — nao use os dois em paralelo na mesma execucao ou
+#         cada call contara em dobro.
 #
 #   state-ondas.sh current-id --state-dir DIR
 #       — Imprime .waves[-1].id (ou "init" se nao ha onda).
@@ -183,6 +190,36 @@ _so_next_onda_num() {
     end' "$_sf" 2>/dev/null
 }
 
+# ---------- Sidecar de ticks (hook PostToolUse) ----------
+#
+# O hook posttooluse-tool-call-tick.sh NAO pode fazer read-modify-write no
+# state.json (dispara concorrente aos writes transacionais do orquestrador —
+# risco de clobber); ele appenda 1 linha por tool call em
+# <state-dir>/tool-call-ticks.log. Aqui esse sidecar e AGREGADO (end soma ao
+# campo .budgets.tool_calls_current_wave, que segue existindo para ticks
+# manuais via `tool-call-tick`) e RESETADO (start e end delimitam a janela
+# de contagem da onda). budget.sh faz a mesma soma mid-onda.
+
+_so_ticks_file() { printf '%s/tool-call-ticks.log\n' "$1"; }
+
+# _so_ticks_count DIR -> nº de linhas do sidecar (0 se ausente/ilegivel).
+_so_ticks_count() {
+  _tf=$(_so_ticks_file "$1")
+  [ -f "$_tf" ] || { printf '0\n'; return 0; }
+  _n=$(wc -l < "$_tf" 2>/dev/null | tr -d '[:space:]') || _n=0
+  case "$_n" in
+    '' | *[!0-9]*) printf '0\n' ;;
+    *) printf '%s\n' "$_n" ;;
+  esac
+}
+
+# _so_ticks_reset DIR -> remove o sidecar (best-effort; hook recria no
+# proximo tick). Ticks appendados na exata fronteira do reset se perdem —
+# aceitavel para proxy de custo.
+_so_ticks_reset() {
+  rm -f -- "$(_so_ticks_file "$1")" 2>/dev/null || :
+}
+
 # ---------- Subcomandos ----------
 
 _so_cmd_start() {
@@ -223,6 +260,10 @@ _so_cmd_start() {
   _so_atomic_write "$_sf" "$_new"
   rm -f -- "$_new" 2>/dev/null || :
   _so_update_sha "$_sdir"
+  # Janela de contagem do sidecar comeca zerada junto com a onda (ticks
+  # entre o end anterior e este start pertencem a fechamento/overhead do
+  # orquestrador, nao a onda nova).
+  _so_ticks_reset "$_sdir"
   printf '%s\n' "$_id"
 }
 
@@ -276,7 +317,11 @@ $2"; shift 2 ;;
   ' "$_sf")
   [ -n "$_start" ] || _so_die "end: nao ha onda em andamento" 1
   _wc=$(_so_wallclock "$_start" "$_now") || true
-  _tc=$(jq -r '(.budgets.tool_calls_current_wave // .orcamentos.tool_calls_onda_corrente) // 0' "$_sf")
+  # tool_calls da onda = campo do state (ticks manuais via tool-call-tick)
+  # + sidecar do hook PostToolUse (ver "Sidecar de ticks" acima).
+  _tc_field=$(jq -r '(.budgets.tool_calls_current_wave // .orcamentos.tool_calls_onda_corrente) // 0' "$_sf")
+  _tc_side=$(_so_ticks_count "$_sdir")
+  _tc=$((_tc_field + _tc_side))
 
   # Monta JSON array das etapas adicionais (uma por linha, ignora linhas vazias).
   _etapas_json=$(printf '%s\n' "$_etapas" \
@@ -315,6 +360,8 @@ $2"; shift 2 ;;
   _so_atomic_write "$_sf" "$_new"
   rm -f -- "$_new" 2>/dev/null || :
   _so_update_sha "$_sdir"
+  # Sidecar consumido por esta onda; zera para nao vazar para a proxima.
+  _so_ticks_reset "$_sdir"
   _so_log "end: onda finalizada (motivo=$_motivo, wallclock=${_wc}s, tool_calls=$_tc)"
 }
 

--- a/global/skills/specify/SKILL.md
+++ b/global/skills/specify/SKILL.md
@@ -101,6 +101,43 @@ Antes de gerar qualquer artefato, classifique o pedido e valide com o usuario
 se o fluxo SDD completo faz sentido para o escopo. O fluxo SDD (spec → clarify
 → plan → tasks) tem custo real e nem todo pedido justifica esse overhead.
 
+### 0.0 Atalho de modo autonomo (agente-00c / feature-00c)
+
+A confirmacao interativa de 0.1-0.3 pressupoe um usuario presente para
+responder o menu. Em execucao autonoma nao ha — e a triagem JA aconteceu:
+o operador decidiu rodar a pipeline SDD completa quando invocou
+`/agente-00c` ou `/feature-00c`.
+
+1. **Detectar execucao autonoma ativa** — mesmos sinais da secao "Leitura
+   de artefatos foundational", com um refinamento para os state.json em
+   disco: exigir status ATIVO (um state antigo/concluido no repo NAO pode
+   pular a triagem de uma invocacao manual):
+   - `AGENTE_00C_STATE_DIR` setada; OU
+   - `<projeto-alvo>/.claude/agente-00c-state/state.json` com
+     `.execution.status` em {`em_andamento`, `aguardando_humano`}; OU
+   - `<projeto-alvo>/.claude/feature-00c-state/<short>/state.json` com
+     `.execution.status` em {`em_andamento`, `aguardando_humano`}.
+
+2. **Se detectado**: a invocacao pelo orquestrador pai VALE como a
+   confirmacao explicita exigida em 0.3 (equivalente a escolher a opcao 2,
+   "Criar feature SDD completa"). NAO apresentar o menu nem aguardar
+   resposta. Executar 0.1 mesmo assim (classificacao e barata e util como
+   auditoria), registrar o pressuposto em UMA linha no output e prosseguir
+   direto a ETAPA 1:
+
+   ```
+   Triagem 0.0: modo autonomo detectado (<sinal>) — confirmacao herdada
+   da invocacao do orquestrador; classificacao: <categoria>.
+   ```
+
+   Se a classificacao 0.1 resultar em **Bugfix** ou **Refactor**, NAO
+   abortar nem trocar de skill: a decisao de rodar a pipeline foi do
+   operador. Apenas registrar a divergencia na mesma linha
+   (`classificacao: bugfix — divergencia registrada para auditoria`) para
+   aparecer no sumario da onda.
+
+3. **Se NAO detectado**: seguir 0.1-0.3 normalmente (fluxo interativo).
+
 ### 0.1 Classificar o pedido
 
 Analise `$ARGUMENTS` e classifique em uma das categorias:
@@ -150,9 +187,10 @@ Antes de criar diretorio ou arquivos, apresentar ao usuario:
 Qual caminho prefere?
 ```
 
-**NUNCA prosseguir para ETAPA 1 sem confirmacao explicita do usuario.**
-Se o usuario escolher opcao 1 ou 3, encerrar a skill e executar o caminho
-escolhido (ou delegar para skill apropriada).
+**NUNCA prosseguir para ETAPA 1 sem confirmacao explicita do usuario** —
+unica excecao: o atalho 0.0, onde a confirmacao e herdada da invocacao do
+orquestrador. Se o usuario escolher opcao 1 ou 3, encerrar a skill e
+executar o caminho escolhido (ou delegar para skill apropriada).
 
 ---
 

--- a/tests/cstk/test_hooks.sh
+++ b/tests/cstk/test_hooks.sh
@@ -193,14 +193,17 @@ scenario_merge_source_ausente() {
 
 # ==== apply_guard_hooks (enforced-guards US1, task 2.4.4) ====
 
-# _guard_src_fixture: monta um src_dir minimo com pretooluse-bash-guard.sh
-# (conteudo trivial, so precisa existir p/ cp) + settings.snippet.json.
+# _guard_src_fixture: monta um src_dir minimo com pretooluse-bash-guard.sh +
+# posttooluse-tool-call-tick.sh (conteudo trivial, so precisa existir p/ cp)
+# + settings.snippet.json (PreToolUse + PostToolUse, como o catalogo real).
 _guard_src_fixture() {
   _gsf_dir="$TMPDIR_TEST/guard-src"
   mkdir -p "$_gsf_dir"
   printf '#!/bin/sh\nexit 0\n' > "$_gsf_dir/pretooluse-bash-guard.sh"
   chmod +x "$_gsf_dir/pretooluse-bash-guard.sh"
-  printf '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"x","timeout":5}]}]}}\n' \
+  printf '#!/bin/sh\nexit 0\n' > "$_gsf_dir/posttooluse-tool-call-tick.sh"
+  chmod +x "$_gsf_dir/posttooluse-tool-call-tick.sh"
+  printf '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"x","timeout":5}]}],"PostToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"y","timeout":5}]}]}}\n' \
     > "$_gsf_dir/settings.snippet.json"
   printf '%s' "$_gsf_dir"
 }
@@ -288,6 +291,39 @@ scenario_apply_guard_hooks_args_invalidos() {
     return 1
   fi
   assert_stdout_contains "error" || return 1
+}
+
+scenario_apply_guard_hooks_copia_posttooluse_tick() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _src=$(_guard_src_fixture)
+  _dest="$TMPDIR_TEST/claude-root"
+  capture sh -c ". $CSTK_LIB/hooks.sh && apply_guard_hooks '$_src' '$_dest' 0"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "apply exit" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "merged" || return 1
+  [ -x "$_dest/hooks/posttooluse-tool-call-tick.sh" ] \
+    || { _fail "tick hook nao copiado/executavel" ""; return 1; }
+  jq -e '.hooks.PostToolUse[0].matcher == "*"' "$_dest/settings.json" >/dev/null \
+    || { _fail "settings.json sem bloco PostToolUse" "$(cat "$_dest/settings.json" 2>/dev/null)"; return 1; }
+}
+
+# Catalogo ANTIGO (skill sem o hook de metrica): provisionamento do guard
+# segue integral — o tick e best-effort e sua ausencia nao e erro.
+scenario_apply_guard_hooks_catalogo_antigo_sem_tick() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _src="$TMPDIR_TEST/guard-src-old"
+  mkdir -p "$_src"
+  printf '#!/bin/sh\nexit 0\n' > "$_src/pretooluse-bash-guard.sh"
+  chmod +x "$_src/pretooluse-bash-guard.sh"
+  printf '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"x","timeout":5}]}]}}\n' \
+    > "$_src/settings.snippet.json"
+  _dest="$TMPDIR_TEST/claude-root-old"
+  capture sh -c ". $CSTK_LIB/hooks.sh && apply_guard_hooks '$_src' '$_dest' 0"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "apply exit" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "merged" || return 1
+  [ -x "$_dest/hooks/pretooluse-bash-guard.sh" ] || { _fail "guard nao copiado" ""; return 1; }
+  [ -f "$_dest/hooks/posttooluse-tool-call-tick.sh" ] \
+    && { _fail "tick fantasma" "catalogo antigo nao traz o tick; nada a copiar"; return 1; }
+  return 0
 }
 
 run_all_scenarios

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -295,6 +295,13 @@ _is_internal_test() {
       # guarded: se o hook sumir, volta a ser orfao real.
       [ -f "$REPO_ROOT/global/skills/agente-00c-runtime/hooks/pretooluse-bash-guard.sh" ] && return 0
       return 1 ;;
+    test_posttooluse-tool-call-tick.sh)
+      # cobre global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh
+      # (hook PostToolUse de metrica de tool calls por onda) — mesma razao
+      # do test_pretooluse-bash-guard.sh acima: hooks/ esta fora do escaneio
+      # por convencao. Existence-guarded.
+      [ -f "$REPO_ROOT/global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh" ] && return 0
+      return 1 ;;
     *) return 1 ;;
   esac
 }

--- a/tests/test_budget.sh
+++ b/tests/test_budget.sh
@@ -216,4 +216,30 @@ JSON
   assert_stdout_contains "wallclock	0	5400" || return 1
 }
 
+# ==== Sidecar de ticks do hook PostToolUse (tool-call-ticks.log) ====
+
+scenario_check_soma_sidecar_e_dispara_threshold() {
+  _sd="$TMPDIR_TEST/state"
+  _init_with_onda "$_sd"
+  # 78 no campo do state + 2 no sidecar do hook = 80 >= threshold 80.
+  capture "$RW" set --state-dir "$_sd" \
+    --field '.budgets.tool_calls_current_wave' --value '78'
+  printf 't1\nt2\n' > "$_sd/tool-call-ticks.log"
+  capture "$SCRIPT" check --state-dir "$_sd"
+  if [ "$_CAPTURED_EXIT" != 1 ]; then
+    _fail "check" "esperado exit 1 (78 campo + 2 sidecar = 80), obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  assert_stdout_contains "tool_calls	80	80" || return 1
+}
+
+scenario_status_reflete_sidecar_sem_disparar() {
+  _sd="$TMPDIR_TEST/state"
+  _init_with_onda "$_sd"
+  printf 't1\nt2\nt3\n' > "$_sd/tool-call-ticks.log"
+  capture "$SCRIPT" status --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "status" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "tool_calls	3	80" || return 1
+}
+
 run_all_scenarios

--- a/tests/test_posttooluse-tool-call-tick.sh
+++ b/tests/test_posttooluse-tool-call-tick.sh
@@ -1,0 +1,191 @@
+#!/bin/sh
+# test_posttooluse-tool-call-tick.sh — cobre
+# global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh
+# (hook PostToolUse de metrica de tool calls por onda; sidecar append-only).
+#
+# Politica sob teste (INVERSA ao pretooluse-bash-guard.sh): fail-OPEN
+# absoluto — o hook NUNCA emite decisao, NUNCA sai com exit != 0 e NUNCA
+# escreve no state.json; unico efeito permitido e o append em
+# <state-dir>/tool-call-ticks.log quando ha execucao ativa.
+#
+# Mesmo idioma de invocacao do test_pretooluse-bash-guard.sh: o script nao
+# aceita argv — le JSON do stdin via
+# `sh -c 'printf "%s" "$1" | "$2"' _ "$json" "$SCRIPT"`.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh"
+
+# _run_hook JSON -> invoca o script com JSON via stdin; popula _CAPTURED_*.
+_run_hook() {
+  capture sh -c 'printf "%s" "$1" | "$2"' _ "$1" "$SCRIPT"
+}
+
+# _active_feature CWD SHORT STATUS -> fixture de execucao feature-00c.
+_active_feature() {
+  mkdir -p "$1/.claude/feature-00c-state/$2"
+  printf '{"execution":{"status":"%s"}}' "$3" \
+    > "$1/.claude/feature-00c-state/$2/state.json"
+}
+
+# _active_agente CWD STATUS -> fixture de execucao agente-00c.
+_active_agente() {
+  mkdir -p "$1/.claude/agente-00c-state"
+  printf '{"execution":{"status":"%s"}}' "$2" > "$1/.claude/agente-00c-state/state.json"
+}
+
+# _ticks_count FILE -> nº de linhas do sidecar (0 se ausente).
+_ticks_count() {
+  [ -f "$1" ] || { printf '0'; return 0; }
+  wc -l < "$1" | tr -d '[:space:]'
+}
+
+# _json_for CWD TOOL -> payload PostToolUse minimo do harness.
+_json_for() {
+  printf '{"cwd":"%s","hook_event_name":"PostToolUse","tool_name":"%s","tool_input":{}}' "$1" "$2"
+}
+
+# _make_shim_path: PATH controlado com POSIX essenciais, SEM jq. Espelha
+# tests/test_pretooluse-bash-guard.sh::_make_shim_path (manter em sync).
+_make_shim_path() {
+  _shim="$TMPDIR_TEST/shimbin"
+  mkdir -p "$_shim"
+  for _cmd in sh mktemp awk sed grep find head printf cp mv rm mkdir \
+              chmod ls dirname basename tr cut wc env command sort \
+              uniq date cat; do
+    _src=$(command -v "$_cmd" 2>/dev/null) || continue
+    [ -n "$_src" ] || continue
+    ln -sf "$_src" "$_shim/$_cmd" 2>/dev/null || :
+  done
+  printf '%s' "$_shim"
+}
+
+# ==== Cenario: execucao feature-00c ativa -> appende 1 tick no sidecar ====
+
+scenario_execucao_feature_ativa_appende_tick() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _run_hook "$(_json_for "$TMPDIR_TEST" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio (metrica silenciosa), obtido: $_CAPTURED_STDOUT"; return 1; }
+  _side="$TMPDIR_TEST/.claude/feature-00c-state/minha-feat/tool-call-ticks.log"
+  [ "$(_ticks_count "$_side")" = 1 ] || { _fail "sidecar" "esperado 1 linha em $_side, obtido $(_ticks_count "$_side")"; return 1; }
+}
+
+# ==== Cenario: ticks acumulam (3 calls -> 3 linhas) ====
+
+scenario_multiplos_ticks_acumulam() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _json=$(_json_for "$TMPDIR_TEST" "Read")
+  _run_hook "$_json"
+  _run_hook "$_json"
+  _run_hook "$_json"
+  _side="$TMPDIR_TEST/.claude/feature-00c-state/minha-feat/tool-call-ticks.log"
+  [ "$(_ticks_count "$_side")" = 3 ] || { _fail "sidecar" "esperado 3 linhas, obtido $(_ticks_count "$_side")"; return 1; }
+}
+
+# ==== Cenario: fora de execucao ativa -> zero interferencia, sem sidecar ====
+
+scenario_fora_de_execucao_zero_interferencia() {
+  _run_hook "$(_json_for "$TMPDIR_TEST" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio, obtido: $_CAPTURED_STDOUT"; return 1; }
+  find "$TMPDIR_TEST" -name 'tool-call-ticks.log' 2>/dev/null | grep -q . \
+    && { _fail "sidecar" "NAO deveria existir sidecar fora de execucao ativa"; return 1; }
+  return 0
+}
+
+# ==== Cenario: status terminal nao ticka ====
+
+scenario_status_terminal_nao_ticka() {
+  _active_feature "$TMPDIR_TEST" "feat-velha" "concluida"
+  _run_hook "$(_json_for "$TMPDIR_TEST" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$TMPDIR_TEST/.claude/feature-00c-state/feat-velha/tool-call-ticks.log" ] \
+    && { _fail "sidecar" "state concluido NAO deveria receber tick"; return 1; }
+  return 0
+}
+
+# ==== Cenario: aguardando_humano tambem conta como ativa ====
+
+scenario_aguardando_humano_ticka() {
+  _active_feature "$TMPDIR_TEST" "feat-pausada" "aguardando_humano"
+  _run_hook "$(_json_for "$TMPDIR_TEST" "Skill")"
+  _side="$TMPDIR_TEST/.claude/feature-00c-state/feat-pausada/tool-call-ticks.log"
+  [ "$(_ticks_count "$_side")" = 1 ] || { _fail "sidecar" "aguardando_humano e status ativo (mesma regra do bash-guard); esperado 1 tick"; return 1; }
+}
+
+# ==== Cenario: precedencia agente-00c > feature-00c (mesma regra do guard) ====
+
+scenario_agente_precede_feature() {
+  _active_agente "$TMPDIR_TEST" "em_andamento"
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _run_hook "$(_json_for "$TMPDIR_TEST" "Bash")"
+  [ "$(_ticks_count "$TMPDIR_TEST/.claude/agente-00c-state/tool-call-ticks.log")" = 1 ] \
+    || { _fail "precedencia" "tick deveria ir para agente-00c-state"; return 1; }
+  [ -f "$TMPDIR_TEST/.claude/feature-00c-state/minha-feat/tool-call-ticks.log" ] \
+    && { _fail "precedencia" "feature-00c NAO deveria receber tick quando agente-00c esta ativo"; return 1; }
+  return 0
+}
+
+# ==== Cenario: entre features ativas, menor short lexicografico vence ====
+
+scenario_feature_menor_short_vence() {
+  _active_feature "$TMPDIR_TEST" "zebra-feat" "em_andamento"
+  _active_feature "$TMPDIR_TEST" "alpha-feat" "em_andamento"
+  _run_hook "$(_json_for "$TMPDIR_TEST" "Write")"
+  [ "$(_ticks_count "$TMPDIR_TEST/.claude/feature-00c-state/alpha-feat/tool-call-ticks.log")" = 1 ] \
+    || { _fail "precedencia" "menor short (alpha-feat) deveria receber o tick"; return 1; }
+  [ -f "$TMPDIR_TEST/.claude/feature-00c-state/zebra-feat/tool-call-ticks.log" ] \
+    && { _fail "precedencia" "zebra-feat NAO deveria receber tick"; return 1; }
+  return 0
+}
+
+# ==== Cenario: jq ausente -> fail-OPEN (no-op, NUNCA deny) ====
+
+scenario_jq_ausente_fail_open() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _shim=$(_make_shim_path)
+  _json=$(_json_for "$TMPDIR_TEST" "Bash")
+  capture env -i PATH="$_shim" HOME="$TMPDIR_TEST" \
+    sh -c 'printf "%s" "$1" | "$2"' _ "$_json" "$SCRIPT"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "fail-open exige exit 0 sem jq, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "fail-open NUNCA emite decisao (contraste com o guard fail-closed): $_CAPTURED_STDOUT"; return 1; }
+  [ -f "$TMPDIR_TEST/.claude/feature-00c-state/minha-feat/tool-call-ticks.log" ] \
+    && { _fail "sidecar" "sem jq nao ha deteccao segura -> sem tick"; return 1; }
+  return 0
+}
+
+# ==== Cenario: stdin vazio / JSON invalido -> no-op exit 0 ====
+
+scenario_stdin_vazio_fail_open() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _run_hook ""
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio: $_CAPTURED_STDOUT"; return 1; }
+  return 0
+}
+
+scenario_stdin_invalido_fail_open() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _run_hook "isto nao e json {"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$TMPDIR_TEST/.claude/feature-00c-state/minha-feat/tool-call-ticks.log" ] \
+    && { _fail "sidecar" "JSON invalido nao pode gerar tick"; return 1; }
+  return 0
+}
+
+# ==== Cenario: tool_name vazio -> payload anomalo, sem tick ====
+
+scenario_tool_name_vazio_nao_ticka() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _run_hook "{\"cwd\":\"$TMPDIR_TEST\",\"hook_event_name\":\"PostToolUse\"}"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$TMPDIR_TEST/.claude/feature-00c-state/minha-feat/tool-call-ticks.log" ] \
+    && { _fail "sidecar" "payload sem tool_name nao pode gerar tick"; return 1; }
+  return 0
+}
+
+run_all_scenarios
+exit $?

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -869,4 +869,49 @@ scenario_git_commit_worktree() {
   esac
 }
 
+# ==== Sidecar de ticks do hook PostToolUse (tool-call-ticks.log) ====
+
+scenario_end_soma_sidecar_ao_campo_do_state() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  # 2 ticks manuais (campo do state) + 5 ticks do hook (sidecar).
+  capture "$SCRIPT" tool-call-tick --state-dir "$_sd"
+  capture "$SCRIPT" tool-call-tick --state-dir "$_sd"
+  printf 't1\nt2\nt3\nt4\nt5\n' > "$_sd/tool-call-ticks.log"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  _tc=$(jq -r '.waves[-1].tool_calls' "$_sd/state.json")
+  [ "$_tc" = 7 ] || { _fail "tool_calls" "esperado 7 (2 campo + 5 sidecar), obtido $_tc"; return 1; }
+  _acc=$(jq -r '.accumulated_metrics.tool_calls_total' "$_sd/state.json")
+  [ "$_acc" = 7 ] || { _fail "accumulated" "esperado 7, obtido $_acc"; return 1; }
+  # Sidecar consumido: end reseta para nao vazar para a proxima onda.
+  [ -f "$_sd/tool-call-ticks.log" ] \
+    && { _fail "sidecar" "end deveria remover o sidecar consumido"; return 1; }
+  return 0
+}
+
+scenario_start_reseta_sidecar_residual() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  # Residuo de ticks do overhead de fechamento (entre end e start).
+  printf 'residuo1\nresiduo2\n' > "$_sd/tool-call-ticks.log"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start" "$_CAPTURED_STDERR"; return 1; }
+  [ -f "$_sd/tool-call-ticks.log" ] \
+    && { _fail "sidecar" "start deveria zerar o sidecar (janela = start->end)"; return 1; }
+  return 0
+}
+
+scenario_end_sem_sidecar_usa_so_o_campo() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" tool-call-tick --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  _tc=$(jq -r '.waves[-1].tool_calls' "$_sd/state.json")
+  [ "$_tc" = 1 ] || { _fail "tool_calls" "sem sidecar, esperado 1 (so campo), obtido $_tc"; return 1; }
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Resumo

Implementa as duas sugestoes levantadas em execucao autonoma (dogfooding):

### 1. `specify`: atalho de modo autonomo na triagem (ETAPA 0.0)

A ETAPA 0 exigia confirmacao interativa sem excecao — em execucao autonoma nao ha usuario para responder o menu. A nova ETAPA 0.0 espelha a deteccao de agente ativo que a skill ja usa no cache foundational, com um refinamento: state.json em disco so conta com status ativo (`em_andamento`/`aguardando_humano`), para que um state antigo no repo nao pule a triagem de uma invocacao manual. Em modo autonomo, a invocacao do orquestrador pai vale como a confirmacao da 0.3; a classificacao 0.1 segue rodando como auditoria.

### 2. `agente-00c-runtime`: hook PostToolUse alimenta a metrica tool_calls

Ondas fechavam com `tool_calls=0` porque nada invocava `state-ondas.sh tool-call-tick` — prosa advisory, mesma classe de falha que motivou enforced-guards. Novo hook `posttooluse-tool-call-tick.sh` (matcher `*`, fail-OPEN absoluto), com a mesma deteccao de execucao ativa do `pretooluse-bash-guard.sh`.

**Decisao de design**: o hook NUNCA toca o `state.json` (PostToolUse dispara concorrente aos writes transacionais do orquestrador — read-modify-write clobberaria Decisoes). O tick vai num sidecar append-only `<state-dir>/tool-call-ticks.log`; `state-ondas.sh end` soma campo + sidecar e o consome, `start` zera a janela, `budget.sh check|status` soma mid-onda. Provisionado por `apply_guard_hooks()` junto do guard (best-effort para catalogo antigo); `settings.snippet.json` ganha o bloco PostToolUse. Prosa dos 2 orquestradores atualizada (tick manual em paralelo ao hook dobraria a contagem).

Threshold `tool_calls_threshold_wave=80` mantido — nunca foi validado com contagem real; estourar gera fim de onda gracioso. Recalibrar com dado de execucao real.

## Testes

- Suite completa: 1697 cenarios, 1 FAIL de lint anti-fantasma corrigido em seguida (doc-lints re-verdes) — demais 1696 PASS
- 11 cenarios novos do hook (fail-open, precedencia, status terminal, jq ausente, stdin invalido)
- Extensoes: `test_state-ondas` (+3: soma/reset do sidecar), `test_budget` (+2: soma mid-onda), `cstk/test_hooks` (+2: provisionamento novo e catalogo antigo)
- Smoke E2E: init real → 3 ticks via hook com payload real → `budget status` 3/80 → `end` agrega e consome sidecar

## Pos-merge

Sync instalado exige **release** (tag) + `cstk update` (catalogo) + `cstk self-update` (runtime `cli/lib/hooks.sh`); projetos-alvo ganham o hook no proximo install/update. Entrada de CHANGELOG fica para o bump da proxima release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)