### PR TITLE
feat: living specs corpus + delta requirements + staging hardening (living-specs)

### DIFF
--- a/docs/specs/living-specs/checklists/requirements.md
+++ b/docs/specs/living-specs/checklists/requirements.md
@@ -39,8 +39,8 @@ todos os contratos estao `[PROPOSTA]`).
   — Satisfeito: FR-006 explicito + US2 Cenario 5.
 - [x] CHK014 - E o caso "corpus/capability ainda nao existe" (primeiro merge) coberto sem exigir passo manual de bootstrap? [Cobertura de Edge Cases, Spec §US2 Cenario 4] {auto}
   — Satisfeito: US2 Cenario 4 + `corpus-format.md` ("Diretorio nasce vazio e e criado pelo primeiro merge") + `delta-gate-cli.md` code `corpus-missing` (severity=info, nao bloqueia).
-- [ ] CHK015 - Existe orientacao para o autor de uma nova feature descobrir/reusar o slug de capability ja em uso por outra feature (evitando fragmentar o mesmo conceito em dois arquivos de corpus por slugs distintos, ex. `commit-mode` vs `commit-staging`)? [Gap, Spec Key Entities "Living Spec Corpus"] {auto}
-  — Nao satisfeito: nenhuma FR nem contrato define um mecanismo de descoberta/reuso de slug; a escolha e inteiramente do autor no momento de preencher a secao delta (research.md Decision 5 so define o formato do slug, nao a governanca de reuso). Risco de fragmentacao silenciosa (nao e um erro do gate, pois slugs diferentes nunca colidem) — nao invalida a feature, mas e um gap de completude do requisito.
+- [x] CHK015 - Existe orientacao para o autor de uma nova feature descobrir/reusar o slug de capability ja em uso por outra feature (evitando fragmentar o mesmo conceito em dois arquivos de corpus por slugs distintos, ex. `commit-mode` vs `commit-staging`)? [Gap, Spec Key Entities "Living Spec Corpus"] {auto}
+  — Satisfeito (fechado por tasks 1.1 + 2.2): `contracts/delta-section-format.md §Gramatica` item 1 fixa a regra de descoberta (`ls docs/specs/current/*.md` antes de declarar slug novo) + `specify/SKILL.md` implementa a prosa da orientacao. Julgamento de reuso permanece do autor (nao script), conforme 1.1.2.
 
 ## Gate Deterministico (US3 / FR-010..FR-013)
 
@@ -52,8 +52,8 @@ todos os contratos estao `[PROPOSTA]`).
   — Satisfeito: FR-012 exige "mesmo padrao ja adotado" + `delta-gate-cli.md` replica literalmente o formato `FINDING|`/`RESULT|` de `validate-sdd.sh`/`requirement-coverage.sh` (research.md Decision 6, fontes verificadas no repo).
 - [x] CHK019 - O skip auditavel (FR-011) e distinguivel de uma aplicacao normal de delta em QUALQUER trilha que liste o archive, nao so no output do gate? [Mensurabilidade, Spec §FR-011] {auto}
   — Satisfeito no nivel do gate: `delta-gate-cli.md` invariante 2 (`delta=skip` no RESULT). Cobertura em `review-features` (relatorio de portfolio) nao verificada nesta checklist — ver CHK023.
-- [ ] CHK020 - E o comportamento do orquestrador autonomo (`agente-00c`, fase `review-features`) especificado para o caso em que `delta-gate.sh` bloqueia (exit 1) durante uma execucao sem supervisao — vira bloqueio humano via `bloqueios.sh`, ou a fase falha silenciosamente? [Gap, Spec Edge Cases + Plan Decision 8] {auto}
-  — Nao satisfeito: research.md Decision 8 diz apenas que o `agente-00c-orchestrator.md` "herda o comportamento por invocar a mesma skill", sem especificar a integracao concreta com o mecanismo de bloqueio humano ja existente nos orquestradores 00c. Sem essa amarracao explicita, o comportamento em modo autonomo fica implicito.
+- [x] CHK020 - E o comportamento do orquestrador autonomo (`agente-00c`, fase `review-features`) especificado para o caso em que `delta-gate.sh` bloqueia (exit 1) durante uma execucao sem supervisao — vira bloqueio humano via `bloqueios.sh`, ou a fase falha silenciosamente? [Gap, Spec Edge Cases + Plan Decision 8] {auto}
+  — Satisfeito (fechado por tasks 1.2 + 4.2): `agente-00c-orchestrator.md` (fase `review-features`) registra `bloqueios.sh register` ESCOPADO a feature bloqueada (nao aborta a onda inteira), citando o `RESULT|...` literal do gate como evidencia; fluxo manual (`/review-features` interativo) segue reportando em prosa, sem `bloqueios.sh`.
 - [x] CHK021 - E exigido que o gate seja um script determinístico (nao julgamento de modelo), removendo variabilidade de veredito entre execucoes? [Mensurabilidade, Spec §FR-012, Edge Cases ultimo item] {auto}
   — Satisfeito: FR-012 + Edge Cases ("roda como script deterministico... MUST produzir sempre o mesmo veredito") + `delta-gate-cli.md` invariante 1 (POSIX puro, sem jq).
 - [ ] CHK022 - A politica de bloqueio para os 4 subcasos de conflito (MODIFIED/REMOVED/RENAMED referenciando id inexistente, colisao ADDED, RENAMED para id ja usado, referencia cross-feature nao arquivada) reflete o apetite de risco correto do mantenedor, ou algum desses casos deveria ser aviso (warning) em vez de bloqueio (error)? [Risco] {humano}
@@ -84,8 +84,8 @@ todos os contratos estao `[PROPOSTA]`).
   — Satisfeito: `delta-gate-cli.md` invariante 4 ("texto delta nunca passa por `printf "$var"` (sempre `printf '%s'`)") + `delta-merge-cli.md` invariante 2-bis (mesma regra para o texto escrito no corpus).
 - [x] CHK033 - E a mutacao do corpus atomica (sem estado parcial visivel em caso de falha no meio de multiplas capabilities)? [Robustez, Spec Edge Cases (colisao/conflito)] {auto}
   — Satisfeito: `delta-merge-cli.md §Comportamento` passo 3-4 (validacao TOTAL de todas as entradas de todas as capabilities ANTES do primeiro `mv`; `mktemp` + `mv` atomico por arquivo).
-- [ ] CHK034 - O corpus gerado (`docs/specs/current/*.md`) tem alguma protecao contra edicao manual acidental que divirja do formato esperado pelo parser do merge (o contrato so recomenda em prosa "nao editar a mao", sem enforcement)? [Gap, Contract corpus-format §Estrutura] {auto}
-  — Nao satisfeito plenamente: `corpus-format.md` cita a advertencia em prosa ("nao editar a mao") mas nenhuma FR exige deteccao/enforcement de drift manual (ex.: um gate que valide a estrutura do corpus antes do merge). Risco baixo (arquivo gerado, uso interno do toolkit) mas e um requisito implicito nao declarado.
+- [x] CHK034 - O corpus gerado (`docs/specs/current/*.md`) tem alguma protecao contra edicao manual acidental que divirja do formato esperado pelo parser do merge (o contrato so recomenda em prosa "nao editar a mao", sem enforcement)? [Gap, Contract corpus-format §Estrutura] {auto}
+  — Satisfeito (fechado por tasks 1.3 + 3.3 + 3.7): `delta-gate.sh` valida estrutura do corpus (headings/duplicidade de ids) ANTES da validacao referencial, novo `FINDING` code `corpus-malformed` (severity=error); `delta-merge.sh` RE-VALIDA a mesma estrutura antes de qualquer mutacao (defesa em profundidade), corpus malformado bloqueia o merge intacto.
 
 ## Consistencia Cross-Artifact e Dependencias
 
@@ -109,16 +109,18 @@ todos os contratos estao `[PROPOSTA]`).
 
 ### Resolucao
 
-- **{auto} resolvidos**: 32 (`[x]` com evidencia citada)
-- **{auto} com gap identificado**: 3 (CHK015, CHK020, CHK034 — `[ ]` + `[Gap]`, evidencia de ausencia citada)
+- **{auto} resolvidos**: 35 (`[x]` com evidencia citada — inclui CHK015,
+  CHK020, CHK034, fechados por `execute-task` FASE 1/2/3/4; ver nota
+  abaixo)
 - **{humano} aguardando decisao**: 3 (CHK022, CHK030, CHK038)
 
-### Proximos Passos
+### Proximos Passos (historico)
 
-- `[Gap]` CHK015, CHK020, CHK034 -> `/create-tasks` (cada um vira uma tarefa
-  de requisito: governanca de slug de capability, integracao explicita
-  gate<->bloqueio-humano no agente-00c, e enforcement/validacao de estrutura
-  do corpus contra edicao manual).
-- `{humano}` CHK022, CHK030, CHK038 -> decisao do dono do produto antes de
-  `/execute-task`; nao bloqueiam `/create-tasks`.
-- `/create-tasks` — backlog executavel.
+- `[Gap]` CHK015, CHK020, CHK034 -> `/create-tasks` gerou tarefas de
+  requisito dedicadas (FASE 1: 1.1/1.2/1.3), implementadas em FASE 2
+  (2.2), FASE 3 (3.3/3.7) e FASE 4 (4.2). Marcados `[x]` nesta revisao
+  (FASE 6, `/analyze`) apos confirmacao empirica de que a implementacao
+  fecha cada gap — ver dec-043 no state da execucao `feature-00c`.
+- `{humano}` CHK022, CHK030, CHK038 -> decisao do dono do produto
+  permanece em aberto; nao bloqueiam a conclusao desta feature
+  (nenhum e `[Conflict]`/`[Gap]` critico).

--- a/docs/specs/living-specs/checklists/requirements.md
+++ b/docs/specs/living-specs/checklists/requirements.md
@@ -1,0 +1,124 @@
+# Requirements Checklist: Specs Vivas — Corpus Canonico, Delta Specs no Archive e Staging Explicito
+
+**Purpose**: validar a qualidade dos requisitos (FR-001..FR-017, US1-4) antes
+de `/create-tasks` — nao valida implementacao (nenhum script existe ainda,
+todos os contratos estao `[PROPOSTA]`).
+**Created**: 2026-07-23
+**Feature**: [spec.md](../spec.md) | [plan.md](../plan.md)
+
+## Delta Requirements Section (US1 / FR-001)
+
+- [x] CHK001 - E a gramatica exata da secao `## Delta Requirements` (heading, blocos `### Capability:`, subgrupos `####`, prefixo de entrada) especificada de forma parseavel deterministicamente? [Clareza, Spec §FR-001] {auto}
+  — Satisfeito: `contracts/delta-section-format.md` define a gramatica completa (heading, `### Capability: <slug>`, 4 subgrupos `####`, formato `- **FR-NNN**: <texto>` / `- **FR-NNN -> FR-MMM**`).
+- [x] CHK002 - O identificador usado em ADDED e explicitamente amarrado ao mesmo esquema `FR-NNN` da secao `### Functional Requirements` da propria spec (evita dois namespaces de id)? [Clareza, Spec §FR-001, US1 Cenario 1] {auto}
+  — Satisfeito: spec.md linha 81-82 ("cada requisito novo aparece listado sob ADDED com o mesmo identificador (`FR-NNN`) usado na secao de Requirements da propria spec") + contrato regra 4.
+- [x] CHK003 - O formato do marcador RENAMED evita ambiguidade de seta (unicode vs ASCII) que quebraria parsing POSIX? [Clareza, Contract delta-section-format §Regras] {auto}
+  — Satisfeito: research.md Decision 4 registra a rejeicao explicita de `→` unicode em favor de `->` ASCII; contrato regra 5 confirma.
+- [x] CHK004 - O registro de Skip explicito (FR-011) especifica TODOS os campos obrigatorios (quem, quando, por que) e o que torna um skip invalido? [Completude, Spec §FR-011] {auto}
+  — Satisfeito: `contracts/delta-section-format.md §Skip explicito` define os 3 campos obrigatorios (justificativa, autor, data) e o codigo `skip-invalid` para ausencia de qualquer um.
+- [x] CHK005 - E vedada a coexistencia de Skip e blocos Capability na mesma secao (estado ambiguo "aplicar delta E pular")? [Consistencia, Contract delta-gate-cli §Codes] {auto}
+  — Satisfeito: code `skip-with-delta` no `delta-gate-cli.md` cobre exatamente esse conflito.
+- [ ] CHK006 - E a interacao entre a secao Delta Requirements nova e os gates SDD ja existentes (`validate-sdd.sh` spec-profile, `requirement-coverage.sh`) verificada para nao gerar falso-positivo (ex.: secao extra confundida com requisito nao coberto)? [Consistencia, Spec §FR-001] {auto}
+  — Satisfeito: research.md Decision 4 cita verificacao real no repo (`validate-sdd.sh` linha 189 exige so 3 secoes fixas; `requirement-coverage.sh` linha 116 so extrai de `### Functional Requirements`, reseta em qualquer `##`/`###` seguinte) — ids delta nao entram na cobertura.
+
+## Corpus Canonico (US2 / FR-002..FR-009)
+
+- [x] CHK007 - E a estrutura de arquivo do corpus (`docs/specs/current/<capability-slug>.md`) especificada com secoes fixas (Requirements ativos, Removed, Renamed) de forma nao-ambigua? [Completude, Spec §FR-002..FR-006] {auto}
+  — Satisfeito: `contracts/corpus-format.md` define as 3 secoes e o template de cada uma.
+- [x] CHK008 - O campo de proveniencia (FR-007: "rastreavel ate a(s) feature(s) que a introduziu ou modificou por ultimo") esta quantificado com um formato concreto, nao so em prosa? [Mensurabilidade, Spec §FR-007] {auto}
+  — Satisfeito: `corpus-format.md` define `*Introduzida por: <feature> (<data>)*` (imutavel) e `*Ultima modificacao: <feature> (<data>)*` (so apos 1o MODIFIED).
+- [x] CHK009 - E o escopo de unicidade do identificador `FR-NNN` dentro do corpus explicitamente definido (global vs por-capability), evitando ambiguidade de colisao entre capabilities distintas? [Clareza, Spec Key Entities "Corpus Entry"] {auto}
+  — Satisfeito: research.md Decision 5 fixa unicidade POR ARQUIVO de capability (namespace = capability); mesma numeracao em capabilities distintas nao colide.
+- [x] CHK010 - E o comportamento de REMOVED especificado para nunca resultar em desaparecimento silencioso (preserva rastro do "porque")? [Completude, Spec §FR-004] {auto}
+  — Satisfeito: FR-004 explicito + `corpus-format.md` secao `## Removed Requirements` com `*Removida por:*` + motivo obrigatorio.
+- [x] CHK011 - E o comportamento de RENAMED especificado para preservar a rastreabilidade historica ligando id antigo a id novo? [Completude, Spec §FR-005] {auto}
+  — Satisfeito: FR-005 + `corpus-format.md` secao `## Renamed Identifiers` (tabela Antigo/Novo/Feature/Data); id aposentado nunca reciclado (regra 1).
+- [x] CHK012 - O determinismo do merge (mesmos inputs => mesmo corpus resultante byte-a-byte) e um requisito explicito, nao so uma expectativa implicita? [Mensurabilidade, Spec Edge Cases ultimo item] {auto}
+  — Satisfeito: spec.md Edge Cases ("gate ... MUST produzir sempre o mesmo veredito") + `delta-merge-cli.md` invariante 3 (ordenacao por id, mesma data => mesmo resultado).
+- [x] CHK013 - E especificado que a atualizacao do corpus e ADICIONAL ao archive existente e nunca uma substituicao (garante nao-regressao do fluxo hoje funcional)? [Consistencia, Spec §FR-006, US2 Cenario 5] {auto}
+  — Satisfeito: FR-006 explicito + US2 Cenario 5.
+- [x] CHK014 - E o caso "corpus/capability ainda nao existe" (primeiro merge) coberto sem exigir passo manual de bootstrap? [Cobertura de Edge Cases, Spec §US2 Cenario 4] {auto}
+  — Satisfeito: US2 Cenario 4 + `corpus-format.md` ("Diretorio nasce vazio e e criado pelo primeiro merge") + `delta-gate-cli.md` code `corpus-missing` (severity=info, nao bloqueia).
+- [ ] CHK015 - Existe orientacao para o autor de uma nova feature descobrir/reusar o slug de capability ja em uso por outra feature (evitando fragmentar o mesmo conceito em dois arquivos de corpus por slugs distintos, ex. `commit-mode` vs `commit-staging`)? [Gap, Spec Key Entities "Living Spec Corpus"] {auto}
+  — Nao satisfeito: nenhuma FR nem contrato define um mecanismo de descoberta/reuso de slug; a escolha e inteiramente do autor no momento de preencher a secao delta (research.md Decision 5 so define o formato do slug, nao a governanca de reuso). Risco de fragmentacao silenciosa (nao e um erro do gate, pois slugs diferentes nunca colidem) — nao invalida a feature, mas e um gap de completude do requisito.
+
+## Gate Deterministico (US3 / FR-010..FR-013)
+
+- [x] CHK016 - O gate especifica TODOS os codigos de bloqueio possiveis (nao so "delta ausente"), incluindo casos de referencia invalida e colisao? [Completude, Spec §FR-010, FR-013] {auto}
+  — Satisfeito: `delta-gate-cli.md §Codes` lista 10 codes (`delta-missing`, `skip-invalid`, `delta-empty`, `capability-slug-invalid`, `entry-malformed`, `ref-not-found`, `added-collision`, `renamed-target-exists`, `skip-with-delta`, `corpus-missing`).
+- [x] CHK017 - E o veredito do gate para "so REMOVED" (sem ADDED/MODIFIED) explicitamente coberto, evitando falso-bloqueio por secao "incompleta"? [Cobertura de Edge Cases, Spec §US3 Cenario 3] {auto}
+  — Satisfeito: US3 Cenario 3 + `delta-gate-cli.md` invariante 3 ("Delta so-REMOVED e valida").
+- [x] CHK018 - E o formato de saida do gate (severidade, exit codes) consistente com o padrao ja adotado por outros gates deterministicos do toolkit, evitando um terceiro formato paralelo? [Consistencia, Spec §FR-012] {auto}
+  — Satisfeito: FR-012 exige "mesmo padrao ja adotado" + `delta-gate-cli.md` replica literalmente o formato `FINDING|`/`RESULT|` de `validate-sdd.sh`/`requirement-coverage.sh` (research.md Decision 6, fontes verificadas no repo).
+- [x] CHK019 - O skip auditavel (FR-011) e distinguivel de uma aplicacao normal de delta em QUALQUER trilha que liste o archive, nao so no output do gate? [Mensurabilidade, Spec §FR-011] {auto}
+  — Satisfeito no nivel do gate: `delta-gate-cli.md` invariante 2 (`delta=skip` no RESULT). Cobertura em `review-features` (relatorio de portfolio) nao verificada nesta checklist — ver CHK023.
+- [ ] CHK020 - E o comportamento do orquestrador autonomo (`agente-00c`, fase `review-features`) especificado para o caso em que `delta-gate.sh` bloqueia (exit 1) durante uma execucao sem supervisao — vira bloqueio humano via `bloqueios.sh`, ou a fase falha silenciosamente? [Gap, Spec Edge Cases + Plan Decision 8] {auto}
+  — Nao satisfeito: research.md Decision 8 diz apenas que o `agente-00c-orchestrator.md` "herda o comportamento por invocar a mesma skill", sem especificar a integracao concreta com o mecanismo de bloqueio humano ja existente nos orquestradores 00c. Sem essa amarracao explicita, o comportamento em modo autonomo fica implicito.
+- [x] CHK021 - E exigido que o gate seja um script determinístico (nao julgamento de modelo), removendo variabilidade de veredito entre execucoes? [Mensurabilidade, Spec §FR-012, Edge Cases ultimo item] {auto}
+  — Satisfeito: FR-012 + Edge Cases ("roda como script deterministico... MUST produzir sempre o mesmo veredito") + `delta-gate-cli.md` invariante 1 (POSIX puro, sem jq).
+- [ ] CHK022 - A politica de bloqueio para os 4 subcasos de conflito (MODIFIED/REMOVED/RENAMED referenciando id inexistente, colisao ADDED, RENAMED para id ja usado, referencia cross-feature nao arquivada) reflete o apetite de risco correto do mantenedor, ou algum desses casos deveria ser aviso (warning) em vez de bloqueio (error)? [Risco] {humano}
+
+## Staging Explicito no Commit Atomico (US4 / FR-014..FR-017)
+
+- [x] CHK023 - A proibicao de staging amplo especifica EXATAMENTE quais formas de "adicionar tudo" sao vedadas (nao so `git add -A`)? [Clareza, Spec §FR-014] {auto}
+  — Satisfeito: `commit-staging-cli.md §stage-derived` passo 5 lista as 3 formas proibidas explicitamente: `git add -A`, `git add .`, `git add --all`.
+- [x] CHK024 - Todos os sites de codigo/prosa que hoje fazem staging amplo estao identificados e listados, evitando que o fix corrija so um caminho e deixe outro intacto (o proprio modo de falha do incidente original)? [Completude, Spec §US4] {auto}
+  — Satisfeito: research.md Decision 1 lista os 3 sites reais (2 arquivos de prosa dos orquestradores + `state-ondas.sh::_so_cmd_git_commit` em codigo), com rationale explicito de por que corrigir so a prosa reintroduziria o bug pelo caminho do wave-commit.
+- [x] CHK025 - E o criterio para distinguir "untracked criado pela task corrente" de "untracked alheio pre-existente" especificado de forma deterministica (nao heuristica)? [Mensurabilidade, Spec §FR-015] {auto}
+  — Satisfeito: `commit-staging-cli.md §snapshot`/`§stage-derived` define baseline capturado ANTES do trabalho da onda + `comm -13` (diff de conjuntos ordenados) — deterministico, sem heuristica de nome/extensao.
+- [x] CHK026 - E o comportamento especificado para o caso "baseline de snapshot ausente" (nao deveria abrir uma janela de fallback para staging amplo)? [Cobertura de Edge Cases, Spec §FR-015] {auto}
+  — Satisfeito: `commit-staging-cli.md` passo 2 ("Baseline AUSENTE => conjunto vazio + aviso em stderr — fail-closed: untracked nunca entram sem baseline; jamais fallback amplo").
+- [x] CHK027 - E o caso "allowlist vazia" (etapa/task sem mudancas) especificado para nao gerar commit vazio nem cair em fallback amplo? [Cobertura de Edge Cases, Spec §FR-016] {auto}
+  — Satisfeito: FR-016 + US4 Cenario 3 + `commit-staging-cli.md` passo 4 (exit 3, nenhum `git add` executado).
+- [x] CHK028 - E exigida cobertura de teste de regressao automatizada especificamente para o cenario que causou o incidente real (nao so para o comportamento geral de staging)? [Mensurabilidade, Spec §FR-017, SC-003] {auto}
+  — Satisfeito: FR-017 + SC-003 + `commit-staging-cli.md §Regressao obrigatoria` lista 5 cenarios de teste, incluindo fixture com arquivo untracked alheio analogo ao `.pptx` do incidente real.
+- [x] CHK029 - O tratamento de paths com caracteres especiais (espacos, unicode, C-style quoting do `git status --porcelain`, renames) esta coberto para evitar que a allowlist derive um path incorreto ou perca uma entrada legitima? [Cobertura de Edge Cases + Seguranca, Contract commit-staging-cli §stage-derived passo 1] {auto}
+  — Satisfeito: `commit-staging-cli.md` passo 1 especifica `core.quotepath=false`, tratamento de renames (path novo staged) e teste dedicado para path com espaco/char nao-ASCII. Cita explicitamente ser hardening do gate `owasp-security` pos-plan (ver onda-003).
+- [ ] CHK030 - O staging por `--scope-dir` no commit por etapa (que confina a allowlist a `docs/specs/<feature>/` + state dir) e suficientemente restritivo para features cuja etapa TAMBEM edita codigo fora desses dirs (ex.: etapa `plan` que ja ajusta um contrato existente em `global/`) — ou esse caso deveria alargar o scope-dir dinamicamente? [Risco] {humano}
+
+## Seguranca e Robustez Cross-Cutting
+
+- [x] CHK031 - E o slug de capability (dado UNTRUSTED vindo de texto livre da spec) validado ANTES de ser usado para compor qualquer path de arquivo, prevenindo path traversal (`../`)? [Seguranca, Contract delta-gate-cli invariante 4, delta-merge-cli invariante 2-bis] {auto}
+  — Satisfeito: ambos os contratos exigem a validacao `[a-z0-9][a-z0-9-]*` como PRIMEIRA checagem, antes de qualquer composicao de path, em AMBOS os scripts (defesa em profundidade — merge nunca confia que o gate ja rodou). Teste dedicado com slug hostil (`../escape`, absoluto, com espaco) exigido.
+- [x] CHK032 - E vedado o uso de `printf "$var"` (format-string injection) ao emitir texto delta UNTRUSTED nos artefatos gerados? [Seguranca, Contract delta-gate-cli invariante 4] {auto}
+  — Satisfeito: `delta-gate-cli.md` invariante 4 ("texto delta nunca passa por `printf "$var"` (sempre `printf '%s'`)") + `delta-merge-cli.md` invariante 2-bis (mesma regra para o texto escrito no corpus).
+- [x] CHK033 - E a mutacao do corpus atomica (sem estado parcial visivel em caso de falha no meio de multiplas capabilities)? [Robustez, Spec Edge Cases (colisao/conflito)] {auto}
+  — Satisfeito: `delta-merge-cli.md §Comportamento` passo 3-4 (validacao TOTAL de todas as entradas de todas as capabilities ANTES do primeiro `mv`; `mktemp` + `mv` atomico por arquivo).
+- [ ] CHK034 - O corpus gerado (`docs/specs/current/*.md`) tem alguma protecao contra edicao manual acidental que divirja do formato esperado pelo parser do merge (o contrato so recomenda em prosa "nao editar a mao", sem enforcement)? [Gap, Contract corpus-format §Estrutura] {auto}
+  — Nao satisfeito plenamente: `corpus-format.md` cita a advertencia em prosa ("nao editar a mao") mas nenhuma FR exige deteccao/enforcement de drift manual (ex.: um gate que valide a estrutura do corpus antes do merge). Risco baixo (arquivo gerado, uso interno do toolkit) mas e um requisito implicito nao declarado.
+
+## Consistencia Cross-Artifact e Dependencias
+
+- [x] CHK035 - Toda FR (FR-001..FR-017) tem pelo menos um cenario de aceite ou edge case associado, evitando requisito "orfao" sem forma de verificacao? [Cobertura, Gate requirement-coverage.sh] {auto}
+  — Satisfeito: `requirement-coverage.sh docs/specs/living-specs/spec.md` executado nesta onda retornou `RESULT|...|requirements=17|covered=17|errors=0` (exit 0, zero FINDING).
+- [x] CHK036 - As decisoes de escopo negativo (Out of Scope: backfill retroativo, multi-repo stores) tem justificativa rastreavel e nao apenas uma omissao silenciosa? [Clareza, Spec §Out of Scope] {auto}
+  — Satisfeito: ambos os itens tem rationale explicito (fonte insuficiente sobre o algoritmo do OpenSpec para multi-repo; volume de 15 features + opcionalidade de task para backfill).
+- [x] CHK037 - A ausencia de fonte externa suficiente sobre o algoritmo exato de merge do OpenSpec concorrente foi tratada como bloqueio de suposicao (Principio VI) em vez de inventada? [Veracidade, Spec §Clarifications Q2] {auto}
+  — Satisfeito: `## Clarifications` Q2 registra explicitamente "sem fonte externa suficiente sobre o algoritmo exato do OpenSpec para adotar como suposicao (Principio VI)" como justificativa da politica de bloqueio automatico escolhida.
+- [ ] CHK038 - A tarefa opcional de backfill incremental (Out of Scope, mas mencionada como possivel task) tem criterio de prontidao definido, ou fica indefinidamente em backlog sem dono? [Risco/Priorizacao] {humano}
+
+## Notes
+
+- Items `{auto}` ja vem resolvidos pelo agente (`[x]` com citacao, ou `[ ]`
+  com `[Gap]`/marcador quando a evidencia nao sustenta).
+- Items `{humano}` ficam `[ ]` aguardando decisao do dono do produto — NAO
+  bloqueiam a progressao para `/create-tasks` (nenhum e `[Conflict]`/`[Gap]`
+  critico).
+- Gate `requirement-coverage.sh` (ETAPA 4.2.1): `RESULT|...|requirements=17|covered=17|errors=0`, exit 0 — nenhum `[Gap]` adicional gerado por esse gate.
+- Rastreabilidade: 38/38 items (100%) citam `[Spec §X]`, `[Contract ...]`, `[Gap]` ou `[Risco]` — acima do minimo de 80%.
+
+### Resolucao
+
+- **{auto} resolvidos**: 32 (`[x]` com evidencia citada)
+- **{auto} com gap identificado**: 3 (CHK015, CHK020, CHK034 — `[ ]` + `[Gap]`, evidencia de ausencia citada)
+- **{humano} aguardando decisao**: 3 (CHK022, CHK030, CHK038)
+
+### Proximos Passos
+
+- `[Gap]` CHK015, CHK020, CHK034 -> `/create-tasks` (cada um vira uma tarefa
+  de requisito: governanca de slug de capability, integracao explicita
+  gate<->bloqueio-humano no agente-00c, e enforcement/validacao de estrutura
+  do corpus contra edicao manual).
+- `{humano}` CHK022, CHK030, CHK038 -> decisao do dono do produto antes de
+  `/execute-task`; nao bloqueiam `/create-tasks`.
+- `/create-tasks` — backlog executavel.

--- a/docs/specs/living-specs/contracts/commit-staging-cli.md
+++ b/docs/specs/living-specs/contracts/commit-staging-cli.md
@@ -1,0 +1,82 @@
+# Contract: commit-mode.sh — subcomandos snapshot + stage-derived
+
+> **[PROPOSTA — a validar na implementacao]** — subcomandos NOVOS em
+> `global/skills/agente-00c-runtime/scripts/commit-mode.sh` (522 linhas
+> hoje; subcomandos existentes verificados: `is-enabled | set-enabled |
+> guard-branch | stage-message | task-message | finalize` — NENHUM faz
+> staging hoje; o staging amplo vive na prosa dos orquestradores e em
+> `state-ondas.sh::_so_cmd_git_commit`, ver research Decision 1).
+
+**Feature**: `living-specs` | FRs: FR-014, FR-015, FR-016, FR-017
+
+## `snapshot`
+
+```
+commit-mode.sh snapshot --state-dir DIR --projeto-alvo-path PATH
+```
+
+Captura o conjunto de untracked ATUAL do repo
+(`git status --porcelain`, linhas `?? `), paths ordenados por `sort`, e
+grava em `DIR/commit-baseline.txt` (sidecar — mesmo padrao de
+`tool-call-ticks.log`: nunca dentro do `state.json`, nunca versionado).
+Sobrescreve baseline anterior (1 baseline por onda; chamado pelo
+orquestrador na abertura de onda `execute-task` com atomic habilitado, e
+pelo caminho de wave-commit do agente-00c).
+
+Exit: 0 gravado; 1 erro git/IO; 2 uso incorreto.
+
+## `stage-derived`
+
+```
+commit-mode.sh stage-derived --state-dir DIR --projeto-alvo-path PATH \
+  [--scope-dir REL_DIR]...
+```
+
+Computa a CommitAllowlist (data-model) e faz staging explicito:
+
+1. `tracked_changed` = paths com mudanca em arquivos ja rastreados
+   (estados de `git status --porcelain` exceto `??`).
+   **Seguranca (gate owasp pos-plan)**: leitura via
+   `git -c core.quotepath=false status --porcelain` — porcelain v1 aplica
+   quoting C-style a paths com caracteres especiais e usa formato
+   `old -> new` em renames; parsing ingenuo derrubaria paths legitimos da
+   allowlist ou passaria path errado ao `git add --`. Renames tratados
+   (staged o path NOVO); teste cobre path com espaco e char nao-ASCII.
+2. `untracked_new` = untracked atuais MENOS `DIR/commit-baseline.txt`
+   (`comm -13` sobre listas ordenadas). Baseline AUSENTE => conjunto
+   vazio + aviso em stderr (fail-closed: untracked nunca entram sem
+   baseline; jamais fallback amplo).
+3. `allowlist` = `tracked_changed` + `untracked_new`; se >=1
+   `--scope-dir`, filtrada aos paths sob esses prefixos relativos.
+4. Allowlist vazia => exit 3, NENHUM `git add` executado (caller pula o
+   commit — FR-016, sem commit vazio).
+5. Senao: `git add -- <path>` por entrada (paths deletados via
+   `git add --` tambem registram a delecao). PROIBIDO `git add -A`,
+   `git add .`, `git add --all` em qualquer caminho do codigo (FR-014).
+
+Exit: 0 staged >=1 path; 3 allowlist vazia (nada a commitar); 1 erro git;
+2 uso incorreto. Erros emitem `DIAG|` (envelope `_diag.sh`, ja sourceable
+same-dir no runtime).
+
+## Regimes de chamada (quem chama, com o que)
+
+| Site (hoje com staging amplo) | Chamada nova |
+|-------------------------------|--------------|
+| prosa passo 10.qui (etapa) — feature-orchestrator | `stage-derived --scope-dir docs/specs/<feature> --scope-dir .claude/feature-00c-state/<short>` |
+| prosa passo 7.bis (task) — feature-orchestrator | `snapshot` na abertura da onda + `stage-derived` (sem scope-dir) |
+| prosa equivalente — agente-00c-orchestrator (2 sites) | idem, com state dir `.claude/agente-00c-state` |
+| `state-ondas.sh::_so_cmd_git_commit` (`git add -- .`) | delega staging a `stage-derived` (mesma skill dir); exit 3 => no-op "nada para commitar" (comportamento atual preservado) |
+
+## Regressao obrigatoria (FR-017, SC-003)
+
+`tests/test_commit-mode.sh` (existente) ganha cenarios com fixture git
+contendo arquivo untracked alheio pre-existente (analogo ao `.pptx` do
+incidente):
+
+1. commit de etapa (scope-dirs) => alheio permanece untracked;
+2. commit de task (baseline + arquivo novo criado pos-snapshot) => novo
+   entra, alheio fica fora;
+3. baseline ausente => untracked todos fora + aviso;
+4. allowlist vazia => exit 3 e nenhum commit;
+5. `state-ondas.sh git-commit` pos-mudanca => alheio fora
+   (`tests/test_state-ondas.sh` estendido).

--- a/docs/specs/living-specs/contracts/commit-staging-cli.md
+++ b/docs/specs/living-specs/contracts/commit-staging-cli.md
@@ -1,11 +1,30 @@
 # Contract: commit-mode.sh — subcomandos snapshot + stage-derived
 
-> **[PROPOSTA — a validar na implementacao]** — subcomandos NOVOS em
-> `global/skills/agente-00c-runtime/scripts/commit-mode.sh` (522 linhas
-> hoje; subcomandos existentes verificados: `is-enabled | set-enabled |
-> guard-branch | stage-message | task-message | finalize` — NENHUM faz
-> staging hoje; o staging amplo vive na prosa dos orquestradores e em
-> `state-ondas.sh::_so_cmd_git_commit`, ver research Decision 1).
+> **[IMPLEMENTADO — living-specs FASE 5]** — subcomandos `snapshot` e
+> `stage-derived` em
+> `global/skills/agente-00c-runtime/scripts/commit-mode.sh` (subcomandos
+> pre-existentes: `is-enabled | set-enabled | guard-branch | stage-message
+> | task-message | finalize` — nenhum fazia staging; o staging amplo vivia
+> na prosa dos orquestradores e em `state-ondas.sh::_so_cmd_git_commit`,
+> ver research Decision 1).
+>
+> **Divergencia medida vs proposta original**: `git -c core.quotepath=false
+> status --porcelain` (sem `-z`) AINDA envolve em aspas duplas C-style
+> qualquer path contendo um espaco — comportamento observado
+> empiricamente, independente de `core.quotepath` (que so controla o
+> octal-escaping de bytes nao-ASCII, nao a quotacao por espaco). Como
+> nomes de arquivo com espaco sao o caso mais comum (nao um edge case
+> raro), a implementacao usa `git status --porcelain -z
+> --untracked-files=all` (paths NUL-terminados, NUNCA quoted, formato de
+> rename tambem NUL-delimitado sem a seta ` -> `) e converte para 1 linha
+> por campo via `tr '\0' '\n'` (paths nao contem NUL; newline literal em
+> nome de arquivo fica fora de escopo — mesma limitacao aceita pelo
+> restante do runtime POSIX). `--untracked-files=all` tambem medido
+> como necessario: sem ele, git colapsa um diretorio INTEIRO-untracked
+> (ex: uma feature nova sob `docs/specs/`) numa unica entrada `?? dir/`
+> em vez de listar cada arquivo — quebrando o casamento por prefixo de
+> `--scope-dir` sempre que o primeiro arquivo tocado vive num diretorio
+> que ainda nao existe no repo.
 
 **Feature**: `living-specs` | FRs: FR-014, FR-015, FR-016, FR-017
 
@@ -16,8 +35,8 @@ commit-mode.sh snapshot --state-dir DIR --projeto-alvo-path PATH
 ```
 
 Captura o conjunto de untracked ATUAL do repo
-(`git status --porcelain`, linhas `?? `), paths ordenados por `sort`, e
-grava em `DIR/commit-baseline.txt` (sidecar — mesmo padrao de
+(`git status --porcelain -z`, entradas `?? `), paths ordenados por `sort`,
+e grava em `DIR/commit-baseline.txt` (sidecar — mesmo padrao de
 `tool-call-ticks.log`: nunca dentro do `state.json`, nunca versionado).
 Sobrescreve baseline anterior (1 baseline por onda; chamado pelo
 orquestrador na abertura de onda `execute-task` com atomic habilitado, e
@@ -35,13 +54,17 @@ commit-mode.sh stage-derived --state-dir DIR --projeto-alvo-path PATH \
 Computa a CommitAllowlist (data-model) e faz staging explicito:
 
 1. `tracked_changed` = paths com mudanca em arquivos ja rastreados
-   (estados de `git status --porcelain` exceto `??`).
+   (estados de `git status --porcelain -z` exceto `??`).
    **Seguranca (gate owasp pos-plan)**: leitura via
-   `git -c core.quotepath=false status --porcelain` — porcelain v1 aplica
-   quoting C-style a paths com caracteres especiais e usa formato
-   `old -> new` em renames; parsing ingenuo derrubaria paths legitimos da
+   `git status --porcelain -z` — a variante `-z` nunca quota/escapa paths
+   (independe de `core.quotepath`; a variante sem `-z` quota qualquer path
+   com espaco em aspas C-style mesmo com `core.quotepath=false`, medido
+   empiricamente) e usa formato NUL-delimitado para renames (path novo,
+   NUL, path antigo, NUL — sem a seta ` -> ` textual, que so existe no
+   formato humano/sem `-z`); parsing ingenuo derrubaria paths legitimos da
    allowlist ou passaria path errado ao `git add --`. Renames tratados
-   (staged o path NOVO); teste cobre path com espaco e char nao-ASCII.
+   (staged o path NOVO, path antigo descartado); teste cobre path com
+   espaco, char nao-ASCII e rename.
 2. `untracked_new` = untracked atuais MENOS `DIR/commit-baseline.txt`
    (`comm -13` sobre listas ordenadas). Baseline AUSENTE => conjunto
    vazio + aviso em stderr (fail-closed: untracked nunca entram sem
@@ -65,7 +88,7 @@ same-dir no runtime).
 | prosa passo 10.qui (etapa) — feature-orchestrator | `stage-derived --scope-dir docs/specs/<feature> --scope-dir .claude/feature-00c-state/<short>` |
 | prosa passo 7.bis (task) — feature-orchestrator | `snapshot` na abertura da onda + `stage-derived` (sem scope-dir) |
 | prosa equivalente — agente-00c-orchestrator (2 sites) | idem, com state dir `.claude/agente-00c-state` |
-| `state-ondas.sh::_so_cmd_git_commit` (`git add -- .`) | delega staging a `stage-derived` (mesma skill dir); exit 3 => no-op "nada para commitar" (comportamento atual preservado) |
+| `state-ondas.sh::_so_cmd_git_commit` (`git add -- .`) | delega staging a `stage-derived` (mesma skill dir; sem scope-dir); exit 3 => no-op "nada para commitar" (comportamento atual preservado). O `snapshot` NAO acontece aqui — `state-ondas.sh start` (inicio de TODA onda) chama `commit-mode.sh snapshot` best-effort via `.execution.target_project_path` do proprio `state.json`, exatamente como a Entity UntrackedBaseline ja especificava ("escrito... no inicio da onda"); `git-commit` e a ULTIMA etapa da onda e snapshotar ali mesmo daria diff sempre vazio (zero janela de tempo — divergencia medida vs tasks.md 5.4.1, corrigida sem exigir mudanca de prosa nos orquestradores chamadores) |
 
 ## Regressao obrigatoria (FR-017, SC-003)
 

--- a/docs/specs/living-specs/contracts/corpus-format.md
+++ b/docs/specs/living-specs/contracts/corpus-format.md
@@ -1,0 +1,78 @@
+# Contract: Living Spec Corpus (docs/specs/current/)
+
+> **[PROPOSTA — a validar na implementacao]** — contrato NOVO; nenhum
+> formato existente e afirmado aqui.
+
+**Feature**: `living-specs` | FRs: FR-002..FR-007, FR-009
+
+## Layout
+
+```
+docs/specs/current/
+├── <capability-a>.md
+├── <capability-b>.md
+└── ...
+```
+
+Um arquivo por capability (research Decision 5). Diretorio nasce vazio e e
+criado pelo primeiro merge (US2 cenario 4). Paralelo a
+`docs/specs/_archived/` — o corpus e destino ADICIONAL, o archive existente
+nao muda (FR-006).
+
+## Estrutura de `<capability-slug>.md`
+
+```markdown
+# Capability: <capability-slug>
+
+> Comportamento ATUAL do sistema para esta capability. Gerado/atualizado
+> exclusivamente por delta-merge.sh na acao de archive — nao editar a mao.
+
+## Requirements
+
+### FR-NNN
+
+<texto integral do requisito, comportamento atual>
+
+*Introduzida por: <feature-short-name> (<YYYY-MM-DD>)*
+*Ultima modificacao: <feature-short-name> (<YYYY-MM-DD>)*
+
+## Removed Requirements
+
+### FR-MMM [REMOVED]
+
+<ultimo texto vigente antes da remocao>
+
+*Introduzida por: <feature> (<data>)*
+*Removida por: <feature> (<YYYY-MM-DD>)* — <motivo declarado no delta>
+
+## Renamed Identifiers
+
+| Antigo | Novo | Feature | Data |
+|--------|------|---------|------|
+| FR-AAA | FR-BBB | <feature> | <YYYY-MM-DD> |
+```
+
+Regras:
+
+1. `### FR-NNN` unico por arquivo considerando `## Requirements` E
+   `## Removed Requirements` E coluna "Antigo"/"Novo" de
+   `## Renamed Identifiers` (id aposentado nunca e reciclado).
+2. Linha `*Ultima modificacao:*` presente apenas apos o primeiro MODIFIED;
+   `*Introduzida por:*` e imutavel (proveniencia de origem — SC-004).
+3. Entradas ordenadas por id crescente dentro de cada secao (determinismo:
+   dois merges com os mesmos inputs produzem bytes identicos).
+4. Secoes `## Removed Requirements` / `## Renamed Identifiers` so existem
+   quando nao-vazias.
+
+## Semantica de aplicacao (delta -> corpus)
+
+| Tipo | Pre-condicao (senao: bloqueio) | Efeito |
+|------|-------------------------------|--------|
+| ADDED | id NAO existe no arquivo (nenhuma secao) | nova entrada em `## Requirements` com `Introduzida por` |
+| MODIFIED | id ativo em `## Requirements` | texto substituido, id preservado, `Ultima modificacao` atualizada |
+| REMOVED | id ativo em `## Requirements` | entrada movida para `## Removed Requirements` com `Removida por` + motivo |
+| RENAMED | old ativo; new inexistente em qualquer secao | heading vira new id; linha na tabela de renames |
+
+Violacao de qualquer pre-condicao => FINDING|error + exit 1 SEM nenhuma
+mutacao (merge atomico via mktemp + mv — clarify: bloqueio com diagnostico,
+nunca merge silencioso/last-write-wins).

--- a/docs/specs/living-specs/contracts/corpus-format.md
+++ b/docs/specs/living-specs/contracts/corpus-format.md
@@ -26,6 +26,12 @@ nao muda (FR-006).
 
 > Comportamento ATUAL do sistema para esta capability. Gerado/atualizado
 > exclusivamente por delta-merge.sh na acao de archive — nao editar a mao.
+> **Enforcement (CHK034)**: esta advertencia em prosa passa a ter
+> checagem deterministica — `delta-gate.sh` e `delta-merge.sh` validam as
+> invariantes estruturais abaixo como pre-checagem (code
+> `corpus-malformed`, severity=error) ANTES de qualquer validacao
+> referencial ou mutacao; ver `delta-gate-cli.md` §Codes/invariante 6 e
+> `delta-merge-cli.md` invariante 2-ter.
 
 ## Requirements
 

--- a/docs/specs/living-specs/contracts/delta-gate-cli.md
+++ b/docs/specs/living-specs/contracts/delta-gate-cli.md
@@ -1,0 +1,71 @@
+# Contract: delta-gate.sh CLI
+
+> **[PROPOSTA — a validar na implementacao]** — script NOVO em
+> `global/skills/review-features/scripts/delta-gate.sh`. O padrao de saida
+> FINDING/RESULT e exit codes replica o dos gates REAIS v5.22.0
+> (`validate-sdd.sh`, `requirement-coverage.sh` — verificados no repo).
+
+**Feature**: `living-specs` | FRs: FR-010, FR-011, FR-012, FR-013
+
+## Uso
+
+```
+delta-gate.sh SPEC_MD [--corpus-dir DIR]
+```
+
+- `SPEC_MD` — path do `spec.md` da feature candidata a archive.
+- `--corpus-dir DIR` — raiz do corpus (default:
+  `<repo>/docs/specs/current/`, resolvida subindo a partir de SPEC_MD pela
+  convencao `docs/specs/<feature>/spec.md`; sem convencao e sem flag =>
+  exit 2).
+
+Read-only: nunca escreve em SPEC_MD nem no corpus. Deterministico: mesmo
+input => mesmo veredito (edge case da spec).
+
+## Saida (stdout)
+
+```
+FINDING|<severity>|<code>|<mensagem>
+RESULT|<spec>|delta=<present|skip|missing>|errors=<N>|warnings=<M>
+```
+
+`severity in {error, warning, info}`. Erros de uso emitem adicionalmente
+`DIAG|error|<code>|<message>|<fix>` em stderr (envelope `_diag.sh` vendored
+— research Decision 7).
+
+## Codes
+
+| Code | Severity | Condicao |
+|------|----------|----------|
+| `delta-missing` | error | sem secao `## Delta Requirements` e sem skip (FR-010) |
+| `skip-invalid` | error | marcador Skip sem justificativa, autor ou data (FR-011) |
+| `delta-empty` | error | secao presente mas sem nenhum bloco Capability nem skip |
+| `capability-slug-invalid` | error | slug fora de `[a-z0-9][a-z0-9-]*` |
+| `entry-malformed` | error | entrada fora da gramatica do contrato delta-section-format |
+| `ref-not-found` | error | MODIFIED/REMOVED/RENAMED referencia id inexistente/inativo no corpus (FR-013, US3 cenario 4) |
+| `added-collision` | error | ADDED com id ja existente na capability (edge case colisao) |
+| `renamed-target-exists` | error | RENAMED para id ja usado (ativo, removido ou aposentado) |
+| `skip-with-delta` | error | Skip E blocos Capability na mesma secao (mutuamente exclusivos) |
+| `corpus-missing` | info | corpus/capability ainda inexistente com apenas ADDED (valido — primeiro merge cria) |
+
+## Exit codes
+
+| Exit | Significado |
+|------|-------------|
+| 0 | archive liberado (delta valida OU skip valido; so warnings/infos) |
+| 1 | archive bloqueado (>=1 FINDING error) |
+| 2 | uso incorreto / SPEC_MD inexistente / corpus-dir irresoluvel |
+
+## Invariantes
+
+1. POSIX sh puro (`#!/bin/sh`, `set -eu`, sem jq — Constitution II).
+2. Skip valido => exit 0 com `delta=skip` no RESULT (distinguivel de
+   aplicacao normal em qualquer trilha — FR-011).
+3. Delta so-REMOVED e valida (US3 cenario 3).
+4. **Seguranca (gate owasp pos-plan)**: o slug vem de texto UNTRUSTED do
+   spec.md — a validacao `[a-z0-9][a-z0-9-]*` e a PRIMEIRA checagem do
+   parser, ANTES de qualquer composicao de path com o valor (anti path
+   traversal `../`); texto delta nunca passa por `printf "$var"` (sempre
+   `printf '%s'`).
+5. Teste: `tests/test_delta-gate.sh` (convencao de cobertura), incluindo
+   cenario de slug hostil (`../escape`, absoluto, com espaco).

--- a/docs/specs/living-specs/contracts/delta-gate-cli.md
+++ b/docs/specs/living-specs/contracts/delta-gate-cli.md
@@ -46,7 +46,8 @@ RESULT|<spec>|delta=<present|skip|missing>|errors=<N>|warnings=<M>
 | `added-collision` | error | ADDED com id ja existente na capability (edge case colisao) |
 | `renamed-target-exists` | error | RENAMED para id ja usado (ativo, removido ou aposentado) |
 | `skip-with-delta` | error | Skip E blocos Capability na mesma secao (mutuamente exclusivos) |
-| `corpus-missing` | info | corpus/capability ainda inexistente com apenas ADDED (valido — primeiro merge cria) |
+| `corpus-malformed` | error | arquivo `docs/specs/current/<slug>.md` referenciado pela secao delta viola invariante estrutural do contrato corpus-format (heading `# Capability:`/`## Requirements`/`### FR-NNN` mal-formado, ou id duplicado considerando `## Requirements` + `## Removed Requirements` + coluna Antigo/Novo de `## Renamed Identifiers` simultaneamente) — CHK034 |
+| `corpus-missing` | info | corpus/capability ainda inexistente com apenas ADDED (valido — primeiro merge cria); distinto de `corpus-malformed` (corpus existe mas esta invalido) |
 
 ## Exit codes
 
@@ -69,3 +70,11 @@ RESULT|<spec>|delta=<present|skip|missing>|errors=<N>|warnings=<M>
    `printf '%s'`).
 5. Teste: `tests/test_delta-gate.sh` (convencao de cobertura), incluindo
    cenario de slug hostil (`../escape`, absoluto, com espaco).
+6. **Ordem de validacao (CHK034)**: para cada capability referenciada
+   pela secao delta que ja existe no corpus, a checagem estrutural
+   (`corpus-malformed`) roda como PRE-CHECAGEM, ANTES de qualquer
+   validacao referencial (`ref-not-found`/`added-collision`/
+   `renamed-target-exists`) contra o conteudo daquele arquivo — um corpus
+   malformado nao pode ser lido de forma confiavel para validar
+   referencias. Corpus inexistente permanece `corpus-missing` (nao e
+   `corpus-malformed`).

--- a/docs/specs/living-specs/contracts/delta-merge-cli.md
+++ b/docs/specs/living-specs/contracts/delta-merge-cli.md
@@ -41,9 +41,10 @@ RESULT|<spec>|delta=<applied|skip|blocked>|added=<N>|modified=<N>|removed=<N>|re
 ```
 
 Codes de erro: mesmos do delta-gate (`ref-not-found`, `added-collision`,
-`renamed-target-exists`, `entry-malformed`, ...) — o merge re-valida
-(defesa em profundidade; gate e merge podem rodar em momentos distintos e o
-corpus pode ter mudado entre eles). Erros de uso: `DIAG|` em stderr.
+`renamed-target-exists`, `entry-malformed`, `corpus-malformed`, ...) — o
+merge re-valida (defesa em profundidade; gate e merge podem rodar em
+momentos distintos e o corpus pode ter mudado entre eles). Erros de uso:
+`DIAG|` em stderr.
 
 ## Exit codes
 
@@ -63,6 +64,13 @@ corpus pode ter mudado entre eles). Erros de uso: `DIAG|` em stderr.
    qualquer path — nunca confia que o gate rodou antes (defesa em
    profundidade contra path traversal); texto delta escrito no corpus
    sempre via `printf '%s'`, nunca como format string.
+2-ter. **Estrutura do corpus (CHK034)**: o merge RE-VALIDA a estrutura de
+   cada arquivo de capability existente (mesmas invariantes de
+   `corpus-format.md`, code `corpus-malformed`) ANTES de aplicar qualquer
+   mutacao — mesmo padrao de defesa em profundidade da invariante 2-bis
+   (gate e merge podem rodar em momentos distintos; o corpus pode ter
+   sido editado a mao entre um e outro). Corpus malformado bloqueia o
+   merge com `corpus-malformed`, exit 1, corpus intacto.
 3. Determinismo byte-a-byte: mesmos inputs (spec + corpus + --date) =>
    mesmo corpus resultante (entradas ordenadas por id).
 4. O fluxo de archive na prosa de `review-features/SKILL.md` roda:

--- a/docs/specs/living-specs/contracts/delta-merge-cli.md
+++ b/docs/specs/living-specs/contracts/delta-merge-cli.md
@@ -1,0 +1,72 @@
+# Contract: delta-merge.sh CLI
+
+> **[PROPOSTA — a validar na implementacao]** — script NOVO em
+> `global/skills/review-features/scripts/delta-merge.sh`.
+
+**Feature**: `living-specs` | FRs: FR-002..FR-008
+
+## Uso
+
+```
+delta-merge.sh SPEC_MD --feature NAME [--corpus-dir DIR] \
+  [--date YYYY-MM-DD] [--dry-run]
+```
+
+- `--feature NAME` — short-name gravado como proveniencia (FR-007).
+- `--date` — data de proveniencia (default: data corrente UTC).
+- `--dry-run` — valida tudo e reporta o que SERIA aplicado; zero escrita.
+- `--corpus-dir` — mesma resolucao do delta-gate.
+
+## Comportamento
+
+1. Parseia a secao `## Delta Requirements` de SPEC_MD (mesma gramatica do
+   contrato delta-section-format).
+2. Skip valido presente => no-op declarado: `RESULT|...|delta=skip` e
+   exit 0 sem tocar o corpus.
+3. Valida TODAS as pre-condicoes de TODAS as entradas contra o corpus
+   (tabela do contrato corpus-format) ANTES de escrever qualquer byte.
+4. Aplicacao atomica por arquivo de capability: novo conteudo montado em
+   `mktemp`, so apos validacao total ocorre `mv` para
+   `docs/specs/current/<slug>.md`. Multiplas capabilities: TODAS validadas
+   antes do primeiro `mv` (falha => exit 1 sem NENHUMA mutacao, nem
+   parcial).
+5. Corpus/arquivo de capability inexistente + so ADDED => cria o arquivo
+   (US2 cenario 4). Diretorio `current/` criado sob demanda.
+
+## Saida (stdout)
+
+```
+FINDING|<severity>|<code>|<mensagem>
+RESULT|<spec>|delta=<applied|skip|blocked>|added=<N>|modified=<N>|removed=<N>|renamed=<N>
+```
+
+Codes de erro: mesmos do delta-gate (`ref-not-found`, `added-collision`,
+`renamed-target-exists`, `entry-malformed`, ...) — o merge re-valida
+(defesa em profundidade; gate e merge podem rodar em momentos distintos e o
+corpus pode ter mudado entre eles). Erros de uso: `DIAG|` em stderr.
+
+## Exit codes
+
+| Exit | Significado |
+|------|-------------|
+| 0 | aplicado com sucesso (ou dry-run valido, ou skip) |
+| 1 | bloqueado — conflito/referencia invalida; corpus intacto |
+| 2 | uso incorreto / SPEC_MD inexistente |
+
+## Invariantes
+
+1. POSIX sh puro (Constitution II).
+2. Nunca last-write-wins: qualquer pre-condicao violada bloqueia TUDO
+   (clarify da spec).
+2-bis. **Seguranca (gate owasp pos-plan)**: o merge RE-VALIDA o slug
+   (`[a-z0-9][a-z0-9-]*`) como primeira checagem, antes de compor
+   qualquer path — nunca confia que o gate rodou antes (defesa em
+   profundidade contra path traversal); texto delta escrito no corpus
+   sempre via `printf '%s'`, nunca como format string.
+3. Determinismo byte-a-byte: mesmos inputs (spec + corpus + --date) =>
+   mesmo corpus resultante (entradas ordenadas por id).
+4. O fluxo de archive na prosa de `review-features/SKILL.md` roda:
+   `delta-gate.sh` -> `delta-merge.sh` -> mover para
+   `_archived/<YYYY-MM-DD>-<feature>/` (fluxo existente intacto — US2
+   cenario 5).
+5. Teste: `tests/test_delta-merge.sh`.

--- a/docs/specs/living-specs/contracts/delta-section-format.md
+++ b/docs/specs/living-specs/contracts/delta-section-format.md
@@ -43,6 +43,17 @@ Regras:
 
 1. `<capability-slug>` casa `[a-z0-9][a-z0-9-]*` e mapeia para
    `docs/specs/current/<capability-slug>.md`.
+   - **Descoberta/reuso de slug (CHK015)**: antes de declarar um
+     `### Capability: <slug>` novo, o autor MUST rodar
+     `ls docs/specs/current/*.md 2>/dev/null` (corpus pode nao existir
+     ainda — lista vazia e um resultado valido) e reusar o slug ja
+     existente sempre que a feature tocar o MESMO conceito, em vez de
+     fragmentar em um slug novo semanticamente equivalente (ex.:
+     `commit-mode` vs `commit-staging` referindo-se ao mesmo mecanismo).
+     A decisao "mesmo conceito ou conceito novo" e julgamento do AUTOR da
+     spec (agente ou humano) no momento de preencher a secao delta — o
+     gate (`delta-gate.sh`) so valida a FORMA do slug (regra acima),
+     nunca a semantica de reuso.
 2. Blocos `### Capability:` sao repetiveis (uma feature pode tocar N
    capabilities). Cada um contem >=1 dos quatro grupos `####`.
 3. Entrada comeca em `- **FR-NNN**:` (ADDED/MODIFIED/REMOVED) ou

--- a/docs/specs/living-specs/contracts/delta-section-format.md
+++ b/docs/specs/living-specs/contracts/delta-section-format.md
@@ -1,0 +1,74 @@
+# Contract: Delta Requirements Section (spec.md)
+
+> **[PROPOSTA — a validar na implementacao]** — contrato NOVO, projetado do
+> zero nesta feature (nenhuma API existente e afirmada aqui). Formato do
+> OpenSpec usado como inspiracao conceitual (ADDED/MODIFIED/REMOVED/RENAMED),
+> nao como fonte de sintaxe (sem fonte suficiente do parser deles —
+> Principio VI).
+
+**Feature**: `living-specs` | FRs: FR-001, FR-010, FR-011
+
+## Localizacao
+
+Secao opcional `## Delta Requirements` no `spec.md` da feature, apos
+`## Success Criteria` (posicao recomendada; o parser localiza pelo heading,
+nao pela posicao). Template: nova secao opcional comentada em
+`global/skills/specify/templates/feature-spec.md`.
+
+## Gramatica (parseavel por awk/grep POSIX)
+
+```markdown
+## Delta Requirements
+
+### Capability: <capability-slug>
+
+#### ADDED
+
+- **FR-NNN**: <texto integral do requisito>
+
+#### MODIFIED
+
+- **FR-NNN**: <novo texto integral que substitui a entrada do corpus>
+
+#### REMOVED
+
+- **FR-NNN**: <motivo da remocao>
+
+#### RENAMED
+
+- **FR-NNN -> FR-MMM**
+```
+
+Regras:
+
+1. `<capability-slug>` casa `[a-z0-9][a-z0-9-]*` e mapeia para
+   `docs/specs/current/<capability-slug>.md`.
+2. Blocos `### Capability:` sao repetiveis (uma feature pode tocar N
+   capabilities). Cada um contem >=1 dos quatro grupos `####`.
+3. Entrada comeca em `- **FR-NNN**:` (ADDED/MODIFIED/REMOVED) ou
+   `- **FR-NNN -> FR-MMM**` (RENAMED). Linhas seguintes indentadas
+   (2+ espacos) continuam o texto da mesma entrada.
+4. Em ADDED, `FR-NNN` e o MESMO identificador usado na secao
+   `### Functional Requirements` da propria spec (US1 cenario 1). Em
+   MODIFIED/REMOVED/RENAMED, o id referencia a entrada do corpus.
+5. Seta do RENAMED e ASCII `->` (nunca `→`).
+
+## Skip explicito (FR-011)
+
+Forma alternativa da secao — mutuamente exclusiva com blocos Capability:
+
+```markdown
+## Delta Requirements
+
+**Skip**: <justificativa nao-vazia> — <autor>, <YYYY-MM-DD>
+```
+
+Os tres campos sao obrigatorios; ausencia de qualquer um => skip invalido
+(gate bloqueia com `skip-invalid`).
+
+## Interacao com gates existentes (verificada no repo)
+
+- `validate-sdd.sh` spec-profile: nao exige nem proibe a secao (exige so
+  "User Scenarios & Testing", "Requirements", "Success Criteria").
+- `requirement-coverage.sh`: ignora a secao (so le
+  `### Functional Requirements`); ids delta nao entram na cobertura.

--- a/docs/specs/living-specs/data-model.md
+++ b/docs/specs/living-specs/data-model.md
@@ -1,0 +1,132 @@
+# Data Model: living-specs
+
+**Feature**: `living-specs` | **Date**: 2026-07-23
+**Input**: [spec.md](./spec.md) · [research.md](./research.md)
+
+Nao ha banco de dados: todas as entidades sao arquivos Markdown (corpus,
+secao delta) ou artefatos de git/sidecar (allowlist, baseline). "Campos"
+abaixo descrevem a estrutura textual deterministicamente parseavel.
+
+## Entity: CorpusCapabilityFile
+
+Um arquivo `docs/specs/current/<capability-slug>.md` por capability
+(research Decision 5).
+
+| Campo | Tipo | Obrigatorio | Notas |
+|-------|------|-------------|-------|
+| `capability_slug` | string kebab-case | sim | derivado do nome do arquivo; `[a-z0-9-]+` |
+| `requirements` | CorpusEntry[] | sim (pode ser vazio) | secao `## Requirements` |
+| `removed_requirements` | RemovedEntry[] | nao | secao `## Removed Requirements` (FR-004) |
+| `renamed_identifiers` | RenameRecord[] | nao | secao `## Renamed Identifiers`, tabela (FR-005) |
+
+**Relacionamentos**: criado/mutado exclusivamente por `delta-merge.sh`;
+lido por `delta-gate.sh` (checagens de referencia) e por humanos/agentes
+(FR-009).
+
+**State transitions**: inexistente -> criado no primeiro merge que declara a
+capability (US2 cenario 4). Nunca deletado pelo merge (mesmo sem entradas
+ativas, remove-se para `## Removed Requirements`, nao o arquivo).
+
+## Entity: CorpusEntry
+
+Uma entrada ativa do corpus — heading `### FR-NNN` dentro de
+`## Requirements`.
+
+| Campo | Tipo | Obrigatorio | Notas |
+|-------|------|-------------|-------|
+| `id` | `FR-NNN` | sim | unico DENTRO do arquivo de capability (colisao => FINDING) |
+| `text` | markdown | sim | corpo do requisito (comportamento ATUAL) |
+| `introduced_by` | feature short-name + data | sim | proveniencia de origem (FR-007, SC-004) |
+| `last_modified_by` | feature short-name + data | nao | presente apos primeiro MODIFIED |
+
+**State transitions**:
+
+```
+(inexistente) --ADDED--> ativa --MODIFIED--> ativa (texto substituido, id preservado)
+ativa --REMOVED--> movida para Removed Requirements (com proveniencia da remocao)
+ativa --RENAMED--> ativa sob novo id + linha em Renamed Identifiers
+```
+
+Transicoes invalidas (todas => bloqueio, nunca no-op silencioso — FR-013):
+MODIFIED/REMOVED/RENAMED sobre id inexistente ou ja removido; ADDED sobre id
+ja ativo na mesma capability; RENAMED para id ja existente.
+
+## Entity: DeltaSection
+
+Secao `## Delta Requirements` dentro do `spec.md` da feature
+(research Decision 4; contrato em
+[contracts/delta-section-format.md](./contracts/delta-section-format.md)).
+
+| Campo | Tipo | Obrigatorio | Notas |
+|-------|------|-------------|-------|
+| `capabilities` | CapabilityDelta[] | condicional | >=1 se nao houver skip |
+| `skip` | SkipRecord | condicional | mutuamente exclusivo com `capabilities` |
+
+Exatamente UM dos dois presentes; ambos ausentes = secao invalida; secao
+inteira ausente = archive bloqueado por default (FR-010).
+
+## Entity: CapabilityDelta
+
+Bloco `### Capability: <slug>` dentro da DeltaSection.
+
+| Campo | Tipo | Obrigatorio | Notas |
+|-------|------|-------------|-------|
+| `capability_slug` | string kebab-case | sim | alvo em `docs/specs/current/` |
+| `added` | DeltaEntry[] | nao | `#### ADDED` |
+| `modified` | DeltaEntry[] | nao | `#### MODIFIED` |
+| `removed` | DeltaEntry[] | nao | `#### REMOVED` |
+| `renamed` | RenameDelta[] | nao | `#### RENAMED` |
+
+Pelo menos um dos quatro grupos nao-vazio (delta valida "mesmo que so com
+entradas REMOVED" — US3 cenario 3).
+
+## Entity: DeltaEntry
+
+| Campo | Tipo | Obrigatorio | Notas |
+|-------|------|-------------|-------|
+| `id` | `FR-NNN` | sim | ADDED: mesmo id da secao Requirements da propria spec (US1 cenario 1); MODIFIED/REMOVED: id da entrada do corpus referenciada |
+| `text` | markdown | sim | ADDED/MODIFIED: texto integral novo; REMOVED: motivo |
+
+## Entity: RenameDelta / RenameRecord
+
+| Campo | Tipo | Obrigatorio | Notas |
+|-------|------|-------------|-------|
+| `old_id` | `FR-NNN` | sim | deve existir ativo no corpus |
+| `new_id` | `FR-NNN` | sim | nao pode existir no corpus (ativo ou removido) |
+| `feature` | short-name | sim (RenameRecord) | proveniencia do rename |
+| `date` | YYYY-MM-DD | sim (RenameRecord) | data do archive |
+
+## Entity: SkipRecord (Archive Skip)
+
+Marcador `**Skip**: <justificativa> — <autor>, <YYYY-MM-DD>` dentro da
+DeltaSection (FR-011: quem, quando, por que; distinguivel de aplicacao
+normal em qualquer trilha — o `RESULT|` do gate reporta `delta=skip`).
+
+| Campo | Tipo | Obrigatorio | Notas |
+|-------|------|-------------|-------|
+| `justification` | texto nao-vazio | sim | por que este archive nao precisa de delta |
+| `author` | texto nao-vazio | sim | quem autorizou |
+| `date` | YYYY-MM-DD | sim | quando |
+
+## Entity: CommitAllowlist (efemera)
+
+Conjunto de caminhos computado por `commit-mode.sh stage-derived` no momento
+do commit (research Decision 2). Nunca persistida; derivada de:
+
+| Componente | Fonte | Notas |
+|-----------|-------|-------|
+| tracked modificados/deletados | `git status --porcelain` (estados `M`, `D`, etc. na arvore) | sempre incluidos |
+| untracked novos do passo | untracked atuais MENOS UntrackedBaseline | exige baseline; sem baseline => excluidos (fail-closed) |
+| filtro de escopo | `--scope-dir` (0..N) | quando presente, allowlist intersectada com os prefixos |
+
+Allowlist vazia => exit 3, nenhum commit (FR-016). Nunca ha fallback para
+`git add -A`/`git add .` (FR-014/FR-015).
+
+## Entity: UntrackedBaseline (sidecar)
+
+Arquivo `commit-baseline.txt` no state dir da execucao (`$SD/`), uma linha
+por path untracked, ordenado (`sort`), escrito por `commit-mode.sh snapshot`
+no inicio da onda. Mesmo padrao sidecar de `tool-call-ticks.log`: fora do
+`state.json`, nunca versionado, reconstruivel. Paths presentes no baseline
+sao "alheios pre-existentes" e NUNCA entram em commit automatico (FR-015 —
+o `.pptx` do incidente cai aqui).

--- a/docs/specs/living-specs/plan.md
+++ b/docs/specs/living-specs/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: Specs Vivas — Corpus Canonico, Delta Specs no Archive e Staging Explicito
+
+**Feature**: `living-specs` | **Date**: 2026-07-23 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Tres entregas acopladas ao mesmo momento do ciclo de vida (o archive) mais um
+hardening independente: (1) secao opcional `## Delta Requirements` no
+`spec.md` (ADDED/MODIFIED/REMOVED/RENAMED + Skip auditavel), parseavel
+deterministicamente; (2) corpus canonico `docs/specs/current/<capability>.md`
+atualizado por `delta-merge.sh` na acao de archive ja existente da skill
+`review-features` (merge atomico, bloqueio em conflito, nunca
+last-write-wins); (3) gate `delta-gate.sh` no padrao FINDING/RESULT dos
+gates v5.22.0 — archive sem delta e invalido salvo skip explicito; (4)
+staging por allowlist derivada (`commit-mode.sh snapshot` +
+`stage-derived`) substituindo os 3 sites reais de staging amplo (prosa
+`git add -A` nos 2 orquestradores + `git add -- .` em
+`state-ondas.sh::_so_cmd_git_commit`), com regressao do incidente `.pptx`.
+
+## Technical Context
+
+**Language/Version**: POSIX sh puro (`#!/bin/sh`, `set -eu`) — Constitution II; prosa de skills/agents em Markdown pt-br
+**Primary Dependencies**: ferramentas POSIX canonicas (`awk`, `grep`, `sed`, `sort`, `comm`, `mktemp`) + `git` (ja dependencia dura do modo atomic-commit e de `state-ondas.sh git-commit`); zero deps novas
+**Storage**: arquivos Markdown (`docs/specs/current/`), sidecar `commit-baseline.txt` no state dir (padrao `tool-call-ticks.log`); nenhum banco
+**Testing**: harness `tests/run.sh` (~1678 cenarios); novos `tests/test_delta-gate.sh`, `tests/test_delta-merge.sh`; extensoes em `tests/test_commit-mode.sh` e `tests/test_state-ondas.sh`; `--check-coverage` gateia
+**Target Platform**: macOS/zsh + Linux CI (dash) — mesma matriz dos scripts atuais
+**Project Type**: toolkit de documentacao/CLI (skills + runtime POSIX)
+**Performance Goals**: gate/merge O(tamanho da spec + corpus da capability); sem requisito de latencia formal (acao de archive e rara)
+**Constraints**: determinismo byte-a-byte (gate e merge); merge atomico sem mutacao parcial; fail-closed no staging (untracked sem baseline nunca entram); nenhum `git add -A`/`add .` remanescente em codigo ou prosa dos caminhos automaticos
+**Scale/Scope**: corpus inicial vazio; ~15 features arquivadas fora de escopo (backfill opcional); 7 features abertas herdarao o gate no archive
+
+## Constitution Check
+
+*GATE: passou antes do Phase 0; re-checado apos Phase 1 (ETAPA 7).*
+
+| Principio | Status | Notas |
+|-----------|--------|-------|
+| I. SDD recursivo (NON-NEG) | PASS | feature roda o pipeline completo via feature-00c; muda contrato de skills (template specify, review-features, commit-mode) => exige spec + CHANGELOG bump (MINOR; sem BREAKING — secao delta e opcional e subcomandos sao aditivos) |
+| II. POSIX sh puro (NON-NEG) | PASS | 3 scripts novos/alterados todos `#!/bin/sh set -eu`; sem jq/bash-isms; `comm`/`sort`/`awk` canonicos; nenhuma dep opcional nova |
+| III. Formato canonico de skill | PASS | mudancas em SKILL.md (review-features, specify) mantem progressive disclosure; conteudo pesado vai para `scripts/` e `templates/`; Gotchas atualizadas |
+| IV. Zero coleta remota (NON-NEG) | PASS | nenhuma requisicao de rede em nenhum artefato |
+| V. Profundidade > adocao | PASS | fecha retrabalho real (corpus evaporando + incidente de staging) |
+| VI. Veracidade de dados (NON-NEG) | PASS | todos os fatos do plan verificados no repo nesta sessao (sites de `add -A`, secoes exigidas pelos gates, fluxo de archive); contratos novos marcados [PROPOSTA]; algoritmo de merge NAO copiado do OpenSpec por falta de fonte (clarify) |
+
+**Re-check pos-Phase 1**: nenhuma camada/servico novo introduzido; 2 scripts
+novos + 2 subcomandos num helper existente e o minimo para separar veredicto
+(read-only) de mutacao (atomica). PASS.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+docs/specs/living-specs/
+├── spec.md
+├── plan.md                          # este arquivo
+├── research.md                      # Phase 0 — 9 decisoes
+├── data-model.md                    # Phase 1 — entidades textuais
+├── quickstart.md                    # Phase 1 — 7 cenarios
+└── contracts/                       # Phase 1 — todos [PROPOSTA]
+    ├── delta-section-format.md
+    ├── corpus-format.md
+    ├── delta-gate-cli.md
+    ├── delta-merge-cli.md
+    └── commit-staging-cli.md
+```
+
+### Source Code (repository root — paths REAIS verificados)
+
+```
+global/
+├── agents/
+│   ├── agente-00c-feature-orchestrator.md   # EDIT: passos 7.bis/10.qui trocam add -A por stage-derived
+│   └── agente-00c-orchestrator.md           # EDIT: 2 sites equivalentes
+├── skills/
+│   ├── agente-00c-runtime/scripts/
+│   │   ├── commit-mode.sh                   # EDIT: + snapshot, + stage-derived
+│   │   └── state-ondas.sh                   # EDIT: _so_cmd_git_commit delega staging
+│   ├── review-features/
+│   │   ├── SKILL.md                         # EDIT: acao de archive ganha gate -> merge -> mover
+│   │   └── scripts/
+│   │       ├── aggregate.sh                 # (existente, intacto)
+│   │       ├── _diag.sh                     # NEW: copia vendored (fonte: runtime)
+│   │       ├── delta-gate.sh                # NEW
+│   │       └── delta-merge.sh               # NEW
+│   └── specify/
+│       ├── SKILL.md                         # EDIT: prosa da secao delta (quando preencher)
+│       └── templates/feature-spec.md        # EDIT: secao opcional Delta Requirements
+docs/specs/current/                          # NEW (nasce vazio; criado pelo 1o merge)
+tests/
+├── test_delta-gate.sh                       # NEW
+├── test_delta-merge.sh                      # NEW
+├── test_commit-mode.sh                      # EDIT: regressao FR-017 (fixture untracked alheio)
+└── test_state-ondas.sh                      # EDIT: cenario wave-commit endurecido
+```
+
+**Structure Decision**: gate+merge vivem na `review-features` porque o
+archive e acao dessa skill (research Decision 3); staging vive no
+`commit-mode.sh` porque os callers sao os orquestradores e o
+`state-ondas.sh` (mesma skill runtime, sourcing same-dir); corpus paralelo a
+`_archived/` conforme clarify da spec.
+
+## Convencoes de Borda
+
+N/A — single-layer: toolkit de arquivos Markdown + scripts POSIX; nenhuma
+fronteira backend/frontend/DB/broker. Unica "borda" e o formato textual
+delta -> corpus, coberto pelos contratos `delta-section-format.md` e
+`corpus-format.md` (fonte da verdade: os contratos; parser e gerador nos
+scripts derivam deles).
+
+## Riscos e mitigacoes
+
+| Risco | Mitigacao |
+|-------|-----------|
+| Drift entre a copia vendored de `_diag.sh` e a canonica | cabecalho aponta fonte canonica; contrato DIAG estavel desde v5.22.0; coberta por `tests/test__diag.sh` via mapeamento por nome |
+| Baseline de untracked obsoleto (onda longa, operador cria arquivo manualmente durante execucao) | arquivo do operador criado POS-snapshot entraria na allowlist da task — mitigado por documentacao do modo atomic (operador nao deve editar o worktree durante execucao autonoma; ja e pressuposto do modo) e por scope-dirs nos commits de etapa |
+| Duas features abertas declarando deltas conflitantes | conflito so materializa no archive (sequencial); o segundo archive bloqueia com `ref-not-found`/`added-collision` — exatamente a politica do clarify |
+| `stage-derived` com paths contendo espacos | staging path-a-path com `git add --` e loop while-read (nao word-splitting) — cenario de teste dedicado |
+| Prosa dos orquestradores nao atualizada junto (drift codigo/prosa) | tarefa explicita no backlog cobrindo os 4 sites de prosa + grep de verificacao `add -A` zerado em `global/agents/` |
+
+## Complexity Tracking
+
+> Sem violacoes de constitution — tabela vazia.
+
+## Proximos passos
+
+1. `/checklist` — quality gate dos requisitos
+2. `/create-tasks` — backlog executavel
+3. `/analyze` — consistencia cross-artifact

--- a/docs/specs/living-specs/quickstart.md
+++ b/docs/specs/living-specs/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart: living-specs
+
+**Feature**: `living-specs` | **Date**: 2026-07-23
+
+Cenarios de validacao dos fluxos criticos. Todos executaveis em fixture git
+temporaria (padrao do harness `tests/run.sh`); nenhum exige rede.
+
+## Cenario 1 — Delta ADDED aplicada no archive (happy path US1+US2)
+
+1. Criar fixture com `docs/specs/feat-x/spec.md` contendo
+   `## Delta Requirements` -> `### Capability: alpha` -> `#### ADDED` com
+   `- **FR-001**: comportamento novo` (mesmo id da secao Requirements).
+2. Rodar `delta-gate.sh docs/specs/feat-x/spec.md --corpus-dir docs/specs/current`
+   -> **Expected**: `RESULT|...|delta=present|errors=0`, exit 0
+   (`corpus-missing` apenas info).
+3. Rodar `delta-merge.sh docs/specs/feat-x/spec.md --feature feat-x --date 2026-07-23`
+   -> **Expected**: exit 0; `docs/specs/current/alpha.md` criado com
+   `### FR-001`, texto e `*Introduzida por: feat-x (2026-07-23)*`
+   (US2 cenario 4 + SC-004).
+4. Mover a feature para `_archived/2026-07-23-feat-x/`
+   -> **Expected**: fluxo existente intacto; corpus permanece (FR-006).
+
+## Cenario 2 — MODIFIED e REMOVED sobre corpus existente (US2)
+
+1. Partir do corpus do Cenario 1.
+2. Spec `feat-y` com MODIFIED `FR-001` (novo texto) na capability `alpha`.
+3. `delta-merge.sh ... --feature feat-y` -> **Expected**: texto de
+   `### FR-001` substituido, id preservado,
+   `*Ultima modificacao: feat-y (...)*` presente, `*Introduzida por:
+   feat-x*` intacta.
+4. Spec `feat-z` com REMOVED `FR-001` -> **Expected**: entrada movida para
+   `## Removed Requirements` com `*Removida por: feat-z*` + motivo — nunca
+   desaparecimento silencioso (FR-004).
+
+## Cenario 3 — Gate bloqueia archive sem delta; skip libera (US3)
+
+1. Spec sem secao `## Delta Requirements`.
+2. `delta-gate.sh spec.md` -> **Expected**:
+   `FINDING|error|delta-missing|...`, `RESULT|...|delta=missing`, exit 1.
+3. Adicionar `## Delta Requirements` + `**Skip**: feature doc-only — jot,
+   2026-07-23`.
+4. Re-rodar gate -> **Expected**: exit 0, `RESULT|...|delta=skip`
+   (auditavel, distinguivel de aplicacao normal — FR-011).
+5. `delta-merge.sh` sobre a mesma spec -> **Expected**: exit 0 sem tocar o
+   corpus (`delta=skip`).
+
+## Cenario 4 — Referencia invalida e conflito bloqueiam sem mutacao (error case, clarify)
+
+1. Spec com MODIFIED `FR-099` (id inexistente na capability `alpha`).
+2. `delta-gate.sh` -> **Expected**: `FINDING|error|ref-not-found|...`,
+   exit 1 (FR-013, US3 cenario 4).
+3. Spec com ADDED `FR-001` (id ja ativo em `alpha`) -> **Expected**:
+   `added-collision`, exit 1.
+4. Spec multi-capability onde a 2a capability tem erro:
+   `delta-merge.sh` -> **Expected**: exit 1 e NENHUM arquivo do corpus
+   alterado (atomicidade total — hash dos arquivos antes == depois).
+5. Determinismo: rodar o gate 2x sobre o mesmo input -> **Expected**:
+   stdout byte-identico (edge case da spec).
+
+## Cenario 5 — Staging por allowlist nunca varre untracked alheio (US4, FR-017)
+
+1. Fixture git com repo inicializado, `alien.pptx` untracked na raiz
+   (analogo ao incidente real) e atomic-commit habilitado no state.
+2. `commit-mode.sh snapshot --state-dir SD --projeto-alvo-path PAP`
+   -> **Expected**: `SD/commit-baseline.txt` contem `alien.pptx`.
+3. Simular etapa: criar `docs/specs/feat-x/plan.md`; rodar
+   `stage-derived --scope-dir docs/specs/feat-x ...` + commit
+   -> **Expected**: commit contem so `docs/specs/feat-x/plan.md`;
+   `alien.pptx` segue untracked (SC-003).
+4. Simular task: criar `cli/lib/new-helper.sh` (pos-snapshot); rodar
+   `stage-derived` sem scope-dir -> **Expected**: `new-helper.sh` staged,
+   `alien.pptx` fora.
+5. Roundtrip real (nao mock): inspecionar `git show --name-only HEAD` no
+   fixture -> **Expected**: nome do alheio ausente em TODOS os commits
+   gerados.
+
+## Cenario 6 — Allowlist vazia: nenhum commit (FR-016)
+
+1. Fixture limpa (nenhuma mudanca alem de `alien.pptx` untracked
+   pre-baseline).
+2. `stage-derived ...` -> **Expected**: exit 3, index intacto
+   (`git diff --cached` vazio), nenhum commit criado.
+3. Baseline AUSENTE + untracked novo presente -> **Expected**: untracked
+   fora do staging, aviso em stderr, jamais fallback amplo (fail-closed).
+
+## Cenario 7 — Wave-commit do agente-00c endurecido
+
+1. Fixture com `alien.pptx` untracked pre-existente + mudanca tracked em
+   `docs/specs/feat-x/spec.md`.
+2. `state-ondas.sh git-commit --state-dir SD --projeto-alvo-path PAP
+   --motivo teste` -> **Expected**: commit contem a mudanca tracked;
+   `alien.pptx` permanece untracked (site 3 da research Decision 1
+   convergido ao mesmo helper).

--- a/docs/specs/living-specs/research.md
+++ b/docs/specs/living-specs/research.md
@@ -239,6 +239,27 @@ comportamento por invocar a mesma skill. Nenhum hook novo e necessario.
 archive ja requer") — o gate e parte da mesma acao, nao um passo extra; a
 skill e o unico ponto de entrada documentado do archive (Decision 3).
 
+**Politica de bloqueio no fluxo autonomo (CHK020)**: quando
+`delta-gate.sh` retorna exit 1 (archive bloqueado) durante a fase
+`review-features` do `agente-00c-orchestrator` em execucao SEM
+supervisao, o orquestrador MUST registrar um `bloqueios.sh register`
+ESCOPADO aquela feature especifica — pergunta citando os
+`FINDING|error|<code>|<mensagem>` literais emitidos pelo gate + path do
+`spec.md`; contexto-para-resposta cita o
+`RESULT|<spec>|delta=missing|errors=N|...` literal (aterramento de
+evidencia, Constitution VI — nunca resumo parafraseado sem a linha
+real) — nunca falhar silenciosamente nem pular o archive sem rastro. O
+bloqueio NAO aborta a onda de `review-features` inteira: as demais
+features do portfolio sem bloqueio de gate continuam sendo processadas
+(arquivadas/avaliadas) normalmente na mesma onda — mesmo padrao ja usado
+pelos demais Quality Gates complementares do orquestrador (severidade
+alta escala para bloqueio, mas nao trava as demais features do lote). O
+fluxo MANUAL (operador rodando `/review-features` interativamente) segue
+com o bloqueio reportado em prosa pela skill, sem precisar de
+`bloqueios.sh` (mecanismo exclusivo dos orquestradores autonomos). Local
+de implementacao: `agente-00c-orchestrator.md` fase `review-features`
+(tarefa 4.2 desta feature) — esta decisao so fixa a definicao.
+
 ## Decision 9 — Migracao retroativa e primeiro corpus
 
 **Decision**: `docs/specs/current/` nasce VAZIO (criado pelo primeiro merge

--- a/docs/specs/living-specs/research.md
+++ b/docs/specs/living-specs/research.md
@@ -1,0 +1,250 @@
+# Research: living-specs
+
+**Feature**: `living-specs` | **Date**: 2026-07-23
+**Input**: [spec.md](./spec.md)
+
+Todas as fontes citadas foram verificadas no repo real nesta sessao
+(Constitution VI — nenhum fato abaixo e suposicao).
+
+## Decision 1 — Onde vive o `git add` amplo que causou o incidente
+
+**Decision**: o staging amplo NAO esta em `commit-mode.sh` (o helper nao tem
+subcomando de staging nenhum — so `is-enabled | set-enabled | guard-branch |
+stage-message | task-message | finalize`). Os sites reais de staging amplo sao
+TRES:
+
+1. `global/agents/agente-00c-feature-orchestrator.md` — prosa dos passos
+   7.bis e 10.qui: `git -C "$PAP" add -A` (linhas 335 e 403).
+2. `global/agents/agente-00c-orchestrator.md` — prosa equivalente
+   (linhas 678 e 1552): `git -C <PAP> add -A`.
+3. `global/skills/agente-00c-runtime/scripts/state-ondas.sh` —
+   `_so_cmd_git_commit` (linha ~794): `git add -- .` real em codigo
+   (commit local por onda do agente-00c).
+
+**Rationale**: o fix precisa de um subcomando de staging DETERMINISTICO em
+`commit-mode.sh` (codigo, testavel) que os 3 sites passem a consumir — corrigir
+so a prosa deixaria o site (3) em codigo intacto e o bug voltaria pelo caminho
+do wave-commit.
+
+**Alternatives considered**: corrigir apenas a prosa dos orquestradores
+(rejeitado: prosa nao e testavel por `tests/run.sh` e o site (3) e codigo);
+corrigir apenas `state-ondas.sh` (rejeitado: o incidente real veio do caminho
+da prosa via atomic-commit).
+
+## Decision 2 — Derivacao da allowlist de staging (FR-014..FR-016)
+
+**Decision**: novo par de subcomandos em `commit-mode.sh`:
+
+- `snapshot` — captura baseline de untracked (`git status --porcelain`,
+  paths ordenados) num sidecar `commit-baseline.txt` no state dir (mesmo
+  padrao sidecar de `tool-call-ticks.log`: NUNCA dentro do `state.json`).
+- `stage-derived` — computa a allowlist e faz `git add --` caminho a
+  caminho. Allowlist = (tracked modificados/deletados) + (untracked atuais
+  MENOS baseline), opcionalmente intersectada com `--scope-dir` (repetivel).
+  Allowlist vazia => exit 3 (nada a commitar; caller pula o commit — FR-016).
+  Baseline ausente => degrada FAIL-CLOSED: so tracked entram, untracked
+  ficam fora, com aviso em stderr (nunca fallback para staging amplo).
+
+Dois regimes de chamada:
+
+| Caller | scope-dirs | baseline |
+|--------|-----------|----------|
+| commit por etapa (specify/plan/clarify/checklist/create-tasks) | `docs/specs/<feature>/` + state dir da execucao | dispensavel (escopo confina) |
+| commit por task (execute-task) e wave-commit (state-ondas) | nenhum (task pode tocar qualquer path do repo) | obrigatorio (snapshot no inicio da onda) |
+
+**Rationale**: tasks legitimamente CRIAM arquivos untracked em qualquer lugar
+do repo — a unica forma deterministica de distinguir "untracked criado pela
+task" de "untracked alheio pre-existente" (o `.pptx` do incidente) e o
+diff de conjuntos contra um baseline capturado antes do trabalho da onda.
+`comm` sobre listas ordenadas e POSIX puro (Constitution II).
+
+**Alternatives considered**: allowlist so por scope-dirs para tasks
+(rejeitado: task que cria `cli/lib/foo.sh` ficaria fora de qualquer escopo
+previsivel); derivar dos `touched_files` de `.tasks[]` (rejeitado: hoje esse
+campo e computado de `git diff HEAD~1..HEAD` APOS o commit — circular);
+`git add -u` + lista manual de untracked na prosa (rejeitado: prosa nao
+testavel, mesmo modo de falha do incidente).
+
+## Decision 3 — Quem orquestra o archive hoje
+
+**Decision**: o archive e ACAO MANUAL sugerida pela skill `review-features`
+(SKILL.md, "Proximos passos sugeridos" item 3: "Mover features `ARQUIVAR`
+para `docs/specs/_archived/<YYYY-MM-DD>-<feature>/` (acao manual, pedir
+confirmacao ao usuario antes de mover...)"). Nao existe script que mova specs
+para `_archived/` — verificado por grep em `global/` e `cli/`. Portanto o
+gate (US3) e o merge (US2) entram como PASSOS OBRIGATORIOS na prosa dessa
+mesma acao de archive em `review-features/SKILL.md`, implementados como
+scripts em `global/skills/review-features/scripts/` (a skill ja tem
+`scripts/aggregate.sh`, entao o diretorio e precedente).
+
+**Rationale**: FR-008 exige que o corpus atualize "como parte da acao de
+archive ja existente" — a acao existente e a da review-features; ancorar os
+scripts nela evita criar um fluxo paralelo. O archive atual (mover para
+`_archived/`) permanece intacto (US2 cenario 5).
+
+**Alternatives considered**: skill nova dedicada "archive" (rejeitado: bump
+de contagem de skills + fluxo paralelo ao ja documentado); scripts no
+`agente-00c-runtime` (rejeitado: archive e acao de operador/skill, nao passo
+do runtime dos orquestradores).
+
+## Decision 4 — Formato da secao Delta na spec (US1)
+
+**Decision**: secao OPCIONAL `## Delta Requirements` dentro do proprio
+`spec.md` (a spec ja fixou isso na Key Entity "Delta Requirements Section:
+bloco dentro da spec de uma feature"), com agrupamento por capability e
+quatro subtipos:
+
+```markdown
+## Delta Requirements
+
+### Capability: <capability-slug>
+
+#### ADDED
+- **FR-NNN**: <texto>
+
+#### MODIFIED
+- **FR-NNN**: <novo texto>
+
+#### REMOVED
+- **FR-NNN**: <motivo>
+
+#### RENAMED
+- **FR-NNN -> FR-MMM**
+```
+
+Skip explicito (FR-011) e um marcador na MESMA secao:
+`**Skip**: <justificativa> — <autor>, <YYYY-MM-DD>`.
+
+Contrato completo em
+[contracts/delta-section-format.md](./contracts/delta-section-format.md)
+`[PROPOSTA — a validar na implementacao]`.
+
+**Impacto verificado nos gates existentes (fatos, nao suposicao)**:
+
+- `validate-sdd.sh` spec-profile exige apenas "User Scenarios & Testing",
+  "Requirements" e "Success Criteria" (linha 189) — secao adicional nao gera
+  finding.
+- `requirement-coverage.sh` so extrai FR ids de dentro de
+  `### Functional Requirements` (linha 116; reseta em qualquer `##`/`###`
+  seguinte) — entradas delta nao entram na contagem de cobertura.
+- A nota "templates core congelados" (memoria `reference_spec_kit_benchmark`)
+  refere-se aos templates do UPSTREAM spec-kit (sem drift a perseguir), nao a
+  um congelamento do template do cstk — mudar
+  `global/skills/specify/templates/feature-spec.md` e permitido.
+
+**Rationale**: arquivo separado (`delta.md`) criaria segundo artefato a
+sincronizar e a spec ja decidiu "bloco dentro da spec". Marcador de skip
+dentro da secao viaja junto com a spec para `_archived/` (auditavel por git
+e por qualquer leitor), sem estado paralelo.
+
+**Alternatives considered**: `delta.md` separado (rejeitado: segunda fonte a
+manter em sync; a spec ja fixou secao interna); skip como flag de CLI sem
+registro em arquivo (rejeitado: FR-011 exige quem/quando/por-que auditavel e
+persistente); seta unicode `→` no RENAMED (rejeitado: `->` ASCII e mais
+robusto para parsing POSIX e digitacao).
+
+## Decision 5 — Organizacao do corpus (US2)
+
+**Decision**: `docs/specs/current/<capability-slug>.md` — um arquivo por
+capability, paralelo a `_archived/` (layout fixado no clarify). Identificador
+de entrada (`FR-NNN`) e unico POR ARQUIVO de capability, nao globalmente.
+Colisao dentro da mesma capability (edge case da spec) => FINDING + bloqueio.
+Mesma numeracao em capabilities distintas nao colide (namespace = capability).
+
+Estrutura do arquivo de capability (contrato completo em
+[contracts/corpus-format.md](./contracts/corpus-format.md)):
+
+- `## Requirements` — entradas ativas (`### FR-NNN` + texto + proveniencia
+  "Introduzida por" e "Ultima modificacao" — FR-007).
+- `## Removed Requirements` — remocoes rastreaveis (FR-004: nunca
+  desaparecimento silencioso).
+- `## Renamed Identifiers` — tabela old-id -> new-id com feature e data
+  (FR-005).
+
+**Rationale**: id global unico exigiria coordenacao de numeracao entre todas
+as features (fragil); arquivo unico monolitico cresce sem limite e maximiza
+conflito; per-capability e o desenho do proprio OpenSpec (requirements
+escopados por capability spec) adaptado a arquivo unico por capability. O
+autor do delta declara a capability-alvo no header da subsecao (Decision 4).
+
+**Alternatives considered**: corpus monolitico `current/corpus.md`
+(rejeitado: crescimento sem particao e todo archive toca o mesmo arquivo);
+id globalmente unico (rejeitado: forca renumeracao cross-feature);
+diretorio por capability com spec.md dentro (paridade literal com OpenSpec;
+rejeitado: profundidade extra sem ganho para arquivo unico de texto).
+
+## Decision 6 — Gate e merge como scripts deterministicos (FR-012)
+
+**Decision**: dois scripts POSIX novos em
+`global/skills/review-features/scripts/`:
+
+- `delta-gate.sh SPEC_MD [--corpus-dir DIR]` — read-only; veredito
+  bloquear/liberar. Padrao de saida IDENTICO aos gates v5.22.0
+  (verificado em `validate-sdd.sh` linhas 28-41 e
+  `requirement-coverage.sh`): linhas `FINDING|<severity>|<code>|<msg>` +
+  linha final `RESULT|...`; exit 0 (pass) / 1 (bloqueio) / 2 (uso
+  incorreto).
+- `delta-merge.sh SPEC_MD --feature NAME [--corpus-dir DIR] [--dry-run]` —
+  aplica ADDED/MODIFIED/REMOVED/RENAMED no corpus de forma ATOMICA:
+  monta os arquivos novos em `mktemp`, valida TODAS as entradas, e so
+  entao faz `mv`; qualquer conflito => exit 1 SEM mutacao parcial
+  (clarify: bloqueio com diagnostico, nunca merge silencioso).
+
+Ambos com testes `tests/test_delta-gate.sh` e `tests/test_delta-merge.sh`
+(convencao `global/skills/<X>/scripts/<n>.sh -> tests/test_<n>.sh`;
+`--check-coverage` gateia).
+
+**Rationale**: duas responsabilidades distintas (veredicto read-only vs
+mutacao) com codigos de saida proprios; o fluxo de archive roda gate ->
+merge -> mover para `_archived/`. Determinismo do edge case da spec ("duas
+execucoes MUST produzir o mesmo veredito") vem de ser script puro, sem
+julgamento de modelo.
+
+**Alternatives considered**: script unico com flag `--apply` (rejeitado:
+mistura exit codes de veredicto com exit codes de mutacao e complica os
+testes); implementar como prosa de skill (rejeitado: viola FR-012
+explicitamente).
+
+## Decision 7 — Envelope `_diag.sh` nos scripts novos
+
+**Decision**: os scripts novos emitem a linha `DIAG|severity|code|message|fix`
+nas saidas de erro (dogfooding do piloto v5.22.0). Como o piloto vive
+confinado em `global/skills/agente-00c-runtime/scripts/_diag.sh` e e
+consumido apenas por sourcing same-dir (verificado: consumidores sao
+`bloqueios.sh`, `state-lock.sh`, `state-rw.sh`, `state-ondas.sh` — todos no
+mesmo diretorio; nenhum sourcing cross-skill existe no repo), a
+`review-features/scripts/` recebe uma COPIA vendored de `_diag.sh` (skills
+sao self-contained quando instaladas em `~/.claude/skills/<nome>/`).
+Cabecalho da copia aponta a fonte canonica
+(`agente-00c-runtime/scripts/_diag.sh`) e o contrato
+(`docs/specs/openspec-hygiene/contracts/diagnostic-envelope.md`).
+Cobertura: `tests/test__diag.sh` ja existe e o mapeamento por NOME do
+`--check-coverage` cobre a copia automaticamente.
+
+**Alternatives considered**: sourcing por path relativo cross-skill
+(`../../agente-00c-runtime/scripts/_diag.sh`) (rejeitado: acopla layout de
+instalacao entre skills; quebra se uma skill for instalada sem a outra);
+inline de um printf avulso (rejeitado: perderia as validacoes de contrato
+de `diag_emit` — severity valida, fix != message).
+
+## Decision 8 — Enforcement do gate no fluxo autonomo vs manual
+
+**Decision**: o gate roda nos DOIS fluxos pela mesma porta: a prosa da acao
+de archive em `review-features/SKILL.md` passa a exigir
+`delta-gate.sh` (exit != 0 => nao mover para `_archived/`) e, no fluxo
+autonomo, o `agente-00c-orchestrator.md` (fase review-features) herda o
+comportamento por invocar a mesma skill. Nenhum hook novo e necessario.
+
+**Rationale**: FR-008 ("sem exigir passo manual adicional alem do que o
+archive ja requer") — o gate e parte da mesma acao, nao um passo extra; a
+skill e o unico ponto de entrada documentado do archive (Decision 3).
+
+## Decision 9 — Migracao retroativa e primeiro corpus
+
+**Decision**: `docs/specs/current/` nasce VAZIO (criado pelo primeiro merge
+— US2 cenario 4: corpus inexistente => criado). Nenhum backfill das ~15
+features de `_archived/` (Out of Scope explicito da spec; backfill pode
+virar task OPCIONAL no backlog sem gatear conclusao). Features hoje abertas
+em `docs/specs/*` (7 alem desta) chegarao ao archive sem secao delta e
+cairao no gate: preencher delta retroativamente ou registrar skip (edge
+case previsto na spec).

--- a/docs/specs/living-specs/spec.md
+++ b/docs/specs/living-specs/spec.md
@@ -32,8 +32,27 @@ SDD, sem rastreabilidade a nenhuma feature especifica).
 
 ## Clarifications
 
-_Nenhuma sessao de clarificacao realizada ainda — dois pontos em aberto
-estao marcados diretamente nos Edge Cases e nas Key Entities abaixo._
+### Session 2026-07-23
+
+- Q: Onde o Living Spec Corpus vive fisicamente — novo diretorio dedicado
+  (ex. `docs/specs/current/`), evolucao de `docs/02-requisitos-casos-uso/`,
+  ou outro layout? → A: `docs/specs/current/`, novo diretorio dedicado,
+  paralelo a `docs/specs/_archived/`. `docs/02-requisitos-casos-uso` nao
+  existe neste repositorio — e a estrutura de UC-* que `initialize-docs`
+  cria para PROJETOS-ALVO (formato de casos de uso), distinta do formato
+  FR/SC ja usado pelas specs do proprio toolkit em
+  `docs/specs/<feature>/spec.md`. Um dir novo mantem o corpus no mesmo
+  formato SDD homogeneo, sem misturar UC com FR no mesmo diretorio.
+- Q: Qual a politica de resolucao quando duas features tocam o mesmo
+  identificador do corpus de forma incompativel no merge (ou quando
+  REMOVED/MODIFIED referencia um identificador inexistente/nunca criado
+  no corpus)? → A: Bloqueio automatico com diagnostico, exigindo
+  resolucao humana explicita — estende uniformemente o padrao ja adotado
+  por FR-010/FR-013/US3 desta mesma spec (sinalizar em vez de aplicar
+  silenciosamente; bloquear salvo skip explicito auditavel) para os 3
+  subcasos. Sem merge automatico (last-write-wins arriscaria perda
+  silenciosa de informacao); sem fonte externa suficiente sobre o
+  algoritmo exato do OpenSpec para adotar como suposicao (Principio VI).
 
 ## User Scenarios & Testing
 
@@ -188,13 +207,11 @@ caminhos.
 
 - Duas features arquivadas em momentos diferentes com Delta Requirements
   que tocam o MESMO identificador do corpus de formas incompativeis (uma
-  MODIFICA o que a outra REMOVEU, por exemplo) — politica de resolucao
-  **[NEEDS CLARIFICATION: last-write-wins com registro auditavel,
-  bloqueio automatico exigindo resolucao humana, ou deteccao com merge
-  manual assistido? O material lido do OpenSpec (`docs/concepts.md`)
-  menciona que "two changes can touch the same spec file without
-  conflicting", mas nao ha fonte suficiente sobre o algoritmo exato de
-  resolucao para adotar como suposicao (Principio VI)]**.
+  MODIFICA o que a outra REMOVEU, por exemplo) — politica de resolucao:
+  bloqueio automatico com diagnostico exigindo resolucao humana explicita,
+  na mesma linha de FR-010/FR-013 (nunca last-write-wins silencioso, nunca
+  merge automatico sem fonte suficiente sobre o algoritmo — ver
+  `## Clarifications`).
 - Feature cuja spec foi escrita ANTES desta feature entrar em vigor
   (todas as features hoje abertas em `docs/specs/*`, fora `_archived/`)
   chega ao momento de archive sem nunca ter tido a secao delta pensada
@@ -283,13 +300,10 @@ caminhos.
 
 - **Living Spec Corpus**: local canonico que descreve o comportamento
   ATUAL do sistema-alvo, organizado por requisito rastreavel; distinto do
-  historico de mudancas por feature preservado em `_archived/`. Onde esse
-  corpus vive fisicamente **[NEEDS CLARIFICATION: novo diretorio dedicado
-  (ex. `docs/specs/current/`, paralelo a `_archived/`), evolucao da
-  hierarquia `docs/0X-.../` (ex. um `docs/02-requisitos-casos-uso/`
-  dedicado a comportamento atual — hoje esse diretorio nao existe neste
-  repositorio), ou outro layout? Impacta o desenho do `plan.md` — resolver
-  antes de prosseguir para `/plan`]**.
+  historico de mudancas por feature preservado em `_archived/`. Vive em
+  `docs/specs/current/`, novo diretorio dedicado, paralelo a
+  `docs/specs/_archived/`, mantendo o formato SDD (FR/SC) homogeneo com
+  as specs de origem — ver `## Clarifications`.
 - **Delta Requirements Section**: bloco dentro da spec de uma feature que
   declara requisitos ADICIONADOS, MODIFICADOS, REMOVIDOS ou RENOMEADOS em
   relacao ao comportamento atual, usando o mesmo esquema de identificador

--- a/docs/specs/living-specs/spec.md
+++ b/docs/specs/living-specs/spec.md
@@ -1,0 +1,334 @@
+# Feature Specification: Specs Vivas — Corpus Canonico, Delta Specs no Archive e Staging Explicito no Commit Atomico
+
+**Feature**: `living-specs`
+**Created**: 2026-07-23
+**Status**: Draft
+
+## Visao geral
+
+Continuacao do benchmark do concorrente [OpenSpec](https://github.com/Fission-AI/OpenSpec)
+(Fission-AI, ver memoria `reference-openspec-benchmark` e a feature irma
+`openspec-hygiene`, que absorveu os quatro itens de higiene mais baratos e
+deixou explicitamente fora de escopo o item estrutural mais caro). Esta
+feature trata esse item estrutural — o corpus de specs vivas + delta specs
+no archive — e, em paralelo, endurece o modo `atomic-commit` contra o
+incidente real observado durante a execucao da `openspec-hygiene`
+(sug-001): um commit automatico por etapa usou staging amplo e varreu um
+arquivo `.pptx` untracked alheio para dentro do commit.
+
+Hoje `docs/specs/<feature>/spec.md` descreve uma MUDANCA e, ao ser
+arquivada em `docs/specs/_archived/<data>-<feature>/`, o conhecimento
+"como o sistema se comporta AGORA" para aquela capacidade evapora junto —
+o unico jeito de reconstitui-lo e reabrir cada spec arquivada. O sintoma
+observado no proprio toolkit e o `CLAUDE.md` gigante fazendo papel de spec
+viva improvisada (secoes de "estado atual" mantidas a mao, fora do fluxo
+SDD, sem rastreabilidade a nenhuma feature especifica).
+
+> **Decisoes de infraestrutura**: N/A — esta feature nao introduz
+> scheduling, sessao persistente, refresh de token externo, rotacao de
+> chaves, mutex multi-pod, backup/restore nem idempotencia de request. O
+> merge de delta no corpus e sincrono e disparado sob demanda pela acao de
+> arquivamento (ja hoje manual/sob demanda, conforme `review-features`).
+
+## Clarifications
+
+_Nenhuma sessao de clarificacao realizada ainda — dois pontos em aberto
+estao marcados diretamente nos Edge Cases e nas Key Entities abaixo._
+
+## User Scenarios & Testing
+
+### User Story 1 - Declarar o que mudou via secoes delta na spec da feature (Priority: P1)
+
+Como autor de uma feature spec, ao escrever ou evoluir `spec.md` eu
+declaro explicitamente, numa secao dedicada, quais Requisitos Funcionais
+foram ADICIONADOS, MODIFICADOS, REMOVIDOS ou RENOMEADOS em relacao ao
+comportamento atual do sistema — em vez de deixar essa informacao
+implicita, espalhada em prosa, ou perdida quando a feature for arquivada.
+
+**Why this priority**: sem um formato declarado para "o que mudou", nao
+ha dado estruturado nenhum para aplicar no corpus no momento do archive —
+e o pre-requisito de dados de todo o resto da feature.
+
+**Independent Test**: escrever uma spec de teste com uma secao de Delta
+Requirements contendo pelo menos um item de cada tipo (ADDED/MODIFIED/
+REMOVED/RENAMED) e verificar que a secao e reconhecida e extraivel de
+forma deterministica (sem depender de merge/gate ja estarem prontos).
+
+**Acceptance Scenarios**:
+
+1. **Given** uma spec nova sendo escrita para uma feature que introduz
+   capacidade inedita, **When** o autor preenche a secao de Delta
+   Requirements, **Then** cada requisito novo aparece listado sob ADDED
+   com o mesmo identificador (`FR-NNN`) usado na secao de Requirements
+   da propria spec.
+2. **Given** uma spec que altera o comportamento de um requisito ja
+   existente no corpus, **When** o autor preenche a secao delta,
+   **Then** o requisito aparece sob MODIFIED referenciando o
+   identificador do corpus que esta sendo substituido.
+3. **Given** uma spec que torna obsoleto um comportamento hoje ativo,
+   **When** o autor preenche a secao delta, **Then** o requisito aparece
+   sob REMOVED referenciando o identificador do corpus a ser retirado.
+
+---
+
+### User Story 2 - Corpus canonico atualizado no momento do archive (Priority: P1)
+
+Como qualquer pessoa (operador humano ou orquestrador autonomo) que
+precisa responder "como o sistema se comporta hoje" para uma dada
+capacidade, eu consulto um unico corpus canonico e encontro a resposta —
+sem precisar abrir `docs/specs/_archived/` feature por feature nem
+reconstituir historico manualmente.
+
+**Why this priority**: e a entrega de valor central da feature — sem o
+corpus sendo de fato escrito/atualizado, as secoes delta da US1 nao tem
+destino e o problema original (conhecimento evaporando) continua intacto.
+
+**Independent Test**: arquivar uma feature de teste com secao delta
+preenchida e verificar que o corpus reflete os requisitos ADDED/MODIFIED/
+REMOVED/RENAMED apos a acao de archive, sem exigir nenhuma outra feature
+desta spec.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma feature com Delta Requirements do tipo ADDED sendo
+   arquivada, **When** a acao de archive e executada, **Then** o corpus
+   ganha uma nova entrada para cada requisito ADDED, rastreavel ate a
+   feature de origem.
+2. **Given** uma feature com Delta Requirements do tipo MODIFIED
+   referenciando um identificador ja existente no corpus, **When** a
+   acao de archive e executada, **Then** a entrada correspondente no
+   corpus e substituida pelo novo texto, preservando o identificador.
+3. **Given** uma feature com Delta Requirements do tipo REMOVED, **When**
+   a acao de archive e executada, **Then** a entrada correspondente
+   deixa de valer como comportamento atual, com um registro rastreavel
+   de que foi removida (nao um desaparecimento silencioso).
+4. **Given** o corpus ainda nao existe (primeiro archive apos esta
+   feature entrar em vigor), **When** a acao de archive e executada,
+   **Then** o corpus e criado com as entradas daquela feature.
+5. **Given** um archive concluido, **When** o fluxo hoje existente de
+   mover a feature para `_archived/<data>-<feature>/` roda, **Then** ele
+   continua funcionando exatamente como antes — o corpus e um destino
+   ADICIONAL do conteudo, nunca uma substituicao do archive.
+
+---
+
+### User Story 3 - Gate deterministico: archive sem delta e invalido salvo skip explicito (Priority: P2)
+
+Como mantenedor do toolkit, eu quero que arquivar uma feature sem secao
+de Delta Requirements seja bloqueado por padrao — para que o corpus nunca
+fique desatualizado por simples esquecimento — a menos que eu registre
+explicitamente por que aquele archive nao precisa de delta (ex.: feature
+puramente doc-only ou meta, sem impacto em comportamento do sistema).
+
+**Why this priority**: fecha a lacuna que faria a US1+US2 degradarem
+lentamente pelo mesmo motivo que o `CLAUDE.md` virou spec-viva-improvisada
+— disciplina que nao e enforced por um gate tende a nao ser seguida.
+
+**Independent Test**: tentar arquivar (a) uma feature sem secao delta e
+sem skip — deve bloquear; (b) a mesma feature com um skip explicito
+registrado — deve prosseguir; (c) uma feature com secao delta valida —
+deve prosseguir sem exigir skip.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma feature sem secao de Delta Requirements na sua spec,
+   **When** a acao de archive e tentada sem nenhum skip registrado,
+   **Then** o archive e bloqueado com diagnostico apontando exatamente o
+   que falta.
+2. **Given** a mesma situacao, **When** o operador registra um skip
+   explicito com justificativa, **Then** o archive prossegue e o skip
+   fica auditavel (quem, quando, por que) em qualquer relatorio/trilha
+   que liste aquele archive.
+3. **Given** uma feature com secao de Delta Requirements valida (mesmo
+   que so com entradas REMOVED, por exemplo), **When** a acao de archive
+   e tentada, **Then** ela prossegue sem exigir skip.
+4. **Given** uma entrada MODIFIED/REMOVED/RENAMED cujo identificador
+   referenciado nao existe no corpus atual, **When** o gate roda,
+   **Then** ele sinaliza a inconsistencia em vez de aplicar
+   silenciosamente um no-op.
+
+---
+
+### User Story 4 - Staging explicito por allowlist no commit atomico, nunca "add tudo" (Priority: P2)
+
+Como operador rodando `agente-00c`/`feature-00c` com o modo atomic-commit
+habilitado, eu quero que cada commit automatico (por etapa ou por task)
+inclua apenas os arquivos de fato pertencentes aquele passo da pipeline —
+para que um arquivo untracked alheio presente no repositorio nunca seja
+varrido para dentro de um commit que eu nao pedi para incluir.
+
+**Why this priority**: e um bug de seguranca/correcao ja materializado em
+producao (incidente real na execucao `openspec-hygiene`, corrigido so em
+follow-up manual apos o fato) — independente do resto da feature, e uma
+fonte de risco toda vez que o modo atomic-commit roda.
+
+**Independent Test**: com um arquivo untracked alheio presente no
+working tree, rodar um commit automatico de etapa e de task e verificar
+que o arquivo alheio nunca aparece no commit gerado, em nenhum dos dois
+caminhos.
+
+**Acceptance Scenarios**:
+
+1. **Given** um arquivo untracked que nao pertence a etapa corrente
+   presente no working tree, **When** o commit atomico de etapa
+   (`specify`/`plan`/`clarify`/`checklist`/`create-tasks`) e disparado,
+   **Then** o commit gerado contem somente os artefatos daquela etapa —
+   o arquivo alheio permanece untracked.
+2. **Given** o mesmo cenario durante `execute-task`, **When** o commit
+   atomico agrupado por task e disparado, **Then** o commit contem
+   somente os arquivos tocados pelas tasks com `outcome=pass` daquela
+   onda — o arquivo alheio permanece untracked.
+3. **Given** uma etapa/task que nao tocou nenhum arquivo (no-op),
+   **When** o commit automatico seria disparado, **Then** nenhum commit
+   vazio e criado.
+
+---
+
+### Edge Cases
+
+- Duas features arquivadas em momentos diferentes com Delta Requirements
+  que tocam o MESMO identificador do corpus de formas incompativeis (uma
+  MODIFICA o que a outra REMOVEU, por exemplo) — politica de resolucao
+  **[NEEDS CLARIFICATION: last-write-wins com registro auditavel,
+  bloqueio automatico exigindo resolucao humana, ou deteccao com merge
+  manual assistido? O material lido do OpenSpec (`docs/concepts.md`)
+  menciona que "two changes can touch the same spec file without
+  conflicting", mas nao ha fonte suficiente sobre o algoritmo exato de
+  resolucao para adotar como suposicao (Principio VI)]**.
+- Feature cuja spec foi escrita ANTES desta feature entrar em vigor
+  (todas as features hoje abertas em `docs/specs/*`, fora `_archived/`)
+  chega ao momento de archive sem nunca ter tido a secao delta pensada
+  durante specify/plan — o gate da US3 ainda se aplica: o autor precisa
+  retroceder e preencher a secao delta na hora do archive, ou registrar
+  skip explicito.
+- Entrada RENAMED cujo identificador antigo e referenciado por uma
+  entrada MODIFIED de outra feita em outra feature ainda nao arquivada —
+  o gate deve sinalizar a inconsistencia de referencia, nao aplicar
+  silenciosamente.
+- Colisao de identificador: duas features declaram ADDED com o mesmo
+  `FR-NNN` para entradas de corpus diferentes — deve ser sinalizado, nao
+  sobrescrito silenciosamente.
+- Allowlist do commit atomico calculada como vazia porque a etapa/task
+  gerou arquivos fora do projeto-alvo (ex.: escrita acidental fora do
+  blast radius) — nao deve resultar em fallback para staging amplo; o
+  comportamento correto e nao commitar esses arquivos.
+- O gate de delta obrigatorio roda como script deterministico, nao como
+  julgamento de modelo: duas execucoes do gate sobre a mesma spec e o
+  mesmo estado de corpus MUST produzir sempre o mesmo veredito (bloquear
+  ou liberar o archive), sem variacao entre chamadas.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Autores de spec MUST ser capazes de declarar, dentro da
+  spec da feature, uma secao de Delta Requirements com quatro tipos de
+  entrada — ADDED, MODIFIED, REMOVED e RENAMED — usando o mesmo esquema
+  de identificador (`FR-NNN`) ja usado na secao de Requirements da propria
+  spec.
+- **FR-002**: Uma entrada ADDED MUST, ao a feature ser arquivada, se
+  tornar uma nova entrada no corpus canonico.
+- **FR-003**: Uma entrada MODIFIED MUST, ao a feature ser arquivada,
+  substituir a entrada correspondente do corpus (casada por
+  identificador) pelo novo texto, preservando o identificador.
+- **FR-004**: Uma entrada REMOVED MUST, ao a feature ser arquivada,
+  retirar a entrada correspondente do corpus como comportamento atual,
+  preservando um registro rastreavel da remocao (nunca um desaparecimento
+  silencioso do historico).
+- **FR-005**: Uma entrada RENAMED MUST, ao a feature ser arquivada,
+  aposentar o identificador antigo e registrar o novo identificador para
+  a mesma entrada do corpus, sem perder a rastreabilidade historica da
+  entrada.
+- **FR-006**: System MUST manter um corpus canonico descrevendo o
+  comportamento ATUAL do sistema, distinto do historico de mudancas por
+  feature preservado sob `_archived/` — o corpus e ADICIONAL, nunca
+  substitui o archive existente.
+- **FR-007**: Cada entrada do corpus MUST ser rastreavel ate a(s)
+  feature(s) que a introduziu ou modificou por ultimo (proveniencia).
+- **FR-008**: A atualizacao do corpus MUST acontecer como parte da acao
+  de archive ja existente, sem exigir um passo manual adicional alem do
+  que o archive ja requer hoje.
+- **FR-009**: Consultar o corpus MUST responder "como o sistema se
+  comporta hoje" para qualquer capacidade coberta, sem exigir abrir
+  nenhum diretorio sob `_archived/`.
+- **FR-010**: A acao de archive MUST ser bloqueada, por padrao, para
+  qualquer feature que nao tenha secao de Delta Requirements — salvo
+  quando um skip explicito for registrado.
+- **FR-011**: Um skip de delta MUST ser um registro auditavel (quem,
+  quando, por que), distinguivel de uma aplicacao normal de delta em
+  qualquer relatorio ou trilha de auditoria que liste aquele archive.
+- **FR-012**: O gate da FR-010 MUST ser deterministico (script, nao
+  julgamento de modelo), no mesmo padrao ja adotado pelo toolkit para
+  outros gates de qualidade estrutural (ex.: `requirement-coverage.sh`).
+- **FR-013**: O gate MUST sinalizar (nao aplicar silenciosamente)
+  qualquer entrada MODIFIED, REMOVED ou RENAMED cujo identificador
+  referenciado nao exista no corpus atual.
+- **FR-014**: O staging de commits automaticos do modo atomic-commit
+  (por etapa e por task, em execucao autonoma) MUST usar uma allowlist
+  explicita de caminhos derivada dos artefatos tocados pelo passo/task
+  corrente — MUST NOT usar staging amplo (equivalente a "adicionar tudo
+  do working tree").
+- **FR-015**: Quando um arquivo untracked alheio ao passo/task corrente
+  estiver presente no working tree no momento do commit automatico, ele
+  MUST NOT ser incluido no commit gerado, independentemente do tipo de
+  arquivo.
+- **FR-016**: Quando a allowlist de um passo/task for vazia, nenhum
+  commit MUST ser criado para aquele passo/task (sem commits vazios, sem
+  fallback para staging amplo).
+- **FR-017**: O cenario que causou o incidente original (arquivo
+  untracked alheio presente durante commit atomico de etapa) MUST ter
+  cobertura de teste de regressao automatizada.
+
+### Key Entities
+
+- **Living Spec Corpus**: local canonico que descreve o comportamento
+  ATUAL do sistema-alvo, organizado por requisito rastreavel; distinto do
+  historico de mudancas por feature preservado em `_archived/`. Onde esse
+  corpus vive fisicamente **[NEEDS CLARIFICATION: novo diretorio dedicado
+  (ex. `docs/specs/current/`, paralelo a `_archived/`), evolucao da
+  hierarquia `docs/0X-.../` (ex. um `docs/02-requisitos-casos-uso/`
+  dedicado a comportamento atual — hoje esse diretorio nao existe neste
+  repositorio), ou outro layout? Impacta o desenho do `plan.md` — resolver
+  antes de prosseguir para `/plan`]**.
+- **Delta Requirements Section**: bloco dentro da spec de uma feature que
+  declara requisitos ADICIONADOS, MODIFICADOS, REMOVIDOS ou RENOMEADOS em
+  relacao ao comportamento atual, usando o mesmo esquema de identificador
+  `FR-NNN` da propria spec.
+- **Corpus Entry**: unidade individual do corpus — um requisito de
+  comportamento atual, com proveniencia (feature de origem) e
+  identificador estavel.
+- **Archive Skip Record**: registro auditavel (quem, quando, por que)
+  que autoriza arquivar uma feature sem secao de Delta Requirements.
+- **Commit Allowlist**: conjunto explicito de caminhos, derivado dos
+  artefatos tocados pelo passo/task corrente da pipeline, usado para
+  staging de um commit automatico em vez de "adicionar tudo".
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 100% das features arquivadas apos esta feature entrar em
+  vigor tem, no momento do archive, ou uma atualizacao aplicada ao corpus
+  ou um registro de skip auditavel — zero features desaparecem sem deixar
+  rastro de "o que mudou no comportamento atual".
+- **SC-002**: Para qualquer capacidade ja tocada por uma feature
+  arquivada, um leitor consegue responder "como o sistema se comporta
+  hoje" consultando um unico local canonico, sem abrir nenhum
+  subdiretorio de `_archived/`.
+- **SC-003**: 0% dos commits automaticos gerados durante execucao
+  autonoma com atomic-commit habilitado incluem um arquivo untracked
+  alheio ao passo/task corrente, verificado pela suite de regressao.
+- **SC-004**: Toda entrada do corpus permite identificar sua feature de
+  origem em uma unica consulta (campo de proveniencia), para 100% das
+  entradas.
+
+## Out of Scope
+
+- Migrar retroativamente as features ja hoje em `docs/specs/_archived/`
+  (aprox. 15) para o corpus canonico. Pode existir uma task OPCIONAL de
+  backfill incremental no backlog desta feature, mas nao e criterio de
+  aceite — nao bloqueia a conclusao.
+- Stores/worksets multi-repo do OpenSpec (mecanismo de agregacao entre
+  multiplos repositorios) — nao ha fonte suficiente sobre esse mecanismo
+  no material ja lido do benchmark, e esta feature trata de um unico
+  projeto-alvo por vez, em paridade com o restante do toolkit.

--- a/docs/specs/living-specs/spec.md
+++ b/docs/specs/living-specs/spec.md
@@ -233,6 +233,14 @@ caminhos.
   julgamento de modelo: duas execucoes do gate sobre a mesma spec e o
   mesmo estado de corpus MUST produzir sempre o mesmo veredito (bloquear
   ou liberar o archive), sem variacao entre chamadas.
+- Fase `review-features` do orquestrador autonomo (`agente-00c`) encontra
+  `delta-gate.sh` bloqueado (exit 1) para uma feature candidata a archive
+  durante execucao SEM supervisao — o orquestrador MUST registrar
+  `bloqueios.sh register` ESCOPADO aquela feature especifica (pergunta
+  citando os `FINDING`/`RESULT` literais emitidos pelo gate), nunca
+  falhar silenciosamente nem pular o archive sem rastro; as demais
+  features do portfolio sem bloqueio de gate continuam sendo processadas
+  normalmente na mesma onda (research.md Decision 8).
 
 ## Requirements
 

--- a/docs/specs/living-specs/tasks.md
+++ b/docs/specs/living-specs/tasks.md
@@ -136,7 +136,7 @@ Ref: checklists/requirements.md CHK034 · Contract corpus-format.md §Estrutura
 
 Ref: FR-001 · contracts/delta-section-format.md · plan.md §Project Structure
 
-- [ ] 2.1.1 Adicionar em
+- [x] 2.1.1 Adicionar em
   `global/skills/specify/templates/feature-spec.md`, apos
   `## Success Criteria` (posicao recomendada do contrato — o parser
   localiza pelo heading, nao pela posicao), a secao opcional
@@ -144,12 +144,12 @@ Ref: FR-001 · contracts/delta-section-format.md · plan.md §Project Structure
   `REMOVED`/`RENAMED` sob `### Capability: <capability-slug>`, seguindo a
   gramatica EXATA de `contracts/delta-section-format.md` (seta `->` ASCII
   no RENAMED, nunca `→`)
-- [ ] 2.1.2 Adicionar comentario de template explicando que a secao e
+- [x] 2.1.2 Adicionar comentario de template explicando que a secao e
   OPCIONAL (feature pode nao tocar nenhum comportamento de corpus ainda) e
   que o marcador de Skip (`**Skip**: <justificativa> — <autor>,
   <YYYY-MM-DD>`) e a forma alternativa mutuamente exclusiva com os blocos
   `### Capability:` — usada quando o archive nao precisa de delta (US3)
-- [ ] 2.1.3 Confirmar (grep) que `validate-sdd.sh` spec-profile nao passa a
+- [x] 2.1.3 Confirmar (grep) que `validate-sdd.sh` spec-profile nao passa a
   exigir a secao nova (permanece exigindo so "User Scenarios & Testing",
   "Requirements", "Success Criteria" — research.md Decision 4, fato ja
   verificado) e que `requirement-coverage.sh` continua ignorando ids sob
@@ -160,17 +160,17 @@ Ref: FR-001 · contracts/delta-section-format.md · plan.md §Project Structure
 
 Ref: FR-001, FR-011 · tarefa 1.1 (consome CHK015) · contracts/delta-section-format.md §Skip explicito
 
-- [ ] 2.2.1 Adicionar secao de prosa em `global/skills/specify/SKILL.md`
+- [x] 2.2.1 Adicionar secao de prosa em `global/skills/specify/SKILL.md`
   orientando: (a) quando preencher Delta Requirements (feature que
   adiciona/muda/remove/renomeia comportamento hoje ativo do sistema-alvo);
   (b) a regra de descoberta/reuso de slug fixada na tarefa 1.1.1-1.1.3
   (`ls docs/specs/current/*.md` antes de nomear capability nova); (c) como
   preencher o marcador de Skip quando a feature e puramente doc-only/meta
   (formato dos 3 campos obrigatorios: justificativa, autor, data)
-- [ ] 2.2.2 Citar no SKILL.md que a validacao de forma (nao de semantica de
+- [x] 2.2.2 Citar no SKILL.md que a validacao de forma (nao de semantica de
   reuso) fica a cargo de `delta-gate.sh` (FASE 3), rodado apenas no
   momento do archive — `specify` nunca invoca o gate diretamente
-- [ ] 2.2.3 Adicionar exemplo minimo de secao `## Delta Requirements`
+- [x] 2.2.3 Adicionar exemplo minimo de secao `## Delta Requirements`
   preenchida (um bloco ADDED simples) na prosa do SKILL.md, ilustrando a
   gramatica de `delta-section-format.md` sem exigir abrir o contrato
   completo para o caso comum

--- a/docs/specs/living-specs/tasks.md
+++ b/docs/specs/living-specs/tasks.md
@@ -49,48 +49,48 @@ os 3 sites reais de `git add -A`/`git add -- .` que causaram o incidente
 
 Ref: checklists/requirements.md CHK015 · Spec Key Entities "Living Spec Corpus" · contracts/delta-section-format.md regra 1
 
-- [ ] 1.1.1 Fixar a regra: antes de declarar um `### Capability: <slug>` novo
+- [x] 1.1.1 Fixar a regra: antes de declarar um `### Capability: <slug>` novo
   numa secao Delta Requirements, o autor MUST consultar as capabilities ja
   existentes rodando `ls docs/specs/current/*.md 2>/dev/null` (corpus pode
   nao existir ainda — lista vazia e um resultado valido) e reusar o slug
   existente sempre que a feature tocar o MESMO conceito, em vez de
   fragmentar em um slug novo semanticamente equivalente (ex.: `commit-mode`
   vs `commit-staging` citado no gap do checklist)
-- [ ] 1.1.2 Definir que a decisao de "mesmo conceito ou conceito novo" e
+- [x] 1.1.2 Definir que a decisao de "mesmo conceito ou conceito novo" e
   julgamento do AUTOR da spec (agente ou humano) no momento de preencher a
   secao delta — nao um script determinístico (mesma natureza de decisao ja
   delegada ao agente em `origin -> story_priority` no precedente
   `skill-converge`, research.md Decision 1 daquela feature); o gate
   (`delta-gate.sh`) so valida a FORMA do slug (`[a-z0-9][a-z0-9-]*`), nunca
   a semantica de reuso
-- [ ] 1.1.3 Anotar a regra acima em
+- [x] 1.1.3 Anotar a regra acima em
   `contracts/delta-section-format.md` §Gramatica, item 1 (apos a definicao
   do padrao do slug), citando o comando de descoberta e o exemplo de
   fragmentacao do gap
-- [ ] 1.1.4 Registrar que a tarefa 2.2 (prosa da skill `specify`) e o local
+- [x] 1.1.4 Registrar que a tarefa 2.2 (prosa da skill `specify`) e o local
   de implementacao desta orientacao — este item so fixa a definicao
 
 ### 1.2 Definir integracao gate-bloqueado <-> bloqueios.sh no fluxo autonomo `[A]`
 
 Ref: checklists/requirements.md CHK020 · Spec Edge Cases · research.md Decision 8 · Plan Constitution Check
 
-- [ ] 1.2.1 Fixar a politica: quando `delta-gate.sh` retorna exit 1 (archive
+- [x] 1.2.1 Fixar a politica: quando `delta-gate.sh` retorna exit 1 (archive
   bloqueado) durante a fase `review-features` do `agente-00c-orchestrator`
   em execucao SEM supervisao, o orquestrador MUST registrar um
   `bloqueios.sh register` para AQUELA feature especifica (pergunta:
   resumo dos `FINDING|error|...` emitidos pelo gate + path da spec),
   nunca falhar silenciosamente nem pular o archive sem rastro
-- [ ] 1.2.2 Fixar que o bloqueio e ESCOPADO a feature (nao aborta a onda
+- [x] 1.2.2 Fixar que o bloqueio e ESCOPADO a feature (nao aborta a onda
   inteira de `review-features`): as demais features do portfolio sem
   bloqueio de gate continuam sendo processadas (arquivadas/avaliadas)
   normalmente na mesma onda — paridade com o padrao ja usado pelos demais
   Quality Gates complementares do orquestrador (severidade alta escala,
   mas nao trava as demais features do lote)
-- [ ] 1.2.3 Fixar o formato da pergunta do bloqueio: contexto-para-resposta
+- [x] 1.2.3 Fixar o formato da pergunta do bloqueio: contexto-para-resposta
   cita o `RESULT|<spec>|delta=missing|errors=N|...` literal emitido pelo
   gate (aterramento de evidencia — nunca resumo parafraseado sem a linha
   real, Constitution VI)
-- [ ] 1.2.4 Registrar que a tarefa 4.2 (`agente-00c-orchestrator.md`, fase
+- [x] 1.2.4 Registrar que a tarefa 4.2 (`agente-00c-orchestrator.md`, fase
   review-features) e o local de implementacao desta politica — este item
   so fixa a definicao; o fluxo MANUAL (operador rodando `/review-features`
   interativamente) segue com o bloqueio reportado em prosa pela skill
@@ -101,7 +101,7 @@ Ref: checklists/requirements.md CHK020 · Spec Edge Cases · research.md Decisio
 
 Ref: checklists/requirements.md CHK034 · Contract corpus-format.md §Estrutura
 
-- [ ] 1.3.1 Fixar que a validacao estrutural do corpus acontece DENTRO de
+- [x] 1.3.1 Fixar que a validacao estrutural do corpus acontece DENTRO de
   `delta-gate.sh`, como pre-checagem ANTES de qualquer validacao
   referencial (ref-not-found/added-collision/renamed-target-exists): para
   cada arquivo `docs/specs/current/<slug>.md` que a secao delta da spec
@@ -111,20 +111,20 @@ Ref: checklists/requirements.md CHK034 · Contract corpus-format.md §Estrutura
   `## Removed Requirements` + coluna "Antigo"/"Novo" de
   `## Renamed Identifiers` simultaneamente — invariante 1 de
   `corpus-format.md`)
-- [ ] 1.3.2 Fixar o novo `FINDING` code `corpus-malformed` (severity=error)
+- [x] 1.3.2 Fixar o novo `FINDING` code `corpus-malformed` (severity=error)
   para violacao de qualquer invariante da tarefa 1.3.1; corpus ausente
   NAO e `corpus-malformed` (permanece `corpus-missing`, severity=info, ja
   definido — US2 cenario 4)
-- [ ] 1.3.3 Fixar que `delta-merge.sh` RE-VALIDA a mesma estrutura antes de
+- [x] 1.3.3 Fixar que `delta-merge.sh` RE-VALIDA a mesma estrutura antes de
   aplicar qualquer mutacao (defesa em profundidade — mesmo padrao ja
   adotado para a re-validacao de slug entre gate e merge,
   `delta-merge-cli.md` invariante 2-bis); corpus malformado bloqueia o
   merge com o MESMO code, exit 1, corpus intacto
-- [ ] 1.3.4 Atualizar `contracts/delta-gate-cli.md` §Codes (nova linha
+- [x] 1.3.4 Atualizar `contracts/delta-gate-cli.md` §Codes (nova linha
   `corpus-malformed`) e `contracts/corpus-format.md` (nota apontando que a
   "advertencia em prosa" hoje existente passa a ter enforcement
   determinístico via este code)
-- [ ] 1.3.5 Registrar que as tarefas 3.3 (`delta-gate.sh`) e 3.7
+- [x] 1.3.5 Registrar que as tarefas 3.3 (`delta-gate.sh`) e 3.7
   (`delta-merge.sh`) sao o local de implementacao — este item so fixa a
   definicao
 

--- a/docs/specs/living-specs/tasks.md
+++ b/docs/specs/living-specs/tasks.md
@@ -392,21 +392,21 @@ Ref: CLAUDE.md §Como testar scripts shell · Regra de ouro (mapeamento por nome
 
 Ref: FR-006, FR-008 · research.md Decision 3, Decision 8 · delta-merge-cli.md invariante 4
 
-- [ ] 4.1.1 Atualizar "Proximos passos sugeridos" item 3 de
+- [x] 4.1.1 Atualizar "Proximos passos sugeridos" item 3 de
   `global/skills/review-features/SKILL.md`: antes de mover uma feature
   `ARQUIVAR` para `_archived/<YYYY-MM-DD>-<feature>/`, a skill roda
   `delta-gate.sh docs/specs/<feature>/spec.md --corpus-dir
   docs/specs/current` — exit != 0 => NAO mover, reportar os `FINDING|` ao
   operador e pedir preenchimento da secao delta ou skip explicito (US3
   cenario 1/2)
-- [ ] 4.1.2 Gate liberado (exit 0) => rodar `delta-merge.sh
+- [x] 4.1.2 Gate liberado (exit 0) => rodar `delta-merge.sh
   docs/specs/<feature>/spec.md --feature <feature>` ANTES do `mv` para
   `_archived/` — merge bloqueado (exit 1, corpus mudou entre gate e merge)
   tambem impede o `mv` (defesa em profundidade — tarefa 3.6.3)
-- [ ] 4.1.3 Documentar que o fluxo de mover para `_archived/` permanece
+- [x] 4.1.3 Documentar que o fluxo de mover para `_archived/` permanece
   EXATAMENTE como hoje apos o merge ter sucesso (US2 cenario 5, FR-006 —
   corpus e destino ADICIONAL, nunca substituicao)
-- [ ] 4.1.4 Adicionar nota curta no SKILL.md apontando `docs/specs/current/`
+- [x] 4.1.4 Adicionar nota curta no SKILL.md apontando `docs/specs/current/`
   como fonte para responder "como o sistema se comporta hoje" (FR-009),
   complementando (nao substituindo) a leitura de `_archived/` para
   historico de mudancas
@@ -415,16 +415,16 @@ Ref: FR-006, FR-008 · research.md Decision 3, Decision 8 · delta-merge-cli.md 
 
 Ref: checklists/requirements.md CHK020 · tarefa 1.2 (consome o gap) · research.md Decision 8
 
-- [ ] 4.2.1 Na fase `review-features` do `agente-00c-orchestrator.md`,
+- [x] 4.2.1 Na fase `review-features` do `agente-00c-orchestrator.md`,
   apos a acao de archive de CADA feature `ARQUIVAR` do portfolio, invocar
   `delta-gate.sh` conforme tarefa 4.1.1; exit 1 => aplicar a politica
   fixada na tarefa 1.2.1: `bloqueios.sh register` com a pergunta citando o
   `RESULT|` literal do gate (tarefa 1.2.3), sem abortar a onda inteira
   (tarefa 1.2.2)
-- [ ] 4.2.2 Registrar Decisao auditavel (`state-decisions.sh register`)
+- [x] 4.2.2 Registrar Decisao auditavel (`state-decisions.sh register`)
   documentando o veredito do gate por feature avaliada (padrao ja usado
   pelos demais Quality Gates complementares do orquestrador)
-- [ ] 4.2.3 Feature SEM bloqueio de gate na mesma onda continua sendo
+- [x] 4.2.3 Feature SEM bloqueio de gate na mesma onda continua sendo
   arquivada/mergeada normalmente — bloqueio de uma feature nao impede o
   processamento das demais (tarefa 1.2.2)
 
@@ -436,14 +436,18 @@ Ref: checklists/requirements.md CHK020 · tarefa 1.2 (consome o gap) · research
 
 Ref: FR-014 · contracts/commit-staging-cli.md §snapshot · research.md Decision 2
 
-- [ ] 5.1.1 Implementar `commit-mode.sh snapshot --state-dir DIR
+- [x] 5.1.1 Implementar `commit-mode.sh snapshot --state-dir DIR
   --projeto-alvo-path PATH`: captura untracked atual via
-  `git status --porcelain` (linhas `?? `), paths ordenados (`sort`), grava
-  em `DIR/commit-baseline.txt` (sidecar — mesmo padrao de
-  `tool-call-ticks.log`, nunca dentro de `state.json`, nunca versionado)
-- [ ] 5.1.2 Sobrescreve baseline anterior (1 baseline por onda); exit 0
+  `git status --porcelain -z` (entradas `?? `), paths ordenados (`sort`),
+  grava em `DIR/commit-baseline.txt` (sidecar — mesmo padrao de
+  `tool-call-ticks.log`, nunca dentro de `state.json`, nunca versionado).
+  **Divergencia medida da proposta original** (sem `-z`): `git status
+  --porcelain` (mesmo com `-c core.quotepath=false`) ainda envolve em
+  aspas C-style qualquer path com espaco — `-z` e a unica forma que nunca
+  quota (ver contracts/commit-staging-cli.md, nota de topo)
+- [x] 5.1.2 Sobrescreve baseline anterior (1 baseline por onda); exit 0
   gravado, exit 1 erro git/IO, exit 2 uso incorreto
-- [ ] 5.1.3 Confirmar que `commit-baseline.txt` nunca e commitado — vive
+- [x] 5.1.3 Confirmar que `commit-baseline.txt` nunca e commitado — vive
   sob `.claude/` (state dir da execucao), ja coberto pelo `.gitignore` do
   repo-alvo (linha `.claude` — mesmo caso ja garantido para
   `tool-call-ticks.log`, sem gitignore novo necessario)
@@ -452,98 +456,132 @@ Ref: FR-014 · contracts/commit-staging-cli.md §snapshot · research.md Decisio
 
 Ref: FR-014, FR-015, FR-016 · contracts/commit-staging-cli.md §stage-derived · research.md Decision 2
 
-- [ ] 5.2.1 Computar `tracked_changed` = paths com mudanca em arquivos ja
-  rastreados via `git -c core.quotepath=false status --porcelain`
-  (todos os estados exceto `??`); renames tratados (staged o path NOVO;
-  porcelain v1 usa formato `old -> new` em rename — parsing precisa
-  reconhecer esse formato, nao so split por espaco)
-- [ ] 5.2.2 Computar `untracked_new` = untracked atuais MENOS
+- [x] 5.2.1 Computar `tracked_changed` = paths com mudanca em arquivos ja
+  rastreados via `git status --porcelain -z` (todos os estados exceto
+  `??`); renames tratados (staged o path NOVO; formato `-z` emite o path
+  antigo como campo NUL-delimitado SEPARADO, sem a seta ` -> ` textual —
+  parsing consome e descarta esse campo extra via flag `_skip_next`)
+- [x] 5.2.2 Computar `untracked_new` = untracked atuais MENOS
   `DIR/commit-baseline.txt` (`comm -13` sobre listas ordenadas); baseline
   AUSENTE => conjunto vazio + aviso em stderr (fail-closed — untracked
   nunca entram sem baseline, jamais fallback para staging amplo)
-- [ ] 5.2.3 `allowlist` = `tracked_changed` + `untracked_new`; se >=1
+- [x] 5.2.3 `allowlist` = `tracked_changed` + `untracked_new`; se >=1
   `--scope-dir REL_DIR` (repetivel), filtrar aos paths sob esses prefixos
   relativos
-- [ ] 5.2.4 Allowlist vazia => exit 3, NENHUM `git add` executado (caller
+- [x] 5.2.4 Allowlist vazia => exit 3, NENHUM `git add` executado (caller
   pula o commit — FR-016, sem commit vazio, sem fallback amplo mesmo se a
   etapa/task gerou arquivos fora do projeto-alvo — edge case da spec)
-- [ ] 5.2.5 Senao: `git add -- <path>` por entrada, loop `while read` linha
+- [x] 5.2.5 Senao: `git add -- <path>` por entrada, loop `while read` linha
   a linha (nunca word-splitting — paths com espaco tratados corretamente);
   PROIBIDO `git add -A`, `git add .`, `git add --all` em qualquer caminho
   do codigo (FR-014); exit 0 quando >=1 path staged
-- [ ] 5.2.6 Erros de uso/git emitem `DIAG|` (envelope `_diag.sh`, ja
+- [x] 5.2.6 Erros de uso/git emitem `DIAG|` (envelope `_diag.sh`, ja
   sourceable same-dir no runtime — sem vendoring necessario aqui)
 
 ### 5.3 Teste `tests/test_commit-mode.sh`: regressao do incidente `[C]`
 
 Ref: FR-017, SC-003 · contracts/commit-staging-cli.md §Regressao obrigatoria · quickstart.md Cenarios 5, 6
 
-- [ ] 5.3.1 Fixture git com `alien.pptx` untracked pre-existente (analogo
+- [x] 5.3.1 Fixture git com `alien.pptx` untracked pre-existente (analogo
   ao incidente real); commit de etapa com `--scope-dir docs/specs/feat-x`
   => commit contem SO `docs/specs/feat-x/plan.md`, `alien.pptx` permanece
   untracked
-- [ ] 5.3.2 Commit de task: `snapshot` no inicio da onda + arquivo NOVO
+- [x] 5.3.2 Commit de task: `snapshot` no inicio da onda + arquivo NOVO
   criado pos-snapshot (`cli/lib/new-helper.sh`) => `stage-derived` sem
   scope-dir inclui o novo arquivo, `alien.pptx` fora
-- [ ] 5.3.3 Baseline AUSENTE + untracked novo presente => untracked TODOS
+- [x] 5.3.3 Baseline AUSENTE + untracked novo presente => untracked TODOS
   fora do staging, aviso em stderr, jamais fallback amplo (fail-closed)
-- [ ] 5.3.4 Allowlist vazia (fixture limpa) => exit 3, `git diff --cached`
+- [x] 5.3.4 Allowlist vazia (fixture limpa) => exit 3, `git diff --cached`
   vazio, nenhum commit criado
-- [ ] 5.3.5 Roundtrip real (nao mock): `git show --name-only HEAD` em cada
+- [x] 5.3.5 Roundtrip real (nao mock): `git show --name-only HEAD` em cada
   commit gerado pelos cenarios acima => nome do alheio ausente em TODOS
-- [ ] 5.3.6 Cenario de seguranca: path com espaco e path com caractere
-  nao-ASCII, tracked e untracked — staged corretamente via `core.quotepath
-  =false` + parsing de quoting C-style (tarefa 5.2.1)
+- [x] 5.3.6 Cenario de seguranca: path com espaco e path com caractere
+  nao-ASCII, tracked e untracked — staged corretamente via `git status
+  --porcelain -z --untracked-files=all` (parsing NUL-delimitado, sem
+  ambiguidade de quoting — divergencia medida da proposta original
+  `core.quotepath=false`, ver contracts/commit-staging-cli.md nota de
+  topo; tarefa 5.2.1). Adicionalmente cobertos (nao previstos originalmente
+  nesta tarefa, mas necessarios para a mesma seguranca): rename (path novo
+  staged, antigo descartado) e `--untracked-files=all` (evita rollup de
+  diretorio novo inteiro numa unica entrada, que quebraria `--scope-dir`)
 
 ### 5.4 `state-ondas.sh`: `_so_cmd_git_commit` delega staging `[C]`
 
 Ref: FR-014 · research.md Decision 1 site 3 (`state-ondas.sh` linha ~794) · commit-staging-cli.md §Regimes de chamada
 
-- [ ] 5.4.1 Substituir `git add -- .` (linha ~794 de
+- [x] 5.4.1 Substituir `git add -- .` (linha ~794 de
   `global/skills/agente-00c-runtime/scripts/state-ondas.sh`,
-  `_so_cmd_git_commit`) por: `snapshot` (se baseline ainda nao existir
-  nesta onda) + `stage-derived --state-dir "$_sdir" --projeto-alvo-path
-  "$_pap"` (sem `--scope-dir` — wave-commit pode tocar qualquer path do
-  repo, mesmo regime de commit por task da tabela do contrato)
-- [ ] 5.4.2 `stage-derived` exit 3 (allowlist vazia) => preservar o
+  `_so_cmd_git_commit`) por `stage-derived --state-dir "$_sdir"
+  --projeto-alvo-path "$_pap"` (sem `--scope-dir` — wave-commit pode tocar
+  qualquer path do repo, mesmo regime de commit por task da tabela do
+  contrato). **Divergencia medida da proposta original** ("snapshot se
+  baseline ainda nao existir, DENTRO de `_so_cmd_git_commit`"): `git-commit`
+  e a ULTIMA etapa da onda (passo 10, chamado 1x por onda, apos TODO o
+  trabalho ja ter acontecido) — snapshotar ali mesmo, imediatamente antes
+  de `stage-derived`, captura o MESMO untracked que o proprio
+  `stage-derived` tentaria marcar como "novo" (zero janela de tempo entre
+  as duas chamadas), entao o diff da PRIMEIRA onda sempre da vazio para
+  untracked (confirmado empiricamente — regressao nos testes
+  pre-existentes `scenario_git_commit_cria_commit`/`_worktree`). Corrigido
+  movendo o `snapshot` para `state-ondas.sh start` (INICIO da onda, via
+  nova funcao `_so_start_snapshot_baseline`, best-effort, deriva
+  `.execution.target_project_path` do proprio `state.json` — zero mudanca
+  de assinatura/prosa exigida dos orquestradores chamadores), exatamente
+  como `data-model.md` ja especificava (Entity UntrackedBaseline: "escrito
+  por commit-mode.sh snapshot NO INICIO DA ONDA") — a tasks.md original
+  simplesmente errou o ponto de invocacao dentro do proprio contrato ja
+  fixado
+- [x] 5.4.2 `stage-derived` exit 3 (allowlist vazia) => preservar o
   comportamento atual de "nada para commitar" (no-op, `_so_log`), sem
   quebrar o contrato existente de `_so_cmd_git_commit`
-- [ ] 5.4.3 `stage-derived` exit 0 => prosseguir com `git commit -m
+- [x] 5.4.3 `stage-derived` exit 0 => prosseguir com `git commit -m
   "chore(agente-00c): $_onda - $_motivo_safe"` exatamente como hoje
 
 ### 5.5 Teste `tests/test_state-ondas.sh`: cenario wave-commit endurecido `[C]`
 
 Ref: quickstart.md Cenario 7 · commit-staging-cli.md §Regressao item 5
 
-- [ ] 5.5.1 Fixture com `alien.pptx` untracked pre-existente + mudanca
+- [x] 5.5.1 Fixture com `alien.pptx` untracked pre-existente + mudanca
   tracked em `docs/specs/feat-x/spec.md`; `state-ondas.sh git-commit
   --state-dir SD --projeto-alvo-path PAP --motivo teste` => commit contem
   a mudanca tracked, `alien.pptx` permanece untracked
-- [ ] 5.5.2 Confirmar via `git show --name-only HEAD` que o site 3 da
+  (`scenario_5_5_wave_commit_endurecido_exclui_alien`)
+- [x] 5.5.2 Confirmar via `git show --name-only HEAD` que o site 3 da
   research Decision 1 esta convergido ao mesmo helper de staging dos
   demais sites (5.1-5.4)
-- [ ] 5.5.3 Rodar `./tests/run.sh test_state-ondas` isoladamente apos a
+- [x] 5.5.3 Rodar `./tests/run.sh test_state-ondas` isoladamente apos a
   extensao, confirmar 0 FAIL/0 ERROR (sem regressao nos cenarios
-  pre-existentes de `git-commit`)
+  pre-existentes de `git-commit`) — 63/63 PASS, incluindo os 2 cenarios
+  pre-existentes (`scenario_git_commit_cria_commit`,
+  `scenario_git_commit_worktree`) atualizados para refletir o novo ponto
+  de captura do baseline (ver divergencia registrada na tarefa 5.4.1:
+  `_init_state` ganhou `--projeto-alvo-path` real opcional + chamada a
+  `start` antes do arquivo untracked de teste ser criado)
 
 ### 5.6 `agente-00c-feature-orchestrator.md`: 2 sites trocam `add -A` `[A]`
 
 Ref: FR-014 · research.md Decision 1 site 1 (linhas 335, 403) · commit-staging-cli.md §Regimes de chamada
 
-- [ ] 5.6.1 Passo 10.qui (commit atomico por etapa): trocar
-  `git -C "$PAP" add -A 2>/dev/null || true` (linha ~335) por chamada a
+- [x] 5.6.1 Passo 10.qui (commit atomico por etapa): trocar
+  `git -C "$PAP" add -A 2>/dev/null || true` por chamada a
   `commit-mode.sh stage-derived --state-dir "$STATE_DIR"
   --projeto-alvo-path "$PAP" --scope-dir "docs/specs/$SHORT_NAME"
   --scope-dir ".claude/feature-00c-state/$SHORT_NAME"` — exit 3 => pular
   o commit desta etapa (sem commit vazio); exit 0 => prosseguir com o
-  `git commit` existente
-- [ ] 5.6.2 Passo 7.bis (commit atomico por task, agrupado por onda):
-  trocar `git -C "$PAP" add -A 2>/dev/null || true` (linha ~403) por
-  `commit-mode.sh snapshot` na ABERTURA da onda `execute-task` + `
-  stage-derived --state-dir "$STATE_DIR" --projeto-alvo-path "$PAP"` (sem
-  `--scope-dir` — tasks tocam qualquer path do repo) no momento do commit
-  agrupado
-- [ ] 5.6.3 Atualizar a prosa dos dois blocos de pseudocodigo bash no
+  `git commit` existente. **Nota**: a linha ~335 citada na proposta
+  original pertencia na verdade ao bloco 7.bis (task); o site real da
+  etapa (10.qui) esta ~403 — corrigido sem impacto na tarefa, apenas
+  aponta o site certo
+- [x] 5.6.2 Passo 7.bis (commit atomico por task, agrupado por onda):
+  trocar `git -C "$PAP" add -A 2>/dev/null || true` por `stage-derived
+  --state-dir "$STATE_DIR" --projeto-alvo-path "$PAP"` (sem `--scope-dir`
+  — tasks tocam qualquer path do repo). **Divergencia medida**: nao
+  precisa de `commit-mode.sh snapshot` explicito neste ponto — o baseline
+  ja e capturado no INICIO de TODA onda por `state-ondas.sh start`
+  (fix da tarefa 5.4.1, `_so_start_snapshot_baseline`, best-effort via
+  `.execution.target_project_path` do state.json), que roda no passo
+  3.bis/4 do Loop principal, SEMPRE antes do passo 7.bis na mesma onda
+- [x] 5.6.3 Atualizar a prosa dos dois blocos de pseudocodigo bash no
   arquivo (`global/agents/agente-00c-feature-orchestrator.md`) refletindo
   as chamadas novas, preservando o resto do fluxo (guard-branch, mensagem,
   Decisao auditavel) intacto
@@ -552,33 +590,41 @@ Ref: FR-014 · research.md Decision 1 site 1 (linhas 335, 403) · commit-staging
 
 Ref: FR-014 · research.md Decision 1 site 2 (linhas 678, 1552)
 
-- [ ] 5.7.1 Aplicar a MESMA troca da tarefa 5.6.1/5.6.2 nos dois sites
+- [x] 5.7.1 Aplicar a MESMA troca da tarefa 5.6.1/5.6.2 nos dois sites
   equivalentes de `global/agents/agente-00c-orchestrator.md` (linhas
-  ~678 e ~1552), com `--scope-dir` apontando `.claude/agente-00c-state`
-  em vez de `.claude/feature-00c-state/<short>` (state dir do agente-00c)
-- [ ] 5.7.2 Manter paridade textual entre os dois arquivos de orquestrador
+  ~678 e ~1609), com `--scope-dir` apontando `.claude/agente-00c-state`
+  em vez de `.claude/feature-00c-state/<short>` (state dir do agente-00c).
+  Site etapa (~1609) usa `--scope-dir "<FD>"` (feature-dir corrente, ja
+  usado por `pipeline.sh detect-completion --feature-dir <FD>` em outras
+  secoes do mesmo arquivo) como equivalente ao `docs/specs/$SHORT_NAME` do
+  feature-orchestrator — agente-00c nao tem `$SHORT_NAME` fixo, mas opera
+  por feature-dir corrente na mesma onda
+- [x] 5.7.2 Manter paridade textual entre os dois arquivos de orquestrador
   (mesma estrutura de bloco bash, mesmos nomes de variavel) para nao
   divergir prosa entre agente-00c e feature-00c (padrao ja seguido pelas
   demais secoes espelhadas dos dois arquivos)
-- [ ] 5.7.3 Grep de verificacao pontual pos-edicao: confirmar 0 ocorrencias
+- [x] 5.7.3 Grep de verificacao pontual pos-edicao: confirmar 0 ocorrencias
   de `add -A` remanescentes nos 2 sites editados (linhas antigas ~678 e
-  ~1552 de `agente-00c-orchestrator.md`)
+  ~1552 de `agente-00c-orchestrator.md`) — confirmado via
+  `grep -n "add -A" global/agents/agente-00c-orchestrator.md`: zero
+  invocacoes reais (so comentarios `NUNCA git add -A`)
 
 ### 5.8 Verificacao final: zero `add -A`/`add .` remanescente `[A]`
 
 Ref: FR-014, FR-017 · plan.md §Constraints ("nenhum git add -A/add . remanescente em codigo ou prosa dos caminhos automaticos")
 
-- [ ] 5.8.1 Rodar `grep -rn "add -A\|add --all\|add -- \.\b" global/agents/
+- [x] 5.8.1 Rodar `grep -rn "add -A\|add --all\|add -- \.\b" global/agents/
   global/skills/agente-00c-runtime/scripts/` e confirmar 0 ocorrencias nos
   caminhos automaticos (fora de comentarios explicativos que citam o
-  antipattern como PROIBIDO, ex.: contracts e mensagens de erro)
-- [ ] 5.8.2 Se algum resultado remanescente aparecer fora dos 5 sites
+  antipattern como PROIBIDO, ex.: contracts e mensagens de erro) — 9
+  ocorrencias encontradas, TODAS comentarios `NUNCA`/`jamais git add -A`
+- [x] 5.8.2 Se algum resultado remanescente aparecer fora dos 5 sites
   cobertos (5.1-5.7), tratar como escopo desta feature (nao adiar) —
   FR-017 exige cobertura de regressao do incidente original completa,
-  nao parcial
-- [ ] 5.8.3 Registrar Decisao auditavel citando a saida literal do grep
+  nao parcial (nenhum resultado remanescente fora dos 5 sites)
+- [x] 5.8.3 Registrar Decisao auditavel citando a saida literal do grep
   final (zero ocorrencias, ou lista das remanescentes tratadas) como
-  evidencia (score 3, aterramento Constitution VI)
+  evidencia (score 3, aterramento Constitution VI) — dec-038
 
 ---
 

--- a/docs/specs/living-specs/tasks.md
+++ b/docs/specs/living-specs/tasks.md
@@ -634,40 +634,60 @@ Ref: FR-014, FR-017 · plan.md §Constraints ("nenhum git add -A/add . remanesce
 
 Ref: plan.md §Constitution Check ("MINOR; sem BREAKING") · CLAUDE.md §CHANGELOG
 
-- [ ] 6.1.1 Adicionar entrada no `CHANGELOG.md` (bump MINOR — secao delta
-  e opcional e os 2 subcomandos novos de `commit-mode.sh` sao aditivos,
-  sem quebra de contrato existente) resumindo as 4 entregas (delta
-  section, corpus canonico, gate deterministico, staging por allowlist)
-- [ ] 6.1.2 Conferir o bloco de link references do rodape do CHANGELOG
-  (`[X.Y.Z]: https://github.com/JotJunior/cstk/releases/tag/vX.Y.Z`) —
-  nova versao precisa de entrada correspondente (checagem `comm -23` do
-  CLAUDE.md)
-- [ ] 6.1.3 Rodar `validate-docs-rendered` sobre `docs/specs/living-specs/
+- [ ] 6.1.1 **DEFERIDO ao pai (pos-merge)**: adicionar entrada no
+  `CHANGELOG.md` (bump MINOR — secao delta e opcional e os 2
+  subcomandos novos de `commit-mode.sh` sao aditivos, sem quebra de
+  contrato existente) resumindo as 4 entregas (delta section, corpus
+  canonico, gate deterministico, staging por allowlist). Nao executado
+  nesta onda: o pai corta a release (numero de versao + data) somente
+  apos o merge da branch `feat/living-specs`, mesmo padrao observado em
+  features anteriores (ex.: `openspec-hygiene`, commit `4141163` "chore:
+  CHANGELOG 5.22.0" feito como commit separado pelo pai pos-merge) — ver
+  dec-041
+- [ ] 6.1.2 **DEFERIDO ao pai (pos-merge)**: conferir o bloco de link
+  references do rodape do CHANGELOG (`[X.Y.Z]: https://github.com/
+  JotJunior/cstk/releases/tag/vX.Y.Z`) — nova versao precisa de entrada
+  correspondente (checagem `comm -23` do CLAUDE.md). Depende de 6.1.1
+  (so faz sentido apos a entrada de versao existir) — mesma deferral,
+  ver dec-041
+- [x] 6.1.3 Rodar `validate-docs-rendered` sobre `docs/specs/living-specs/
   tasks.md` e sobre este arquivo apos qualquer edicao posterior — Mermaid
-  parseavel, links internos resolvem, frontmatter consistente
+  parseavel, links internos resolvem, frontmatter consistente. Resultado:
+  `tasks.md`/`spec.md` 0 ERRO/0 AVISO; `plan.md` 0 ERRO/2 AVISO (fence sem
+  linguagem, linhas 53/70, nao-bloqueante) — dec-042
 
 ### 6.2 `/analyze` — consistencia cross-artifact `[M]`
 
 Ref: skill analyze · precedente skill-converge FASE 5
 
-- [ ] 6.2.1 Rodar `/analyze` sobre `docs/specs/living-specs/` (spec + plan
+- [x] 6.2.1 Rodar `/analyze` sobre `docs/specs/living-specs/` (spec + plan
   + tasks + constitution) e resolver quaisquer findings de inconsistencia
-  antes de `execute-task` iniciar
-- [ ] 6.2.2 Findings de severidade alta => resolver antes de prosseguir
+  antes de `execute-task` iniciar. Resultado: 17/17 FRs cobertos, 0
+  CRITICAL, 0 HIGH — dec-043
+- [x] 6.2.2 Findings de severidade alta => resolver antes de prosseguir
   para `execute-task`; findings de baixa severidade => registrar como
-  Decisao informativa e seguir (mesmo padrao dos demais gates da FASE 3/4)
+  Decisao informativa e seguir (mesmo padrao dos demais gates da FASE 3/4).
+  1 MEDIUM encontrado (checklist CHK015/CHK020/CHK034 desatualizado vs
+  implementacao real) — corrigido inline em
+  `checklists/requirements.md` — dec-043
 
 ### 6.3 Suite completa + doctor `[A]`
 
 Ref: CLAUDE.md §Como testar scripts shell · §Installed vs Source Drift
 
-- [ ] 6.3.1 Rodar `./tests/run.sh` completo (nao so `--fast`) apos todas as
+- [x] 6.3.1 Rodar `./tests/run.sh` completo (nao so `--fast`) apos todas as
   tasks de FASE 3/5 concluidas — 0 FAIL/0 ERROR obrigatorio antes de
-  `review-task`
-- [ ] 6.3.2 Rodar `./tests/run.sh --check-coverage` — 0 script orfao
-  (delta-gate.sh, delta-merge.sh, `_diag.sh` vendorizado)
-- [ ] 6.3.3 Apos instalar via `cstk install --from` local (build de dev),
-  rodar `cstk doctor` e confirmar drift zero entre catalogo e disco
+  `review-task`. Resultado (rodado em background pelo pai): `PASS: 1758
+  FAIL: 0  ERROR: 0  ORPHANS: 0  TIME: 828s` — dec-044
+- [x] 6.3.2 Rodar `./tests/run.sh --check-coverage` — 0 script orfao
+  (delta-gate.sh, delta-merge.sh, `_diag.sh` vendorizado). Resultado:
+  "Cobertura completa: zero orfaos." — dec-044
+- [x] 6.3.3 Apos instalar via `cstk install --from` local (build de dev),
+  rodar `cstk doctor` e confirmar drift zero entre catalogo e disco.
+  Build `5.23.0-dev` + install (scope=global, updated=17, commands=6,
+  agents=7) + doctor: `ok=43 edited=1 missing=0 orphan=0` — o unico
+  `[EDITED]` e `go-review-service` (pre-existente, fora do escopo desta
+  feature); zero drift nos artefatos tocados por living-specs — dec-045
 
 ### 6.4 (OPCIONAL, fora de criterio de aceite) Backfill incremental do corpus `[M]`
 
@@ -765,3 +785,36 @@ flowchart TD
 | CHK022 (apetite de risco dos 4 subcasos de conflito serem error vs warning) | Nao vira tarefa — decisao de politica de risco do mantenedor | `{humano}`, aguarda decisao do dono do produto antes de `execute-task`; nao bloqueia `create-tasks` |
 | CHK030 (scope-dir de etapa `plan` que edita `global/` alargar dinamicamente?) | Nao vira tarefa — trade-off de seguranca vs abrangencia do commit de etapa | `{humano}`, aguarda decisao do dono do produto; implementacao atual (5.6.1) usa scope-dir fixo por etapa, revisitavel apos feedback real de uso |
 | CHK038 (criterio de prontidao do backfill opcional) | Nao vira tarefa — apenas anotado em 6.4 como backlog sem dono | `{humano}`, spec.md §Out of Scope ja marca como nao-bloqueante; criterio de prontidao fica para quando/se o operador priorizar |
+
+## FASE 7 - Convergência
+
+> Fase gerada automaticamente pela skill `converge` (reconciliação
+> spec-vs-código). Cada tarefa abaixo corresponde a um achado (`Gap`)
+> entre o que `spec.md`/`plan.md`/`tasks.md` descreveram e o estado
+> presente do código. Tarefas sem o prefixo `[Revisar]` são acionáveis
+> (`missing`/`partial`/`contradicts`); tarefas com `[Revisar]` são item de
+> revisão (`unrequested`, FR-013) — nunca "implementar", o código já
+> existe. Append-only: esta fase nunca reescreve fases/tarefas anteriores
+> do arquivo (FR-009).
+
+### 7.1 Docstring de `state-ondas.sh git-commit` descreve staging antigo `[A]`
+
+Ref: task 5.4 · tipo: `contradicts` · severidade: `MEDIUM`
+
+O cabeçalho de uso de `state-ondas.sh` (linhas 116-121, comando
+`git-commit`) ainda documenta o comportamento PRE-FASE-5: "— Faz `git add
+.` + `git commit -m '...'`". A implementação real de `_so_cmd_git_commit`
+(linhas ~815-853) foi refatorada pela task 5.4 e HOJE delega o staging a
+`commit-mode.sh stage-derived` (allowlist derivada, nunca `git add .`) —
+confirmado pelas linhas 826 ("delega a commit-mode.sh stage-derived em
+vez de `git add -- .`") e 844 (`sh "$_sog_cm" stage-derived ...`). O
+comportamento de fato está correto (FR-014 não é violado em runtime); o
+que diverge é a documentação inline, que pode induzir um leitor/mantenedor
+futuro a acreditar que o subcomando ainda faz staging amplo.
+
+- [x] 7.1.1 Atualizar o comentário de cabeçalho de `state-ondas.sh`
+  (linhas 116-121) para descrever o comportamento real pós-FASE-5:
+  delegação a `commit-mode.sh stage-derived` (allowlist derivada do
+  baseline de untracked), não mais `git add .`
+
+<!-- converge-key: 5438a1045359 -->

--- a/docs/specs/living-specs/tasks.md
+++ b/docs/specs/living-specs/tasks.md
@@ -183,15 +183,15 @@ Ref: FR-001, FR-011 · tarefa 1.1 (consome CHK015) · contracts/delta-section-fo
 
 Ref: research.md Decision 7 · plan.md §Project Structure
 
-- [ ] 3.1.1 Copiar `global/skills/agente-00c-runtime/scripts/_diag.sh` para
+- [x] 3.1.1 Copiar `global/skills/agente-00c-runtime/scripts/_diag.sh` para
   `global/skills/review-features/scripts/_diag.sh`, com cabecalho apontando
   a fonte canonica (`agente-00c-runtime/scripts/_diag.sh`) e o contrato
   `docs/specs/openspec-hygiene/contracts/diagnostic-envelope.md` (mesmo
   padrao de vendoring documentado na Decision 7)
-- [ ] 3.1.2 Confirmar que `tests/test__diag.sh` cobre a copia
+- [x] 3.1.2 Confirmar que `tests/test__diag.sh` cobre a copia
   automaticamente via mapeamento por NOME do `--check-coverage` (sem criar
   teste novo — mesmo arquivo, dois locais)
-- [ ] 3.1.3 Smoke-test manual: sourcing a copia vendorizada e chamar
+- [x] 3.1.3 Smoke-test manual: sourcing a copia vendorizada e chamar
   `diag_emit` com severity valida e invalida, confirmando paridade de
   output com o `_diag.sh` canonico (mesmo contrato, dogfooding do envelope
   antes de consumi-lo em 3.4/3.8)
@@ -200,22 +200,22 @@ Ref: research.md Decision 7 · plan.md §Project Structure
 
 Ref: FR-001, FR-010, FR-011 · contracts/delta-gate-cli.md · contracts/delta-section-format.md
 
-- [ ] 3.2.1 Implementar `delta-gate.sh SPEC_MD [--corpus-dir DIR]`
+- [x] 3.2.1 Implementar `delta-gate.sh SPEC_MD [--corpus-dir DIR]`
   (POSIX sh puro, `set -eu`); resolucao de `--corpus-dir` default subindo
   de `SPEC_MD` pela convencao `docs/specs/<feature>/spec.md` ate
   `docs/specs/current/`; sem convencao e sem flag => exit 2 (uso incorreto)
-- [ ] 3.2.2 Parsear `## Delta Requirements`: ausente => `FINDING|error|
+- [x] 3.2.2 Parsear `## Delta Requirements`: ausente => `FINDING|error|
   delta-missing|...`, `RESULT|...|delta=missing`, exit 1 (FR-010)
-- [ ] 3.2.3 Detectar marcador `**Skip**: <justificativa> — <autor>,
+- [x] 3.2.3 Detectar marcador `**Skip**: <justificativa> — <autor>,
   <YYYY-MM-DD>`; validar os 3 campos nao-vazios — qualquer ausente =>
   `FINDING|error|skip-invalid|...` (FR-011); Skip + blocos `### Capability:`
   na mesma secao => `FINDING|error|skip-with-delta|...` (mutuamente
   exclusivos); Skip valido isolado => `RESULT|...|delta=skip`, exit 0
   (US3 cenario 2)
-- [ ] 3.2.4 Parsear blocos `### Capability: <slug>` repetiveis, cada um com
+- [x] 3.2.4 Parsear blocos `### Capability: <slug>` repetiveis, cada um com
   >=1 dos 4 grupos `####` nao-vazio; secao presente mas sem NENHUM bloco
   Capability nem skip => `FINDING|error|delta-empty|...`
-- [ ] 3.2.5 Parsear entradas `- **FR-NNN**: <texto>` (ADDED/MODIFIED/
+- [x] 3.2.5 Parsear entradas `- **FR-NNN**: <texto>` (ADDED/MODIFIED/
   REMOVED) e `- **FR-NNN -> FR-MMM**` (RENAMED), incluindo continuacao de
   texto em linhas indentadas (2+ espacos); entrada fora da gramatica =>
   `FINDING|error|entry-malformed|...`
@@ -224,24 +224,24 @@ Ref: FR-001, FR-010, FR-011 · contracts/delta-gate-cli.md · contracts/delta-se
 
 Ref: FR-013 · tarefa 1.3 (consome CHK034) · contracts/corpus-format.md §Semantica de aplicacao
 
-- [ ] 3.3.1 Implementar a pre-checagem estrutural do corpus fixada na
+- [x] 3.3.1 Implementar a pre-checagem estrutural do corpus fixada na
   tarefa 1.3.1: para cada capability referenciada pela secao delta, se o
   arquivo `docs/specs/current/<slug>.md` existir, validar headings
   `# Capability:`/`## Requirements`/`### FR-NNN` bem-formados e ausencia de
   id duplicado entre `## Requirements`/`## Removed Requirements`/tabela de
   renames; violacao => `FINDING|error|corpus-malformed|...` (code fixado
   na tarefa 1.3.2), ANTES de qualquer validacao referencial
-- [ ] 3.3.2 Validacao referencial por tipo (tabela `corpus-format.md`
+- [x] 3.3.2 Validacao referencial por tipo (tabela `corpus-format.md`
   §Semantica de aplicacao): MODIFIED/REMOVED exigem id ATIVO no corpus =>
   senao `FINDING|error|ref-not-found|...` (FR-013, US3 cenario 4); ADDED
   com id ja ativo na mesma capability => `FINDING|error|added-collision|
   ...`; RENAMED exige `old_id` ativo E `new_id` inexistente (ativo ou
   removido/aposentado) em qualquer secao => senao `FINDING|error|
   renamed-target-exists|...`
-- [ ] 3.3.3 Corpus/capability inexistente com APENAS entradas ADDED =>
+- [x] 3.3.3 Corpus/capability inexistente com APENAS entradas ADDED =>
   `FINDING|info|corpus-missing|...` (nao bloqueia — US2 cenario 4,
   distinto de `corpus-malformed`)
-- [ ] 3.3.4 Emitir `RESULT|<spec>|delta=<present|skip|missing>|errors=<N>|
+- [x] 3.3.4 Emitir `RESULT|<spec>|delta=<present|skip|missing>|errors=<N>|
   warnings=<M>` como ultima linha de stdout, sempre; exit 0 (errors=0),
   exit 1 (errors>=1), exit 2 (uso incorreto — nao emite RESULT)
 
@@ -249,18 +249,18 @@ Ref: FR-013 · tarefa 1.3 (consome CHK034) · contracts/corpus-format.md §Seman
 
 Ref: contracts/delta-gate-cli.md invariante 4 · gate owasp-security pos-plan · tarefa 3.1
 
-- [ ] 3.4.1 Validar o slug (`[a-z0-9][a-z0-9-]*`) como a PRIMEIRA checagem
+- [x] 3.4.1 Validar o slug (`[a-z0-9][a-z0-9-]*`) como a PRIMEIRA checagem
   do parser sobre cada `### Capability:` lida, ANTES de qualquer composicao
   de path com o valor — slug fora do padrao => `FINDING|error|
   capability-slug-invalid|...`, NUNCA compor `docs/specs/current/$slug.md`
   com valor nao-validado (anti path traversal `../`, absoluto, com espaco)
-- [ ] 3.4.2 Nunca `printf "$var"` com texto delta (sempre `printf '%s'`);
+- [x] 3.4.2 Nunca `printf "$var"` com texto delta (sempre `printf '%s'`);
   todas as variaveis quotadas; zero `eval` sobre conteudo lido do spec.md
   (SEC-1, mesmo padrao de `skill-converge/scripts/*.sh`)
-- [ ] 3.4.3 Erros de uso (SPEC_MD inexistente, `--corpus-dir` irresoluvel)
+- [x] 3.4.3 Erros de uso (SPEC_MD inexistente, `--corpus-dir` irresoluvel)
   emitem `DIAG|error|<code>|<message>|<fix>` em stderr via `_diag.sh`
   vendorizado (tarefa 3.1), ADITIVO a mensagem legada
-- [ ] 3.4.4 Determinismo: mesma spec + mesmo corpus => stdout byte-identico
+- [x] 3.4.4 Determinismo: mesma spec + mesmo corpus => stdout byte-identico
   entre execucoes (edge case da spec) — nenhuma dependencia de ordem de
   filesystem (`sort` explicito onde a ordem de entrada nao e garantida)
 
@@ -268,37 +268,37 @@ Ref: contracts/delta-gate-cli.md invariante 4 · gate owasp-security pos-plan ·
 
 Ref: contracts/delta-gate-cli.md invariante 5 · quickstart.md Cenarios 1, 3, 4 · CLAUDE.md convencao de cobertura
 
-- [ ] 3.5.1 Cenarios happy-path: delta ADDED valida (corpus ausente =>
+- [x] 3.5.1 Cenarios happy-path: delta ADDED valida (corpus ausente =>
   `corpus-missing` info, exit 0); delta MODIFIED/REMOVED sobre corpus
   existente valido; delta so-REMOVED valida (US3 cenario 3)
-- [ ] 3.5.2 Cenarios de bloqueio: sem secao (`delta-missing`, exit 1); skip
+- [x] 3.5.2 Cenarios de bloqueio: sem secao (`delta-missing`, exit 1); skip
   invalido (`skip-invalid`); skip + delta simultaneo (`skip-with-delta`);
   secao vazia (`delta-empty`); entrada malformada (`entry-malformed`)
-- [ ] 3.5.3 Cenarios referenciais: `ref-not-found` (MODIFIED/REMOVED/RENAMED
+- [x] 3.5.3 Cenarios referenciais: `ref-not-found` (MODIFIED/REMOVED/RENAMED
   para id inexistente); `added-collision`; `renamed-target-exists`
-- [ ] 3.5.4 Cenario `corpus-malformed`: fixture com
+- [x] 3.5.4 Cenario `corpus-malformed`: fixture com
   `docs/specs/current/<slug>.md` editado a mao violando o contrato
   (heading fora do padrao, id duplicado) — gate bloqueia ANTES de checar
   referencias (tarefa 3.3.1)
-- [ ] 3.5.5 Cenario de seguranca: slug hostil (`../escape`, path absoluto,
+- [x] 3.5.5 Cenario de seguranca: slug hostil (`../escape`, path absoluto,
   slug com espaco) — `capability-slug-invalid`, nenhum path composto fora
   do corpus-dir (SEC, tarefa 3.4.1)
-- [ ] 3.5.6 Cenario de determinismo: rodar o gate 2x sobre o mesmo input,
+- [x] 3.5.6 Cenario de determinismo: rodar o gate 2x sobre o mesmo input,
   comparar stdout byte-a-byte
-- [ ] 3.5.7 Cenarios de uso incorreto: SPEC_MD inexistente e
+- [x] 3.5.7 Cenarios de uso incorreto: SPEC_MD inexistente e
   `--corpus-dir` irresoluvel sem convencao => exit 2, `DIAG|` em stderr
 
 ### 3.6 `delta-merge.sh`: parse + validacao pre-mutacao `[C]`
 
 Ref: FR-002..FR-005 · contracts/delta-merge-cli.md · contracts/corpus-format.md
 
-- [ ] 3.6.1 Implementar `delta-merge.sh SPEC_MD --feature NAME
+- [x] 3.6.1 Implementar `delta-merge.sh SPEC_MD --feature NAME
   [--corpus-dir DIR] [--date YYYY-MM-DD] [--dry-run]`; reusar o MESMO
   parser da secao delta da tarefa 3.2 (nao duplicar gramatica); `--date`
   default = data corrente UTC
-- [ ] 3.6.2 Skip valido presente => `RESULT|...|delta=skip`, exit 0, zero
+- [x] 3.6.2 Skip valido presente => `RESULT|...|delta=skip`, exit 0, zero
   escrita no corpus (no-op declarado)
-- [ ] 3.6.3 Re-validar TODAS as pre-condicoes de TODAS as entradas de TODAS
+- [x] 3.6.3 Re-validar TODAS as pre-condicoes de TODAS as entradas de TODAS
   as capabilities tocadas contra o corpus ANTES de escrever qualquer byte
   (defesa em profundidade — o merge pode rodar em momento distinto do
   gate, corpus pode ter mudado); mesmos codes de erro do gate
@@ -310,40 +310,40 @@ Ref: FR-002..FR-005 · contracts/delta-merge-cli.md · contracts/corpus-format.m
 
 Ref: FR-002..FR-005, FR-007 · contracts/corpus-format.md §Semantica de aplicacao
 
-- [ ] 3.7.1 ADDED: nova entrada em `## Requirements` com
+- [x] 3.7.1 ADDED: nova entrada em `## Requirements` com
   `### FR-NNN` + texto + `*Introduzida por: <feature> (<data>)*`
-- [ ] 3.7.2 MODIFIED: substitui texto da entrada ativa, id preservado,
+- [x] 3.7.2 MODIFIED: substitui texto da entrada ativa, id preservado,
   adiciona/atualiza `*Ultima modificacao: <feature> (<data>)*`
   (`*Introduzida por:*` permanece imutavel — SC-004)
-- [ ] 3.7.3 REMOVED: move a entrada para `## Removed Requirements` com
+- [x] 3.7.3 REMOVED: move a entrada para `## Removed Requirements` com
   `*Removida por: <feature> (<data>)* — <motivo>` (nunca desaparecimento
   silencioso — FR-004)
-- [ ] 3.7.4 RENAMED: heading `### FR-NNN` vira `### FR-MMM`, linha
+- [x] 3.7.4 RENAMED: heading `### FR-NNN` vira `### FR-MMM`, linha
   adicionada em `## Renamed Identifiers` (tabela old/new/feature/data);
   id antigo nunca reciclado (invariante 1 do contrato)
-- [ ] 3.7.5 Corpus/arquivo de capability inexistente + so ADDED => cria o
+- [x] 3.7.5 Corpus/arquivo de capability inexistente + so ADDED => cria o
   arquivo de capability (US2 cenario 4); diretorio `docs/specs/current/`
   criado sob demanda se ainda nao existir
-- [ ] 3.7.6 Aplicacao atomica: conteudo novo montado via `mktemp`, `mv`
+- [x] 3.7.6 Aplicacao atomica: conteudo novo montado via `mktemp`, `mv`
   so apos validacao TOTAL de TODAS as capabilities da spec (multi-capability
   => nenhum `mv` acontece se qualquer uma falhar); entradas ordenadas por
   id crescente dentro de cada secao (determinismo byte-a-byte — invariante 3)
-- [ ] 3.7.7 `--dry-run`: valida e reporta o que SERIA aplicado
+- [x] 3.7.7 `--dry-run`: valida e reporta o que SERIA aplicado
   (`added=N|modified=N|removed=N|renamed=N`), zero escrita real
-- [ ] 3.7.8 Emitir `RESULT|<spec>|delta=<applied|skip|blocked>|added=<N>|
+- [x] 3.7.8 Emitir `RESULT|<spec>|delta=<applied|skip|blocked>|added=<N>|
   modified=<N>|removed=<N>|renamed=<N>`
 
 ### 3.8 `delta-merge.sh`: seguranca `[C]`
 
 Ref: contracts/delta-merge-cli.md invariante 2-bis · gate owasp-security pos-plan
 
-- [ ] 3.8.1 Re-validar o slug (`[a-z0-9][a-z0-9-]*`) como primeira
+- [x] 3.8.1 Re-validar o slug (`[a-z0-9][a-z0-9-]*`) como primeira
   checagem, ANTES de compor qualquer path — nunca confiar que
   `delta-gate.sh` rodou antes (defesa em profundidade contra path
   traversal, mesma regra da tarefa 3.4.1)
-- [ ] 3.8.2 Texto delta escrito no corpus sempre via `printf '%s'`, nunca
+- [x] 3.8.2 Texto delta escrito no corpus sempre via `printf '%s'`, nunca
   como format string; variaveis quotadas; zero `eval`
-- [ ] 3.8.3 Erros de uso emitem `DIAG|` via `_diag.sh` vendorizado
+- [x] 3.8.3 Erros de uso emitem `DIAG|` via `_diag.sh` vendorizado
   (tarefa 3.1); erros de conflito/bloqueio permanecem no formato
   `FINDING|`/`RESULT|` (nao viram DIAG — sao veredito de dominio, nao erro
   de uso do script)
@@ -352,34 +352,34 @@ Ref: contracts/delta-merge-cli.md invariante 2-bis · gate owasp-security pos-pl
 
 Ref: contracts/delta-merge-cli.md · quickstart.md Cenarios 1, 2, 4
 
-- [ ] 3.9.1 Cenario 1 (happy path ADDED): corpus inexistente => criado com
+- [x] 3.9.1 Cenario 1 (happy path ADDED): corpus inexistente => criado com
   `### FR-001` + proveniencia correta (SC-004)
-- [ ] 3.9.2 Cenario 2 (MODIFIED/REMOVED sobre corpus existente): texto
+- [x] 3.9.2 Cenario 2 (MODIFIED/REMOVED sobre corpus existente): texto
   substituido com id preservado + `Ultima modificacao`; entrada REMOVED
   movida para `## Removed Requirements` com motivo
-- [ ] 3.9.3 Cenario de skip: `delta=skip`, exit 0, corpus (se existir)
+- [x] 3.9.3 Cenario de skip: `delta=skip`, exit 0, corpus (se existir)
   byte-identico antes/depois (hash comparado)
-- [ ] 3.9.4 Cenario de atomicidade (quickstart Cenario 4 item 4): spec
+- [x] 3.9.4 Cenario de atomicidade (quickstart Cenario 4 item 4): spec
   multi-capability com erro na 2a capability => exit 1, hash de TODOS os
   arquivos do corpus identico antes/depois (nenhuma mutacao parcial)
-- [ ] 3.9.5 Cenario `--dry-run`: reporta contagens corretas, zero escrita
+- [x] 3.9.5 Cenario `--dry-run`: reporta contagens corretas, zero escrita
   (hash do corpus inalterado)
-- [ ] 3.9.6 Cenario `corpus-malformed`: merge tambem bloqueia (nao so o
+- [x] 3.9.6 Cenario `corpus-malformed`: merge tambem bloqueia (nao so o
   gate) sobre corpus editado a mao violando o contrato (tarefa 3.6.3)
-- [ ] 3.9.7 Cenario de determinismo: dois merges com os MESMOS inputs
+- [x] 3.9.7 Cenario de determinismo: dois merges com os MESMOS inputs
   (spec + corpus + `--date`) produzem corpus resultante byte-identico
 
 ### 3.10 Fechar cobertura de teste dos scripts novos `[A]`
 
 Ref: CLAUDE.md §Como testar scripts shell · Regra de ouro (mapeamento por nome)
 
-- [ ] 3.10.1 Rodar `./tests/run.sh --check-coverage` e confirmar exit 0 —
+- [x] 3.10.1 Rodar `./tests/run.sh --check-coverage` e confirmar exit 0 —
   `delta-gate.sh`/`delta-merge.sh` mapeados para `tests/test_delta-gate.sh`/
   `tests/test_delta-merge.sh`; `_diag.sh` vendorizado coberto por
   `tests/test__diag.sh` (mapeamento por nome, sem teste duplicado)
-- [ ] 3.10.2 Rodar `./tests/run.sh test_delta-gate` e
+- [x] 3.10.2 Rodar `./tests/run.sh test_delta-gate` e
   `./tests/run.sh test_delta-merge` isoladamente, confirmar 0 FAIL/0 ERROR
-- [ ] 3.10.3 Rodar `shellcheck -s sh` (advisory, mesmo padrao ja adotado
+- [x] 3.10.3 Rodar `shellcheck -s sh` (advisory, mesmo padrao ja adotado
   pelo precedente `skill-converge`) sobre `delta-gate.sh`, `delta-merge.sh`
   e a copia vendorizada de `_diag.sh`; resolver findings antes de
   prosseguir para a FASE 4

--- a/docs/specs/living-specs/tasks.md
+++ b/docs/specs/living-specs/tasks.md
@@ -1,0 +1,721 @@
+# Tasks — living-specs
+
+**Escopo**: introduzir o corpus canonico de specs vivas (`docs/specs/current/`)
+alimentado por secoes `## Delta Requirements` opcionais na spec de cada
+feature, aplicado deterministicamente no momento do archive por
+`delta-gate.sh` (veredito bloquear/liberar) + `delta-merge.sh` (aplicacao
+atomica), e endurecer o modo `atomic-commit` para staging explicito por
+allowlist derivada (`commit-mode.sh snapshot`/`stage-derived`), eliminando
+os 3 sites reais de `git add -A`/`git add -- .` que causaram o incidente
+`.pptx` observado na execucao `openspec-hygiene`. Deriva de
+[spec.md](./spec.md) + [plan.md](./plan.md) + [research.md](./research.md)
+(9 decisoes) + [data-model.md](./data-model.md) +
+[quickstart.md](./quickstart.md) (7 cenarios) +
+[contracts/delta-section-format.md](./contracts/delta-section-format.md) +
+[contracts/corpus-format.md](./contracts/corpus-format.md) +
+[contracts/delta-gate-cli.md](./contracts/delta-gate-cli.md) +
+[contracts/delta-merge-cli.md](./contracts/delta-merge-cli.md) +
+[contracts/commit-staging-cli.md](./contracts/commit-staging-cli.md) +
+[checklists/requirements.md](./checklists/requirements.md).
+
+**Legenda de status**: `[ ]` Pendente · `[~]` Em andamento · `[x]` Concluido · `[!]` Bloqueado
+**Legenda de criticidade**: `[C]` Critico (seguranca/integridade/regressao do incidente real) · `[A]` Alto (funcionalidade essencial da feature) · `[M]` Medio (necessario, sem urgencia imediata)
+
+> **Reuso obrigatorio (nao reinventar)**: envelope `DIAG|` de
+> `agente-00c-runtime/scripts/_diag.sh` `[REAL]` (vendorizado — research
+> Decision 7); padrao `FINDING|<severity>|<code>|<msg>` + `RESULT|...` ja
+> usado por `validate-sdd.sh`/`requirement-coverage.sh` `[REAL]`;
+> `bloqueios.sh register` `[REAL]` para a integracao da tarefa 4.2;
+> `create-tasks/scripts/next-task-id.sh` nao se aplica aqui (backlog sem
+> fase de convergencia apendada nesta onda). Todo script novo e 100% POSIX
+> sh puro (`#!/bin/sh`, `set -eu`), sem `jq`, sem dependencia opcional nova
+> (Constitution II). Zero coleta remota/rede (Constitution IV). Todo path
+> derivado de texto lido (slug de capability, paths de staging) e
+> quotado/validado antes de compor comandos — nunca `eval`, nunca
+> `printf "$var"` (Constitution VI + gate `owasp-security` pos-plan).
+
+> **Gaps do checklist fechados nesta decomposicao** (FASE 1, ver
+> `checklists/requirements.md` CHK015/CHK020/CHK034): as 3 lacunas `{auto}`
+> com `[Gap]` recebem resolucao concreta e citavel ANTES de qualquer script
+> que as consuma ser implementado — nao ficam como "definir depois" solto.
+> Os 3 itens `{humano}` (CHK022, CHK030, CHK038) NAO viram tarefa — ver
+> "## Escopo Excluido" para o encaminhamento de cada um.
+
+---
+
+## FASE 1 - Fundacao: Fechar Gaps de Definicao do Checklist
+
+### 1.1 Definir orientacao de descoberta/reuso de slug de capability `[A]`
+
+Ref: checklists/requirements.md CHK015 · Spec Key Entities "Living Spec Corpus" · contracts/delta-section-format.md regra 1
+
+- [ ] 1.1.1 Fixar a regra: antes de declarar um `### Capability: <slug>` novo
+  numa secao Delta Requirements, o autor MUST consultar as capabilities ja
+  existentes rodando `ls docs/specs/current/*.md 2>/dev/null` (corpus pode
+  nao existir ainda — lista vazia e um resultado valido) e reusar o slug
+  existente sempre que a feature tocar o MESMO conceito, em vez de
+  fragmentar em um slug novo semanticamente equivalente (ex.: `commit-mode`
+  vs `commit-staging` citado no gap do checklist)
+- [ ] 1.1.2 Definir que a decisao de "mesmo conceito ou conceito novo" e
+  julgamento do AUTOR da spec (agente ou humano) no momento de preencher a
+  secao delta — nao um script determinístico (mesma natureza de decisao ja
+  delegada ao agente em `origin -> story_priority` no precedente
+  `skill-converge`, research.md Decision 1 daquela feature); o gate
+  (`delta-gate.sh`) so valida a FORMA do slug (`[a-z0-9][a-z0-9-]*`), nunca
+  a semantica de reuso
+- [ ] 1.1.3 Anotar a regra acima em
+  `contracts/delta-section-format.md` §Gramatica, item 1 (apos a definicao
+  do padrao do slug), citando o comando de descoberta e o exemplo de
+  fragmentacao do gap
+- [ ] 1.1.4 Registrar que a tarefa 2.2 (prosa da skill `specify`) e o local
+  de implementacao desta orientacao — este item so fixa a definicao
+
+### 1.2 Definir integracao gate-bloqueado <-> bloqueios.sh no fluxo autonomo `[A]`
+
+Ref: checklists/requirements.md CHK020 · Spec Edge Cases · research.md Decision 8 · Plan Constitution Check
+
+- [ ] 1.2.1 Fixar a politica: quando `delta-gate.sh` retorna exit 1 (archive
+  bloqueado) durante a fase `review-features` do `agente-00c-orchestrator`
+  em execucao SEM supervisao, o orquestrador MUST registrar um
+  `bloqueios.sh register` para AQUELA feature especifica (pergunta:
+  resumo dos `FINDING|error|...` emitidos pelo gate + path da spec),
+  nunca falhar silenciosamente nem pular o archive sem rastro
+- [ ] 1.2.2 Fixar que o bloqueio e ESCOPADO a feature (nao aborta a onda
+  inteira de `review-features`): as demais features do portfolio sem
+  bloqueio de gate continuam sendo processadas (arquivadas/avaliadas)
+  normalmente na mesma onda — paridade com o padrao ja usado pelos demais
+  Quality Gates complementares do orquestrador (severidade alta escala,
+  mas nao trava as demais features do lote)
+- [ ] 1.2.3 Fixar o formato da pergunta do bloqueio: contexto-para-resposta
+  cita o `RESULT|<spec>|delta=missing|errors=N|...` literal emitido pelo
+  gate (aterramento de evidencia — nunca resumo parafraseado sem a linha
+  real, Constitution VI)
+- [ ] 1.2.4 Registrar que a tarefa 4.2 (`agente-00c-orchestrator.md`, fase
+  review-features) e o local de implementacao desta politica — este item
+  so fixa a definicao; o fluxo MANUAL (operador rodando `/review-features`
+  interativamente) segue com o bloqueio reportado em prosa pela skill
+  (sem precisar de `bloqueios.sh`, que e mecanismo exclusivo dos
+  orquestradores autonomos)
+
+### 1.3 Definir validacao de estrutura do corpus contra edicao manual `[A]`
+
+Ref: checklists/requirements.md CHK034 · Contract corpus-format.md §Estrutura
+
+- [ ] 1.3.1 Fixar que a validacao estrutural do corpus acontece DENTRO de
+  `delta-gate.sh`, como pre-checagem ANTES de qualquer validacao
+  referencial (ref-not-found/added-collision/renamed-target-exists): para
+  cada arquivo `docs/specs/current/<slug>.md` que a secao delta da spec
+  candidata referencia, o parser confere invariantes estruturais do
+  contrato (headings `# Capability:`/`## Requirements`/`### FR-NNN`
+  bem-formados; nenhum id duplicado considerando `## Requirements` +
+  `## Removed Requirements` + coluna "Antigo"/"Novo" de
+  `## Renamed Identifiers` simultaneamente — invariante 1 de
+  `corpus-format.md`)
+- [ ] 1.3.2 Fixar o novo `FINDING` code `corpus-malformed` (severity=error)
+  para violacao de qualquer invariante da tarefa 1.3.1; corpus ausente
+  NAO e `corpus-malformed` (permanece `corpus-missing`, severity=info, ja
+  definido — US2 cenario 4)
+- [ ] 1.3.3 Fixar que `delta-merge.sh` RE-VALIDA a mesma estrutura antes de
+  aplicar qualquer mutacao (defesa em profundidade — mesmo padrao ja
+  adotado para a re-validacao de slug entre gate e merge,
+  `delta-merge-cli.md` invariante 2-bis); corpus malformado bloqueia o
+  merge com o MESMO code, exit 1, corpus intacto
+- [ ] 1.3.4 Atualizar `contracts/delta-gate-cli.md` §Codes (nova linha
+  `corpus-malformed`) e `contracts/corpus-format.md` (nota apontando que a
+  "advertencia em prosa" hoje existente passa a ter enforcement
+  determinístico via este code)
+- [ ] 1.3.5 Registrar que as tarefas 3.3 (`delta-gate.sh`) e 3.7
+  (`delta-merge.sh`) sao o local de implementacao — este item so fixa a
+  definicao
+
+---
+
+## FASE 2 - Secao Delta Requirements na Spec (US1, FR-001)
+
+### 2.1 Template `feature-spec.md`: secao opcional Delta Requirements `[A]`
+
+Ref: FR-001 · contracts/delta-section-format.md · plan.md §Project Structure
+
+- [ ] 2.1.1 Adicionar em
+  `global/skills/specify/templates/feature-spec.md`, apos
+  `## Success Criteria` (posicao recomendada do contrato — o parser
+  localiza pelo heading, nao pela posicao), a secao opcional
+  `## Delta Requirements` com os 4 subgrupos `#### ADDED`/`MODIFIED`/
+  `REMOVED`/`RENAMED` sob `### Capability: <capability-slug>`, seguindo a
+  gramatica EXATA de `contracts/delta-section-format.md` (seta `->` ASCII
+  no RENAMED, nunca `→`)
+- [ ] 2.1.2 Adicionar comentario de template explicando que a secao e
+  OPCIONAL (feature pode nao tocar nenhum comportamento de corpus ainda) e
+  que o marcador de Skip (`**Skip**: <justificativa> — <autor>,
+  <YYYY-MM-DD>`) e a forma alternativa mutuamente exclusiva com os blocos
+  `### Capability:` — usada quando o archive nao precisa de delta (US3)
+- [ ] 2.1.3 Confirmar (grep) que `validate-sdd.sh` spec-profile nao passa a
+  exigir a secao nova (permanece exigindo so "User Scenarios & Testing",
+  "Requirements", "Success Criteria" — research.md Decision 4, fato ja
+  verificado) e que `requirement-coverage.sh` continua ignorando ids sob
+  `## Delta Requirements` (reset em qualquer `##`/`###` seguinte —
+  research.md Decision 4)
+
+### 2.2 `specify/SKILL.md`: prosa de quando/como preencher a secao `[A]`
+
+Ref: FR-001, FR-011 · tarefa 1.1 (consome CHK015) · contracts/delta-section-format.md §Skip explicito
+
+- [ ] 2.2.1 Adicionar secao de prosa em `global/skills/specify/SKILL.md`
+  orientando: (a) quando preencher Delta Requirements (feature que
+  adiciona/muda/remove/renomeia comportamento hoje ativo do sistema-alvo);
+  (b) a regra de descoberta/reuso de slug fixada na tarefa 1.1.1-1.1.3
+  (`ls docs/specs/current/*.md` antes de nomear capability nova); (c) como
+  preencher o marcador de Skip quando a feature e puramente doc-only/meta
+  (formato dos 3 campos obrigatorios: justificativa, autor, data)
+- [ ] 2.2.2 Citar no SKILL.md que a validacao de forma (nao de semantica de
+  reuso) fica a cargo de `delta-gate.sh` (FASE 3), rodado apenas no
+  momento do archive — `specify` nunca invoca o gate diretamente
+- [ ] 2.2.3 Adicionar exemplo minimo de secao `## Delta Requirements`
+  preenchida (um bloco ADDED simples) na prosa do SKILL.md, ilustrando a
+  gramatica de `delta-section-format.md` sem exigir abrir o contrato
+  completo para o caso comum
+
+---
+
+## FASE 3 - Corpus Canonico + Scripts Deterministicos (US2/US3, FR-002..FR-013)
+
+### 3.1 Vendorizar `_diag.sh` em `review-features/scripts/` `[C]`
+
+Ref: research.md Decision 7 · plan.md §Project Structure
+
+- [ ] 3.1.1 Copiar `global/skills/agente-00c-runtime/scripts/_diag.sh` para
+  `global/skills/review-features/scripts/_diag.sh`, com cabecalho apontando
+  a fonte canonica (`agente-00c-runtime/scripts/_diag.sh`) e o contrato
+  `docs/specs/openspec-hygiene/contracts/diagnostic-envelope.md` (mesmo
+  padrao de vendoring documentado na Decision 7)
+- [ ] 3.1.2 Confirmar que `tests/test__diag.sh` cobre a copia
+  automaticamente via mapeamento por NOME do `--check-coverage` (sem criar
+  teste novo — mesmo arquivo, dois locais)
+- [ ] 3.1.3 Smoke-test manual: sourcing a copia vendorizada e chamar
+  `diag_emit` com severity valida e invalida, confirmando paridade de
+  output com o `_diag.sh` canonico (mesmo contrato, dogfooding do envelope
+  antes de consumi-lo em 3.4/3.8)
+
+### 3.2 `delta-gate.sh`: parser da secao delta + deteccao de skip `[C]`
+
+Ref: FR-001, FR-010, FR-011 · contracts/delta-gate-cli.md · contracts/delta-section-format.md
+
+- [ ] 3.2.1 Implementar `delta-gate.sh SPEC_MD [--corpus-dir DIR]`
+  (POSIX sh puro, `set -eu`); resolucao de `--corpus-dir` default subindo
+  de `SPEC_MD` pela convencao `docs/specs/<feature>/spec.md` ate
+  `docs/specs/current/`; sem convencao e sem flag => exit 2 (uso incorreto)
+- [ ] 3.2.2 Parsear `## Delta Requirements`: ausente => `FINDING|error|
+  delta-missing|...`, `RESULT|...|delta=missing`, exit 1 (FR-010)
+- [ ] 3.2.3 Detectar marcador `**Skip**: <justificativa> — <autor>,
+  <YYYY-MM-DD>`; validar os 3 campos nao-vazios — qualquer ausente =>
+  `FINDING|error|skip-invalid|...` (FR-011); Skip + blocos `### Capability:`
+  na mesma secao => `FINDING|error|skip-with-delta|...` (mutuamente
+  exclusivos); Skip valido isolado => `RESULT|...|delta=skip`, exit 0
+  (US3 cenario 2)
+- [ ] 3.2.4 Parsear blocos `### Capability: <slug>` repetiveis, cada um com
+  >=1 dos 4 grupos `####` nao-vazio; secao presente mas sem NENHUM bloco
+  Capability nem skip => `FINDING|error|delta-empty|...`
+- [ ] 3.2.5 Parsear entradas `- **FR-NNN**: <texto>` (ADDED/MODIFIED/
+  REMOVED) e `- **FR-NNN -> FR-MMM**` (RENAMED), incluindo continuacao de
+  texto em linhas indentadas (2+ espacos); entrada fora da gramatica =>
+  `FINDING|error|entry-malformed|...`
+
+### 3.3 `delta-gate.sh`: validacao estrutural + referencial `[C]`
+
+Ref: FR-013 · tarefa 1.3 (consome CHK034) · contracts/corpus-format.md §Semantica de aplicacao
+
+- [ ] 3.3.1 Implementar a pre-checagem estrutural do corpus fixada na
+  tarefa 1.3.1: para cada capability referenciada pela secao delta, se o
+  arquivo `docs/specs/current/<slug>.md` existir, validar headings
+  `# Capability:`/`## Requirements`/`### FR-NNN` bem-formados e ausencia de
+  id duplicado entre `## Requirements`/`## Removed Requirements`/tabela de
+  renames; violacao => `FINDING|error|corpus-malformed|...` (code fixado
+  na tarefa 1.3.2), ANTES de qualquer validacao referencial
+- [ ] 3.3.2 Validacao referencial por tipo (tabela `corpus-format.md`
+  §Semantica de aplicacao): MODIFIED/REMOVED exigem id ATIVO no corpus =>
+  senao `FINDING|error|ref-not-found|...` (FR-013, US3 cenario 4); ADDED
+  com id ja ativo na mesma capability => `FINDING|error|added-collision|
+  ...`; RENAMED exige `old_id` ativo E `new_id` inexistente (ativo ou
+  removido/aposentado) em qualquer secao => senao `FINDING|error|
+  renamed-target-exists|...`
+- [ ] 3.3.3 Corpus/capability inexistente com APENAS entradas ADDED =>
+  `FINDING|info|corpus-missing|...` (nao bloqueia — US2 cenario 4,
+  distinto de `corpus-malformed`)
+- [ ] 3.3.4 Emitir `RESULT|<spec>|delta=<present|skip|missing>|errors=<N>|
+  warnings=<M>` como ultima linha de stdout, sempre; exit 0 (errors=0),
+  exit 1 (errors>=1), exit 2 (uso incorreto — nao emite RESULT)
+
+### 3.4 `delta-gate.sh`: seguranca + envelope DIAG `[C]`
+
+Ref: contracts/delta-gate-cli.md invariante 4 · gate owasp-security pos-plan · tarefa 3.1
+
+- [ ] 3.4.1 Validar o slug (`[a-z0-9][a-z0-9-]*`) como a PRIMEIRA checagem
+  do parser sobre cada `### Capability:` lida, ANTES de qualquer composicao
+  de path com o valor — slug fora do padrao => `FINDING|error|
+  capability-slug-invalid|...`, NUNCA compor `docs/specs/current/$slug.md`
+  com valor nao-validado (anti path traversal `../`, absoluto, com espaco)
+- [ ] 3.4.2 Nunca `printf "$var"` com texto delta (sempre `printf '%s'`);
+  todas as variaveis quotadas; zero `eval` sobre conteudo lido do spec.md
+  (SEC-1, mesmo padrao de `skill-converge/scripts/*.sh`)
+- [ ] 3.4.3 Erros de uso (SPEC_MD inexistente, `--corpus-dir` irresoluvel)
+  emitem `DIAG|error|<code>|<message>|<fix>` em stderr via `_diag.sh`
+  vendorizado (tarefa 3.1), ADITIVO a mensagem legada
+- [ ] 3.4.4 Determinismo: mesma spec + mesmo corpus => stdout byte-identico
+  entre execucoes (edge case da spec) — nenhuma dependencia de ordem de
+  filesystem (`sort` explicito onde a ordem de entrada nao e garantida)
+
+### 3.5 Teste `tests/test_delta-gate.sh` `[C]`
+
+Ref: contracts/delta-gate-cli.md invariante 5 · quickstart.md Cenarios 1, 3, 4 · CLAUDE.md convencao de cobertura
+
+- [ ] 3.5.1 Cenarios happy-path: delta ADDED valida (corpus ausente =>
+  `corpus-missing` info, exit 0); delta MODIFIED/REMOVED sobre corpus
+  existente valido; delta so-REMOVED valida (US3 cenario 3)
+- [ ] 3.5.2 Cenarios de bloqueio: sem secao (`delta-missing`, exit 1); skip
+  invalido (`skip-invalid`); skip + delta simultaneo (`skip-with-delta`);
+  secao vazia (`delta-empty`); entrada malformada (`entry-malformed`)
+- [ ] 3.5.3 Cenarios referenciais: `ref-not-found` (MODIFIED/REMOVED/RENAMED
+  para id inexistente); `added-collision`; `renamed-target-exists`
+- [ ] 3.5.4 Cenario `corpus-malformed`: fixture com
+  `docs/specs/current/<slug>.md` editado a mao violando o contrato
+  (heading fora do padrao, id duplicado) — gate bloqueia ANTES de checar
+  referencias (tarefa 3.3.1)
+- [ ] 3.5.5 Cenario de seguranca: slug hostil (`../escape`, path absoluto,
+  slug com espaco) — `capability-slug-invalid`, nenhum path composto fora
+  do corpus-dir (SEC, tarefa 3.4.1)
+- [ ] 3.5.6 Cenario de determinismo: rodar o gate 2x sobre o mesmo input,
+  comparar stdout byte-a-byte
+- [ ] 3.5.7 Cenarios de uso incorreto: SPEC_MD inexistente e
+  `--corpus-dir` irresoluvel sem convencao => exit 2, `DIAG|` em stderr
+
+### 3.6 `delta-merge.sh`: parse + validacao pre-mutacao `[C]`
+
+Ref: FR-002..FR-005 · contracts/delta-merge-cli.md · contracts/corpus-format.md
+
+- [ ] 3.6.1 Implementar `delta-merge.sh SPEC_MD --feature NAME
+  [--corpus-dir DIR] [--date YYYY-MM-DD] [--dry-run]`; reusar o MESMO
+  parser da secao delta da tarefa 3.2 (nao duplicar gramatica); `--date`
+  default = data corrente UTC
+- [ ] 3.6.2 Skip valido presente => `RESULT|...|delta=skip`, exit 0, zero
+  escrita no corpus (no-op declarado)
+- [ ] 3.6.3 Re-validar TODAS as pre-condicoes de TODAS as entradas de TODAS
+  as capabilities tocadas contra o corpus ANTES de escrever qualquer byte
+  (defesa em profundidade — o merge pode rodar em momento distinto do
+  gate, corpus pode ter mudado); mesmos codes de erro do gate
+  (`ref-not-found`, `added-collision`, `renamed-target-exists`,
+  `entry-malformed`, `corpus-malformed` da tarefa 3.3.1) — qualquer
+  violacao => exit 1, corpus intacto (nenhuma mutacao, nem parcial)
+
+### 3.7 `delta-merge.sh`: aplicacao atomica por capability `[C]`
+
+Ref: FR-002..FR-005, FR-007 · contracts/corpus-format.md §Semantica de aplicacao
+
+- [ ] 3.7.1 ADDED: nova entrada em `## Requirements` com
+  `### FR-NNN` + texto + `*Introduzida por: <feature> (<data>)*`
+- [ ] 3.7.2 MODIFIED: substitui texto da entrada ativa, id preservado,
+  adiciona/atualiza `*Ultima modificacao: <feature> (<data>)*`
+  (`*Introduzida por:*` permanece imutavel — SC-004)
+- [ ] 3.7.3 REMOVED: move a entrada para `## Removed Requirements` com
+  `*Removida por: <feature> (<data>)* — <motivo>` (nunca desaparecimento
+  silencioso — FR-004)
+- [ ] 3.7.4 RENAMED: heading `### FR-NNN` vira `### FR-MMM`, linha
+  adicionada em `## Renamed Identifiers` (tabela old/new/feature/data);
+  id antigo nunca reciclado (invariante 1 do contrato)
+- [ ] 3.7.5 Corpus/arquivo de capability inexistente + so ADDED => cria o
+  arquivo de capability (US2 cenario 4); diretorio `docs/specs/current/`
+  criado sob demanda se ainda nao existir
+- [ ] 3.7.6 Aplicacao atomica: conteudo novo montado via `mktemp`, `mv`
+  so apos validacao TOTAL de TODAS as capabilities da spec (multi-capability
+  => nenhum `mv` acontece se qualquer uma falhar); entradas ordenadas por
+  id crescente dentro de cada secao (determinismo byte-a-byte — invariante 3)
+- [ ] 3.7.7 `--dry-run`: valida e reporta o que SERIA aplicado
+  (`added=N|modified=N|removed=N|renamed=N`), zero escrita real
+- [ ] 3.7.8 Emitir `RESULT|<spec>|delta=<applied|skip|blocked>|added=<N>|
+  modified=<N>|removed=<N>|renamed=<N>`
+
+### 3.8 `delta-merge.sh`: seguranca `[C]`
+
+Ref: contracts/delta-merge-cli.md invariante 2-bis · gate owasp-security pos-plan
+
+- [ ] 3.8.1 Re-validar o slug (`[a-z0-9][a-z0-9-]*`) como primeira
+  checagem, ANTES de compor qualquer path — nunca confiar que
+  `delta-gate.sh` rodou antes (defesa em profundidade contra path
+  traversal, mesma regra da tarefa 3.4.1)
+- [ ] 3.8.2 Texto delta escrito no corpus sempre via `printf '%s'`, nunca
+  como format string; variaveis quotadas; zero `eval`
+- [ ] 3.8.3 Erros de uso emitem `DIAG|` via `_diag.sh` vendorizado
+  (tarefa 3.1); erros de conflito/bloqueio permanecem no formato
+  `FINDING|`/`RESULT|` (nao viram DIAG — sao veredito de dominio, nao erro
+  de uso do script)
+
+### 3.9 Teste `tests/test_delta-merge.sh` `[C]`
+
+Ref: contracts/delta-merge-cli.md · quickstart.md Cenarios 1, 2, 4
+
+- [ ] 3.9.1 Cenario 1 (happy path ADDED): corpus inexistente => criado com
+  `### FR-001` + proveniencia correta (SC-004)
+- [ ] 3.9.2 Cenario 2 (MODIFIED/REMOVED sobre corpus existente): texto
+  substituido com id preservado + `Ultima modificacao`; entrada REMOVED
+  movida para `## Removed Requirements` com motivo
+- [ ] 3.9.3 Cenario de skip: `delta=skip`, exit 0, corpus (se existir)
+  byte-identico antes/depois (hash comparado)
+- [ ] 3.9.4 Cenario de atomicidade (quickstart Cenario 4 item 4): spec
+  multi-capability com erro na 2a capability => exit 1, hash de TODOS os
+  arquivos do corpus identico antes/depois (nenhuma mutacao parcial)
+- [ ] 3.9.5 Cenario `--dry-run`: reporta contagens corretas, zero escrita
+  (hash do corpus inalterado)
+- [ ] 3.9.6 Cenario `corpus-malformed`: merge tambem bloqueia (nao so o
+  gate) sobre corpus editado a mao violando o contrato (tarefa 3.6.3)
+- [ ] 3.9.7 Cenario de determinismo: dois merges com os MESMOS inputs
+  (spec + corpus + `--date`) produzem corpus resultante byte-identico
+
+### 3.10 Fechar cobertura de teste dos scripts novos `[A]`
+
+Ref: CLAUDE.md §Como testar scripts shell · Regra de ouro (mapeamento por nome)
+
+- [ ] 3.10.1 Rodar `./tests/run.sh --check-coverage` e confirmar exit 0 —
+  `delta-gate.sh`/`delta-merge.sh` mapeados para `tests/test_delta-gate.sh`/
+  `tests/test_delta-merge.sh`; `_diag.sh` vendorizado coberto por
+  `tests/test__diag.sh` (mapeamento por nome, sem teste duplicado)
+- [ ] 3.10.2 Rodar `./tests/run.sh test_delta-gate` e
+  `./tests/run.sh test_delta-merge` isoladamente, confirmar 0 FAIL/0 ERROR
+- [ ] 3.10.3 Rodar `shellcheck -s sh` (advisory, mesmo padrao ja adotado
+  pelo precedente `skill-converge`) sobre `delta-gate.sh`, `delta-merge.sh`
+  e a copia vendorizada de `_diag.sh`; resolver findings antes de
+  prosseguir para a FASE 4
+
+---
+
+## FASE 4 - Integracao no Fluxo de Archive (US2/US3, FR-006, FR-008, CHK020)
+
+### 4.1 `review-features/SKILL.md`: acao de archive roda gate -> merge -> mover `[A]`
+
+Ref: FR-006, FR-008 · research.md Decision 3, Decision 8 · delta-merge-cli.md invariante 4
+
+- [ ] 4.1.1 Atualizar "Proximos passos sugeridos" item 3 de
+  `global/skills/review-features/SKILL.md`: antes de mover uma feature
+  `ARQUIVAR` para `_archived/<YYYY-MM-DD>-<feature>/`, a skill roda
+  `delta-gate.sh docs/specs/<feature>/spec.md --corpus-dir
+  docs/specs/current` — exit != 0 => NAO mover, reportar os `FINDING|` ao
+  operador e pedir preenchimento da secao delta ou skip explicito (US3
+  cenario 1/2)
+- [ ] 4.1.2 Gate liberado (exit 0) => rodar `delta-merge.sh
+  docs/specs/<feature>/spec.md --feature <feature>` ANTES do `mv` para
+  `_archived/` — merge bloqueado (exit 1, corpus mudou entre gate e merge)
+  tambem impede o `mv` (defesa em profundidade — tarefa 3.6.3)
+- [ ] 4.1.3 Documentar que o fluxo de mover para `_archived/` permanece
+  EXATAMENTE como hoje apos o merge ter sucesso (US2 cenario 5, FR-006 —
+  corpus e destino ADICIONAL, nunca substituicao)
+- [ ] 4.1.4 Adicionar nota curta no SKILL.md apontando `docs/specs/current/`
+  como fonte para responder "como o sistema se comporta hoje" (FR-009),
+  complementando (nao substituindo) a leitura de `_archived/` para
+  historico de mudancas
+
+### 4.2 `agente-00c-orchestrator.md`: gate bloqueado vira bloqueio humano `[A]`
+
+Ref: checklists/requirements.md CHK020 · tarefa 1.2 (consome o gap) · research.md Decision 8
+
+- [ ] 4.2.1 Na fase `review-features` do `agente-00c-orchestrator.md`,
+  apos a acao de archive de CADA feature `ARQUIVAR` do portfolio, invocar
+  `delta-gate.sh` conforme tarefa 4.1.1; exit 1 => aplicar a politica
+  fixada na tarefa 1.2.1: `bloqueios.sh register` com a pergunta citando o
+  `RESULT|` literal do gate (tarefa 1.2.3), sem abortar a onda inteira
+  (tarefa 1.2.2)
+- [ ] 4.2.2 Registrar Decisao auditavel (`state-decisions.sh register`)
+  documentando o veredito do gate por feature avaliada (padrao ja usado
+  pelos demais Quality Gates complementares do orquestrador)
+- [ ] 4.2.3 Feature SEM bloqueio de gate na mesma onda continua sendo
+  arquivada/mergeada normalmente — bloqueio de uma feature nao impede o
+  processamento das demais (tarefa 1.2.2)
+
+---
+
+## FASE 5 - Staging Explicito por Allowlist no Commit Atomico (US4, FR-014..FR-017)
+
+### 5.1 `commit-mode.sh`: subcomando `snapshot` `[C]`
+
+Ref: FR-014 · contracts/commit-staging-cli.md §snapshot · research.md Decision 2
+
+- [ ] 5.1.1 Implementar `commit-mode.sh snapshot --state-dir DIR
+  --projeto-alvo-path PATH`: captura untracked atual via
+  `git status --porcelain` (linhas `?? `), paths ordenados (`sort`), grava
+  em `DIR/commit-baseline.txt` (sidecar — mesmo padrao de
+  `tool-call-ticks.log`, nunca dentro de `state.json`, nunca versionado)
+- [ ] 5.1.2 Sobrescreve baseline anterior (1 baseline por onda); exit 0
+  gravado, exit 1 erro git/IO, exit 2 uso incorreto
+- [ ] 5.1.3 Confirmar que `commit-baseline.txt` nunca e commitado — vive
+  sob `.claude/` (state dir da execucao), ja coberto pelo `.gitignore` do
+  repo-alvo (linha `.claude` — mesmo caso ja garantido para
+  `tool-call-ticks.log`, sem gitignore novo necessario)
+
+### 5.2 `commit-mode.sh`: subcomando `stage-derived` `[C]`
+
+Ref: FR-014, FR-015, FR-016 · contracts/commit-staging-cli.md §stage-derived · research.md Decision 2
+
+- [ ] 5.2.1 Computar `tracked_changed` = paths com mudanca em arquivos ja
+  rastreados via `git -c core.quotepath=false status --porcelain`
+  (todos os estados exceto `??`); renames tratados (staged o path NOVO;
+  porcelain v1 usa formato `old -> new` em rename — parsing precisa
+  reconhecer esse formato, nao so split por espaco)
+- [ ] 5.2.2 Computar `untracked_new` = untracked atuais MENOS
+  `DIR/commit-baseline.txt` (`comm -13` sobre listas ordenadas); baseline
+  AUSENTE => conjunto vazio + aviso em stderr (fail-closed — untracked
+  nunca entram sem baseline, jamais fallback para staging amplo)
+- [ ] 5.2.3 `allowlist` = `tracked_changed` + `untracked_new`; se >=1
+  `--scope-dir REL_DIR` (repetivel), filtrar aos paths sob esses prefixos
+  relativos
+- [ ] 5.2.4 Allowlist vazia => exit 3, NENHUM `git add` executado (caller
+  pula o commit — FR-016, sem commit vazio, sem fallback amplo mesmo se a
+  etapa/task gerou arquivos fora do projeto-alvo — edge case da spec)
+- [ ] 5.2.5 Senao: `git add -- <path>` por entrada, loop `while read` linha
+  a linha (nunca word-splitting — paths com espaco tratados corretamente);
+  PROIBIDO `git add -A`, `git add .`, `git add --all` em qualquer caminho
+  do codigo (FR-014); exit 0 quando >=1 path staged
+- [ ] 5.2.6 Erros de uso/git emitem `DIAG|` (envelope `_diag.sh`, ja
+  sourceable same-dir no runtime — sem vendoring necessario aqui)
+
+### 5.3 Teste `tests/test_commit-mode.sh`: regressao do incidente `[C]`
+
+Ref: FR-017, SC-003 · contracts/commit-staging-cli.md §Regressao obrigatoria · quickstart.md Cenarios 5, 6
+
+- [ ] 5.3.1 Fixture git com `alien.pptx` untracked pre-existente (analogo
+  ao incidente real); commit de etapa com `--scope-dir docs/specs/feat-x`
+  => commit contem SO `docs/specs/feat-x/plan.md`, `alien.pptx` permanece
+  untracked
+- [ ] 5.3.2 Commit de task: `snapshot` no inicio da onda + arquivo NOVO
+  criado pos-snapshot (`cli/lib/new-helper.sh`) => `stage-derived` sem
+  scope-dir inclui o novo arquivo, `alien.pptx` fora
+- [ ] 5.3.3 Baseline AUSENTE + untracked novo presente => untracked TODOS
+  fora do staging, aviso em stderr, jamais fallback amplo (fail-closed)
+- [ ] 5.3.4 Allowlist vazia (fixture limpa) => exit 3, `git diff --cached`
+  vazio, nenhum commit criado
+- [ ] 5.3.5 Roundtrip real (nao mock): `git show --name-only HEAD` em cada
+  commit gerado pelos cenarios acima => nome do alheio ausente em TODOS
+- [ ] 5.3.6 Cenario de seguranca: path com espaco e path com caractere
+  nao-ASCII, tracked e untracked — staged corretamente via `core.quotepath
+  =false` + parsing de quoting C-style (tarefa 5.2.1)
+
+### 5.4 `state-ondas.sh`: `_so_cmd_git_commit` delega staging `[C]`
+
+Ref: FR-014 · research.md Decision 1 site 3 (`state-ondas.sh` linha ~794) · commit-staging-cli.md §Regimes de chamada
+
+- [ ] 5.4.1 Substituir `git add -- .` (linha ~794 de
+  `global/skills/agente-00c-runtime/scripts/state-ondas.sh`,
+  `_so_cmd_git_commit`) por: `snapshot` (se baseline ainda nao existir
+  nesta onda) + `stage-derived --state-dir "$_sdir" --projeto-alvo-path
+  "$_pap"` (sem `--scope-dir` — wave-commit pode tocar qualquer path do
+  repo, mesmo regime de commit por task da tabela do contrato)
+- [ ] 5.4.2 `stage-derived` exit 3 (allowlist vazia) => preservar o
+  comportamento atual de "nada para commitar" (no-op, `_so_log`), sem
+  quebrar o contrato existente de `_so_cmd_git_commit`
+- [ ] 5.4.3 `stage-derived` exit 0 => prosseguir com `git commit -m
+  "chore(agente-00c): $_onda - $_motivo_safe"` exatamente como hoje
+
+### 5.5 Teste `tests/test_state-ondas.sh`: cenario wave-commit endurecido `[C]`
+
+Ref: quickstart.md Cenario 7 · commit-staging-cli.md §Regressao item 5
+
+- [ ] 5.5.1 Fixture com `alien.pptx` untracked pre-existente + mudanca
+  tracked em `docs/specs/feat-x/spec.md`; `state-ondas.sh git-commit
+  --state-dir SD --projeto-alvo-path PAP --motivo teste` => commit contem
+  a mudanca tracked, `alien.pptx` permanece untracked
+- [ ] 5.5.2 Confirmar via `git show --name-only HEAD` que o site 3 da
+  research Decision 1 esta convergido ao mesmo helper de staging dos
+  demais sites (5.1-5.4)
+- [ ] 5.5.3 Rodar `./tests/run.sh test_state-ondas` isoladamente apos a
+  extensao, confirmar 0 FAIL/0 ERROR (sem regressao nos cenarios
+  pre-existentes de `git-commit`)
+
+### 5.6 `agente-00c-feature-orchestrator.md`: 2 sites trocam `add -A` `[A]`
+
+Ref: FR-014 · research.md Decision 1 site 1 (linhas 335, 403) · commit-staging-cli.md §Regimes de chamada
+
+- [ ] 5.6.1 Passo 10.qui (commit atomico por etapa): trocar
+  `git -C "$PAP" add -A 2>/dev/null || true` (linha ~335) por chamada a
+  `commit-mode.sh stage-derived --state-dir "$STATE_DIR"
+  --projeto-alvo-path "$PAP" --scope-dir "docs/specs/$SHORT_NAME"
+  --scope-dir ".claude/feature-00c-state/$SHORT_NAME"` — exit 3 => pular
+  o commit desta etapa (sem commit vazio); exit 0 => prosseguir com o
+  `git commit` existente
+- [ ] 5.6.2 Passo 7.bis (commit atomico por task, agrupado por onda):
+  trocar `git -C "$PAP" add -A 2>/dev/null || true` (linha ~403) por
+  `commit-mode.sh snapshot` na ABERTURA da onda `execute-task` + `
+  stage-derived --state-dir "$STATE_DIR" --projeto-alvo-path "$PAP"` (sem
+  `--scope-dir` — tasks tocam qualquer path do repo) no momento do commit
+  agrupado
+- [ ] 5.6.3 Atualizar a prosa dos dois blocos de pseudocodigo bash no
+  arquivo (`global/agents/agente-00c-feature-orchestrator.md`) refletindo
+  as chamadas novas, preservando o resto do fluxo (guard-branch, mensagem,
+  Decisao auditavel) intacto
+
+### 5.7 `agente-00c-orchestrator.md`: 2 sites equivalentes `[A]`
+
+Ref: FR-014 · research.md Decision 1 site 2 (linhas 678, 1552)
+
+- [ ] 5.7.1 Aplicar a MESMA troca da tarefa 5.6.1/5.6.2 nos dois sites
+  equivalentes de `global/agents/agente-00c-orchestrator.md` (linhas
+  ~678 e ~1552), com `--scope-dir` apontando `.claude/agente-00c-state`
+  em vez de `.claude/feature-00c-state/<short>` (state dir do agente-00c)
+- [ ] 5.7.2 Manter paridade textual entre os dois arquivos de orquestrador
+  (mesma estrutura de bloco bash, mesmos nomes de variavel) para nao
+  divergir prosa entre agente-00c e feature-00c (padrao ja seguido pelas
+  demais secoes espelhadas dos dois arquivos)
+- [ ] 5.7.3 Grep de verificacao pontual pos-edicao: confirmar 0 ocorrencias
+  de `add -A` remanescentes nos 2 sites editados (linhas antigas ~678 e
+  ~1552 de `agente-00c-orchestrator.md`)
+
+### 5.8 Verificacao final: zero `add -A`/`add .` remanescente `[A]`
+
+Ref: FR-014, FR-017 · plan.md §Constraints ("nenhum git add -A/add . remanescente em codigo ou prosa dos caminhos automaticos")
+
+- [ ] 5.8.1 Rodar `grep -rn "add -A\|add --all\|add -- \.\b" global/agents/
+  global/skills/agente-00c-runtime/scripts/` e confirmar 0 ocorrencias nos
+  caminhos automaticos (fora de comentarios explicativos que citam o
+  antipattern como PROIBIDO, ex.: contracts e mensagens de erro)
+- [ ] 5.8.2 Se algum resultado remanescente aparecer fora dos 5 sites
+  cobertos (5.1-5.7), tratar como escopo desta feature (nao adiar) —
+  FR-017 exige cobertura de regressao do incidente original completa,
+  nao parcial
+- [ ] 5.8.3 Registrar Decisao auditavel citando a saida literal do grep
+  final (zero ocorrencias, ou lista das remanescentes tratadas) como
+  evidencia (score 3, aterramento Constitution VI)
+
+---
+
+## FASE 6 - Consistencia e Release
+
+### 6.1 CHANGELOG e verificacao de gates estruturais `[M]`
+
+Ref: plan.md §Constitution Check ("MINOR; sem BREAKING") · CLAUDE.md §CHANGELOG
+
+- [ ] 6.1.1 Adicionar entrada no `CHANGELOG.md` (bump MINOR — secao delta
+  e opcional e os 2 subcomandos novos de `commit-mode.sh` sao aditivos,
+  sem quebra de contrato existente) resumindo as 4 entregas (delta
+  section, corpus canonico, gate deterministico, staging por allowlist)
+- [ ] 6.1.2 Conferir o bloco de link references do rodape do CHANGELOG
+  (`[X.Y.Z]: https://github.com/JotJunior/cstk/releases/tag/vX.Y.Z`) —
+  nova versao precisa de entrada correspondente (checagem `comm -23` do
+  CLAUDE.md)
+- [ ] 6.1.3 Rodar `validate-docs-rendered` sobre `docs/specs/living-specs/
+  tasks.md` e sobre este arquivo apos qualquer edicao posterior — Mermaid
+  parseavel, links internos resolvem, frontmatter consistente
+
+### 6.2 `/analyze` — consistencia cross-artifact `[M]`
+
+Ref: skill analyze · precedente skill-converge FASE 5
+
+- [ ] 6.2.1 Rodar `/analyze` sobre `docs/specs/living-specs/` (spec + plan
+  + tasks + constitution) e resolver quaisquer findings de inconsistencia
+  antes de `execute-task` iniciar
+- [ ] 6.2.2 Findings de severidade alta => resolver antes de prosseguir
+  para `execute-task`; findings de baixa severidade => registrar como
+  Decisao informativa e seguir (mesmo padrao dos demais gates da FASE 3/4)
+
+### 6.3 Suite completa + doctor `[A]`
+
+Ref: CLAUDE.md §Como testar scripts shell · §Installed vs Source Drift
+
+- [ ] 6.3.1 Rodar `./tests/run.sh` completo (nao so `--fast`) apos todas as
+  tasks de FASE 3/5 concluidas — 0 FAIL/0 ERROR obrigatorio antes de
+  `review-task`
+- [ ] 6.3.2 Rodar `./tests/run.sh --check-coverage` — 0 script orfao
+  (delta-gate.sh, delta-merge.sh, `_diag.sh` vendorizado)
+- [ ] 6.3.3 Apos instalar via `cstk install --from` local (build de dev),
+  rodar `cstk doctor` e confirmar drift zero entre catalogo e disco
+
+### 6.4 (OPCIONAL, fora de criterio de aceite) Backfill incremental do corpus `[M]`
+
+Ref: spec.md §Out of Scope · CHK038 (nao-bloqueante, ver Escopo Excluido)
+
+- [ ] 6.4.1 NAO EXECUTAR nesta feature salvo pedido explicito do operador:
+  script/rotina que roda `delta-merge.sh` retroativamente sobre as ~15
+  features ja em `docs/specs/_archived/` SEM secao delta (nenhuma tem —
+  feature entrou em vigor depois). Item permanece em backlog aberto,
+  sem dono e sem criterio de prontidao ate decisao humana (CHK038) — task
+  registrada aqui apenas para nao se perder, marcada explicitamente como
+  NAO BLOQUEANTE da conclusao desta feature (spec.md §Out of Scope)
+- [ ] 6.4.2 Se o operador decidir priorizar o backfill no futuro, abrir
+  uma feature NOVA dedicada (nao reabrir `living-specs`) — mantem esta
+  feature fechada e auditavel sem escopo residual pendurado
+
+---
+
+## Matriz de Dependencias
+
+```mermaid
+flowchart TD
+    F1[Fase 1 - Fundacao: Gaps do Checklist]
+    F2[Fase 2 - Delta Requirements na Spec]
+    F3[Fase 3 - Corpus + Scripts Deterministicos]
+    F4[Fase 4 - Integracao no Archive]
+    F5[Fase 5 - Staging por Allowlist]
+    F6[Fase 6 - Consistencia e Release]
+
+    F1 --> F2
+    F1 --> F3
+    F2 --> F3
+    F3 --> F4
+    F5 --> F6
+    F4 --> F6
+    F3 --> F6
+```
+
+> Fase 5 (staging por allowlist) e tecnicamente independente de Fases
+> 2-4 (corpus/delta) — resolve o bug de seguranca real (US4) sem
+> depender do corpus. Pode ser executada em paralelo a Fase 2-4; ambas
+> convergem em Fase 6.
+
+## Resumo Quantitativo
+
+| Fase | Tarefas | Subtarefas | Criticidade |
+|------|---------|------------|-------------|
+| 1 - Fundacao: Gaps do Checklist | 3 | 13 | `[A]` |
+| 2 - Delta Requirements na Spec | 2 | 6 | `[A]` |
+| 3 - Corpus + Scripts Deterministicos | 10 | 47 | `[C]`/`[A]` |
+| 4 - Integracao no Archive | 2 | 7 | `[A]` |
+| 5 - Staging por Allowlist | 8 | 30 | `[C]`/`[A]` |
+| 6 - Consistencia e Release | 4 | 10 | `[M]`/`[A]` |
+| **Total** | **29** | **113** | — |
+
+## Cobertura de Requisitos Funcionais
+
+| FR | Tarefa(s) |
+|----|-----------|
+| FR-001 | 2.1, 2.2, 3.2 |
+| FR-002 | 3.6, 3.7 |
+| FR-003 | 3.7 |
+| FR-004 | 3.7 |
+| FR-005 | 3.7 |
+| FR-006 | 4.1 |
+| FR-007 | 3.7 |
+| FR-008 | 4.1 |
+| FR-009 | 4.1 |
+| FR-010 | 3.2, 3.3 |
+| FR-011 | 2.2, 3.2 |
+| FR-012 | 3.2-3.9 (scripts deterministicos, sem julgamento de modelo) |
+| FR-013 | 3.3 |
+| FR-014 | 5.1, 5.2, 5.4, 5.6, 5.7, 5.8 |
+| FR-015 | 5.2, 5.3 |
+| FR-016 | 5.2 |
+| FR-017 | 5.3, 5.8 |
+
+## Escopo Coberto
+
+| Item | Descricao | Fase |
+|------|-----------|------|
+| Gaps de definicao | Governanca de slug de capability, integracao gate<->bloqueios.sh, enforcement de estrutura do corpus (CHK015/CHK020/CHK034) | 1 |
+| Secao Delta Requirements | Template + prosa da skill `specify` | 2 |
+| Corpus canonico | `docs/specs/current/<slug>.md`, `delta-gate.sh`, `delta-merge.sh`, ambos com teste dedicado | 3 |
+| Integracao no archive | `review-features/SKILL.md` (manual) + `agente-00c-orchestrator.md` (autonomo, bloqueio humano) | 4 |
+| Staging por allowlist | `commit-mode.sh snapshot`/`stage-derived`, `state-ondas.sh`, 4 sites de prosa dos orquestradores, regressao do incidente `.pptx` | 5 |
+| Release | CHANGELOG, `/analyze`, suite completa, `--check-coverage`, `cstk doctor` | 6 |
+
+## Escopo Excluido
+
+| Item | Descricao | Motivo |
+|------|-----------|--------|
+| Backfill retroativo do corpus | Migrar as ~15 features ja em `_archived/` para `docs/specs/current/` | spec.md §Out of Scope — nao bloqueia conclusao; task 6.4 registrada como backlog aberto, sem dono |
+| Stores/worksets multi-repo | Agregacao de corpus entre multiplos repositorios (mecanismo OpenSpec) | spec.md §Out of Scope — sem fonte suficiente sobre o mecanismo (Constitution VI); esta feature trata de um unico projeto-alvo |
+| CHK022 (apetite de risco dos 4 subcasos de conflito serem error vs warning) | Nao vira tarefa — decisao de politica de risco do mantenedor | `{humano}`, aguarda decisao do dono do produto antes de `execute-task`; nao bloqueia `create-tasks` |
+| CHK030 (scope-dir de etapa `plan` que edita `global/` alargar dinamicamente?) | Nao vira tarefa — trade-off de seguranca vs abrangencia do commit de etapa | `{humano}`, aguarda decisao do dono do produto; implementacao atual (5.6.1) usa scope-dir fixo por etapa, revisitavel apos feedback real de uso |
+| CHK038 (criterio de prontidao do backfill opcional) | Nao vira tarefa — apenas anotado em 6.4 como backlog sem dono | `{humano}`, spec.md §Out of Scope ja marca como nao-bloqueante; criterio de prontidao fica para quando/se o operador priorizar |

--- a/global/agents/agente-00c-feature-orchestrator.md
+++ b/global/agents/agente-00c-feature-orchestrator.md
@@ -331,16 +331,30 @@ Sequencia da onda corrente. Cada iteracao:
         # 2. Gerar mensagem para o grupo de tasks (range ou individual)
         _ids=$(printf '%s' "$_tasks_passadas" | tr '\n' ',' | sed 's/,$//') # "1.1,1.2"
         _msg=$(commit-mode.sh task-message --feature "$SHORT_NAME" --task-ids "$_ids")
-        # 3. Stage + commit direto (pipeline non-interactive — CHK047/dec-026)
-        git -C "$PAP" add -A 2>/dev/null || true
-        git -C "$PAP" commit -m "$_msg" 2>/dev/null || true
-        # 4. Registrar Decisao auditavel
-        state-decisions.sh register --state-dir "$STATE_DIR" \
-          --agente "agente-00c-feature-orchestrator" --etapa "execute-task" \
-          --contexto "Commit atomico por task (onda): $_msg" \
-          --opcoes '["commit","skip"]' --escolha "commit" \
-          --justificativa "atomic_commit_enabled=true; tasks passadas: $_ids" \
-          --score 2
+        # 3. Staging por allowlist derivada (FR-014) — NUNCA `git add -A`.
+        #    Sem --scope-dir: tasks tocam qualquer path do repo. O baseline
+        #    de untracked ja foi capturado no INICIO desta onda por
+        #    `state-ondas.sh start` (passo 3.bis/4, best-effort via
+        #    .execution.target_project_path) — nao precisa de snapshot
+        #    explicito aqui.
+        commit-mode.sh stage-derived --state-dir "$STATE_DIR" \
+          --projeto-alvo-path "$PAP"
+        _stage_rc=$?
+        if [ "$_stage_rc" = 0 ]; then
+          # 4. Commit direto (pipeline non-interactive — CHK047/dec-026)
+          git -C "$PAP" commit -m "$_msg" 2>/dev/null || true
+          # 5. Registrar Decisao auditavel
+          state-decisions.sh register --state-dir "$STATE_DIR" \
+            --agente "agente-00c-feature-orchestrator" --etapa "execute-task" \
+            --contexto "Commit atomico por task (onda): $_msg" \
+            --opcoes '["commit","skip"]' --escolha "commit" \
+            --justificativa "atomic_commit_enabled=true; tasks passadas: $_ids" \
+            --score 2
+        elif [ "$_stage_rc" = 3 ]; then
+          log_out "commit-mode: allowlist vazia — commit por task pulado nesta onda (nada staged)"
+        else
+          log_out "commit-mode: stage-derived falhou (exit $_stage_rc) — commit por task pulado nesta onda"
+        fi
       else
         log_out "commit-mode: guard-branch exit $_guard_exit — commit por task pulado nesta onda"
       fi
@@ -349,6 +363,7 @@ Sequencia da onda corrente. Cada iteracao:
 
     REGRA DURA: qualquer falha no bloco acima e NO-OP silencioso (best-effort).
     O commit por task e ADITIVO ao record-task/backup/end — nunca os substitui.
+    NUNCA `git add -A`/`git add .`/`git add --all` (FR-014, living-specs).
 8. gerar backup da onda:
    cat state.json | secrets-filter.sh for-backup --wave-number N \
      > <state_dir>/backups/wave-NNN.json
@@ -399,21 +414,36 @@ Sequencia da onda corrente. Cada iteracao:
         _stage=$(state-rw.sh get --state-dir "$STATE_DIR" --field '.current_stage')
         _msg=$(commit-mode.sh stage-message \
                --feature "$SHORT_NAME" --stage "$_stage")
-        # 3. Commit direto via git (pipeline non-interactive — CHK047/dec-026)
-        git -C "$PAP" add -A 2>/dev/null || true
-        git -C "$PAP" commit -m "$_msg" 2>/dev/null || true
-        # 4. Registrar Decisao auditavel do commit
-        state-decisions.sh register --state-dir "$STATE_DIR" \
-          --agente "agente-00c-feature-orchestrator" --etapa "$_stage" \
-          --contexto "Commit atomico por etapa ($_stage): $_msg" \
-          --opcoes '["commit","skip"]' --escolha "commit" \
-          --justificativa "atomic_commit_enabled=true; guard-branch exit 0" \
-          --score 2
+        # 3. Staging por allowlist derivada (FR-014) — NUNCA `git add -A`.
+        #    --scope-dir confina aos artefatos desta etapa: spec/plan/
+        #    tasks da feature + o proprio state dir da execucao.
+        commit-mode.sh stage-derived --state-dir "$STATE_DIR" \
+          --projeto-alvo-path "$PAP" \
+          --scope-dir "docs/specs/$SHORT_NAME" \
+          --scope-dir ".claude/feature-00c-state/$SHORT_NAME"
+        _stage_rc=$?
+        if [ "$_stage_rc" = 0 ]; then
+          # 4. Commit direto via git (pipeline non-interactive — CHK047/dec-026)
+          git -C "$PAP" commit -m "$_msg" 2>/dev/null || true
+          # 5. Registrar Decisao auditavel do commit
+          state-decisions.sh register --state-dir "$STATE_DIR" \
+            --agente "agente-00c-feature-orchestrator" --etapa "$_stage" \
+            --contexto "Commit atomico por etapa ($_stage): $_msg" \
+            --opcoes '["commit","skip"]' --escolha "commit" \
+            --justificativa "atomic_commit_enabled=true; guard-branch exit 0" \
+            --score 2
+        elif [ "$_stage_rc" = 3 ]; then
+          log_out "commit-mode: allowlist vazia — commit atomico pulado nesta onda (nada staged sob escopo da etapa)"
+        else
+          log_out "commit-mode: stage-derived falhou (exit $_stage_rc) — commit atomico pulado nesta onda"
+        fi
       else
         log_out "commit-mode: guard-branch exit $_guard_exit — commit atomico pulado nesta onda"
       fi
     fi
     ```
+
+    NUNCA `git add -A`/`git add .`/`git add --all` (FR-014, living-specs).
 
     **Finalize terminal (FR-008)**: ao concluir `review-task` com sucesso,
     se `is-enabled` retornar `true`, invocar apos o passo 11 (relatorio final):

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -674,16 +674,29 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
                head -c 40 | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
        _ids=$(printf '%s' "$_tasks_passadas" | tr '\n' ',' | sed 's/,$//') # "1.1,1.2,1.3"
        _msg=$(commit-mode.sh task-message --feature "$_name" --task-ids "$_ids")
-       # 3. Stage + commit direto (pipeline non-interactive — CHK047/dec-026)
-       git -C <PAP> add -A 2>/dev/null || true
-       git -C <PAP> commit -m "$_msg" 2>/dev/null || true
-       # 4. Registrar Decisao auditavel
-       state-decisions.sh register --state-dir <SD> \
-         --agente "orquestrador-00c" --etapa "execute-task" \
-         --contexto "Commit atomico por task (onda): $_msg" \
-         --opcoes '["commit","skip"]' --escolha "commit" \
-         --justificativa "atomic_commit_enabled=true; tasks passadas: $_ids" \
-         --score 2
+       # 3. Staging por allowlist derivada (FR-014) — NUNCA `git add -A`.
+       #    Sem --scope-dir: tasks tocam qualquer path do repo. O baseline
+       #    de untracked ja foi capturado no INICIO desta onda por
+       #    `state-ondas.sh start` (best-effort via
+       #    .execution.target_project_path) — nao precisa de snapshot
+       #    explicito aqui.
+       commit-mode.sh stage-derived --state-dir <SD> --projeto-alvo-path <PAP>
+       _stage_rc=$?
+       if [ "$_stage_rc" = 0 ]; then
+         # 4. Commit direto (pipeline non-interactive — CHK047/dec-026)
+         git -C <PAP> commit -m "$_msg" 2>/dev/null || true
+         # 5. Registrar Decisao auditavel
+         state-decisions.sh register --state-dir <SD> \
+           --agente "orquestrador-00c" --etapa "execute-task" \
+           --contexto "Commit atomico por task (onda): $_msg" \
+           --opcoes '["commit","skip"]' --escolha "commit" \
+           --justificativa "atomic_commit_enabled=true; tasks passadas: $_ids" \
+           --score 2
+       elif [ "$_stage_rc" = 3 ]; then
+         log_out "commit-mode: allowlist vazia — commit por task pulado nesta onda (nada staged)"
+       else
+         log_out "commit-mode: stage-derived falhou (exit $_stage_rc) — commit por task pulado nesta onda"
+       fi
      else
        log_out "commit-mode: guard-branch exit $_guard_exit — commit por task pulado nesta onda"
      fi
@@ -1306,6 +1319,7 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
    | `create-tasks` | template-fidelity | `validate-tasks-template.sh` (Bash, **deterministico**) | tasks.md conforma ao template canonico: prefixo FASE, checkboxes `- [ ]`, tag de criticidade, legendas, Matriz de Dependencias, Resumo, Escopo Coberto/Excluido | findings `critical` (sem FASE / sem checkbox / sem criticidade) -> Decisao + tentativa de Edit (re-normalizar ao template); `warning` -> Decisao informativa |
    | `create-tasks` | docs-render | `validate-docs-rendered` | Mermaid parseavel, links internos, frontmatter, code blocks com linguagem | findings `critical` (link 404, Mermaid invalido) -> Decisao + tentativa de Edit; demais -> Decisao informativa |
    | `execute-task -> review-task` | convergence | `converge` | divergencia spec-vs-codigo nos paths declarados (US5, FR-015/FR-019) | findings `CRITICAL` -> BloqueioHumano (decisao do orquestrador; converge nao trava sozinha); demais -> Decisao informativa (a propria skill se auto-registra — ver 5.f.bis) |
+   | `review-features` (por feature `ARQUIVAR`) | delta-gate | `delta-gate.sh` (Bash, **deterministico**, incondicional) | secao `## Delta Requirements` presente/valida antes do archive (FR-010/FR-013, CHK020) | exit != 0 -> BloqueioHumano ESCOPADO aquela feature, sem abortar a onda (ver 5.f.ter) |
 
    **Pre-gate deterministico do `create-tasks` (template-fidelity):** roda
    ANTES do gate `docs-render` (skeleton antes de render). Motivacao: o
@@ -1415,6 +1429,62 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
    a mesma divergencia nunca vira uma segunda tarefa; os gatilhos de
    aborto do passo 7 (`cycles.sh`/`circular.sh`) permanecem como rede de
    seguranca adicional caso o padrao normal nao se sustente.
+
+   ### 5.f.ter Gate `delta-gate` na etapa `review-features` (archive, CHK020)
+
+   > Origem: feature `living-specs`, FASE 4. Fecha o gate obrigatorio da
+   > FR-010 (US3) tambem no fluxo AUTONOMO — o gate ja e obrigatorio na
+   > prosa manual de `review-features/SKILL.md` ("Proximos passos
+   > sugeridos" item 3); esta secao herda o MESMO comportamento quando o
+   > orquestrador invoca a skill sem supervisao (research.md Decision 8).
+
+   **Gatilho**: etapa corrente `review-features`, apos a skill reportar o
+   portfolio, para CADA feature classificada `ARQUIVAR` que o
+   orquestrador decida mover para `_archived/<YYYY-MM-DD>-<feature>/`:
+
+   ```bash
+   OUT=$(bash "$HOME/.claude/skills/review-features/scripts/delta-gate.sh" \
+     "docs/specs/<feature>/spec.md" --corpus-dir "docs/specs/current" 2>&1)
+   _gate_exit=$?
+   ```
+
+   **Exit 0 (liberado)**: rodar `delta-merge.sh docs/specs/<feature>/spec.md
+   --feature <feature>` ANTES do `mv` para `_archived/`; merge bloqueado
+   (exit 1 — corpus mudou entre gate e merge) suspende o `mv` da MESMA
+   feature pela mesma politica de bloqueio abaixo (defesa em
+   profundidade). Gate e merge liberados => `mv` acontece normalmente
+   (fluxo existente intacto, US2 cenario 5).
+
+   **Exit != 0 (bloqueado)**: aplicar a politica fixada em
+   `docs/specs/living-specs/tasks.md` tarefa 1.2.1-1.2.3 (research.md
+   Decision 8):
+
+   ```bash
+   state-decisions.sh register --state-dir <SD> \
+     --agente "orquestrador-00c" --etapa "review-features" \
+     --contexto "Gate delta-gate bloqueou archive de <feature>: $OUT" \
+     --opcoes '["bloqueio-humano-escopado","abortar-onda"]' \
+     --escolha "bloqueio-humano-escopado" \
+     --justificativa "FR-010/CHK020: archive sem delta requer preenchimento ou skip explicito; nao falhar silenciosamente" \
+     --score 2
+
+   bloqueios.sh register --state-dir <SD> \
+     --pergunta "Archive de <feature> bloqueado pelo delta-gate: <FINDING|error|... literal>. Preencher a secao Delta Requirements, registrar skip explicito, ou pular o archive desta feature?" \
+     --contexto-para-resposta "<RESULT|<spec>|delta=missing|errors=N|... literal emitido pelo gate>"
+   ```
+
+   O bloqueio e **ESCOPADO aquela feature especifica** — NUNCA aborta a
+   onda inteira de `review-features`: as demais features do portfolio
+   sem bloqueio de gate continuam sendo processadas (arquivadas ou
+   apenas avaliadas) normalmente na mesma onda, o mesmo padrao ja usado
+   pelos demais Quality Gates complementares (§5.f). A pergunta e o
+   contexto-para-resposta citam os `FINDING`/`RESULT` LITERAIS emitidos
+   pelo gate (aterramento de evidencia, Constitution VI) — nunca um
+   resumo parafraseado sem a linha real.
+
+   Registrar `state-ondas.sh record-skill --skill delta-gate --kind gate`
+   (script deterministico) por feature avaliada, para que `/review-task`
+   e `/review-features` consigam medir cobertura deste gate tambem.
 
 6. **Detectar conclusao da etapa**:
    `pipeline.sh detect-completion --feature-dir <FD> --stage <STAGE>
@@ -1548,16 +1618,28 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
                 '.execution.target_project_description // "unnamed"' | \
                 head -c 40 | tr ' ' '-' | tr '[:upper:]' '[:lower:]')
         _msg=$(commit-mode.sh stage-message --feature "$_name" --stage "$_stage")
-        # 3. Commit direto via git (pipeline non-interactive — CHK047/dec-026)
-        git -C <PAP> add -A 2>/dev/null || true
-        git -C <PAP> commit -m "$_msg" 2>/dev/null || true
-        # 4. Registrar Decisao auditavel do commit
-        state-decisions.sh register --state-dir <SD> \
-          --agente "orquestrador-00c" --etapa "$_stage" \
-          --contexto "Commit atomico por etapa ($stage): $msg" \
-          --opcoes '["commit","skip"]' --escolha "commit" \
-          --justificativa "atomic_commit_enabled=true; guard-branch exit 0" \
-          --score 2
+        # 3. Staging por allowlist derivada (FR-014) — NUNCA `git add -A`.
+        #    --scope-dir confina aos artefatos desta etapa: o feature-dir
+        #    corrente <FD> (docs/specs/<feature>, ver detect-completion
+        #    --feature-dir) + o proprio state dir do agente-00c.
+        commit-mode.sh stage-derived --state-dir <SD> --projeto-alvo-path <PAP> \
+          --scope-dir "<FD>" --scope-dir ".claude/agente-00c-state"
+        _stage_rc=$?
+        if [ "$_stage_rc" = 0 ]; then
+          # 4. Commit direto via git (pipeline non-interactive — CHK047/dec-026)
+          git -C <PAP> commit -m "$_msg" 2>/dev/null || true
+          # 5. Registrar Decisao auditavel do commit
+          state-decisions.sh register --state-dir <SD> \
+            --agente "orquestrador-00c" --etapa "$_stage" \
+            --contexto "Commit atomico por etapa ($stage): $msg" \
+            --opcoes '["commit","skip"]' --escolha "commit" \
+            --justificativa "atomic_commit_enabled=true; guard-branch exit 0" \
+            --score 2
+        elif [ "$_stage_rc" = 3 ]; then
+          log_out "commit-mode: allowlist vazia — commit atomico pulado nesta onda (nada staged sob escopo da etapa)"
+        else
+          log_out "commit-mode: stage-derived falhou (exit $_stage_rc) — commit atomico pulado nesta onda"
+        fi
       else
         log_out "commit-mode: guard-branch exit $_guard_exit — commit atomico pulado nesta onda"
       fi

--- a/global/skills/agente-00c-runtime/scripts/commit-mode.sh
+++ b/global/skills/agente-00c-runtime/scripts/commit-mode.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 # commit-mode.sh — helper POSIX para o modo opt-in atomic-commit.
 #
-# Feature: atomic-commit-pr
+# Feature: atomic-commit-pr (staging por allowlist: living-specs FASE 5)
 # Ref:     docs/specs/_archived/atomic-commit-pr/contracts/commit-mode.md
 #          docs/specs/_archived/atomic-commit-pr/spec.md §FR-002..011
+#          docs/specs/living-specs/contracts/commit-staging-cli.md
+#          docs/specs/living-specs/spec.md FR-014..FR-017
 #
 # Subcomandos:
 #   is-enabled   --state-dir DIR
@@ -13,16 +15,25 @@
 #   task-message  --feature NAME --task-ids "ID[,ID...]" [--brief TEXT]
 #   finalize     --state-dir DIR --projeto-alvo-path PATH [--session NAME]
 #                [--title T] [--body B]
+#   snapshot      --state-dir DIR --projeto-alvo-path PATH
+#   stage-derived --state-dir DIR --projeto-alvo-path PATH [--scope-dir REL_DIR]...
 #
 # Exit codes globais:
-#   0  sucesso / caso tratado (inclui skips nao-fatais)
+#   0  sucesso / caso tratado (inclui skips nao-fatais; stage-derived: >=1 path staged)
 #   1  erro generico (ex: git ausente, write falhou)
 #   2  erro de uso (flag faltando ou valor invalido)
-#   3  recusa de guard (branch default ou modo desabilitado — nao-fatal)
+#   3  recusa de guard (branch default ou modo desabilitado — nao-fatal);
+#      stage-derived: allowlist vazia, nada staged (FR-016, nao-fatal)
 #
 # POSIX sh puro. Zero deps obrigatorias.
 # Deps opcionais: jq (state read/write), git (branch/commit), gh (PR).
 # Ausencia de dep opcional => skip com status gravado, NUNCA aborta a onda.
+#
+# snapshot/stage-derived (FR-014): staging EXPLICITO por allowlist derivada —
+# jamais `git add -A`/`git add .`/`git add --all` em qualquer caminho de
+# codigo. `stage-derived` so inclui untracked se `snapshot` rodou antes na
+# mesma onda (baseline ausente => untracked ficam FORA, fail-closed —
+# nunca fallback para staging amplo).
 
 set -eu
 
@@ -37,6 +48,20 @@ if _cm_sd=$(_cm_selfdir 2>/dev/null) && [ -f "$_cm_sd/_log.sh" ]; then
   # shellcheck disable=SC1090
   . "$_cm_sd/_log.sh" && _cm_log_sourced=1
 fi
+
+# Tenta sourcear _diag.sh do mesmo dir (envelope DIAG| uniforme, ja
+# canonico em agente-00c-runtime/scripts/ — sem vendoring necessario aqui).
+_cm_diag_sourced=0
+if [ -n "${_cm_sd:-}" ] && [ -f "$_cm_sd/_diag.sh" ]; then
+  # shellcheck disable=SC1090
+  . "$_cm_sd/_diag.sh" && _cm_diag_sourced=1
+fi
+
+# _cm_diag SEVERITY CODE MESSAGE FIX — no-op se _diag.sh indisponivel.
+_cm_diag() {
+  [ "$_cm_diag_sourced" = 1 ] || return 0
+  diag_emit "$1" "$2" "$3" "$4" || :
+}
 
 _cm_err() {
   if [ "$_cm_log_sourced" = 1 ]; then
@@ -328,6 +353,218 @@ EOF
   return 0
 }
 
+# ---------- subcomando: snapshot ----------
+# snapshot --state-dir DIR --projeto-alvo-path PATH
+# Captura o conjunto de untracked ATUAL do repo (git status --porcelain,
+# linhas "?? "), paths ordenados, grava em DIR/commit-baseline.txt
+# (sidecar — nunca dentro do state.json, nunca versionado; 1 baseline por
+# onda, sobrescreve a anterior).
+# exit: 0 gravado; 1 erro git/IO; 2 uso incorreto
+_cm_cmd_snapshot() {
+  _sdir=""
+  _pap=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --state-dir)          _sdir=$2; shift 2 ;;
+      --projeto-alvo-path)  _pap=$2;  shift 2 ;;
+      *) _cm_die_usage "snapshot: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_sdir" ] || _cm_die_usage "snapshot: --state-dir obrigatorio"
+  [ -n "$_pap" ]  || _cm_die_usage "snapshot: --projeto-alvo-path obrigatorio"
+
+  if ! _cm_require_git; then
+    _cm_err "snapshot: git nao encontrado no PATH"
+    _cm_diag "error" "git-missing" "git nao encontrado no PATH" "instale git ou ajuste o PATH antes de habilitar atomic-commit"
+    return 1
+  fi
+
+  mkdir -p "$_sdir" 2>/dev/null || {
+    _cm_err "snapshot: nao foi possivel criar diretorio $_sdir"
+    return 1
+  }
+
+  _baseline="$_sdir/commit-baseline.txt"
+  _tmp="$_baseline.tmp.$$"
+
+  # -z: NUL-terminated entries, paths NUNCA quoted/C-style-escaped pelo git
+  # (independe de core.quotepath) — unica forma robusta de extrair paths com
+  # espaco/unicode sem parsing ambiguo (CHK029). --untracked-files=all
+  # desliga o "rollup" de diretorio inteiro-untracked numa unica entrada
+  # ("?? dir/") — sem isso, um diretorio de feature novo (ex: docs/) vira 1
+  # entrada so, quebrando o casamento por prefixo de --scope-dir. Convertido
+  # para uma linha por entrada via tr (paths nao contem NUL; newline
+  # literal em nome de arquivo e fora de escopo, mesma limitacao aceita
+  # pelo restante do runtime POSIX).
+  if ! git -C "$_pap" status --porcelain -z --untracked-files=all 2>/dev/null \
+      | tr '\0' '\n' | sed -n 's/^?? //p' | sort > "$_tmp"; then
+    rm -f "$_tmp" 2>/dev/null || :
+    _cm_err "snapshot: 'git status --porcelain' falhou em $_pap"
+    _cm_diag "error" "git-status-failed" "git status --porcelain falhou em $_pap" "confirme que $_pap e um repositorio git valido"
+    return 1
+  fi
+
+  mv "$_tmp" "$_baseline" || {
+    _cm_err "snapshot: falha ao gravar $_baseline"
+    return 1
+  }
+
+  return 0
+}
+
+# ---------- subcomando: stage-derived ----------
+# stage-derived --state-dir DIR --projeto-alvo-path PATH [--scope-dir REL_DIR]...
+# Computa a CommitAllowlist (tracked_changed + untracked_new via baseline
+# de snapshot) e faz `git add -- <path>` por entrada — NUNCA `git add -A`,
+# `git add .`, `git add --all` (FR-014).
+# exit: 0 (>=1 path staged); 3 (allowlist vazia — nada a commitar, FR-016);
+#       1 (erro git); 2 (uso incorreto)
+_cm_cmd_stage_derived() {
+  _sdir=""
+  _pap=""
+  _scope_file="${TMPDIR:-/tmp}/cm-scopes.$$"
+  _has_scope=0
+  : > "$_scope_file"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --state-dir)          _sdir=$2; shift 2 ;;
+      --projeto-alvo-path)  _pap=$2;  shift 2 ;;
+      --scope-dir)
+        # Remove barra final para comparacao consistente de prefixo.
+        printf '%s\n' "${2%/}" >> "$_scope_file"
+        _has_scope=1
+        shift 2
+        ;;
+      *) rm -f "$_scope_file" 2>/dev/null || :; _cm_die_usage "stage-derived: flag desconhecida: $1" ;;
+    esac
+  done
+  if [ -z "$_sdir" ] || [ -z "$_pap" ]; then
+    rm -f "$_scope_file" 2>/dev/null || :
+    [ -n "$_sdir" ] || _cm_die_usage "stage-derived: --state-dir obrigatorio"
+    _cm_die_usage "stage-derived: --projeto-alvo-path obrigatorio"
+  fi
+
+  if ! _cm_require_git; then
+    rm -f "$_scope_file" 2>/dev/null || :
+    _cm_err "stage-derived: git nao encontrado no PATH"
+    _cm_diag "error" "git-missing" "git nao encontrado no PATH" "instale git ou ajuste o PATH antes de habilitar atomic-commit"
+    return 1
+  fi
+
+  _raw="${TMPDIR:-/tmp}/cm-raw.$$"
+  _tracked="${TMPDIR:-/tmp}/cm-tracked.$$"
+  _untracked_cur="${TMPDIR:-/tmp}/cm-untracked-cur.$$"
+  _untracked_new="${TMPDIR:-/tmp}/cm-untracked-new.$$"
+  _allowlist="${TMPDIR:-/tmp}/cm-allowlist.$$"
+  _filtered="${TMPDIR:-/tmp}/cm-filtered.$$"
+
+  _cm_cleanup_stage_derived() {
+    rm -f "$_scope_file" "$_raw" "$_tracked" "$_untracked_cur" \
+      "$_untracked_new" "$_allowlist" "$_filtered" 2>/dev/null || :
+  }
+
+  # -z: NUL-terminated entries, paths NUNCA quoted/C-style-escaped pelo git
+  # (independe de core.quotepath — medido empiricamente: mesmo com
+  # core.quotepath=false, `--porcelain` sem -z ainda envolve em aspas
+  # duplas qualquer path com espaco, quebrando parsing por split simples).
+  # -z e a UNICA forma robusta de extrair paths com espaco/unicode sem
+  # ambiguidade (CHK029). --untracked-files=all desliga o "rollup" de
+  # diretorio inteiro-untracked numa unica entrada — sem isso, um path
+  # dentro de um diretorio de feature novo nunca casa com --scope-dir (o
+  # git colapsa TODO o diretorio novo em "?? dir/"). Convertido para 1
+  # linha por campo via tr (paths nao contem NUL; newline literal em nome
+  # de arquivo e fora de escopo).
+  if ! git -C "$_pap" status --porcelain -z --untracked-files=all 2>/dev/null \
+      | tr '\0' '\n' > "$_raw"; then
+    _cm_cleanup_stage_derived
+    _cm_err "stage-derived: 'git status --porcelain' falhou em $_pap"
+    _cm_diag "error" "git-status-failed" "git status --porcelain falhou em $_pap" "confirme que $_pap e um repositorio git valido"
+    return 1
+  fi
+
+  # Split por posicao fixa (cols 1-2 = XY, col 3 = espaco, col 4+ = path)
+  # em vez de word-splitting, entao paths com espaco sao preservados
+  # corretamente. Renames/copies (X ou Y == R/C) emitem, no formato -z, um
+  # segundo campo NUL-terminado logo em seguida com o path ANTIGO — usamos
+  # so o path NOVO (a entrada corrente) e descartamos esse campo extra.
+  : > "$_tracked"
+  : > "$_untracked_cur"
+  _skip_next=0
+  while IFS= read -r _line; do
+    if [ "$_skip_next" = 1 ]; then
+      _skip_next=0
+      continue
+    fi
+    [ -z "$_line" ] && continue
+    _xy=$(printf '%s' "$_line" | cut -c1-2)
+    _rest=$(printf '%s' "$_line" | cut -c4-)
+    case "$_xy" in
+      *R*|*C*) _skip_next=1 ;;
+    esac
+    if [ "$_xy" = "??" ]; then
+      printf '%s\n' "$_rest" >> "$_untracked_cur"
+    else
+      printf '%s\n' "$_rest" >> "$_tracked"
+    fi
+  done < "$_raw"
+
+  sort -u -o "$_tracked" "$_tracked"
+  sort -u -o "$_untracked_cur" "$_untracked_cur"
+
+  _baseline="$_sdir/commit-baseline.txt"
+  if [ -f "$_baseline" ]; then
+    comm -13 "$_baseline" "$_untracked_cur" > "$_untracked_new" 2>/dev/null || : > "$_untracked_new"
+  else
+    _cm_err "stage-derived: baseline ausente ($_baseline) — untracked ficam FORA do staging (fail-closed, nunca fallback amplo)"
+    _cm_diag "warning" "baseline-missing" "commit-baseline.txt ausente em $_sdir" "chame 'commit-mode.sh snapshot' antes de stage-derived para incluir untracked novos"
+    : > "$_untracked_new"
+  fi
+
+  cat "$_tracked" "$_untracked_new" | sort -u > "$_allowlist"
+
+  if [ "$_has_scope" = 1 ]; then
+    : > "$_filtered"
+    while IFS= read -r _path; do
+      [ -z "$_path" ] && continue
+      while IFS= read -r _scope; do
+        [ -z "$_scope" ] && continue
+        case "$_path" in
+          "$_scope"/*|"$_scope")
+            printf '%s\n' "$_path" >> "$_filtered"
+            break
+            ;;
+        esac
+      done < "$_scope_file"
+    done < "$_allowlist"
+    sort -u -o "$_filtered" "$_filtered"
+    cp "$_filtered" "$_allowlist" 2>/dev/null || :
+  fi
+
+  if [ ! -s "$_allowlist" ]; then
+    _cm_cleanup_stage_derived
+    _cm_out "stage-derived: allowlist vazia — nada a commitar (FR-016)"
+    return 3
+  fi
+
+  _add_failed=0
+  while IFS= read -r _path; do
+    [ -z "$_path" ] && continue
+    if ! git -C "$_pap" add -- "$_path" 2>/dev/null; then
+      _cm_err "stage-derived: 'git add -- $_path' falhou"
+      _cm_diag "error" "git-add-failed" "git add -- $_path falhou" "verifique se o path existe/e valido em $_pap"
+      _add_failed=1
+    fi
+  done < "$_allowlist"
+
+  _cm_cleanup_stage_derived
+
+  if [ "$_add_failed" = 1 ]; then
+    return 1
+  fi
+
+  return 0
+}
+
 # ---------- subcomando: finalize ----------
 # finalize --state-dir DIR --projeto-alvo-path PATH [--session NAME]
 #          [--title T] [--body B]
@@ -504,7 +741,7 @@ _cm_cmd_finalize() {
 
 # ---------- dispatch ----------
 
-[ "$#" -gt 0 ] || _cm_die_usage "subcomando obrigatorio: is-enabled|set-enabled|guard-branch|stage-message|task-message|finalize"
+[ "$#" -gt 0 ] || _cm_die_usage "subcomando obrigatorio: is-enabled|set-enabled|guard-branch|stage-message|task-message|finalize|snapshot|stage-derived"
 
 _CM_CMD=$1
 shift
@@ -516,7 +753,9 @@ case "$_CM_CMD" in
   stage-message) _cm_cmd_stage_message "$@" ;;
   task-message)  _cm_cmd_task_message  "$@" ;;
   finalize)      _cm_cmd_finalize      "$@" ;;
+  snapshot)      _cm_cmd_snapshot      "$@" ;;
+  stage-derived) _cm_cmd_stage_derived "$@" ;;
   *)
-    _cm_die_usage "subcomando desconhecido: $_CM_CMD (validos: is-enabled|set-enabled|guard-branch|stage-message|task-message|finalize)"
+    _cm_die_usage "subcomando desconhecido: $_CM_CMD (validos: is-enabled|set-enabled|guard-branch|stage-message|task-message|finalize|snapshot|stage-derived)"
     ;;
 esac

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -276,7 +276,40 @@ _so_cmd_start() {
   # entre o end anterior e este start pertencem a fechamento/overhead do
   # orquestrador, nao a onda nova).
   _so_ticks_reset "$_sdir"
+
+  # Baseline de untracked (living-specs FASE 5, FR-014/data-model.md
+  # UntrackedBaseline: "escrito por commit-mode.sh snapshot no inicio da
+  # onda"). Best-effort: git-commit (passo 10 de toda onda) delega a
+  # `stage-derived`, que so inclui untracked NOVOS desde este baseline —
+  # capturar aqui, ANTES de qualquer trabalho da onda mutar o repo, e o
+  # UNICO ponto onde "pre-existente" (alheio) vs "novo desta onda" pode
+  # ser distinguido corretamente. Nunca bloqueia `start`: ausencia de git,
+  # de target_project_path, ou de commit-mode.sh apenas deixa o baseline
+  # ausente (git-commit cai no fail-closed existente, sem regressao no
+  # ciclo de vida da onda).
+  _so_start_snapshot_baseline "$_sdir"
+
   printf '%s\n' "$_id"
+}
+
+# Best-effort: deriva o projeto-alvo do proprio state.json e chama
+# commit-mode.sh snapshot. Isolado em funcao propria para nunca poluir o
+# fluxo principal de start com `set -e` (toda falha aqui e silenciosa).
+_so_start_snapshot_baseline() {
+  _ssb_sdir="$1"
+  _ssb_sf=$(_so_state_file "$_ssb_sdir")
+  command -v git >/dev/null 2>&1 || return 0
+
+  _ssb_pap=$(jq -r '.execution.target_project_path // ""' "$_ssb_sf" 2>/dev/null) || _ssb_pap=""
+  [ -n "$_ssb_pap" ] && [ -d "$_ssb_pap" ] || return 0
+
+  _ssb_selfdir=$(_so_self_dir) || return 0
+  _ssb_cm="$_ssb_selfdir/commit-mode.sh"
+  [ -f "$_ssb_cm" ] || return 0
+
+  sh "$_ssb_cm" snapshot --state-dir "$_ssb_sdir" --projeto-alvo-path "$_ssb_pap" \
+    >/dev/null 2>&1 || _so_log "start: snapshot de baseline nao gravado (best-effort, sem impacto na onda)"
+  return 0
 }
 
 # Calcula wallclock em segundos entre dois timestamps ISO.
@@ -788,10 +821,38 @@ _so_cmd_git_commit() {
   fi
   # Sanitiza motivo: remove newlines + limita a 100 chars
   _motivo_safe=$(printf '%s' "$_motivo" | tr '\n\r' '  ' | cut -c 1-100)
-  # Add ALL changes (estado + artefatos da pipeline). Sem -A para nao incluir
-  # paths fora de cwd; usamos -- "$_pap" se necessario.
+
+  # Staging por allowlist derivada (living-specs FASE 5, FR-014):
+  # delega a commit-mode.sh stage-derived em vez de `git add -- .` — o
+  # wave-commit pode tocar qualquer path do repo (sem --scope-dir), mas o
+  # staging fica explicito por allowlist (tracked mudados + untracked
+  # NOVOS desde o ultimo snapshot da onda), nunca staging amplo.
+  _sog_selfdir=$(_so_self_dir) || _sog_selfdir="."
+  _sog_cm="$_sog_selfdir/commit-mode.sh"
+  [ -f "$_sog_cm" ] || _so_die "git-commit: commit-mode.sh nao encontrado em $_sog_selfdir" 1
+
+  # O baseline (commit-baseline.txt) e capturado no INICIO da onda por
+  # `state-ondas.sh start` (best-effort, via .execution.target_project_path
+  # do proprio state.json — data-model.md UntrackedBaseline: "escrito...
+  # no inicio da onda"). Snapshotar aqui, no momento do commit (fim da
+  # onda), seria tarde demais: todo trabalho da onda ja teria acontecido,
+  # entao o baseline capturaria o MESMO untracked que stage-derived tentaria
+  # marcar como "novo" — diff sempre vazio. Se `start` nao gravou baseline
+  # (target_project_path ausente/invalido, git ausente), stage-derived cai
+  # no fail-closed documentado: untracked fica fora, tracked segue incluido.
+  _sog_stage_rc=0
+  sh "$_sog_cm" stage-derived --state-dir "$_sdir" --projeto-alvo-path "$_pap" \
+    || _sog_stage_rc=$?
+
+  if [ "$_sog_stage_rc" = 3 ]; then
+    # Allowlist vazia: preserva o comportamento atual de "nada para
+    # commitar" (no-op), sem quebrar o contrato existente.
+    _so_log "git-commit: nada para commitar (no-op)"
+    return 0
+  fi
+  [ "$_sog_stage_rc" = 0 ] || _so_die "git-commit: stage-derived falhou (exit $_sog_stage_rc) em $_pap" 1
+
   ( cd -- "$_pap" \
-    && git add -- . \
     && if git diff --cached --quiet; then
          _so_log "git-commit: nada para commitar (no-op)"
        else

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -115,8 +115,12 @@
 #
 #   state-ondas.sh git-commit --state-dir DIR --projeto-alvo-path PATH
 #                             --motivo MOTIVO [--onda-id ID]
-#       — Faz `git add .` + `git commit -m 'chore(agente-00c): onda <ID> - <MOTIVO>'`
-#         dentro de --projeto-alvo-path. NUNCA push (Principio V).
+#       — Delega o staging a `commit-mode.sh stage-derived` (allowlist
+#         derivada do baseline de untracked capturado por `commit-mode.sh
+#         snapshot` — living-specs FASE 5, FR-014..FR-017), NUNCA `git add
+#         .`/`git add -A`/`git add --all`, depois `git commit -m
+#         'chore(agente-00c): onda <ID> - <MOTIVO>'` dentro de
+#         --projeto-alvo-path. NUNCA push (Principio V).
 #         Idempotente: se nao ha mudancas para commitar, retorna 0 sem erro.
 #         Sem fail-soft: se git nao existe / dir nao e repo, exit 1.
 #

--- a/global/skills/review-features/SKILL.md
+++ b/global/skills/review-features/SKILL.md
@@ -42,13 +42,30 @@ visao global ou comparacao entre features, use esta.
 
 1. `/review-task` em features marcadas como `PRIORIZAR` para detalhar tasks
 2. `/execute-task` na proxima task critica
-3. Mover features `ARQUIVAR` para `docs/specs/_archived/<YYYY-MM-DD>-<feature>/`
-   (acao manual, pedir confirmacao ao usuario antes de mover; `<YYYY-MM-DD>`
-   e a data em que a acao de arquivamento de fato ocorre, nao a data de
-   criacao da feature — permite ordenacao cronologica do diretorio sem
-   abrir cada subpasta). Diretorios ja existentes sob `docs/specs/_archived/`
-   sem esse prefixo de data (arquivados antes desta convencao) permanecem
-   inalterados — NAO renomear nem mover conteudo ja arquivado.
+3. Antes de mover uma feature `ARQUIVAR` para
+   `docs/specs/_archived/<YYYY-MM-DD>-<feature>/`, rodar o gate deterministico
+   `scripts/delta-gate.sh docs/specs/<feature>/spec.md --corpus-dir
+   docs/specs/current`:
+   - **Exit != 0 (bloqueado)**: NAO mover a feature. Reportar ao operador os
+     `FINDING|error|<code>|<mensagem>` literais emitidos pelo gate e pedir
+     que a secao `## Delta Requirements` seja preenchida na spec, ou que um
+     skip explicito seja registrado (ver
+     `contracts/delta-section-format.md`).
+   - **Exit 0 (liberado)**: rodar `scripts/delta-merge.sh
+     docs/specs/<feature>/spec.md --feature <feature>` ANTES do `mv` para
+     `_archived/`. Se o merge tambem bloquear (exit 1 — o corpus mudou entre
+     o gate e o merge), o `mv` fica igualmente suspenso (defesa em
+     profundidade — o gate por si so nunca garante que o merge vai passar).
+   - So apos o merge ter sucesso (exit 0) o `mv` acontece — o fluxo de mover
+     para `_archived/` permanece EXATAMENTE como hoje (acao manual, pedir
+     confirmacao ao usuario antes de mover; `<YYYY-MM-DD>` e a data em que a
+     acao de arquivamento de fato ocorre, nao a data de criacao da feature —
+     permite ordenacao cronologica do diretorio sem abrir cada subpasta).
+     Diretorios ja existentes sob `docs/specs/_archived/` sem esse prefixo de
+     data (arquivados antes desta convencao) permanecem inalterados — NAO
+     renomear nem mover conteudo ja arquivado. O corpus canonico
+     (`docs/specs/current/`) e ADICIONAL ao archive existente, nunca uma
+     substituicao (FR-006).
 
 ---
 
@@ -243,6 +260,17 @@ cronologicamente sem abrir cada diretorio. Diretorios ja existentes sob
 vigor) permanecem para sempre sem alteracao de nome — NAO renomear nem mover
 conteudo ja arquivado retroativamente (risco de quebrar links em `CLAUDE.md`,
 memorias e specs existentes que referenciam o path antigo).
+
+### Corpus canonico (`docs/specs/current/`) e a fonte de "como o sistema se comporta hoje"
+
+`_archived/<YYYY-MM-DD>-<feature>/` preserva o HISTORICO de mudancas por
+feature (o que cada feature mudou, quando). `docs/specs/current/` e o
+corpus canonico, atualizado a cada archive via `delta-gate.sh` +
+`delta-merge.sh` (item 3 acima) — responde "como o sistema se comporta
+hoje" para qualquer capacidade coberta, sem precisar abrir nenhum
+diretorio sob `_archived/` (FR-009). Os dois se complementam: use
+`docs/specs/current/` para o comportamento atual e `_archived/` para
+entender a evolucao historica de uma capacidade.
 
 ### `mtime_days` pode mentir em repos com checkout recente
 

--- a/global/skills/review-features/scripts/_diag.sh
+++ b/global/skills/review-features/scripts/_diag.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# _diag.sh — envelope diagnostico uniforme (DiagnosticEnvelope) para os
+# scripts POSIX de review-features/ (delta-gate.sh, delta-merge.sh).
+#
+# VENDORED: copia da fonte canonica
+# `global/skills/agente-00c-runtime/scripts/_diag.sh` — skills sao
+# self-contained quando instaladas em `~/.claude/skills/<nome>/`, entao a
+# copia evita sourcing cross-skill (research.md Decision 7 da feature
+# living-specs). Ao alterar o contrato, atualize AMBAS as copias.
+#
+# Ref: docs/specs/openspec-hygiene/spec.md FR-012..FR-016
+#      docs/specs/openspec-hygiene/contracts/diagnostic-envelope.md
+#      docs/specs/living-specs/research.md Decision 7
+#
+# NAO e executavel diretamente. Use (mesmo padrao de _log.sh/_hash.sh):
+#   . "$(dirname -- "$0")/_diag.sh"
+#   diag_emit <severity> <code> <message> <fix>
+#
+# Contrato:
+#   severity  "error" | "warning" — qualquer outro valor e rejeitado.
+#   code      kebab-case estavel por (script, condicao de falha); nao
+#             validado por regex aqui (responsabilidade do call-site).
+#   message   texto legivel por humano (pt-br permitido). `|` interno e
+#             substituido por `/` antes de emitir.
+#   fix       instrucao acionavel de proximo passo. MUST NOT ser identica
+#             a `message` (FR-013) — rejeitado se igual. `|` interno e
+#             substituido por `/`.
+#
+# Saida: 1 linha em stderr, ADITIVA a qualquer mensagem legada que o
+# script chamador ja tenha emitido (FR-015, SC-006 — nunca substitui):
+#   DIAG|<severity>|<code>|<message>|<fix>
+#
+# Zero dependencia de jq (FR-016, Constitution II — POSIX sh puro).
+#
+# Semantica de falha (best-effort — nunca mascara o erro original):
+#   severity invalida, ou fix == message -> diag_emit avisa em stderr e
+#   retorna 1 SEM emitir a linha DIAG| (evita envelope malformado). O
+#   script chamador ja emitiu sua mensagem legada antes de chamar
+#   diag_emit e prossegue para o proprio `exit` normalmente — callers sob
+#   `set -eu` devem chamar `diag_emit ... || :` para nao abortar por causa
+#   de uma falha de VALIDACAO do envelope (distinta do erro original).
+
+# diag_emit SEVERITY CODE MESSAGE FIX
+# Exit: 0 emitido; 1 severity invalida ou fix == message (nada emitido).
+diag_emit() {
+  _diag_severity="${1:-}"
+  _diag_code="${2:-}"
+  _diag_message="${3:-}"
+  _diag_fix="${4:-}"
+
+  case "$_diag_severity" in
+    error|warning) ;;
+    *)
+      printf 'diag_emit: severity invalida: "%s" (esperado error|warning) — envelope DIAG nao emitido (code=%s)\n' \
+        "$_diag_severity" "$_diag_code" >&2
+      return 1
+      ;;
+  esac
+
+  if [ "$_diag_fix" = "$_diag_message" ]; then
+    printf 'diag_emit: fix identico a message (code=%s) — MUST NOT repetir a mensagem; envelope DIAG nao emitido\n' \
+      "$_diag_code" >&2
+    return 1
+  fi
+
+  # Escapa `|` interno de message/fix (nao pode quebrar o parsing por
+  # campo do consumidor: cut -d'|' -f2-5).
+  _diag_esc_message=$(printf '%s' "$_diag_message" | tr '|' '/')
+  _diag_esc_fix=$(printf '%s' "$_diag_fix" | tr '|' '/')
+
+  printf 'DIAG|%s|%s|%s|%s\n' \
+    "$_diag_severity" "$_diag_code" "$_diag_esc_message" "$_diag_esc_fix" >&2
+  return 0
+}

--- a/global/skills/review-features/scripts/delta-gate.sh
+++ b/global/skills/review-features/scripts/delta-gate.sh
@@ -1,0 +1,494 @@
+#!/bin/sh
+# delta-gate.sh — gate deterministico, READ-ONLY: valida a secao
+# `## Delta Requirements` de um spec.md contra a gramatica do contrato
+# delta-section-format.md e, quando a capability referenciada ja existe no
+# corpus (docs/specs/current/<slug>.md), contra a estrutura e o estado
+# referencial do contrato corpus-format.md.
+#
+# Ref: docs/specs/living-specs/spec.md FR-010..FR-013
+#      docs/specs/living-specs/contracts/delta-gate-cli.md
+#      docs/specs/living-specs/contracts/delta-section-format.md
+#      docs/specs/living-specs/contracts/corpus-format.md
+#
+# Uso:
+#   delta-gate.sh SPEC_MD [--corpus-dir DIR]
+#
+# Saida (stdout):
+#   FINDING|<severity>|<code>|<mensagem>
+#   RESULT|<spec>|delta=<present|skip|missing>|errors=<N>|warnings=<M>
+#
+# Exit: 0 archive liberado (delta valida ou skip valido; so warnings/infos);
+#       1 archive bloqueado (>=1 FINDING error);
+#       2 uso incorreto / SPEC_MD inexistente / corpus-dir irresoluvel.
+#
+# POSIX sh puro (`set -eu`), zero jq (Constitution II). Este arquivo tambem
+# e SOURCEABLE por delta-merge.sh (mesmo diretorio) para reusar o parser da
+# secao delta e o scanner estrutural do corpus SEM duplicar a gramatica
+# (contracts/delta-merge-cli.md §Comportamento item 1, research.md Decision
+# 7 do mesmo padrao de vendoring same-dir). O caller que so quer as
+# funcoes deve exportar `_DG_SOURCED=1` ANTES de `. delta-gate.sh` — nesse
+# modo a secao "main" abaixo e pulada (nenhum parse de argv, nenhum exit).
+
+set -eu
+
+_DG_SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+_DG_SOURCED="${_DG_SOURCED:-0}"
+_DG_NAME="delta-gate"
+
+# shellcheck source=./_diag.sh
+. "$_DG_SCRIPT_DIR/_diag.sh"
+
+_dg_usage() {
+  cat <<'USAGE' >&2
+Uso: delta-gate.sh SPEC_MD [--corpus-dir DIR]
+
+Valida a secao "## Delta Requirements" de SPEC_MD (gramatica de
+delta-section-format.md) e, para capabilities ja existentes no corpus,
+a estrutura + estado referencial de corpus-format.md. Read-only.
+
+  --corpus-dir DIR   raiz do corpus (default: resolvida subindo de SPEC_MD
+                      pela convencao docs/specs/<feature>/spec.md ate
+                      docs/specs/current/; sem convencao e sem flag => exit 2)
+
+Saida: linhas FINDING|<severity>|<code>|<mensagem> + RESULT final.
+Exit: 0 liberado; 1 bloqueado (>=1 erro); 2 uso incorreto.
+USAGE
+}
+
+# --- funcoes compartilhadas (tambem usadas por delta-merge.sh via source) ---
+
+# _dg_slug_valid SLUG — exit 0 valido, 1 invalido. Padrao [a-z0-9][a-z0-9-]*
+_dg_slug_valid() {
+  _dgv_s="$1"
+  [ -n "$_dgv_s" ] || return 1
+  case "$_dgv_s" in
+    [a-z0-9]*) ;;
+    *) return 1 ;;
+  esac
+  case "$_dgv_s" in
+    *[!a-z0-9-]*) return 1 ;;
+  esac
+  return 0
+}
+
+# _dg_in_list NEEDLE HAYSTACK(space-separated) — exit 0 se presente.
+_dg_in_list() {
+  case " $2 " in
+    *" $1 "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# _dg_resolve_corpus_dir SPEC_MD -> stdout: path do corpus-dir; exit 1 se
+# SPEC_MD nao segue a convencao docs/specs/<feature>/spec.md.
+_dg_resolve_corpus_dir() {
+  _dgr_spec="$1"
+  case "$_dgr_spec" in
+    */docs/specs/*/spec.md|docs/specs/*/spec.md)
+      _dgr_base=${_dgr_spec%/*/spec.md}
+      printf '%s/current\n' "$_dgr_base"
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# _dg_parse_spec SPEC_MD -> stdout: linhas FINDING|..., ENTRY|... (TSV,
+# separador TAB), SKIP_OK|... (TSV) e uma linha final "__STATUS__\t<v>"
+# com v in {missing,skip,present}. Emite o FINDING capability-slug-invalid
+# como a PRIMEIRA checagem sobre cada "### Capability:" lida, ANTES de
+# qualquer composicao de path com o slug (invariante 4 do contrato
+# delta-gate-cli.md / tarefa 3.4.1) — nenhum path e composto aqui.
+_dg_parse_spec() {
+  awk '
+    function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+    function esc(s) { gsub(/\t/, " ", s); return s }
+    function slug_ok(s) { return (s ~ /^[a-z0-9][a-z0-9-]*$/) }
+    function flush_entry() {
+      if (entry_type != "") {
+        printf "ENTRY\t%s\t%s\t%s\t%s\t%s\n", cap_slug, entry_type, entry_id, entry_id2, esc(trim(entry_text))
+      }
+      entry_type = ""; entry_id = ""; entry_id2 = ""; entry_text = ""
+    }
+    BEGIN {
+      in_section = 0; in_capability = 0; cap_valid = 1; cap_slug = ""
+      group = ""; has_heading = 0; has_capability_block = 0
+      skip_seen = 0; skip_valid = 0; skip_just = ""; skip_auth = ""; skip_date = ""
+    }
+    /^## Delta Requirements[ \t]*$/ {
+      flush_entry()
+      in_section = 1; has_heading = 1
+      in_capability = 0; cap_slug = ""; group = ""
+      next
+    }
+    /^#[ \t]/ || /^##[ \t]/ {
+      if (in_section) {
+        flush_entry()
+        in_section = 0; in_capability = 0; cap_slug = ""; group = ""
+      }
+      next
+    }
+    !in_section { next }
+    /^\*\*Skip\*\*:/ {
+      flush_entry()
+      skip_seen = 1
+      rest = $0
+      sub(/^\*\*Skip\*\*:[ \t]*/, "", rest)
+      em = index(rest, "—")
+      if (em == 0) {
+        skip_valid = 0
+      } else {
+        just = trim(substr(rest, 1, em - 1))
+        tail = trim(substr(rest, em + 3))
+        lastcomma = 0
+        for (p = length(tail); p >= 1; p--) {
+          if (substr(tail, p, 1) == ",") { lastcomma = p; break }
+        }
+        if (lastcomma == 0) {
+          skip_valid = 0
+        } else {
+          auth = trim(substr(tail, 1, lastcomma - 1))
+          dt = trim(substr(tail, lastcomma + 1))
+          if (just == "" || auth == "" || dt == "") {
+            skip_valid = 0
+          } else {
+            skip_valid = 1; skip_just = just; skip_auth = auth; skip_date = dt
+          }
+        }
+      }
+      next
+    }
+    /^### Capability:[ \t]/ {
+      flush_entry()
+      has_capability_block = 1
+      in_capability = 1; group = ""
+      raw = $0
+      sub(/^### Capability:[ \t]*/, "", raw)
+      slug = trim(raw)
+      cap_slug = slug
+      if (!slug_ok(slug)) {
+        printf "FINDING|error|capability-slug-invalid|slug \"%s\" fora do padrao [a-z0-9][a-z0-9-]* — capability ignorada\n", esc(slug)
+        cap_valid = 0
+      } else {
+        cap_valid = 1
+      }
+      next
+    }
+    /^#### ADDED[ \t]*$/    { flush_entry(); group = "ADDED"; next }
+    /^#### MODIFIED[ \t]*$/ { flush_entry(); group = "MODIFIED"; next }
+    /^#### REMOVED[ \t]*$/  { flush_entry(); group = "REMOVED"; next }
+    /^#### RENAMED[ \t]*$/  { flush_entry(); group = "RENAMED"; next }
+    /^[ \t]*$/ { next }
+    {
+      if (!in_capability) {
+        printf "FINDING|error|entry-malformed|linha inesperada fora de bloco Capability: %s\n", esc($0)
+        next
+      }
+      if (!cap_valid) { next }
+      if (group == "RENAMED") {
+        if ($0 ~ /^- \*\*FR-[0-9]+ -> FR-[0-9]+\*\*[ \t]*$/) {
+          flush_entry()
+          line = $0
+          sub(/^- \*\*/, "", line); sub(/\*\*[ \t]*$/, "", line)
+          split(line, parts, " -> ")
+          entry_type = "RENAMED"; entry_id = parts[1]; entry_id2 = parts[2]; entry_text = ""
+          next
+        } else if ($0 ~ /^  +[^ \t]/ && entry_type != "") {
+          entry_text = entry_text " " trim($0)
+          next
+        } else {
+          printf "FINDING|error|entry-malformed|entrada RENAMED invalida em %s: %s\n", cap_slug, esc($0)
+          next
+        }
+      } else if (group == "ADDED" || group == "MODIFIED" || group == "REMOVED") {
+        if ($0 ~ /^- \*\*FR-[0-9]+\*\*:/) {
+          flush_entry()
+          line = $0
+          idpart = line
+          sub(/^- \*\*/, "", idpart); sub(/\*\*:.*$/, "", idpart)
+          txt = line
+          sub(/^- \*\*FR-[0-9]+\*\*:[ \t]*/, "", txt)
+          entry_type = group; entry_id = idpart; entry_id2 = ""; entry_text = txt
+          next
+        } else if ($0 ~ /^  +[^ \t]/ && entry_type != "") {
+          entry_text = entry_text " " trim($0)
+          next
+        } else {
+          printf "FINDING|error|entry-malformed|entrada invalida em #### %s de %s: %s\n", group, cap_slug, esc($0)
+          next
+        }
+      } else {
+        printf "FINDING|error|entry-malformed|linha fora de grupo #### em %s: %s\n", cap_slug, esc($0)
+        next
+      }
+    }
+    END {
+      flush_entry()
+      if (!has_heading) {
+        printf "FINDING|error|delta-missing|secao \"## Delta Requirements\" ausente e sem marcador Skip\n"
+        print "__STATUS__\tmissing"
+      } else if (!skip_seen && !has_capability_block) {
+        printf "FINDING|error|delta-empty|secao presente sem blocos Capability nem Skip\n"
+        print "__STATUS__\tpresent"
+      } else if (skip_seen && has_capability_block) {
+        printf "FINDING|error|skip-with-delta|marcador Skip e blocos Capability presentes simultaneamente (mutuamente exclusivos)\n"
+        print "__STATUS__\tpresent"
+      } else if (skip_seen && !has_capability_block) {
+        if (skip_valid) {
+          printf "SKIP_OK\t%s\t%s\t%s\n", esc(skip_just), esc(skip_auth), esc(skip_date)
+          print "__STATUS__\tskip"
+        } else {
+          printf "FINDING|error|skip-invalid|marcador Skip sem justificativa, autor ou data validos\n"
+          print "__STATUS__\tpresent"
+        }
+      } else {
+        print "__STATUS__\tpresent"
+      }
+    }
+  ' "$1"
+}
+
+# _dg_corpus_scan CORPUS_FILE -> stdout: MALFORMED|<motivo> (0+, corte de
+# processamento posterior pelo caller), ACTIVE|<id>, REMOVED|<id>,
+# RENAMED_OLD|<id>, RENAMED_NEW|<id>. Read-only.
+_dg_corpus_scan() {
+  awk '
+    function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+    BEGIN { section = ""; seen_h1 = 0 }
+    /^# Capability:[ \t]/ { seen_h1++; next }
+    /^## Requirements[ \t]*$/ { section = "req"; next }
+    /^## Removed Requirements[ \t]*$/ { section = "removed"; next }
+    /^## Renamed Identifiers[ \t]*$/ { section = "renamed"; next }
+    /^## / { section = ""; next }
+    # Duplicidade: 3 sets independentes (active/removed/old-aposentado).
+    # O id "Novo" de um rename COINCIDE por design com o heading ativo
+    # corrente (e a mesma entidade, so o nome mudou) — NAO entra na
+    # checagem de duplicidade estrutural (so no cross-check referencial
+    # de _dg_process_capability, que e semantica distinta: "id ja usado").
+    /^### / {
+      if (section == "req") {
+        if ($0 ~ /^### FR-[0-9]+[ \t]*$/) {
+          id = $0; sub(/^### /, "", id); sub(/[ \t]+$/, "", id)
+          if (id in active_set) printf "MALFORMED\tid duplicado: %s\n", id
+          if (id in removed_set) printf "MALFORMED\tid ativo e removido simultaneamente: %s\n", id
+          active_set[id] = 1
+          printf "ACTIVE\t%s\n", id
+        } else {
+          printf "MALFORMED\theading em Requirements mal-formado: %s\n", $0
+        }
+      } else if (section == "removed") {
+        if ($0 ~ /^### FR-[0-9]+ \[REMOVED\][ \t]*$/) {
+          id = $0; sub(/^### /, "", id); sub(/ \[REMOVED\].*/, "", id)
+          if (id in removed_set) printf "MALFORMED\tid duplicado: %s\n", id
+          if (id in active_set) printf "MALFORMED\tid ativo e removido simultaneamente: %s\n", id
+          removed_set[id] = 1
+          printf "REMOVED\t%s\n", id
+        } else {
+          printf "MALFORMED\theading em Removed Requirements mal-formado: %s\n", $0
+        }
+      } else {
+        printf "MALFORMED\theading ### fora de secao reconhecida: %s\n", $0
+      }
+      next
+    }
+    section == "renamed" && /^\|/ {
+      if ($0 ~ /^\|[ \t]*-+/) next
+      if ($0 ~ /Antigo/ && $0 ~ /Novo/) next
+      n = split($0, cols, "|")
+      old = trim(cols[2]); new = trim(cols[3])
+      if (old != "") {
+        if (old in old_set) printf "MALFORMED\tid aposentado duplicado (renamed old): %s\n", old
+        if (old in active_set) printf "MALFORMED\tid aposentado ainda ativo: %s\n", old
+        old_set[old] = 1
+        printf "RENAMED_OLD\t%s\n", old
+      }
+      if (new != "") {
+        if (new in new_set) printf "MALFORMED\tid renamed-target duplicado (renamed new): %s\n", new
+        new_set[new] = 1
+        printf "RENAMED_NEW\t%s\n", new
+      }
+      next
+    }
+    END {
+      if (seen_h1 == 0) printf "MALFORMED\theading \"# Capability:\" ausente\n"
+    }
+  ' "$1"
+}
+
+# _dg_process_capability CAP CORPUS_DIR PARSE_OUT_FILE — le/emite FINDINGs
+# via stdout e MUTA a variavel de escopo do caller ERRORS (o caller DEVE
+# invocar esta funcao fora de subshell/pipe: `_dg_process_capability ...`
+# direto, nunca `... | _dg_process_capability`). Ordem CHK034: structural
+# ANTES de referencial (invariante 6 do contrato delta-gate-cli.md).
+_dg_process_capability() {
+  _dgp_cap="$1"
+  _dgp_corpus_dir="$2"
+  _dgp_parse_out="$3"
+  _dgp_corpus_file="$_dgp_corpus_dir/$_dgp_cap.md"
+  _dgp_tab="$(printf '\t')"
+  _dgp_entries=$(mktemp)
+  awk -F"$_dgp_tab" -v c="$_dgp_cap" '$1=="ENTRY" && $2==c {print}' "$_dgp_parse_out" > "$_dgp_entries"
+
+  if [ ! -f "$_dgp_corpus_file" ]; then
+    _dgp_only_added=1
+    _dgp_seen=""
+    while IFS="$_dgp_tab" read -r _tag _c _type _id _id2 _text; do
+      [ "$_tag" = "ENTRY" ] || continue
+      if [ "$_type" != "ADDED" ]; then
+        _dgp_only_added=0
+        printf 'FINDING|error|ref-not-found|%s: %s referencia %s inexistente (corpus/capability ainda nao existe)\n' "$_dgp_cap" "$_type" "$_id"
+        ERRORS=$((ERRORS + 1))
+      else
+        if _dg_in_list "$_id" "$_dgp_seen"; then
+          printf 'FINDING|error|added-collision|%s: ADDED %s duplicado na mesma capability\n' "$_dgp_cap" "$_id"
+          ERRORS=$((ERRORS + 1))
+        else
+          _dgp_seen="$_dgp_seen $_id"
+        fi
+      fi
+    done < "$_dgp_entries"
+    if [ "$_dgp_only_added" = "1" ] && [ -s "$_dgp_entries" ]; then
+      printf 'FINDING|info|corpus-missing|%s: corpus/capability ainda nao existe (sera criado pelo merge)\n' "$_dgp_cap"
+    fi
+  else
+    _dgp_scan=$(mktemp)
+    _dg_corpus_scan "$_dgp_corpus_file" > "$_dgp_scan"
+    if awk -F"$_dgp_tab" '$1=="MALFORMED"{f=1} END{exit !f}' "$_dgp_scan"; then
+      _dgp_reason=$(awk -F"$_dgp_tab" '$1=="MALFORMED"{print $2; exit}' "$_dgp_scan")
+      printf 'FINDING|error|corpus-malformed|%s: %s\n' "$_dgp_cap" "$_dgp_reason"
+      ERRORS=$((ERRORS + 1))
+      rm -f "$_dgp_scan" "$_dgp_entries"
+      return 0
+    fi
+    _dgp_active=$(awk -F"$_dgp_tab" '$1=="ACTIVE"{print $2}' "$_dgp_scan" | tr '\n' ' ')
+    _dgp_removed=$(awk -F"$_dgp_tab" '$1=="REMOVED"{print $2}' "$_dgp_scan" | tr '\n' ' ')
+    _dgp_rold=$(awk -F"$_dgp_tab" '$1=="RENAMED_OLD"{print $2}' "$_dgp_scan" | tr '\n' ' ')
+    _dgp_rnew=$(awk -F"$_dgp_tab" '$1=="RENAMED_NEW"{print $2}' "$_dgp_scan" | tr '\n' ' ')
+    _dgp_all="$_dgp_active $_dgp_removed $_dgp_rold $_dgp_rnew"
+    _dgp_session=""
+    while IFS="$_dgp_tab" read -r _tag _c _type _id _id2 _text; do
+      [ "$_tag" = "ENTRY" ] || continue
+      case "$_type" in
+        ADDED)
+          if _dg_in_list "$_id" "$_dgp_all $_dgp_session"; then
+            printf 'FINDING|error|added-collision|%s: ADDED %s ja existe no corpus (ativo, removido ou renomeado)\n' "$_dgp_cap" "$_id"
+            ERRORS=$((ERRORS + 1))
+          else
+            _dgp_session="$_dgp_session $_id"
+          fi
+          ;;
+        MODIFIED)
+          if ! _dg_in_list "$_id" "$_dgp_active"; then
+            printf 'FINDING|error|ref-not-found|%s: MODIFIED referencia %s inexistente ou inativo\n' "$_dgp_cap" "$_id"
+            ERRORS=$((ERRORS + 1))
+          fi
+          ;;
+        REMOVED)
+          if ! _dg_in_list "$_id" "$_dgp_active"; then
+            printf 'FINDING|error|ref-not-found|%s: REMOVED referencia %s inexistente ou inativo\n' "$_dgp_cap" "$_id"
+            ERRORS=$((ERRORS + 1))
+          fi
+          ;;
+        RENAMED)
+          if ! _dg_in_list "$_id" "$_dgp_active"; then
+            printf 'FINDING|error|ref-not-found|%s: RENAMED referencia %s inexistente ou inativo\n' "$_dgp_cap" "$_id"
+            ERRORS=$((ERRORS + 1))
+          fi
+          if _dg_in_list "$_id2" "$_dgp_all $_dgp_session"; then
+            printf 'FINDING|error|renamed-target-exists|%s: RENAMED alvo %s ja existe no corpus\n' "$_dgp_cap" "$_id2"
+            ERRORS=$((ERRORS + 1))
+          else
+            _dgp_session="$_dgp_session $_id2"
+          fi
+          ;;
+      esac
+    done < "$_dgp_entries"
+    rm -f "$_dgp_scan"
+  fi
+  rm -f "$_dgp_entries"
+}
+
+# ------------------------------- main -------------------------------
+# Pulado quando sourced por delta-merge.sh (_DG_SOURCED=1 setado ANTES do
+# `.`). Nesse modo so as funcoes acima ficam disponiveis ao caller.
+if [ "$_DG_SOURCED" != "1" ]; then
+
+  SPEC_MD=""
+  CORPUS_DIR=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --corpus-dir)
+        [ $# -ge 2 ] || { _dg_usage; exit 2; }
+        CORPUS_DIR=$2; shift 2 ;;
+      --corpus-dir=*)
+        CORPUS_DIR=${1#--corpus-dir=}; shift ;;
+      -h|--help)
+        _dg_usage; exit 2 ;;
+      --*)
+        printf '%s: opcao desconhecida: %s\n' "$_DG_NAME" "$1" >&2
+        diag_emit error unknown-option "opcao desconhecida: $1" "consulte delta-gate.sh --help" || :
+        _dg_usage; exit 2 ;;
+      *)
+        if [ -z "$SPEC_MD" ]; then
+          SPEC_MD=$1; shift
+        else
+          printf '%s: argumento extra: %s\n' "$_DG_NAME" "$1" >&2
+          diag_emit error extra-argument "argumento extra: $1" "delta-gate.sh aceita apenas SPEC_MD + --corpus-dir" || :
+          _dg_usage; exit 2
+        fi ;;
+    esac
+  done
+
+  if [ -z "$SPEC_MD" ]; then
+    _dg_usage; exit 2
+  fi
+  if [ ! -f "$SPEC_MD" ]; then
+    printf '%s: spec nao encontrado: %s\n' "$_DG_NAME" "$SPEC_MD" >&2
+    diag_emit error spec-not-found "spec.md nao encontrado: $SPEC_MD" "verifique o path de SPEC_MD" || :
+    exit 2
+  fi
+
+  if [ -z "$CORPUS_DIR" ]; then
+    if ! CORPUS_DIR=$(_dg_resolve_corpus_dir "$SPEC_MD"); then
+      printf '%s: nao foi possivel resolver --corpus-dir (SPEC_MD fora da convencao docs/specs/<feature>/spec.md)\n' "$_DG_NAME" >&2
+      diag_emit error corpus-dir-unresolvable "corpus-dir nao resolvido para $SPEC_MD" "passe --corpus-dir explicitamente" || :
+      exit 2
+    fi
+  fi
+
+  ERRORS=0
+  WARNINGS=0
+  PARSE_OUT=$(mktemp)
+  trap 'rm -f "$PARSE_OUT"' EXIT
+  _dg_parse_spec "$SPEC_MD" > "$PARSE_OUT"
+
+  DELTA_STATUS=$(awk -F"$(printf '\t')" '$1=="__STATUS__"{print $2}' "$PARSE_OUT")
+
+  while IFS= read -r _dg_line; do
+    case "$_dg_line" in
+      FINDING\|error\|*)
+        printf '%s\n' "$_dg_line"
+        ERRORS=$((ERRORS + 1)) ;;
+      FINDING\|warning\|*)
+        printf '%s\n' "$_dg_line"
+        WARNINGS=$((WARNINGS + 1)) ;;
+      FINDING\|*)
+        printf '%s\n' "$_dg_line" ;;
+    esac
+  done < "$PARSE_OUT"
+
+  CAPS=$(awk -F"$(printf '\t')" '$1=="ENTRY"{print $2}' "$PARSE_OUT" | sort -u)
+  for _cap in $CAPS; do
+    _dg_process_capability "$_cap" "$CORPUS_DIR" "$PARSE_OUT"
+  done
+
+  printf 'RESULT|%s|delta=%s|errors=%d|warnings=%d\n' "$SPEC_MD" "$DELTA_STATUS" "$ERRORS" "$WARNINGS"
+
+  if [ "$ERRORS" -gt 0 ]; then
+    exit 1
+  fi
+  exit 0
+fi

--- a/global/skills/review-features/scripts/delta-merge.sh
+++ b/global/skills/review-features/scripts/delta-merge.sh
@@ -1,0 +1,421 @@
+#!/bin/sh
+# delta-merge.sh — aplica atomicamente a secao "## Delta Requirements" de um
+# spec.md ao corpus (docs/specs/current/<slug>.md), por capability.
+#
+# Ref: docs/specs/living-specs/spec.md FR-002..FR-008
+#      docs/specs/living-specs/contracts/delta-merge-cli.md
+#      docs/specs/living-specs/contracts/corpus-format.md
+#
+# Uso:
+#   delta-merge.sh SPEC_MD --feature NAME [--corpus-dir DIR] \
+#     [--date YYYY-MM-DD] [--dry-run]
+#
+# Saida (stdout):
+#   FINDING|<severity>|<code>|<mensagem>
+#   RESULT|<spec>|delta=<applied|skip|blocked>|added=<N>|modified=<N>|removed=<N>|renamed=<N>
+#
+# Exit: 0 aplicado (ou dry-run valido, ou skip); 1 bloqueado (corpus intacto);
+#       2 uso incorreto / SPEC_MD inexistente.
+#
+# POSIX sh puro (`set -eu`), zero jq (Constitution II). REUSA o parser da
+# secao delta e o scanner estrutural do corpus de delta-gate.sh via source
+# same-dir (contracts/delta-merge-cli.md §Comportamento item 1 — "mesma
+# gramatica do contrato delta-section-format"; nao duplica a gramatica).
+
+set -eu
+
+_DM_SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+_DM_NAME="delta-merge"
+
+# shellcheck source=./_diag.sh
+. "$_DM_SCRIPT_DIR/_diag.sh"
+
+# Reusa delta-gate.sh apenas como biblioteca de funcoes (parser + scanner +
+# validacao referencial + resolucao de corpus-dir + slug). _DG_SOURCED=1
+# pula a secao "main" de delta-gate.sh (sem parse de argv, sem exit).
+_DG_SOURCED=1
+# shellcheck source=./delta-gate.sh
+. "$_DM_SCRIPT_DIR/delta-gate.sh"
+
+_dm_usage() {
+  cat <<'USAGE' >&2
+Uso: delta-merge.sh SPEC_MD --feature NAME [--corpus-dir DIR] \
+       [--date YYYY-MM-DD] [--dry-run]
+
+Aplica a secao "## Delta Requirements" de SPEC_MD ao corpus
+(docs/specs/current/<slug>.md), por capability, de forma atomica
+(mktemp + mv, so apos validacao TOTAL de todas as capabilities).
+
+  --feature NAME      short-name gravado como proveniencia (obrigatorio)
+  --corpus-dir DIR    mesma resolucao de delta-gate.sh
+  --date YYYY-MM-DD   data de proveniencia (default: data corrente UTC)
+  --dry-run           valida e reporta o que SERIA aplicado; zero escrita
+
+Saida: FINDING|<severity>|<code>|<mensagem> + RESULT final.
+Exit: 0 aplicado/skip/dry-run valido; 1 bloqueado; 2 uso incorreto.
+USAGE
+}
+
+# _dm_render_capability CAP CORPUS_DIR ENTRIES_FILE FEATURE DATE
+# Le o arquivo de corpus existente (se houver) + as entradas ENTRY desta
+# capability, e imprime em stdout o CONTEUDO RENDERIZADO completo do novo
+# arquivo, mais uma linha final "%%COUNTS%%|<added>|<modified>|<removed>|<renamed>".
+# Read-only sobre o corpus (nunca escreve — quem grava e o caller, via mktemp+mv).
+_dm_render_capability() {
+  _dmr_cap="$1"
+  _dmr_corpus_file="$2/$1.md"
+  _dmr_entries="$3"
+  _dmr_feature="$4"
+  _dmr_date="$5"
+  _dmr_existing="/dev/null"
+  [ -f "$_dmr_corpus_file" ] && _dmr_existing="$_dmr_corpus_file"
+
+  awk -v capslug="$_dmr_cap" -v feature="$_dmr_feature" -v date="$_dmr_date" -v entriesfile="$_dmr_entries" '
+    BEGIN { FS = "\t"; section = ""; cur_id = ""; body_acc = ""; pass1_open = 1 }
+    function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+    function flush_body() {
+      if (cur_id != "" && section == "req") req_body[cur_id] = trim(body_acc)
+      if (cur_id != "" && section == "removed") rem_body[cur_id] = trim(body_acc)
+      cur_id = ""; body_acc = ""
+    }
+    # ---- Passe 1: le o corpus EXISTENTE (arquivo 1). Distincao por
+    # FILENAME (NAO por FNR==NR — esse idioma falha quando o arquivo 1 e
+    # vazio/inexistente (/dev/null), pois NR nao avanca e a 1a linha do
+    # arquivo 2 tambem casaria FNR==NR). `pass1_open` fecha explicitamente
+    # o passe 1 (flush do ultimo corpo acumulado) na PRIMEIRA linha do
+    # passe 2 — sem isso, o `flush_body()` do END reflete estado STALE de
+    # cur_id/body_acc do passe 1 e sobrescreve um MODIFIED aplicado no
+    # passe 2 (bug real encontrado via teste manual: FR-001 modificado
+    # perdia o novo texto, retendo o corpo original do corpus). ----
+    FILENAME != entriesfile {
+      if ($0 ~ /^## Requirements[ \t]*$/) { flush_body(); section = "req"; next }
+      if ($0 ~ /^## Removed Requirements[ \t]*$/) { flush_body(); section = "removed"; next }
+      if ($0 ~ /^## Renamed Identifiers[ \t]*$/) { flush_body(); section = "renamed"; next }
+      if ($0 ~ /^## /) { flush_body(); section = ""; next }
+      if ($0 ~ /^# Capability:/) { next }
+      if (section == "req" && $0 ~ /^### FR-[0-9]+[ \t]*$/) {
+        flush_body()
+        cur_id = $0; sub(/^### /, "", cur_id); sub(/[ \t]+$/, "", cur_id)
+        req_active[cur_id] = 1
+        next
+      }
+      if (section == "removed" && $0 ~ /^### FR-[0-9]+ \[REMOVED\][ \t]*$/) {
+        flush_body()
+        cur_id = $0; sub(/^### /, "", cur_id); sub(/ \[REMOVED\].*/, "", cur_id)
+        rem_set[cur_id] = 1
+        next
+      }
+      if ((section == "req" || section == "removed") && $0 ~ /^\*Introduzida por: .*\([^)]*\)\*[ \t]*$/) {
+        line = $0
+        sub(/^\*Introduzida por: /, "", line); sub(/\*[ \t]*$/, "", line)
+        match(line, /\(([^)]*)\)$/)
+        dt = substr(line, RSTART + 1, RLENGTH - 2)
+        feat = trim(substr(line, 1, RSTART - 1))
+        if (section == "req") { req_intro_feat[cur_id] = feat; req_intro_date[cur_id] = dt }
+        else { rem_intro_feat[cur_id] = feat; rem_intro_date[cur_id] = dt }
+        next
+      }
+      if (section == "req" && $0 ~ /^\*Ultima modificacao: .*\([^)]*\)\*[ \t]*$/) {
+        line = $0
+        sub(/^\*Ultima modificacao: /, "", line); sub(/\*[ \t]*$/, "", line)
+        match(line, /\(([^)]*)\)$/)
+        dt = substr(line, RSTART + 1, RLENGTH - 2)
+        feat = trim(substr(line, 1, RSTART - 1))
+        req_mod_feat[cur_id] = feat; req_mod_date[cur_id] = dt
+        next
+      }
+      if (section == "removed" && index($0, "*Removida por: ") == 1) {
+        line = $0
+        sub(/^\*Removida por: /, "", line)
+        star = index(line, "*")
+        meta = substr(line, 1, star - 1)
+        rest = substr(line, star + 1)
+        sub(/^[ \t]*—[ \t]*/, "", rest)
+        match(meta, /\(([^)]*)\)$/)
+        dt = substr(meta, RSTART + 1, RLENGTH - 2)
+        feat = trim(substr(meta, 1, RSTART - 1))
+        rem_removed_feat[cur_id] = feat; rem_removed_date[cur_id] = dt; rem_removed_motivo[cur_id] = trim(rest)
+        next
+      }
+      if (section == "renamed" && $0 ~ /^\|/) {
+        if ($0 ~ /^\|[ \t]*-+/) next
+        if ($0 ~ /Antigo/ && $0 ~ /Novo/) next
+        m = split($0, cols, "|")
+        old = trim(cols[2]); new = trim(cols[3]); rfeat = trim(cols[4]); rdate = trim(cols[5])
+        if (old != "") {
+          ren_count++
+          ren_old[ren_count] = old; ren_new[ren_count] = new
+          ren_feat[ren_count] = rfeat; ren_date[ren_count] = rdate
+        }
+        next
+      }
+      if ((section == "req" || section == "removed") && cur_id != "" && $0 !~ /^\*/ && $0 !~ /^### / && $0 !~ /^[ \t]*$/) {
+        body_acc = body_acc " " $0
+        next
+      }
+      next
+    }
+    # ---- Passe 2: aplica as entradas ENTRY do delta (arquivo 2) ----
+    FILENAME == entriesfile {
+      if (pass1_open) { flush_body(); pass1_open = 0 }
+      if ($1 != "ENTRY") next
+      etype = $3; eid = $4; eid2 = $5; etext = $6
+      if (etype == "ADDED") {
+        req_active[eid] = 1
+        req_body[eid] = etext
+        req_intro_feat[eid] = feature; req_intro_date[eid] = date
+        added_count++
+      } else if (etype == "MODIFIED") {
+        req_body[eid] = etext
+        req_mod_feat[eid] = feature; req_mod_date[eid] = date
+        modified_count++
+      } else if (etype == "REMOVED") {
+        rem_set[eid] = 1
+        rem_body[eid] = req_body[eid]
+        rem_intro_feat[eid] = req_intro_feat[eid]; rem_intro_date[eid] = req_intro_date[eid]
+        rem_removed_feat[eid] = feature; rem_removed_date[eid] = date; rem_removed_motivo[eid] = etext
+        delete req_active[eid]
+        removed_count++
+      } else if (etype == "RENAMED") {
+        old = eid; new = eid2
+        req_active[new] = 1
+        req_body[new] = req_body[old]
+        req_intro_feat[new] = req_intro_feat[old]; req_intro_date[new] = req_intro_date[old]
+        if (old in req_mod_feat) { req_mod_feat[new] = req_mod_feat[old]; req_mod_date[new] = req_mod_date[old] }
+        delete req_active[old]
+        ren_count++
+        ren_old[ren_count] = old; ren_new[ren_count] = new
+        ren_feat[ren_count] = feature; ren_date[ren_count] = date
+        renamed_count++
+      }
+      next
+    }
+    function numid(id,   n) { n = id; sub(/^FR-/, "", n); return n + 0 }
+    function sort_ids(arr, n,    i, j, tmp) {
+      for (i = 1; i <= n; i++)
+        for (j = i + 1; j <= n; j++)
+          if (numid(arr[i]) > numid(arr[j])) { tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp }
+    }
+    END {
+      if (pass1_open) flush_body()
+      print "# Capability: " capslug
+      print ""
+      print "> Comportamento ATUAL do sistema para esta capability. Gerado/atualizado"
+      print "> exclusivamente por delta-merge.sh na acao de archive — nao editar a mao."
+      print ""
+      print "## Requirements"
+      print ""
+      nreq = 0
+      for (id in req_active) { nreq++; reqids[nreq] = id }
+      sort_ids(reqids, nreq)
+      for (i = 1; i <= nreq; i++) {
+        id = reqids[i]
+        print "### " id
+        print ""
+        print req_body[id]
+        print ""
+        print "*Introduzida por: " req_intro_feat[id] " (" req_intro_date[id] ")*"
+        if (id in req_mod_feat) {
+          print "*Ultima modificacao: " req_mod_feat[id] " (" req_mod_date[id] ")*"
+        }
+        print ""
+      }
+      nrem = 0
+      for (id in rem_set) { nrem++; remids[nrem] = id }
+      if (nrem > 0) {
+        sort_ids(remids, nrem)
+        print "## Removed Requirements"
+        print ""
+        for (i = 1; i <= nrem; i++) {
+          id = remids[i]
+          print "### " id " [REMOVED]"
+          print ""
+          print rem_body[id]
+          print ""
+          print "*Introduzida por: " rem_intro_feat[id] " (" rem_intro_date[id] ")*"
+          print "*Removida por: " rem_removed_feat[id] " (" rem_removed_date[id] ")* — " rem_removed_motivo[id]
+          print ""
+        }
+      }
+      if (ren_count > 0) {
+        print "## Renamed Identifiers"
+        print ""
+        print "| Antigo | Novo | Feature | Data |"
+        print "|--------|------|---------|------|"
+        for (i = 1; i <= ren_count; i++) {
+          print "| " ren_old[i] " | " ren_new[i] " | " ren_feat[i] " | " ren_date[i] " |"
+        }
+        print ""
+      }
+      printf "%%%%COUNTS%%%%|%d|%d|%d|%d\n", added_count, modified_count, removed_count, renamed_count
+    }
+  ' "$_dmr_existing" "$_dmr_entries"
+}
+
+# ------------------------------- main -------------------------------
+
+SPEC_MD=""
+FEATURE=""
+CORPUS_DIR=""
+DATE=""
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --feature)
+      [ $# -ge 2 ] || { _dm_usage; exit 2; }
+      FEATURE=$2; shift 2 ;;
+    --feature=*)
+      FEATURE=${1#--feature=}; shift ;;
+    --corpus-dir)
+      [ $# -ge 2 ] || { _dm_usage; exit 2; }
+      CORPUS_DIR=$2; shift 2 ;;
+    --corpus-dir=*)
+      CORPUS_DIR=${1#--corpus-dir=}; shift ;;
+    --date)
+      [ $# -ge 2 ] || { _dm_usage; exit 2; }
+      DATE=$2; shift 2 ;;
+    --date=*)
+      DATE=${1#--date=}; shift ;;
+    --dry-run)
+      DRY_RUN=1; shift ;;
+    -h|--help)
+      _dm_usage; exit 2 ;;
+    --*)
+      printf '%s: opcao desconhecida: %s\n' "$_DM_NAME" "$1" >&2
+      diag_emit error unknown-option "opcao desconhecida: $1" "consulte delta-merge.sh --help" || :
+      _dm_usage; exit 2 ;;
+    *)
+      if [ -z "$SPEC_MD" ]; then
+        SPEC_MD=$1; shift
+      else
+        printf '%s: argumento extra: %s\n' "$_DM_NAME" "$1" >&2
+        diag_emit error extra-argument "argumento extra: $1" "delta-merge.sh aceita apenas SPEC_MD + flags" || :
+        _dm_usage; exit 2
+      fi ;;
+  esac
+done
+
+if [ -z "$SPEC_MD" ]; then
+  _dm_usage; exit 2
+fi
+if [ ! -f "$SPEC_MD" ]; then
+  printf '%s: spec nao encontrado: %s\n' "$_DM_NAME" "$SPEC_MD" >&2
+  diag_emit error spec-not-found "spec.md nao encontrado: $SPEC_MD" "verifique o path de SPEC_MD" || :
+  exit 2
+fi
+if [ -z "$FEATURE" ]; then
+  printf '%s: --feature e obrigatorio\n' "$_DM_NAME" >&2
+  diag_emit error feature-missing "--feature NAME nao informado" "passe --feature <short-name> da feature que origina a mudanca" || :
+  _dm_usage; exit 2
+fi
+if [ -z "$DATE" ]; then
+  DATE=$(date -u +%Y-%m-%d)
+fi
+
+if [ -z "$CORPUS_DIR" ]; then
+  if ! CORPUS_DIR=$(_dg_resolve_corpus_dir "$SPEC_MD"); then
+    printf '%s: nao foi possivel resolver --corpus-dir (SPEC_MD fora da convencao docs/specs/<feature>/spec.md)\n' "$_DM_NAME" >&2
+    diag_emit error corpus-dir-unresolvable "corpus-dir nao resolvido para $SPEC_MD" "passe --corpus-dir explicitamente" || :
+    exit 2
+  fi
+fi
+
+ERRORS=0
+PARSE_OUT=$(mktemp)
+trap 'rm -f "$PARSE_OUT"' EXIT
+_dg_parse_spec "$SPEC_MD" > "$PARSE_OUT"
+
+DELTA_STATUS=$(awk -F"$(printf '\t')" '$1=="__STATUS__"{print $2}' "$PARSE_OUT")
+
+while IFS= read -r _dm_line; do
+  case "$_dm_line" in
+    FINDING\|error\|*)
+      printf '%s\n' "$_dm_line"
+      ERRORS=$((ERRORS + 1)) ;;
+    FINDING\|*)
+      printf '%s\n' "$_dm_line" ;;
+  esac
+done < "$PARSE_OUT"
+
+if [ "$DELTA_STATUS" = "skip" ] && [ "$ERRORS" -eq 0 ]; then
+  printf 'RESULT|%s|delta=skip|added=0|modified=0|removed=0|renamed=0\n' "$SPEC_MD"
+  exit 0
+fi
+
+if [ "$ERRORS" -gt 0 ]; then
+  printf 'RESULT|%s|delta=blocked|added=0|modified=0|removed=0|renamed=0\n' "$SPEC_MD"
+  exit 1
+fi
+
+# Validacao referencial + estrutural por capability (mesma logica do gate —
+# defesa em profundidade, invariante 2-ter do contrato: NUNCA confia que
+# delta-gate.sh rodou antes).
+CAPS=$(awk -F"$(printf '\t')" '$1=="ENTRY"{print $2}' "$PARSE_OUT" | sort -u)
+for _cap in $CAPS; do
+  _dg_process_capability "$_cap" "$CORPUS_DIR" "$PARSE_OUT"
+done
+
+if [ "$ERRORS" -gt 0 ]; then
+  printf 'RESULT|%s|delta=blocked|added=0|modified=0|removed=0|renamed=0\n' "$SPEC_MD"
+  exit 1
+fi
+
+if [ -z "$CAPS" ]; then
+  printf 'RESULT|%s|delta=applied|added=0|modified=0|removed=0|renamed=0\n' "$SPEC_MD"
+  exit 0
+fi
+
+TAB="$(printf '\t')"
+TOTAL_ADDED=0
+TOTAL_MODIFIED=0
+TOTAL_REMOVED=0
+TOTAL_RENAMED=0
+
+# Fase 1: renderiza TODAS as capabilities para arquivos temporarios ANTES de
+# qualquer mv (atomicidade multi-capability — invariante 3.7.6).
+_pending_list=""
+for _cap in $CAPS; do
+  _entries=$(mktemp)
+  awk -F"$TAB" -v c="$_cap" '$1=="ENTRY" && $2==c {print}' "$PARSE_OUT" > "$_entries"
+  _rendered=$(mktemp)
+  _dm_render_capability "$_cap" "$CORPUS_DIR" "$_entries" "$FEATURE" "$DATE" > "$_rendered"
+  rm -f "$_entries"
+
+  _counts=$(grep '^%%COUNTS%%' "$_rendered")
+  _added=$(printf '%s' "$_counts" | cut -d'|' -f2)
+  _modified=$(printf '%s' "$_counts" | cut -d'|' -f3)
+  _removed=$(printf '%s' "$_counts" | cut -d'|' -f4)
+  _renamed=$(printf '%s' "$_counts" | cut -d'|' -f5)
+  TOTAL_ADDED=$((TOTAL_ADDED + _added))
+  TOTAL_MODIFIED=$((TOTAL_MODIFIED + _modified))
+  TOTAL_REMOVED=$((TOTAL_REMOVED + _removed))
+  TOTAL_RENAMED=$((TOTAL_RENAMED + _renamed))
+
+  _final=$(mktemp)
+  grep -v '^%%COUNTS%%' "$_rendered" > "$_final"
+  rm -f "$_rendered"
+
+  _pending_list="$_pending_list $_cap:$_final"
+done
+
+if [ "$DRY_RUN" = "1" ]; then
+  for _pair in $_pending_list; do
+    _f=${_pair#*:}
+    rm -f "$_f"
+  done
+  printf 'RESULT|%s|delta=applied|added=%d|modified=%d|removed=%d|renamed=%d\n' \
+    "$SPEC_MD" "$TOTAL_ADDED" "$TOTAL_MODIFIED" "$TOTAL_REMOVED" "$TOTAL_RENAMED"
+  exit 0
+fi
+
+mkdir -p "$CORPUS_DIR"
+for _pair in $_pending_list; do
+  _cap=${_pair%%:*}
+  _f=${_pair#*:}
+  mv "$_f" "$CORPUS_DIR/$_cap.md"
+done
+
+printf 'RESULT|%s|delta=applied|added=%d|modified=%d|removed=%d|renamed=%d\n' \
+  "$SPEC_MD" "$TOTAL_ADDED" "$TOTAL_MODIFIED" "$TOTAL_REMOVED" "$TOTAL_RENAMED"
+exit 0

--- a/global/skills/specify/SKILL.md
+++ b/global/skills/specify/SKILL.md
@@ -353,6 +353,39 @@ NAO deixar implicito — `N/A explicito > silencio`.
 - "Database handles 1000 TPS" (detalhe de implementacao)
 - "React components render efficiently" (framework-specific)
 
+**Delta Requirements (opcional — secao `## Delta Requirements`):**
+
+Preencher quando a feature adiciona, muda, remove ou renomeia
+comportamento HOJE ATIVO do sistema-alvo (algo ja documentado no corpus
+canonico `docs/specs/current/`) — contrato completo em
+`docs/specs/living-specs/contracts/delta-section-format.md`.
+
+- Antes de declarar uma `### Capability: <slug>` NOVA, rodar
+  `ls docs/specs/current/*.md 2>/dev/null` (lista vazia e resultado
+  valido — corpus pode nao existir ainda) e reusar o slug ja existente
+  sempre que a feature tocar o MESMO conceito, em vez de fragmentar em
+  um slug novo semanticamente equivalente (ex.: `commit-mode` vs
+  `commit-staging` referindo-se ao mesmo mecanismo). Essa decisao e
+  julgamento do autor da spec — a validacao de FORMA do slug fica a
+  cargo de `delta-gate.sh`, rodado apenas no momento do archive
+  (`specify` nunca invoca o gate diretamente).
+- Feature que nao toca comportamento ativo (puramente nova, ou
+  doc-only/meta) usa o marcador de Skip em vez dos blocos
+  `### Capability:` (mutuamente exclusivos): `**Skip**: <justificativa
+  nao-vazia> — <autor>, <YYYY-MM-DD>` — os 3 campos sao obrigatorios.
+- Exemplo minimo de bloco preenchido:
+
+  ```markdown
+  ## Delta Requirements
+
+  ### Capability: commit-mode
+
+  #### ADDED
+
+  - **FR-018**: Sistema MUST suportar staging por allowlist derivada no
+    modo atomic-commit
+  ```
+
 ---
 
 ## ETAPA 4: VALIDACAO

--- a/global/skills/specify/templates/feature-spec.md
+++ b/global/skills/specify/templates/feature-spec.md
@@ -76,3 +76,49 @@
 - **SC-001**: [Metrica mensuravel, ex: "Usuarios completam cadastro em menos de 2 minutos"]
 - **SC-002**: [Metrica mensuravel, ex: "Sistema suporta 1000 usuarios concorrentes"]
 - **SC-003**: [Metrica de satisfacao, ex: "90% dos usuarios completam a tarefa na primeira tentativa"]
+
+## Delta Requirements
+
+<!--
+  OPCIONAL. Preencha esta secao apenas se a feature adiciona, muda,
+  remove ou renomeia comportamento HOJE ATIVO do sistema-alvo (algo que
+  ja esta documentado no corpus canonico `docs/specs/current/`). Feature
+  puramente nova (sem nada ativo pra alterar) ou puramente doc-only/meta
+  pode pular os blocos abaixo e usar o marcador de Skip.
+
+  Antes de declarar uma `### Capability: <slug>` NOVA, rode
+  `ls docs/specs/current/*.md 2>/dev/null` (lista vazia e valida — corpus
+  pode nao existir ainda) e reuse o slug ja existente sempre que a
+  feature tocar o MESMO conceito, em vez de fragmentar em um slug novo
+  semanticamente equivalente (ex.: `commit-mode` vs `commit-staging`).
+
+  Cada bloco `### Capability:` pode conter 1 ou mais dos 4 grupos abaixo.
+  Seta do RENAMED e SEMPRE ASCII `->` (nunca `→`).
+-->
+
+### Capability: <capability-slug>
+
+#### ADDED
+
+- **FR-NNN**: <texto integral do requisito — mesmo id usado em
+  `### Functional Requirements` acima>
+
+#### MODIFIED
+
+- **FR-NNN**: <novo texto integral que substitui a entrada do corpus>
+
+#### REMOVED
+
+- **FR-NNN**: <motivo da remocao>
+
+#### RENAMED
+
+- **FR-NNN -> FR-MMM**
+
+<!--
+  Forma alternativa — mutuamente exclusiva com os blocos acima. Use
+  quando a feature nao precisa tocar o corpus (os 3 campos sao
+  obrigatorios):
+
+  **Skip**: <justificativa nao-vazia> — <autor>, <YYYY-MM-DD>
+-->

--- a/tests/test_commit-mode.sh
+++ b/tests/test_commit-mode.sh
@@ -16,6 +16,12 @@
 #   - stage-message: todos os stages mapeados
 #   - task-message: ID unico, range, lista
 #   - guard-branch: git ausente => exit 1
+#   - snapshot: baseline ordenado; uso incorreto => exit 2
+#   - stage-derived (living-specs FASE 5, FR-014..FR-017): regressao do
+#     incidente .pptx — scope-dir exclui alheio, task-baseline inclui
+#     arquivo novo, baseline ausente => untracked fora (fail-closed),
+#     allowlist vazia => exit 3, paths com espaco/unicode, rename,
+#     roundtrip real via 'git show --name-only'
 #   - is-enabled: campo=true => stdout "true"
 
 TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
@@ -398,6 +404,220 @@ scenario_fr015c_guard_branch_nao_default_nao_bloqueia() {
 
   capture "$SCRIPT" guard-branch --state-dir "$_sd" --projeto-alvo-path "$_gdir"
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "feat/: exit esperado 0" "obtido $_CAPTURED_EXIT"; return 1; }
+}
+
+# ==== snapshot: grava baseline ordenado de untracked ====
+
+scenario_snapshot_grava_baseline_untracked_ordenado() {
+  _gdir="$TMPDIR_TEST/repo-snap"
+  _sd="$TMPDIR_TEST/sd-snap"
+  _init_git_repo "$_gdir" "feat/snap"
+  printf 'b\n' > "$_gdir/beta.txt"
+  printf 'a\n' > "$_gdir/alpha.txt"
+
+  capture "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$_sd/commit-baseline.txt" ] || { _fail "baseline nao gravado" "arquivo ausente"; return 1; }
+
+  _expected="alpha.txt
+beta.txt"
+  _got=$(cat "$_sd/commit-baseline.txt")
+  [ "$_got" = "$_expected" ] || { _fail "baseline ordenado" "esperado '$_expected' obtido '$_got'"; return 1; }
+}
+
+# ==== snapshot: uso incorreto sem --state-dir/--projeto-alvo-path => exit 2 ====
+
+scenario_snapshot_uso_incorreto_exit2() {
+  capture "$SCRIPT" snapshot --state-dir "$TMPDIR_TEST/x"
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit esperado 2" "obtido $_CAPTURED_EXIT"; return 1; }
+}
+
+# ==== 5.3.1: commit de etapa (scope-dir) exclui alheio pre-existente ====
+
+scenario_5_3_1_stagederived_scope_dir_exclui_alien() {
+  _gdir="$TMPDIR_TEST/repo-etapa"
+  _sd="$TMPDIR_TEST/sd-etapa"
+  _init_git_repo "$_gdir" "feat/etapa"
+
+  # Alheio untracked PRE-EXISTENTE (analogo ao incidente .pptx real).
+  printf 'alien\n' > "$_gdir/alien.pptx"
+
+  capture "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  mkdir -p "$_gdir/docs/specs/feat-x"
+  printf 's\n' > "$_gdir/docs/specs/feat-x/plan.md"
+
+  capture "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir" \
+    --scope-dir "docs/specs/feat-x"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "stage-derived exit" "obtido $_CAPTURED_EXIT stderr='$_CAPTURED_STDERR'"; return 1; }
+
+  _staged=$(git -C "$_gdir" diff --cached --name-only)
+  case "$_staged" in
+    *alien.pptx*) _fail "alien.pptx nao deveria estar staged" "obtido: $_staged"; return 1 ;;
+  esac
+  case "$_staged" in
+    *"docs/specs/feat-x/plan.md"*) : ;;
+    *) _fail "plan.md deveria estar staged" "obtido: $_staged"; return 1 ;;
+  esac
+
+  _untracked=$(git -C "$_gdir" status --porcelain | grep '^??' || :)
+  case "$_untracked" in
+    *alien.pptx*) : ;;
+    *) _fail "alien.pptx deveria permanecer untracked" "obtido: $_untracked"; return 1 ;;
+  esac
+}
+
+# ==== 5.3.2: commit de task (baseline + arquivo novo pos-snapshot) inclui o novo ====
+
+scenario_5_3_2_stagederived_task_baseline_inclui_novo_arquivo() {
+  _gdir="$TMPDIR_TEST/repo-task"
+  _sd="$TMPDIR_TEST/sd-task"
+  _init_git_repo "$_gdir" "feat/task"
+  printf 'alien\n' > "$_gdir/alien.pptx"
+
+  capture "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  mkdir -p "$_gdir/cli"
+  printf 'helper\n' > "$_gdir/cli/new-helper.sh"
+
+  capture "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "stage-derived exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  _staged=$(git -C "$_gdir" diff --cached --name-only)
+  case "$_staged" in
+    *"cli/new-helper.sh"*) : ;;
+    *) _fail "new-helper.sh deveria estar staged" "obtido: $_staged"; return 1 ;;
+  esac
+  case "$_staged" in
+    *alien.pptx*) _fail "alien.pptx nao deveria estar staged" "obtido: $_staged"; return 1 ;;
+  esac
+}
+
+# ==== 5.3.3: baseline AUSENTE => untracked todos fora, fail-closed ====
+
+scenario_5_3_3_stagederived_baseline_ausente_untracked_fora() {
+  _gdir="$TMPDIR_TEST/repo-nobase"
+  _sd="$TMPDIR_TEST/sd-nobase"
+  _init_git_repo "$_gdir" "feat/nobase"
+  mkdir -p "$_sd"
+
+  printf 'novo\n' > "$_gdir/untracked-novo.txt"
+  printf 'a\n' >> "$_gdir/README.md"
+
+  capture "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "stage-derived exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  case "$_CAPTURED_STDERR" in
+    *baseline*) : ;;
+    *) _fail "aviso de baseline ausente esperado em stderr" "obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+
+  _staged=$(git -C "$_gdir" diff --cached --name-only)
+  case "$_staged" in
+    *untracked-novo.txt*) _fail "untracked sem baseline nao deveria ser staged" "obtido: $_staged"; return 1 ;;
+  esac
+  case "$_staged" in
+    *README.md*) : ;;
+    *) _fail "README.md (tracked) deveria estar staged mesmo sem baseline" "obtido: $_staged"; return 1 ;;
+  esac
+}
+
+# ==== 5.3.4: allowlist vazia (fixture limpa) => exit 3, nenhum commit ====
+
+scenario_5_3_4_stagederived_allowlist_vazia_exit3() {
+  _gdir="$TMPDIR_TEST/repo-clean"
+  _sd="$TMPDIR_TEST/sd-clean"
+  _init_git_repo "$_gdir" "feat/clean"
+
+  capture "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  capture "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "exit esperado 3" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  _cached=$(git -C "$_gdir" diff --cached --name-only)
+  [ -z "$_cached" ] || { _fail "diff --cached deveria estar vazio" "obtido: $_cached"; return 1; }
+}
+
+# ==== 5.3.6: path com espaco e char nao-ASCII, tracked e untracked ====
+
+scenario_5_3_6_stagederived_paths_espaco_unicode() {
+  _gdir="$TMPDIR_TEST/repo-unicode"
+  _sd="$TMPDIR_TEST/sd-unicode"
+  mkdir -p "$_gdir"
+  git -C "$_gdir" init -q
+  git -C "$_gdir" config user.email "test@test.com"
+  git -C "$_gdir" config user.name "Test"
+  printf 'a\n' > "$_gdir/tracked file.txt"
+  git -C "$_gdir" add -A 2>/dev/null
+  git -C "$_gdir" commit -q -m init 2>/dev/null
+  git -C "$_gdir" checkout -q -b "feat/unicode" 2>/dev/null
+
+  capture "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  printf 'b\n' >> "$_gdir/tracked file.txt"
+  printf 'n\n' > "$_gdir/new \303\274nicode file.txt"
+
+  capture "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "stage-derived exit" "obtido $_CAPTURED_EXIT stderr='$_CAPTURED_STDERR'"; return 1; }
+
+  _count=$(git -C "$_gdir" diff --cached --name-only | wc -l | tr -d ' ')
+  [ "$_count" = 2 ] || { _fail "esperado 2 paths staged (tracked+unicode)" "obtido $_count: $(git -C "$_gdir" diff --cached --name-only)"; return 1; }
+}
+
+# ==== rename: path novo staged, path antigo descartado (formato -z) ====
+
+scenario_stagederived_rename_stage_path_novo() {
+  _gdir="$TMPDIR_TEST/repo-rename"
+  _sd="$TMPDIR_TEST/sd-rename"
+  _init_git_repo "$_gdir" "feat/rename"
+  printf 'conteudo estavel o suficiente para o git detectar rename\n' > "$_gdir/oldname.txt"
+  git -C "$_gdir" add -A 2>/dev/null
+  git -C "$_gdir" commit -q -m "add oldname" 2>/dev/null
+
+  capture "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  git -C "$_gdir" mv oldname.txt newname.txt 2>/dev/null
+
+  capture "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "stage-derived exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  _staged=$(git -C "$_gdir" diff --cached --name-status)
+  case "$_staged" in
+    *newname.txt*) : ;;
+    *) _fail "newname.txt deveria estar staged" "obtido: $_staged"; return 1 ;;
+  esac
+}
+
+# ==== roundtrip real: git show --name-only HEAD confirma alheio ausente em TODOS os commits ====
+
+scenario_5_3_5_roundtrip_git_show_alien_ausente() {
+  _gdir="$TMPDIR_TEST/repo-roundtrip"
+  _sd="$TMPDIR_TEST/sd-roundtrip"
+  _init_git_repo "$_gdir" "feat/roundtrip"
+  printf 'alien\n' > "$_gdir/alien.pptx"
+
+  capture "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  printf 'novo\n' > "$_gdir/legit.txt"
+  capture "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "stage-derived exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  git -C "$_gdir" commit -q -m "add legit.txt" 2>/dev/null
+
+  _shown=$(git -C "$_gdir" show --name-only --format= HEAD)
+  case "$_shown" in
+    *alien.pptx*) _fail "alien.pptx nao deveria aparecer no commit real" "obtido: $_shown"; return 1 ;;
+  esac
+  case "$_shown" in
+    *legit.txt*) : ;;
+    *) _fail "legit.txt deveria estar no commit" "obtido: $_shown"; return 1 ;;
+  esac
 }
 
 run_all_scenarios

--- a/tests/test_delta-gate.sh
+++ b/tests/test_delta-gate.sh
@@ -1,0 +1,421 @@
+#!/bin/sh
+# test_delta-gate.sh —
+# cobre global/skills/review-features/scripts/delta-gate.sh.
+#
+# Contrato: docs/specs/living-specs/contracts/delta-gate-cli.md
+#   delta-gate.sh SPEC_MD [--corpus-dir DIR]
+#     Emite FINDING|<severity>|<code>|<mensagem> e um
+#     RESULT|<spec>|delta=<present|skip|missing>|errors=<N>|warnings=<M>.
+#     Exit: 0 liberado (delta valida ou skip valido); 1 bloqueado (>=1 erro);
+#     2 uso incorreto / SPEC_MD inexistente / corpus-dir irresoluvel.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/review-features/scripts/delta-gate.sh"
+
+# Escreve $1 em $TMPDIR_TEST/spec.md e retorna o path via stdout.
+_write_spec() {
+  _dest="$TMPDIR_TEST/spec.md"
+  printf '%s\n' "$1" > "$_dest"
+  printf '%s' "$_dest"
+}
+
+_corpus_dir() {
+  printf '%s/current' "$TMPDIR_TEST"
+}
+
+_write_corpus_file() {
+  # $1 = slug, $2 = conteudo
+  _cd=$(_corpus_dir)
+  mkdir -p "$_cd"
+  printf '%s\n' "$2" > "$_cd/$1.md"
+}
+
+_BASE_CORPUS='# Capability: sample-cap
+
+> Comportamento ATUAL do sistema para esta capability.
+
+## Requirements
+
+### FR-001
+
+Texto do requisito 1.
+
+*Introduzida por: feat-orig (2026-01-01)*
+
+### FR-002
+
+Texto do requisito 2.
+
+*Introduzida por: feat-orig (2026-01-01)*
+
+## Removed Requirements
+
+### FR-003 [REMOVED]
+
+Texto antigo.
+
+*Introduzida por: feat-orig (2026-01-01)*
+*Removida por: feat-y (2026-02-01)* — obsoleto
+
+## Renamed Identifiers
+
+| Antigo | Novo | Feature | Data |
+|--------|------|---------|------|
+| FR-004 | FR-005 | feat-z | 2026-03-01 |'
+
+# ==== 3.5.1 happy-path ====
+
+scenario_added_corpus_ausente_info_exit0() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### ADDED
+
+- **FR-010**: Novo requisito.')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|info|corpus-missing|sample-cap" || return 1
+  assert_stdout_contains "delta=present|errors=0" || return 1
+}
+
+scenario_modified_removed_sobre_corpus_existente() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### MODIFIED
+
+- **FR-001**: Novo texto do requisito 1.
+
+#### REMOVED
+
+- **FR-002**: motivo da remocao.')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_not_contains "FINDING|error" || return 1
+  assert_stdout_contains "delta=present|errors=0" || return 1
+}
+
+scenario_removed_only_valida() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### REMOVED
+
+- **FR-002**: motivo qualquer.')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "delta=present|errors=0" || return 1
+}
+
+# ==== 3.5.2 bloqueio ====
+
+scenario_sem_secao_delta_missing() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Success Criteria
+Nada aqui.')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|delta-missing|" || return 1
+  assert_stdout_contains "delta=missing|errors=1" || return 1
+}
+
+scenario_skip_invalido() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+**Skip**: sem autor nem data')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|skip-invalid|" || return 1
+}
+
+scenario_skip_com_delta_simultaneo() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+**Skip**: justificativa valida — Jot, 2026-07-22
+
+### Capability: sample-cap
+
+#### ADDED
+
+- **FR-010**: Novo requisito.')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|skip-with-delta|" || return 1
+}
+
+scenario_secao_vazia_delta_empty() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+## Success Criteria
+Nada aqui.')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|delta-empty|" || return 1
+}
+
+scenario_entrada_malformada() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### ADDED
+
+texto solto sem marcador de entrada')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|entry-malformed|" || return 1
+}
+
+# ==== 3.5.1 skip valido isolado (complementa happy-path) ====
+
+scenario_skip_valido_isolado_exit0() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+**Skip**: feature pure-doc sem capability tocada — Jot, 2026-07-22')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_not_contains "FINDING|" || return 1
+  assert_stdout_contains "delta=skip|errors=0" || return 1
+}
+
+# ==== 3.5.3 referencial ====
+
+scenario_ref_not_found_modified() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### MODIFIED
+
+- **FR-999**: texto.')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|ref-not-found|" || return 1
+}
+
+scenario_ref_not_found_removed() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### REMOVED
+
+- **FR-999**: motivo.')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|ref-not-found|" || return 1
+}
+
+scenario_ref_not_found_renamed() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### RENAMED
+
+- **FR-999 -> FR-020**')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|ref-not-found|" || return 1
+}
+
+scenario_added_collision() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### ADDED
+
+- **FR-001**: duplicado.')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|added-collision|" || return 1
+}
+
+scenario_renamed_target_exists() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### RENAMED
+
+- **FR-002 -> FR-003**')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|renamed-target-exists|" || return 1
+}
+
+# ==== 3.5.4 corpus-malformed (CHK034: bloqueia antes de checar referencias) ====
+
+scenario_corpus_malformed_bloqueia_antes_de_referencial() {
+  _write_corpus_file "sample-cap" '# Capability: sample-cap
+
+## Requirements
+
+### FR-001
+
+texto
+
+### FR-001
+
+texto duplicado (heading repetido — corpus editado a mao)'
+
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### MODIFIED
+
+- **FR-999**: id que tambem seria ref-not-found se a checagem referencial rodasse.')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|corpus-malformed|" || return 1
+  assert_stdout_not_contains "ref-not-found" || return 1
+}
+
+# ==== 3.5.5 seguranca: slug hostil ====
+
+scenario_slug_hostil_path_traversal() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: ../escape
+
+#### ADDED
+
+- **FR-001**: x')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|capability-slug-invalid|" || return 1
+  # Nenhum path fora do corpus-dir foi tocado/lido — o teste antecipa que
+  # o arquivo ../current/escape.md (fora de TMPDIR_TEST) jamais e referenciado
+  # verificando ausencia de qualquer FINDING de corpus (malformed/missing)
+  # para o slug hostil.
+  assert_stdout_not_contains "corpus-missing" || return 1
+}
+
+scenario_slug_hostil_path_absoluto() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: /etc/passwd
+
+#### ADDED
+
+- **FR-001**: x')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|capability-slug-invalid|" || return 1
+}
+
+scenario_slug_hostil_com_espaco() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: has space
+
+#### ADDED
+
+- **FR-001**: x')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|capability-slug-invalid|" || return 1
+}
+
+# ==== 3.5.6 determinismo ====
+
+scenario_determinismo_stdout_identico() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### MODIFIED
+
+- **FR-001**: Novo texto.
+
+#### ADDED
+
+- **FR-011**: Requisito novo.')
+
+  capture sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  _out1="$_CAPTURED_STDOUT"
+  capture sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  _out2="$_CAPTURED_STDOUT"
+  if [ "$_out1" != "$_out2" ]; then
+    _fail "determinismo" "stdout divergiu entre duas execucoes do mesmo input"
+    return 1
+  fi
+  return 0
+}
+
+# ==== 3.5.7 uso incorreto ====
+
+scenario_spec_md_inexistente() {
+  assert_exit 2 sh "$SCRIPT" "$TMPDIR_TEST/nao-existe/spec.md" || return 1
+  assert_stderr_contains "nao encontrado" || return 1
+  assert_stderr_contains "DIAG|error|spec-not-found|" || return 1
+}
+
+scenario_corpus_dir_irresoluvel_sem_convencao() {
+  _dest="$TMPDIR_TEST/random-name.md"
+  printf '# Feature Spec: fixture\n' > "$_dest"
+
+  assert_exit 2 sh "$SCRIPT" "$_dest" || return 1
+  assert_stderr_contains "DIAG|error|corpus-dir-unresolvable|" || return 1
+}
+
+scenario_sem_argumentos() {
+  assert_exit 2 sh "$SCRIPT" || return 1
+  assert_stderr_contains "Uso:" || return 1
+}
+
+run_all_scenarios

--- a/tests/test_delta-merge.sh
+++ b/tests/test_delta-merge.sh
@@ -1,0 +1,322 @@
+#!/bin/sh
+# test_delta-merge.sh —
+# cobre global/skills/review-features/scripts/delta-merge.sh.
+#
+# Contrato: docs/specs/living-specs/contracts/delta-merge-cli.md
+#   delta-merge.sh SPEC_MD --feature NAME [--corpus-dir DIR]
+#     [--date YYYY-MM-DD] [--dry-run]
+#     Emite FINDING|<severity>|<code>|<mensagem> e um
+#     RESULT|<spec>|delta=<applied|skip|blocked>|added=<N>|modified=<N>|
+#     removed=<N>|renamed=<N>.
+#     Exit: 0 aplicado (ou dry-run valido, ou skip); 1 bloqueado; 2 uso incorreto.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/review-features/scripts/delta-merge.sh"
+
+_write_spec() {
+  _dest="$TMPDIR_TEST/spec.md"
+  printf '%s\n' "$1" > "$_dest"
+  printf '%s' "$_dest"
+}
+
+_corpus_dir() {
+  printf '%s/current' "$TMPDIR_TEST"
+}
+
+_write_corpus_file() {
+  _cd=$(_corpus_dir)
+  mkdir -p "$_cd"
+  printf '%s\n' "$2" > "$_cd/$1.md"
+}
+
+_BASE_CORPUS='# Capability: sample-cap
+
+## Requirements
+
+### FR-001
+
+Texto do requisito 1.
+
+*Introduzida por: feat-orig (2026-01-01)*
+
+### FR-002
+
+Texto do requisito 2.
+
+*Introduzida por: feat-orig (2026-01-01)*'
+
+# ==== 3.9.1 happy path ADDED: corpus inexistente => criado ====
+
+scenario_added_cria_corpus_com_provenencia() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### ADDED
+
+- **FR-001**: Requisito inaugural.')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --feature feat-x --corpus-dir "$(_corpus_dir)" --date 2026-07-22 || return 1
+  assert_stdout_contains "delta=applied|added=1|modified=0|removed=0|renamed=0" || return 1
+
+  _corpus_file="$(_corpus_dir)/sample-cap.md"
+  [ -f "$_corpus_file" ] || { _fail "arquivo_nao_criado" "$_corpus_file ausente"; return 1; }
+  case "$(cat "$_corpus_file")" in
+    *"### FR-001"*"Requisito inaugural."*"Introduzida por: feat-x (2026-07-22)"*) : ;;
+    *) _fail "conteudo_incorreto" "arquivo criado sem os campos esperados"; return 1 ;;
+  esac
+}
+
+# ==== 3.9.2 MODIFIED/REMOVED sobre corpus existente ====
+
+scenario_modified_preserva_id_atualiza_texto() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### MODIFIED
+
+- **FR-001**: Texto atualizado.')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --feature feat-y --corpus-dir "$(_corpus_dir)" --date 2026-07-23 || return 1
+  assert_stdout_contains "delta=applied|added=0|modified=1|removed=0|renamed=0" || return 1
+
+  _content=$(cat "$(_corpus_dir)/sample-cap.md")
+  case "$_content" in
+    *"### FR-001"*"Texto atualizado."*"Introduzida por: feat-orig (2026-01-01)"*"Ultima modificacao: feat-y (2026-07-23)"*) : ;;
+    *) _fail "modified_incorreto" "id/provenencia nao preservados corretamente: $_content"; return 1 ;;
+  esac
+}
+
+scenario_removed_move_para_removed_requirements_com_motivo() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### REMOVED
+
+- **FR-002**: nao e mais necessario.')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --feature feat-z --corpus-dir "$(_corpus_dir)" --date 2026-07-24 || return 1
+  assert_stdout_contains "delta=applied|added=0|modified=0|removed=1|renamed=0" || return 1
+
+  _content=$(cat "$(_corpus_dir)/sample-cap.md")
+  case "$_content" in
+    *"## Removed Requirements"*"### FR-002 [REMOVED]"*"Removida por: feat-z (2026-07-24)"*"— nao e mais necessario."*) : ;;
+    *) _fail "removed_incorreto" "entrada nao movida corretamente: $_content"; return 1 ;;
+  esac
+  case "$_content" in
+    *"### FR-002"$'\n'*)
+      if printf '%s\n' "$_content" | grep -q '^## Requirements$'; then
+        _reqsec=$(printf '%s\n' "$_content" | awk '/^## Requirements$/,/^## Removed Requirements$/')
+        case "$_reqsec" in
+          *"### FR-002"*) _fail "removed_ainda_ativo" "FR-002 ainda aparece em Requirements"; return 1 ;;
+        esac
+      fi
+      ;;
+  esac
+}
+
+# ==== 3.9.3 skip: no-op declarado ====
+
+scenario_skip_no_op_corpus_intacto() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _corpus_file="$(_corpus_dir)/sample-cap.md"
+  _before=$(cksum "$_corpus_file")
+
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+**Skip**: feature pure-doc — Jot, 2026-07-22')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --feature feat-skip --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "delta=skip|added=0|modified=0|removed=0|renamed=0" || return 1
+
+  _after=$(cksum "$_corpus_file")
+  [ "$_before" = "$_after" ] || { _fail "corpus_mudou" "skip deveria ser no-op"; return 1; }
+}
+
+# ==== 3.9.4 atomicidade: erro na 2a capability bloqueia TUDO ====
+
+scenario_atomicidade_erro_2a_capability_bloqueia_tudo() {
+  _write_corpus_file "cap-a" "# Capability: cap-a
+
+## Requirements
+
+### FR-001
+
+Texto A.
+
+*Introduzida por: orig (2026-01-01)*"
+  _cap_a_file="$(_corpus_dir)/cap-a.md"
+  _before_a=$(cksum "$_cap_a_file")
+
+  _spec=$(_write_spec '# Feature Spec: multi
+
+## Delta Requirements
+
+### Capability: cap-a
+
+#### MODIFIED
+
+- **FR-001**: Texto A atualizado.
+
+### Capability: cap-b
+
+#### MODIFIED
+
+- **FR-999**: id inexistente, deve bloquear tudo.')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --feature multi-feat --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "delta=blocked|added=0|modified=0|removed=0|renamed=0" || return 1
+
+  _after_a=$(cksum "$_cap_a_file")
+  [ "$_before_a" = "$_after_a" ] || { _fail "cap_a_mudou" "cap-a deveria permanecer intocado (atomicidade multi-capability)"; return 1; }
+  [ -f "$(_corpus_dir)/cap-b.md" ] && { _fail "cap_b_criado" "cap-b.md nao deveria ter sido criado"; return 1; }
+  return 0
+}
+
+# ==== 3.9.5 --dry-run: contagens corretas, zero escrita ====
+
+scenario_dry_run_reporta_contagens_sem_escrever() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _corpus_file="$(_corpus_dir)/sample-cap.md"
+  _before=$(cksum "$_corpus_file")
+
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### ADDED
+
+- **FR-010**: novo requisito dry-run.')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --feature feat-dry --corpus-dir "$(_corpus_dir)" --dry-run || return 1
+  assert_stdout_contains "delta=applied|added=1|modified=0|removed=0|renamed=0" || return 1
+
+  _after=$(cksum "$_corpus_file")
+  [ "$_before" = "$_after" ] || { _fail "dry_run_escreveu" "dry-run nao deveria alterar o corpus"; return 1; }
+}
+
+# ==== 3.9.6 corpus-malformed bloqueia o merge (nao so o gate) ====
+
+scenario_corpus_malformed_bloqueia_merge() {
+  _write_corpus_file "broken" '# Capability: broken
+
+## Requirements
+
+### FR-001
+
+texto
+
+### FR-001
+
+duplicado (corpus editado a mao)'
+  _broken_file="$(_corpus_dir)/broken.md"
+  _before=$(cksum "$_broken_file")
+
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: broken
+
+#### MODIFIED
+
+- **FR-001**: novo texto.')
+
+  assert_exit 1 sh "$SCRIPT" "$_spec" --feature feat-broken --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stdout_contains "FINDING|error|corpus-malformed|" || return 1
+
+  _after=$(cksum "$_broken_file")
+  [ "$_before" = "$_after" ] || { _fail "corpus_malformed_mudou" "corpus malformado deveria permanecer intacto"; return 1; }
+}
+
+# ==== 3.9.7 determinismo: mesmos inputs => corpus resultante byte-identico ====
+
+scenario_determinismo_dois_merges_mesmo_resultado() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: det-cap
+
+#### ADDED
+
+- **FR-001**: um.
+
+#### ADDED
+
+- **FR-002**: dois.')
+
+  _dir1="$TMPDIR_TEST/run1"
+  _dir2="$TMPDIR_TEST/run2"
+  mkdir -p "$_dir1" "$_dir2"
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --feature feat-det --corpus-dir "$_dir1" --date 2026-07-22 || return 1
+  assert_exit 0 sh "$SCRIPT" "$_spec" --feature feat-det --corpus-dir "$_dir2" --date 2026-07-22 || return 1
+
+  cmp -s "$_dir1/det-cap.md" "$_dir2/det-cap.md" || { _fail "nao_deterministico" "corpus resultante divergiu entre duas execucoes"; return 1; }
+}
+
+# ==== RENAMED: heading migra, tabela ganha linha ====
+
+scenario_renamed_migra_heading_e_registra_tabela() {
+  _write_corpus_file "sample-cap" "$_BASE_CORPUS"
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+### Capability: sample-cap
+
+#### RENAMED
+
+- **FR-001 -> FR-100**')
+
+  assert_exit 0 sh "$SCRIPT" "$_spec" --feature feat-ren --corpus-dir "$(_corpus_dir)" --date 2026-07-25 || return 1
+  assert_stdout_contains "delta=applied|added=0|modified=0|removed=0|renamed=1" || return 1
+
+  _content=$(cat "$(_corpus_dir)/sample-cap.md")
+  case "$_content" in
+    *"### FR-100"*"## Renamed Identifiers"*"| FR-001 | FR-100 | feat-ren | 2026-07-25 |"*) : ;;
+    *) _fail "renamed_incorreto" "heading/tabela nao migrados corretamente: $_content"; return 1 ;;
+  esac
+  case "$_content" in
+    *"### FR-001"$'\n'*) _fail "old_id_ainda_presente" "FR-001 nao deveria mais existir como heading ativo"; return 1 ;;
+  esac
+}
+
+# ==== uso incorreto ====
+
+scenario_feature_ausente() {
+  _spec=$(_write_spec '# Feature Spec: fixture
+
+## Delta Requirements
+
+**Skip**: x — Jot, 2026-07-22')
+
+  assert_exit 2 sh "$SCRIPT" "$_spec" --corpus-dir "$(_corpus_dir)" || return 1
+  assert_stderr_contains "DIAG|error|feature-missing|" || return 1
+}
+
+scenario_spec_md_inexistente() {
+  assert_exit 2 sh "$SCRIPT" "$TMPDIR_TEST/nao-existe/spec.md" --feature x || return 1
+  assert_stderr_contains "DIAG|error|spec-not-found|" || return 1
+}
+
+run_all_scenarios

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -15,8 +15,14 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 _init_state() {
+  # $2 opcional: projeto-alvo-path real (default "/tmp/p" para cenarios que
+  # nao exercitam git de verdade). Cenarios de git-commit precisam do path
+  # REAL para que `state-ondas.sh start` (living-specs FASE 5) consiga
+  # derivar .execution.target_project_path e capturar o baseline de
+  # untracked no inicio da onda.
+  _init_pap="${2:-/tmp/p}"
   capture "$RW" init --state-dir "$1" \
-    --execucao-id "exec-onda-test" --projeto-alvo-path "/tmp/p" --descricao "POC ondas"
+    --execucao-id "exec-onda-test" --projeto-alvo-path "$_init_pap" --descricao "POC ondas"
 }
 
 scenario_start_cria_onda_001() {
@@ -143,12 +149,18 @@ scenario_current_id_retorna_init_sem_onda() {
 scenario_git_commit_cria_commit() {
   _sd="$TMPDIR_TEST/state"
   _pap="$TMPDIR_TEST/proj"
-  _init_state "$_sd"
   mkdir -p "$_pap"
   ( cd "$_pap" && git init -q -b main \
     && git config user.email t@t \
-    && git config user.name t \
-    && touch hello.txt )
+    && git config user.name t )
+  # state.json aponta para o repo REAL (nao o fake "/tmp/p") + start ANTES
+  # de qualquer arquivo novo: e o `start` (living-specs FASE 5) quem
+  # captura o baseline de untracked "no inicio da onda" (data-model.md
+  # UntrackedBaseline) — hello.txt so entra no diff porque e criado DEPOIS
+  # do baseline, nunca porque git-commit varre tudo cegamente.
+  _init_state "$_sd" "$_pap"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  ( cd "$_pap" && touch hello.txt )
   capture "$SCRIPT" git-commit --state-dir "$_sd" --projeto-alvo-path "$_pap" \
     --motivo "test commit FASE 3"
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "commit" "$_CAPTURED_STDERR"; return 1; }
@@ -156,6 +168,11 @@ scenario_git_commit_cria_commit() {
   case "$_msg" in
     *"chore(agente-00c):"*"test commit FASE 3"*) ;;
     *) _fail "commit msg" "esperado contem 'chore(agente-00c)' e motivo; obtido: $_msg"; return 1 ;;
+  esac
+  _shown=$(git -C "$_pap" show --name-only --format= HEAD)
+  case "$_shown" in
+    *hello.txt*) : ;;
+    *) _fail "hello.txt deveria estar no commit" "obtido: $_shown"; return 1 ;;
   esac
 }
 
@@ -858,13 +875,17 @@ scenario_git_commit_worktree() {
   _sd="$TMPDIR_TEST/state"
   _main="$TMPDIR_TEST/mainrepo"
   _wt="$TMPDIR_TEST/wt"
-  _init_state "$_sd"
   mkdir -p "$_main"
   ( cd "$_main" && git init -q -b main \
     && git config user.email t@t && git config user.name t \
     && touch base.txt && git add . && git commit -q -m initial \
     && git worktree add -b feat "$_wt" ) >/dev/null 2>&1
   [ -f "$_wt/.git" ] || { _fail "worktree setup" ".git deveria ser ARQUIVO em $_wt"; return 1; }
+  # state.json aponta para o worktree real + start ANTES do arquivo novo
+  # (baseline capturado no inicio da onda — mesma razao de
+  # scenario_git_commit_cria_commit).
+  _init_state "$_sd" "$_wt"
+  capture "$SCRIPT" start --state-dir "$_sd"
   ( cd "$_wt" && touch novo.txt )
   capture "$SCRIPT" git-commit --state-dir "$_sd" --projeto-alvo-path "$_wt" \
     --motivo "commit em worktree"
@@ -873,6 +894,54 @@ scenario_git_commit_worktree() {
   case "$_msg" in
     *"chore(agente-00c):"*"commit em worktree"*) ;;
     *) _fail "worktree commit msg" "obtido: $_msg"; return 1 ;;
+  esac
+}
+
+# ==== quickstart.md Cenario 7: wave-commit endurecido (living-specs FASE 5.5) ====
+# alien.pptx untracked PRE-EXISTENTE (analogo ao incidente real) +
+# mudanca tracked em docs/specs/feat-x/spec.md => commit contem SO a
+# mudanca tracked, alien.pptx permanece untracked. Confirma que o site 3
+# da research Decision 1 (git add -- .) esta convergido ao mesmo helper de
+# staging dos demais sites (5.1-5.4).
+
+scenario_5_5_wave_commit_endurecido_exclui_alien() {
+  _sd="$TMPDIR_TEST/state"
+  _pap="$TMPDIR_TEST/proj-wc"
+  mkdir -p "$_pap/docs/specs/feat-x"
+  ( cd "$_pap" && git init -q -b main \
+    && git config user.email t@t && git config user.name t \
+    && printf 's\n' > docs/specs/feat-x/spec.md \
+    && git add -A && git commit -q -m initial )
+
+  # alien.pptx untracked PRE-EXISTENTE, antes de start capturar o baseline.
+  printf 'alien\n' > "$_pap/alien.pptx"
+
+  _init_state "$_sd" "$_pap"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ -f "$_sd/commit-baseline.txt" ] || { _fail "baseline" "commit-baseline.txt deveria existir apos start"; return 1; }
+  grep -qx "alien.pptx" "$_sd/commit-baseline.txt" \
+    || { _fail "baseline conteudo" "alien.pptx deveria estar no baseline"; return 1; }
+
+  # Trabalho da onda: mudanca TRACKED.
+  printf 's2\n' >> "$_pap/docs/specs/feat-x/spec.md"
+
+  capture "$SCRIPT" git-commit --state-dir "$_sd" --projeto-alvo-path "$_pap" \
+    --motivo "wave-commit endurecido"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "git-commit exit" "obtido $_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"; return 1; }
+
+  _shown=$(git -C "$_pap" show --name-only --format= HEAD)
+  case "$_shown" in
+    *alien.pptx*) _fail "alien.pptx nao deveria estar no commit" "obtido: $_shown"; return 1 ;;
+  esac
+  case "$_shown" in
+    *"docs/specs/feat-x/spec.md"*) : ;;
+    *) _fail "spec.md deveria estar no commit" "obtido: $_shown"; return 1 ;;
+  esac
+
+  _untracked=$(git -C "$_pap" status --porcelain | grep '^??' || :)
+  case "$_untracked" in
+    *alien.pptx*) : ;;
+    *) _fail "alien.pptx deveria permanecer untracked" "obtido: $_untracked"; return 1 ;;
   esac
 }
 


### PR DESCRIPTION
Feature living-specs via feature-00c (9 ondas, 30 tasks/114 subtarefas 96% — 4 itens opcionais documentados fora de escopo, converge 1 MEDIUM corrigido, suite completa 1758 PASS / 0 FAIL / 0 ORPHANS).

## Entregas
**Specs vivas + delta specs (aprendizado estrutural do benchmark OpenSpec):**
- Corpus canonico do comportamento atual em `docs/specs/current/` (formato definido em contracts/corpus-format.md)
- Secao opcional `## Delta Requirements` (ADDED/MODIFIED/REMOVED/RENAMED) no template de spec do specify
- `global/skills/review-features/scripts/delta-gate.sh` — gate read-only (parser, validacao estrutural CHK034 + referencial, anti-path-traversal, envelope DIAG) + 22 cenarios
- `global/skills/review-features/scripts/delta-merge.sh` — merge atomico por capability (mktemp+mv) + 11 cenarios
- Archive do review-features roda gate -> merge -> mv; no fluxo autonomo, gate bloqueado vira `bloqueios.sh register` (nunca merge silencioso)

**Hardening de staging (sug-001):**
- Subcomandos `snapshot`/`stage-derived` no `commit-mode.sh` — staging por allowlist derivada (porcelain -z + --untracked-files=all), NUNCA `git add -A`
- 4 sites de staging amplo (prosa dos 2 orquestradores + state-ondas.sh) convergidos ao helper; zero `git add -A` vivo (provado por grep)
- +32 cenarios em test_commit-mode.sh, +regressao em test_state-ondas.sh (63 cenarios)

3 gaps do checklist consumidos como tarefas (CHK015/CHK020/CHK034); 3 divergencias contrato-vs-implementacao medidas e documentadas no proprio commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiU6PogVLtCUyPT3ok4kkd