### PR TITLE
docs(i18n): inglês como idioma principal + leitura pt-BR (5.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.24.0] - 2026-07-24
+
+Documentação passa a ter o **inglês como idioma principal**, com a leitura em
+pt-BR a um clique. Cada documento vira o par `X.md` (inglês, primário) +
+`X.pt-BR.md` (português), com uma linha de troca de idioma no topo. Mudança
+puramente documental — nenhum comportamento de skill, CLI ou runtime foi
+alterado.
+
+### Added
+
+- **Cópias em português** de 11 documentos, como siblings `*.pt-BR.md`:
+  `README`, `CONTRIBUTING`, `THIRD-PARTY-NOTICES`, `cli/README` e os 7 docs
+  de tópico (`docs/sdd-pipeline`, `agente-00c`, `cstk-session`, `cstk-recall`,
+  `cstk-serve`, `go-toolkit`, `conventions`).
+- **Troca de idioma** no topo de cada arquivo (`**English** · [Português
+  (pt-BR)](…)` no primário; inverso no sibling), com links cruzados entre
+  docs resolvendo para o sibling do mesmo idioma.
+
+### Changed
+
+- **`README.md` e os 10 documentos relacionados agora são a versão em inglês**
+  (o conteúdo em português foi preservado 1:1 nos `*.pt-BR.md`). Comandos,
+  paths, nomes de skill/flag, contagens, URLs, marcadores de snippet mkdocs e
+  gatilhos de skill (frases literais em pt-BR) foram mantidos byte-a-byte.
+- **`tests/test_doc-counts.sh`**: a guarda de contagem de skills passa a casar
+  a frase em inglês (`"<N> global skills"`) do README primário.
+
 ## [5.23.0] - 2026-07-23
 
 Absorve o aprendizado ESTRUTURAL do benchmark OpenSpec — specs vivas com
@@ -3879,6 +3906,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.24.0]: https://github.com/JotJunior/cstk/releases/tag/v5.24.0
 [5.23.0]: https://github.com/JotJunior/cstk/releases/tag/v5.23.0
 [5.22.0]: https://github.com/JotJunior/cstk/releases/tag/v5.22.0
 [5.21.0]: https://github.com/JotJunior/cstk/releases/tag/v5.21.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,50 +1,53 @@
-# Contribuindo com o Claude Code Toolkit
+**English** · [Português (pt-BR)](./CONTRIBUTING.pt-BR.md)
 
-Este guia expõe o **modelo mental** do toolkit para que um contribuidor externo
-consiga abrir um PR com segurança. Para detalhes operacionais já documentados,
-ele aponta para o [README.md](./README.md) e o `CLAUDE.md` em vez de duplicar.
+# Contributing to the Claude Code Toolkit
 
-> Contribuindo só com **conteúdo do site de documentação** (páginas em
-> `docs-site/`)? Veja [docs-site/CONTRIBUTING.md](./docs-site/CONTRIBUTING.md) —
-> regras diferentes (princípio D-I / fonte canônica).
+This guide lays out the toolkit's **mental model** so that an external
+contributor can open a PR with confidence. For operational details already
+documented elsewhere, it points to the [README.md](./README.md) and `CLAUDE.md`
+instead of duplicating them.
+
+> Contributing only **documentation-site content** (pages under `docs-site/`)?
+> See [docs-site/CONTRIBUTING.md](./docs-site/CONTRIBUTING.md) — different rules
+> (the D-I principle / canonical source).
 
 ---
 
-## 1. Como o sistema "pensa"
+## 1. How the system "thinks"
 
-O toolkit tem três tipos de artefato que o Claude Code consome, em camadas de
-abstração crescente:
+The toolkit has three kinds of artifact that Claude Code consumes, in layers of
+increasing abstraction:
 
-- **skills** (`global/skills/<nome>/SKILL.md`) — capacidades auto-invocadas por
-  contexto. Unidade fundamental.
-- **commands** (`global/commands/<nome>.md`) — workflows disparados por
+- **skills** (`global/skills/<name>/SKILL.md`) — capabilities auto-invoked by
+  context. The fundamental unit.
+- **commands** (`global/commands/<name>.md`) — workflows triggered by a
   `/slash-command`.
-- **agents** (`global/agents/<nome>.md`) — especialistas autônomos para tarefas
-  multi-passo (ex.: os orquestradores `agente-00c`).
+- **agents** (`global/agents/<name>.md`) — autonomous specialists for multi-step
+  tasks (e.g. the `agente-00c` orchestrators).
 
-Sobre isso correm dois sistemas de mais alto nível: o **pipeline SDD** (a
-sequência de skills do discovery à implementação) e o **`cstk`** (a CLI POSIX que
-instala/versiona/atualiza tudo na máquina do usuário).
+On top of these run two higher-level systems: the **SDD pipeline** (the sequence
+of skills from discovery to implementation) and **`cstk`** (the POSIX CLI that
+installs/versions/updates everything on the user's machine).
 
 ```mermaid
 flowchart TD
-    subgraph Fonte["Repositório (fonte da verdade)"]
+    subgraph Source["Repository (source of truth)"]
         S[global/skills/*]
         C[global/commands/*]
         A[global/agents/*]
         L[language-related/*]
     end
     BR[scripts/build-release.sh] -->|tarball + SHA-256| REL[(GitHub Release)]
-    Fonte --> BR
+    Source --> BR
     REL -->|"curl | sh / cstk update"| INST["~/.claude/skills, commands, agents"]
-    INST -->|consumido por| CC[Claude Code]
-    CC -.->|cstk doctor detecta drift| INST
+    INST -->|consumed by| CC[Claude Code]
+    CC -.->|cstk doctor detects drift| INST
 ```
 
-### 1.1 O pipeline SDD
+### 1.1 The SDD pipeline
 
-A sequência recomendada para levar uma ideia do discovery à implementação. Cada
-skill consome o artefato da anterior:
+The recommended sequence for taking an idea from discovery to implementation.
+Each skill consumes the artifact from the previous one:
 
 ```mermaid
 flowchart LR
@@ -53,121 +56,122 @@ flowchart LR
     analyze -. read-only cross-check .-> specify
 ```
 
-Detalhe de cada etapa: [README §Pipeline SDD](./README.md#pipeline-sdd-spec-driven-development).
+Details of each step: [README §SDD Pipeline](./README.md#sdd-pipeline-spec-driven-development).
 
-### 1.2 Orquestradores autônomos (`agente-00c` / `feature-00c`)
+### 1.2 Autonomous orchestrators (`agente-00c` / `feature-00c`)
 
-Para quem vai mexer no avançado: os orquestradores rodam o pipeline SDD inteiro
-de forma autônoma, em "ondas", mantendo estado transacional em
-`.claude/agente-00c-state/`. Conceitos que você **precisa** respeitar antes de
-tocar nesse código (todos detalhados no `CLAUDE.md`):
+For anyone touching the advanced parts: the orchestrators run the entire SDD
+pipeline autonomously, in "waves", keeping transactional state in
+`.claude/agente-00c-state/`. Concepts you **must** respect before touching that
+code (all detailed in `CLAUDE.md`):
 
-- **`state.json` é a fonte de verdade transacional** — nunca derive lógica
-  crítica de índices secundários.
-- **`cstk recall` (knowledge.db)** é uma camada **aditiva e best-effort**:
-  qualquer degradação vira no-op (exit 0), nunca aborta uma onda.
-- **model-routing** é **suggest-only**: a skill `model-selector` sugere, o
-  operador sempre pode dar override; nada troca de modelo silenciosamente.
-- **Decisões são auditáveis** (`state-decisions.sh`) e **half-records** têm
-  reconciliador próprio (`state-decisions-reconcile.sh`).
+- **`state.json` is the transactional source of truth** — never derive critical
+  logic from secondary indexes.
+- **`cstk recall` (knowledge.db)** is an **additive, best-effort** layer: any
+  degradation becomes a no-op (exit 0), never aborts a wave.
+- **model-routing** is **suggest-only**: the `model-selector` skill suggests, the
+  operator can always override; nothing switches model silently.
+- **Decisions are auditable** (`state-decisions.sh`) and **half-records** have
+  their own reconciler (`state-decisions-reconcile.sh`).
 
 ---
 
-## 2. Fluxo de desenvolvimento
+## 2. Development flow
 
-A armadilha nº 1 deste projeto é **drift entre a fonte (este repo) e a cópia
-instalada** (`~/.claude/skills/`), que o Claude Code de fato consome.
+The #1 pitfall of this project is **drift between the source (this repo) and the
+installed copy** (`~/.claude/skills/`), which is what Claude Code actually
+consumes.
 
 ```mermaid
 flowchart TD
-    D1{cstk doctor<br/>reporta drift?} -->|sim| R[reconciliar:<br/>cstk update ou rebuild] --> D2
-    D1 -->|não| E[editar fonte em<br/>global/skills ou cli/lib]
+    D1{cstk doctor<br/>reports drift?} -->|yes| R[reconcile:<br/>cstk update or rebuild] --> D2
+    D1 -->|no| E[edit source in<br/>global/skills or cli/lib]
     R --> E
     E --> T[./tests/run.sh<br/>+ --check-coverage]
-    T -->|verde| SYNC[sincronizar instalado:<br/>cstk update / install --from file://]
-    SYNC --> V[validar no Claude Code]
+    T -->|green| SYNC[sync installed copy:<br/>cstk update / install --from file://]
+    SYNC --> V[validate in Claude Code]
 ```
 
-**Sempre rode `cstk doctor` ANTES de editar uma skill.** Se houver drift,
-reconcilie primeiro — senão seu fix pousa em estado stale e "funciona no repo mas
-não na sessão". Passo a passo completo: [README §Instalação](./README.md#instalação)
-e a seção "Installed vs Source Drift" do `CLAUDE.md`.
+**Always run `cstk doctor` BEFORE editing a skill.** If there is drift,
+reconcile first — otherwise your fix lands on stale state and "works in the repo
+but not in the session". Full step-by-step: [README §Installation](./README.md#installation)
+and the "Installed vs Source Drift" section of `CLAUDE.md`.
 
-### Em DEV (iterando sem release)
+### In DEV (iterating without a release)
 
 ```bash
-# após build local (scripts/build-release.sh)
+# after a local build (scripts/build-release.sh)
 cstk install --from "file://$PWD/dist/cstk-X.Y.Z.tar.gz"
 ```
 
 ---
 
-## 3. Adicionando artefatos
+## 3. Adding artifacts
 
-### Uma skill nova
+### A new skill
 
-1. Crie `global/skills/<nome>/SKILL.md` seguindo a [Anatomia de uma skill](./README.md#anatomia-de-uma-skill).
-2. **`description` como trigger condition**, não resumo: "Use quando X, Y ou Z.
-   NÃO use quando W."
-3. Documente **gotchas** — o conteúdo mais valioso.
-4. **Generalize**: skills em `global/skills/` ou `language-related/` **não podem
-   nomear clientes/empresas/projetos específicos** (ver o aviso em
-   [README §Contribuindo](./README.md#contribuindo); caso histórico: remoção de
-   `create-report` na v3.12.0). Se não generalizar, a skill pertence a
-   `<projeto>/.claude/skills/`.
-5. Registre o perfil em `scripts/profiles.txt.in` (`sdd` ou `complementary`).
-6. Se a skill tem `scripts/*.sh`, **crie o teste correspondente** (§4).
+1. Create `global/skills/<name>/SKILL.md` following the [Anatomy of a skill](./README.md#anatomy-of-a-skill).
+2. **`description` as a trigger condition**, not a summary: "Use when X, Y or Z.
+   Do NOT use when W."
+3. Document **gotchas** — the most valuable content.
+4. **Generalize**: skills in `global/skills/` or `language-related/` **must not
+   name specific clients/companies/projects** (see the warning in
+   [README §Contributing](./README.md#contributing); historical case: removal of
+   `create-report` in v3.12.0). If it can't be generalized, the skill belongs in
+   `<project>/.claude/skills/`.
+5. Register the profile in `scripts/profiles.txt.in` (`sdd` or `complementary`).
+6. If the skill has `scripts/*.sh`, **create the corresponding test** (§4).
 
-### Um command novo
+### A new command
 
-Crie `global/commands/<nome>.md`. Commands de spawn/resume que integram
-model-routing precisam carregar a instrução `wave-select` — veja os 4 commands
-`agente-00c`/`feature-00c` existentes como referência.
+Create `global/commands/<name>.md`. Spawn/resume commands that integrate
+model-routing need to load the `wave-select` instruction — see the 4 existing
+`agente-00c`/`feature-00c` commands as a reference.
 
-### Um teste novo (regra de ouro)
+### A new test (golden rule)
 
-Todo `.sh` novo em `global/skills/*/scripts/` ou `cli/lib/` **exige** um teste
-1:1 (o `--check-coverage` falha com exit 1 sem ele):
+Every new `.sh` in `global/skills/*/scripts/` or `cli/lib/` **requires** a 1:1
+test (`--check-coverage` fails with exit 1 without it):
 
-| Origem do script | Teste esperado |
+| Script origin | Expected test |
 |------------------|----------------|
 | `global/skills/<X>/scripts/<n>.sh` | `tests/test_<n>.sh` |
 | `cli/lib/<n>.sh` | `tests/cstk/test_<n>.sh` |
 
-Estrutura mínima e convenções (POSIX puro, sem `set -eu`, scenarios retornam
-0/1/2): [tests/README.md](./tests/README.md). Rode antes de commitar:
+Minimal structure and conventions (pure POSIX, no `set -eu`, scenarios return
+0/1/2): [tests/README.md](./tests/README.md). Run before committing:
 
 ```bash
-./tests/run.sh                  # suite completa
-./tests/run.sh --check-coverage # zero órfãos (exit 1 em violação)
+./tests/run.sh                  # full suite
+./tests/run.sh --check-coverage # zero orphans (exit 1 on violation)
 ```
 
 ---
 
-## 4. Versionamento (SemVer)
+## 4. Versioning (SemVer)
 
-O projeto segue [Semantic Versioning](https://semver.org/) com
+The project follows [Semantic Versioning](https://semver.org/) with a
 [CHANGELOG.md](./CHANGELOG.md):
 
-- **PATCH** — correções, ajustes de doc, refinamentos sem mudança de contrato.
-- **MINOR** — skill/command/feature nova retrocompatível.
-- **MAJOR** — **breaking change**. O caso mais comum aqui é **renomear uma
-  skill**: ao renomear, remova **todas** as referências ao nome antigo antes de
-  commitar (`grep -rn "nome-antigo" --include="*.md" --include="*.json" .`) —
-  referência residual vira nome-fantasma que falha silenciosamente. Também é
-  MAJOR remover skill, mudar contrato de CLI ou de `state.json`.
+- **PATCH** — fixes, doc tweaks, refinements with no contract change.
+- **MINOR** — new backward-compatible skill/command/feature.
+- **MAJOR** — **breaking change**. The most common case here is **renaming a
+  skill**: when renaming, remove **all** references to the old name before
+  committing (`grep -rn "old-name" --include="*.md" --include="*.json" .`) — a
+  leftover reference becomes a phantom name that fails silently. Removing a skill
+  or changing a CLI or `state.json` contract is also MAJOR.
 
-Release: `git tag vX.Y.Z` + push dispara `.github/workflows/release.yml`, que
-gera e publica o tarball. Depois, na máquina: `cstk update`.
+Release: `git tag vX.Y.Z` + push triggers `.github/workflows/release.yml`, which
+builds and publishes the tarball. Then, on the machine: `cstk update`.
 
 ---
 
-## 5. Checklist de PR
+## 5. PR checklist
 
-- [ ] `cstk doctor` sem drift antes de começar.
-- [ ] Código/identificadores em **inglês** (comentários e mensagens podem ser pt-br).
-- [ ] `./tests/run.sh` verde e `--check-coverage` com zero órfãos.
-- [ ] Script novo tem teste 1:1 no diretório certo.
-- [ ] Skill nova sem acoplamento a cliente/projeto específico.
-- [ ] `CHANGELOG.md` atualizado e bump de versão coerente com o tipo de mudança.
-- [ ] Se renomeou skill: zero referências ao nome antigo no repo.
+- [ ] `cstk doctor` with no drift before starting.
+- [ ] Code/identifiers in **English** (comments and messages may be pt-br).
+- [ ] `./tests/run.sh` green and `--check-coverage` with zero orphans.
+- [ ] New script has a 1:1 test in the right directory.
+- [ ] New skill with no coupling to a specific client/project.
+- [ ] `CHANGELOG.md` updated and version bump consistent with the type of change.
+- [ ] If you renamed a skill: zero references to the old name in the repo.

--- a/CONTRIBUTING.pt-BR.md
+++ b/CONTRIBUTING.pt-BR.md
@@ -1,0 +1,175 @@
+[English](./CONTRIBUTING.md) · **Português (pt-BR)**
+
+# Contribuindo com o Claude Code Toolkit
+
+Este guia expõe o **modelo mental** do toolkit para que um contribuidor externo
+consiga abrir um PR com segurança. Para detalhes operacionais já documentados,
+ele aponta para o [README.md](./README.pt-BR.md) e o `CLAUDE.md` em vez de duplicar.
+
+> Contribuindo só com **conteúdo do site de documentação** (páginas em
+> `docs-site/`)? Veja [docs-site/CONTRIBUTING.md](./docs-site/CONTRIBUTING.md) —
+> regras diferentes (princípio D-I / fonte canônica).
+
+---
+
+## 1. Como o sistema "pensa"
+
+O toolkit tem três tipos de artefato que o Claude Code consome, em camadas de
+abstração crescente:
+
+- **skills** (`global/skills/<nome>/SKILL.md`) — capacidades auto-invocadas por
+  contexto. Unidade fundamental.
+- **commands** (`global/commands/<nome>.md`) — workflows disparados por
+  `/slash-command`.
+- **agents** (`global/agents/<nome>.md`) — especialistas autônomos para tarefas
+  multi-passo (ex.: os orquestradores `agente-00c`).
+
+Sobre isso correm dois sistemas de mais alto nível: o **pipeline SDD** (a
+sequência de skills do discovery à implementação) e o **`cstk`** (a CLI POSIX que
+instala/versiona/atualiza tudo na máquina do usuário).
+
+```mermaid
+flowchart TD
+    subgraph Fonte["Repositório (fonte da verdade)"]
+        S[global/skills/*]
+        C[global/commands/*]
+        A[global/agents/*]
+        L[language-related/*]
+    end
+    BR[scripts/build-release.sh] -->|tarball + SHA-256| REL[(GitHub Release)]
+    Fonte --> BR
+    REL -->|"curl | sh / cstk update"| INST["~/.claude/skills, commands, agents"]
+    INST -->|consumido por| CC[Claude Code]
+    CC -.->|cstk doctor detecta drift| INST
+```
+
+### 1.1 O pipeline SDD
+
+A sequência recomendada para levar uma ideia do discovery à implementação. Cada
+skill consome o artefato da anterior:
+
+```mermaid
+flowchart LR
+    briefing --> constitution --> specify --> clarify --> plan
+    plan --> checklist --> create-tasks --> execute-task --> review-task
+    analyze -. read-only cross-check .-> specify
+```
+
+Detalhe de cada etapa: [README §Pipeline SDD](./README.pt-BR.md#pipeline-sdd-spec-driven-development).
+
+### 1.2 Orquestradores autônomos (`agente-00c` / `feature-00c`)
+
+Para quem vai mexer no avançado: os orquestradores rodam o pipeline SDD inteiro
+de forma autônoma, em "ondas", mantendo estado transacional em
+`.claude/agente-00c-state/`. Conceitos que você **precisa** respeitar antes de
+tocar nesse código (todos detalhados no `CLAUDE.md`):
+
+- **`state.json` é a fonte de verdade transacional** — nunca derive lógica
+  crítica de índices secundários.
+- **`cstk recall` (knowledge.db)** é uma camada **aditiva e best-effort**:
+  qualquer degradação vira no-op (exit 0), nunca aborta uma onda.
+- **model-routing** é **suggest-only**: a skill `model-selector` sugere, o
+  operador sempre pode dar override; nada troca de modelo silenciosamente.
+- **Decisões são auditáveis** (`state-decisions.sh`) e **half-records** têm
+  reconciliador próprio (`state-decisions-reconcile.sh`).
+
+---
+
+## 2. Fluxo de desenvolvimento
+
+A armadilha nº 1 deste projeto é **drift entre a fonte (este repo) e a cópia
+instalada** (`~/.claude/skills/`), que o Claude Code de fato consome.
+
+```mermaid
+flowchart TD
+    D1{cstk doctor<br/>reporta drift?} -->|sim| R[reconciliar:<br/>cstk update ou rebuild] --> D2
+    D1 -->|não| E[editar fonte em<br/>global/skills ou cli/lib]
+    R --> E
+    E --> T[./tests/run.sh<br/>+ --check-coverage]
+    T -->|verde| SYNC[sincronizar instalado:<br/>cstk update / install --from file://]
+    SYNC --> V[validar no Claude Code]
+```
+
+**Sempre rode `cstk doctor` ANTES de editar uma skill.** Se houver drift,
+reconcilie primeiro — senão seu fix pousa em estado stale e "funciona no repo mas
+não na sessão". Passo a passo completo: [README §Instalação](./README.pt-BR.md#instalação)
+e a seção "Installed vs Source Drift" do `CLAUDE.md`.
+
+### Em DEV (iterando sem release)
+
+```bash
+# após build local (scripts/build-release.sh)
+cstk install --from "file://$PWD/dist/cstk-X.Y.Z.tar.gz"
+```
+
+---
+
+## 3. Adicionando artefatos
+
+### Uma skill nova
+
+1. Crie `global/skills/<nome>/SKILL.md` seguindo a [Anatomia de uma skill](./README.pt-BR.md#anatomia-de-uma-skill).
+2. **`description` como trigger condition**, não resumo: "Use quando X, Y ou Z.
+   NÃO use quando W."
+3. Documente **gotchas** — o conteúdo mais valioso.
+4. **Generalize**: skills em `global/skills/` ou `language-related/` **não podem
+   nomear clientes/empresas/projetos específicos** (ver o aviso em
+   [README §Contribuindo](./README.pt-BR.md#contribuindo); caso histórico: remoção de
+   `create-report` na v3.12.0). Se não generalizar, a skill pertence a
+   `<projeto>/.claude/skills/`.
+5. Registre o perfil em `scripts/profiles.txt.in` (`sdd` ou `complementary`).
+6. Se a skill tem `scripts/*.sh`, **crie o teste correspondente** (§4).
+
+### Um command novo
+
+Crie `global/commands/<nome>.md`. Commands de spawn/resume que integram
+model-routing precisam carregar a instrução `wave-select` — veja os 4 commands
+`agente-00c`/`feature-00c` existentes como referência.
+
+### Um teste novo (regra de ouro)
+
+Todo `.sh` novo em `global/skills/*/scripts/` ou `cli/lib/` **exige** um teste
+1:1 (o `--check-coverage` falha com exit 1 sem ele):
+
+| Origem do script | Teste esperado |
+|------------------|----------------|
+| `global/skills/<X>/scripts/<n>.sh` | `tests/test_<n>.sh` |
+| `cli/lib/<n>.sh` | `tests/cstk/test_<n>.sh` |
+
+Estrutura mínima e convenções (POSIX puro, sem `set -eu`, scenarios retornam
+0/1/2): [tests/README.md](./tests/README.md). Rode antes de commitar:
+
+```bash
+./tests/run.sh                  # suite completa
+./tests/run.sh --check-coverage # zero órfãos (exit 1 em violação)
+```
+
+---
+
+## 4. Versionamento (SemVer)
+
+O projeto segue [Semantic Versioning](https://semver.org/) com
+[CHANGELOG.md](./CHANGELOG.md):
+
+- **PATCH** — correções, ajustes de doc, refinamentos sem mudança de contrato.
+- **MINOR** — skill/command/feature nova retrocompatível.
+- **MAJOR** — **breaking change**. O caso mais comum aqui é **renomear uma
+  skill**: ao renomear, remova **todas** as referências ao nome antigo antes de
+  commitar (`grep -rn "nome-antigo" --include="*.md" --include="*.json" .`) —
+  referência residual vira nome-fantasma que falha silenciosamente. Também é
+  MAJOR remover skill, mudar contrato de CLI ou de `state.json`.
+
+Release: `git tag vX.Y.Z` + push dispara `.github/workflows/release.yml`, que
+gera e publica o tarball. Depois, na máquina: `cstk update`.
+
+---
+
+## 5. Checklist de PR
+
+- [ ] `cstk doctor` sem drift antes de começar.
+- [ ] Código/identificadores em **inglês** (comentários e mensagens podem ser pt-br).
+- [ ] `./tests/run.sh` verde e `--check-coverage` com zero órfãos.
+- [ ] Script novo tem teste 1:1 no diretório certo.
+- [ ] Skill nova sem acoplamento a cliente/projeto específico.
+- [ ] `CHANGELOG.md` atualizado e bump de versão coerente com o tipo de mudança.
+- [ ] Se renomeou skill: zero referências ao nome antigo no repo.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**English** · [Português (pt-BR)](./README.pt-BR.md)
+
 # Claude Code Toolkit
 
 [![Latest Release](https://img.shields.io/github/v/release/JotJunior/cstk?label=latest%20release&color=blue)](https://github.com/JotJunior/cstk/releases/latest)
@@ -6,59 +8,59 @@
 [![Docs Site](https://img.shields.io/badge/docs-jotjunior.github.io/cstk-blue?logo=readthedocs)](https://jotjunior.github.io/cstk/)
 [![Publish Site](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml/badge.svg?branch=main)](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml)
 
-Conjunto de ferramentas para aumentar a produtividade no desenvolvimento do dia a dia com
-o [Claude Code](https://claude.ai/code): **skills** e **hooks** para
-documentação, desenvolvimento, segurança e qualidade de código.
+A set of tools to boost day-to-day development productivity with
+[Claude Code](https://claude.ai/code): **skills** and **hooks** for
+documentation, development, security and code quality.
 
-> **Quem mantém / para quem é.** Mantido por uma pessoa, otimizado primeiro
-> para o fluxo do mantenedor (microserviços em Go). As partes concretas —
-> skills, hooks, CLI — são de uso geral; a **trilha avançada** (orquestrador
-> autônomo) é mais experimental.
+> **Who maintains it / who it's for.** Maintained by a single person, optimized
+> first for the maintainer's workflow (Go microservices). The concrete parts —
+> skills, hooks, CLI — are general-purpose; the **advanced track** (autonomous
+> orchestrator) is more experimental.
 
-> **Versão atual:** [release mais recente](https://github.com/JotJunior/cstk/releases/latest)
-> · histórico no [CHANGELOG.md](./CHANGELOG.md). Instalação recomendada via
-> `cstk` CLI (ver [Instalação](#instalação)).
+> **Current version:** [latest release](https://github.com/JotJunior/cstk/releases/latest)
+> · history in [CHANGELOG.md](./CHANGELOG.md). Installation recommended via
+> the `cstk` CLI (see [Installation](#installation)).
 
-## Comece aqui
+## Start here
 
-Duas trilhas, dependendo do que você procura:
+Two tracks, depending on what you're looking for:
 
-| Trilha | Para quem | Onde ir |
+| Track | For whom | Where to go |
 |--------|-----------|---------|
-| **Básico** | Quer produtividade no dia a dia — especificar, revisar, corrigir, documentar com algumas skills | Esta seção + [Skills Globais](#skills-globais) |
-| **Avançado** | Quer o orquestrador autônomo rodando o pipeline SDD inteiro sozinho | [Trilha avançada](#trilha-avançada-orquestrador-autônomo) |
+| **Basic** | Wants day-to-day productivity — specify, review, fix, document with a few skills | This section + [Global Skills](#global-skills) |
+| **Advanced** | Wants the autonomous orchestrator running the whole SDD pipeline on its own | [Advanced track](#advanced-track-autonomous-orchestrator) |
 
-### Trilha básica em 3 passos
+### Basic track in 3 steps
 
 ```bash
-# 1. Instale (uma vez por máquina)
+# 1. Install (once per machine)
 curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh | sh
 ```
 
 ```text
-# 2. Abra o Claude Code no seu projeto e invoque uma skill pelo gatilho:
-#    "especifica essa feature: ..."   → specify  (ideia → spec)
+# 2. Open Claude Code in your project and invoke a skill via its trigger:
+#    "especifica essa feature: ..."   → specify  (idea → spec)
 #    "revisa a segurança desse código" → owasp-security
-#    "corrige esse bug: ..."          → bugfix   (investigação multi-camada)
-#    "me aconselhe sobre esse plano"  → advisor  (crítica estratégica)
+#    "corrige esse bug: ..."          → bugfix   (multi-layer investigation)
+#    "me aconselhe sobre esse plano"  → advisor  (strategic critique)
 ```
 
 ```text
-# 3. Pronto. As skills são auto-invocadas por contexto — você descreve a
-#    intenção em linguagem natural e o gatilho dispara a skill certa.
+# 3. Done. Skills are auto-invoked by context — you describe the
+#    intent in natural language and the trigger fires the right skill.
 ```
 
-> Não precisa do orquestrador autônomo para começar. Ele é a trilha avançada
-> — adote quando quiser que o pipeline SDD rode de ponta a ponta sem você
-> conduzir cada etapa.
+> You don't need the autonomous orchestrator to get started. It's the advanced
+> track — adopt it when you want the SDD pipeline to run end to end without you
+> driving each step.
 
-## Estrutura
+## Structure
 
 ```
-├── global/                     # Skills globais (independentes de linguagem)
-│   └── skills/                 # 24 skills globais (cada skill é uma pasta)
+├── global/                     # Global skills (language-independent)
+│   └── skills/                 # 24 global skills (each skill is a folder)
 │       ├── advisor/
-│       ├── agente-00c-runtime/ # runtime POSIX interno (não user-invocável)
+│       ├── agente-00c-runtime/ # internal POSIX runtime (not user-invocable)
 │       ├── analyze/
 │       ├── apply-insights/
 │       ├── briefing/
@@ -66,14 +68,14 @@ curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh
 │       ├── checklist/
 │       ├── clarify/
 │       ├── constitution/
-│       ├── converge/           # reconcilia spec/plan/tasks vs código real
+│       ├── converge/           # reconciles spec/plan/tasks vs actual code
 │       ├── create-tasks/
 │       ├── decision-tree/      # ⚠️ DEPRECATED (remove_in 6.0.0) — use cstk-panel (cstk serve)
-│       ├── e2e-integration-flow/ # testes E2E de integração full-stack (Playwright)
+│       ├── e2e-integration-flow/ # full-stack E2E integration tests (Playwright)
 │       ├── execute-task/
-│       ├── image-generation/   # ⚠️ DEPRECATED (remove_in 6.0.0) — fora do escopo do toolkit
+│       ├── image-generation/   # ⚠️ DEPRECATED (remove_in 6.0.0) — out of toolkit scope
 │       ├── initialize-docs/
-│       ├── model-selector/     # heurística de roteamento de modelo (sugestor)
+│       ├── model-selector/     # model routing heuristic (suggester)
 │       ├── owasp-security/
 │       ├── plan/
 │       ├── review-features/
@@ -81,232 +83,232 @@ curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh
 │       ├── specify/
 │       ├── validate-docs-rendered/
 │       └── validate-documentation/
-├── language-related/           # Skills e hooks específicos por linguagem
+├── language-related/           # Language-specific skills and hooks
 │   └── go/                     # Go — ver docs/go-toolkit.md
-├── cli/                        # Binário cstk + libs POSIX
-└── docs/                       # Documentação por tópicos (ver índice abaixo)
+├── cli/                        # cstk binary + POSIX libs
+└── docs/                       # Topic-based documentation (see index below)
 ```
 
-### Anatomia de uma skill
+### Anatomy of a skill
 
-Cada skill é uma pasta com um `SKILL.md` (ponto de entrada) e, conforme o
-caso, subpastas consultadas sob demanda (*progressive disclosure* — o modelo
-paga só o contexto necessário no momento da invocação):
+Each skill is a folder with a `SKILL.md` (entry point) and, as needed,
+subfolders consulted on demand (*progressive disclosure* — the model
+pays only for the context needed at invocation time):
 
 ```
-skills/<nome>/
-├── SKILL.md             # Quando invocar, regras de alto nível, gotchas
-├── templates/           # Templates preenchíveis
-├── examples/            # Casos concretos (good.md vs bad.md)
-├── references/          # Documentação de apoio
-├── scripts/             # Scripts POSIX determinísticos
-└── config.json          # Configuração por projeto (opcional)
+skills/<name>/
+├── SKILL.md             # When to invoke, high-level rules, gotchas
+├── templates/           # Fill-in templates
+├── examples/            # Concrete cases (good.md vs bad.md)
+├── references/          # Supporting documentation
+├── scripts/             # Deterministic POSIX scripts
+└── config.json          # Per-project configuration (optional)
 ```
 
-Nem toda skill usa todas as subpastas — skills simples são só um `SKILL.md`.
+Not every skill uses all subfolders — simple skills are just a `SKILL.md`.
 
-## Skills Globais
+## Global Skills
 
-Skills em `global/skills/`, independentes de linguagem ou framework.
+Skills in `global/skills/`, independent of language or framework.
 
-### Pipeline SDD (Spec-Driven Development)
+### SDD Pipeline (Spec-Driven Development)
 
-Sequência recomendada para levar uma ideia do discovery à implementação.
-Detalhes, diagrama do fluxo e atalhos em
+Recommended sequence to take an idea from discovery to implementation.
+Details, flow diagram and shortcuts in
 [docs/sdd-pipeline.md](./docs/sdd-pipeline.md).
 
-| Skill | Trigger | Descrição |
+| Skill | Trigger | Description |
 |-------|---------|-----------|
-| **briefing** | "briefing", "discovery", "novo projeto" | Entrevista estruturada de discovery (visão, usuários, restrições, stack) |
-| **constitution** | "constitution", "princípios do projeto" | Princípios imutáveis de governança que guiam decisões |
-| **specify** | "specify", "criar spec", "nova feature" | Descrição natural → feature spec SDD (stories, requisitos, success criteria). Gate: todo requisito exige >=1 cenário; seção opcional Delta Requirements (specs vivas) |
-| **clarify** | "clarify", "resolver ambiguidades" | Resolve ambiguidades da spec via perguntas estruturadas (max 5) |
-| **plan** | "plan", "plano técnico" | Plano de implementação: pesquisa, modelo de dados, contratos |
-| **checklist** | "checklist", "quality gate" | "Unit Tests for English" — valida qualidade dos REQUISITOS; gaps viram tarefas |
-| **create-tasks** | "criar tarefas", "criar backlog" | Backlog de tarefas por fases com dependências e criticidade |
-| **analyze** | "analyze", "analisar consistência" | Análise read-only de consistência cross-artifact |
-| **execute-task** | "executar tarefa", "execute task" | Executa tarefa seguindo workflow obrigatório de 9 etapas |
-| **review-task** | "revisar tarefas", "status das tarefas" | Relatório de status com progresso e recomendações |
+| **briefing** | "briefing", "discovery", "novo projeto" | Structured discovery interview (vision, users, constraints, stack) |
+| **constitution** | "constitution", "princípios do projeto" | Immutable governance principles that guide decisions |
+| **specify** | "specify", "criar spec", "nova feature" | Natural description → SDD feature spec (stories, requirements, success criteria). Gate: every requirement needs >=1 scenario; optional Delta Requirements section (living specs) |
+| **clarify** | "clarify", "resolver ambiguidades" | Resolves spec ambiguities via structured questions (max 5) |
+| **plan** | "plan", "plano técnico" | Implementation plan: research, data model, contracts |
+| **checklist** | "checklist", "quality gate" | "Unit Tests for English" — validates REQUIREMENT quality; gaps become tasks |
+| **create-tasks** | "criar tarefas", "criar backlog" | Task backlog by phases with dependencies and criticality |
+| **analyze** | "analyze", "analisar consistência" | Read-only cross-artifact consistency analysis |
+| **execute-task** | "executar tarefa", "execute task" | Executes a task following the mandatory 9-step workflow |
+| **review-task** | "revisar tarefas", "status das tarefas" | Status report with progress and recommendations |
 
-### Skills Complementares
+### Complementary Skills
 
-| Skill | Trigger | Descrição |
+| Skill | Trigger | Description |
 |-------|---------|-----------|
-| **advisor** | "me aconselhe", "analise estratégica" | Conselheiro brutalmente honesto que disseca raciocínio e gera planos de ação |
-| **bugfix** | "bugfix", "fix bug", "debug" | Protocolo estruturado de correção de bugs multi-camada |
-| **converge** | "converge", "o código bate com a spec?" | Reconcilia spec/plan/tasks contra o código ATUAL e apenda gaps como nova fase de tasks. Gate incondicional entre execute-task e review-task nos orquestradores |
-| **e2e-integration-flow** | "e2e", "playwright", "validar fluxo completo" | Testes E2E de integração full-stack (UI → API → banco → fila → efeitos colaterais) |
-| **initialize-docs** | "inicializar docs", "setup documentação" | Cria hierarquia padrão de documentação com 9 níveis |
-| **apply-insights** | "aplicar insights", "melhorar claude.md" | Aplica insights de uso comprovados ao CLAUDE.md, hooks e workflows — ver [Insights de uso](#insights-de-uso) |
-| **owasp-security** | Ao revisar segurança | Revisão guiada por checklist (OWASP Top 10:2025, ASVS 5.0, LLM/Agentic, NIST, OAuth 2.1...). Não substitui auditoria/pentest |
-| **review-features** | "status global", "comparar features" | Relatório cross-feature com sugestão de arquivar/abandonar/priorizar; a ação de archive aplica os deltas ao corpus de specs vivas |
-| **validate-documentation** | "validar documentação", "verificar UC" | Valida documentos individuais contra padrões estruturais |
-| **validate-docs-rendered** | "validar renderização", "verificar diagramas" | Valida que o Markdown renderiza (Mermaid, links, frontmatter, tabelas) |
-| **image-generation** | Ao gerar imagens | ⚠️ DEPRECATED (remove_in 6.0.0) |
+| **advisor** | "me aconselhe", "analise estratégica" | Brutally honest advisor that dissects reasoning and generates action plans |
+| **bugfix** | "bugfix", "fix bug", "debug" | Structured multi-layer bug-fixing protocol |
+| **converge** | "converge", "o código bate com a spec?" | Reconciles spec/plan/tasks against the CURRENT code and appends gaps as a new task phase. Unconditional gate between execute-task and review-task in the orchestrators |
+| **e2e-integration-flow** | "e2e", "playwright", "validar fluxo completo" | Full-stack E2E integration tests (UI → API → database → queue → side effects) |
+| **initialize-docs** | "inicializar docs", "setup documentação" | Creates the standard documentation hierarchy with 9 levels |
+| **apply-insights** | "aplicar insights", "melhorar claude.md" | Applies proven usage insights to CLAUDE.md, hooks and workflows — see [Usage insights](#usage-insights) |
+| **owasp-security** | When reviewing security | Checklist-guided review (OWASP Top 10:2025, ASVS 5.0, LLM/Agentic, NIST, OAuth 2.1...). Does not replace audit/pentest |
+| **review-features** | "status global", "comparar features" | Cross-feature report suggesting archive/abandon/prioritize; the archive action applies deltas to the living-specs corpus |
+| **validate-documentation** | "validar documentação", "verificar UC" | Validates individual documents against structural standards |
+| **validate-docs-rendered** | "validar renderização", "verificar diagramas" | Validates that the Markdown renders (Mermaid, links, frontmatter, tables) |
+| **image-generation** | When generating images | ⚠️ DEPRECATED (remove_in 6.0.0) |
 
-## Trilha avançada (orquestrador autônomo)
+## Advanced track (autonomous orchestrator)
 
-> **Experimental** — funcional e em uso pelo mantenedor, sem garantias de
-> suporte para adoção externa.
+> **Experimental** — functional and in use by the maintainer, with no support
+> guarantees for external adoption.
 
-O `/agente-00c` conduz a pipeline SDD inteira sobre um projeto-alvo, pausando
-apenas em bloqueios reais; o `/feature-00c` faz o mesmo para UMA feature em
-projeto existente. Subsistemas: roteamento de modelos por onda, modo
-atomic-commit (commits automáticos + push/PR no finalize), guardas enforced
-(hook fail-closed), sessões paralelas em worktrees e memória de conhecimento
-cross-feature consultada antes de decidir.
+`/agente-00c` drives the entire SDD pipeline over a target project, pausing
+only on real blockers; `/feature-00c` does the same for ONE feature in an
+existing project. Subsystems: per-wave model routing, atomic-commit mode
+(automatic commits + push/PR at finalize), enforced guards (fail-closed hook),
+parallel sessions in worktrees, and cross-feature knowledge memory consulted
+before deciding.
 
-| Tópico | Documento |
+| Topic | Document |
 |--------|-----------|
-| Orquestradores `/agente-00c` + `/feature-00c`, model-routing, atomic-commit, guardas | [docs/agente-00c.md](./docs/agente-00c.md) |
-| Sessões paralelas (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.md) |
-| Memória de conhecimento (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.md) |
-| Painel web de métricas (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.md) |
+| `/agente-00c` + `/feature-00c` orchestrators, model-routing, atomic-commit, guards | [docs/agente-00c.md](./docs/agente-00c.md) |
+| Parallel sessions (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.md) |
+| Knowledge memory (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.md) |
+| Web metrics panel (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.md) |
 
-## Insights de uso
+## Usage insights
 
-A skill `apply-insights` é **prescritiva**: lê seu playbook
-(`~/.claude/insights/usage-insights.md`, por usuário — gere via `/insights`
-nativo do Claude Code) e o aplica ao projeto. Distinta do `/insights` nativo,
-que é **introspectivo** (analisa suas sessões).
+The `apply-insights` skill is **prescriptive**: it reads your playbook
+(`~/.claude/insights/usage-insights.md`, per user — generate it via Claude
+Code's native `/insights`) and applies it to the project. Distinct from the
+native `/insights`, which is **introspective** (analyzes your sessions).
 
 <!-- --8<-- [start:install-section] -->
-## Instalação
+## Installation
 
-### Via cstk CLI (recomendado)
+### Via cstk CLI (recommended)
 
-O toolkit é instalado via `cstk` — CLI POSIX shell que baixa, valida
-(SHA-256), instala e atualiza skills sem exigir clone do repositório.
+The toolkit is installed via `cstk` — a POSIX shell CLI that downloads,
+validates (SHA-256), installs and updates skills without requiring a clone of
+the repository.
 
-**One-liner de bootstrap** (instala `cstk` em `~/.local/bin/`):
+**Bootstrap one-liner** (installs `cstk` into `~/.local/bin/`):
 
 ```bash
 curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh | sh
 ```
 
-Depois disso, comandos típicos:
+After that, typical commands:
 
 ```bash
-cstk --version                       # confirma instalação
-cstk install                         # instala perfil 'sdd' em ~/.claude/skills/
-cstk install --profile all           # instala TODAS as 31 skills (inclui language-go)
-cstk install advisor bugfix          # cherry-pick por nome
-cstk update                          # aplica novas releases preservando edits locais
-cstk update --force                  # sobrescreve skills com edição local
-cstk list                            # lista skills instaladas + status
-cstk doctor                          # detecta drift entre manifest e disco
-cstk self-update                     # atualiza o próprio binário cstk + cli/lib
+cstk --version                       # confirms installation
+cstk install                         # installs the 'sdd' profile into ~/.claude/skills/
+cstk install --profile all           # installs ALL 31 skills (includes language-go)
+cstk install advisor bugfix          # cherry-pick by name
+cstk update                          # applies new releases preserving local edits
+cstk update --force                  # overwrites locally edited skills
+cstk list                            # lists installed skills + status
+cstk doctor                          # detects drift between manifest and disk
+cstk self-update                     # updates the cstk binary itself + cli/lib
 ```
 
-> **`install`/`update` tocam só o catálogo** (skills/commands/agents em
-> `~/.claude/`); o runtime (`cli/lib/*.sh` + binário) atualiza via
+> **`install`/`update` touch only the catalog** (skills/commands/agents in
+> `~/.claude/`); the runtime (`cli/lib/*.sh` + binary) updates via
 > **`cstk self-update`**.
 
-**Perfis disponíveis:**
+**Available profiles:**
 
-| Perfil | Conteúdo | Uso típico |
+| Profile | Content | Typical use |
 |--------|----------|------------|
-| `sdd` | 17 skills: pipeline Spec-Driven Development completa (briefing → review-features) + runtime interno, model-selector e os 4 gates de qualidade dos orquestradores | Instalação global default |
-| `complementary` | 13 skills independentes (advisor, bugfix, e2e-integration-flow, etc.) | Complementa o pipeline SDD |
-| `all` | Todas as 31 skills (sdd + complementary + language-go) | Instalação completa |
-| `language-go` | Skills + hooks específicos para Go | Apenas em projetos Go |
+| `sdd` | 17 skills: complete Spec-Driven Development pipeline (briefing → review-features) + internal runtime, model-selector and the orchestrators' 4 quality gates | Default global installation |
+| `complementary` | 13 independent skills (advisor, bugfix, e2e-integration-flow, etc.) | Complements the SDD pipeline |
+| `all` | All 31 skills (sdd + complementary + language-go) | Full installation |
+| `language-go` | Go-specific skills + hooks | Only in Go projects |
 
-Profile padrão quando nada é informado: `sdd`.
+Default profile when none is given: `sdd`.
 
-**Escopo de projeto** (`./.claude/skills/` no CWD em vez de `~/.claude/skills/`):
+**Project scope** (`./.claude/skills/` in the CWD instead of `~/.claude/skills/`):
 
 ```bash
-# Em um projeto Go: instala skills + hooks + merge de settings.json
-cd ~/projetos/meu-app-go
+# In a Go project: installs skills + hooks + settings.json merge
+cd ~/projects/my-go-app
 cstk install --scope project --profile language-go
 
-# Cherry-pick em escopo de projeto
+# Cherry-pick in project scope
 cstk install --scope project advisor owasp-security
 
-# Hooks de language-* SÃO instalados apenas em --scope project
-# (em --scope global, hooks são omitidos com aviso no summary — FR-009c)
+# language-* hooks ARE installed only in --scope project
+# (in --scope global, hooks are omitted with a warning in the summary — FR-009c)
 ```
 
-**Modo interativo** (seletor numerado em TTY) e **dry-run**:
+**Interactive mode** (numbered selector in a TTY) and **dry-run**:
 
 ```bash
-cstk install --interactive   # lista perfis + skills numerados; seleção via toggle
+cstk install --interactive   # lists numbered profiles + skills; selection via toggle
 cstk install --dry-run --profile all
 cstk update --dry-run
 ```
 
-### Instalação manual (deprecated, ainda suportada)
+### Manual installation (deprecated, still supported)
 
-Copia direta dos diretórios continua funcionando (`cp -r global/skills/
-~/.claude/skills/`), mas **não rastreia versões nem detecta drift** — ver
-[`CLAUDE.md`](./CLAUDE.md) §"Installed vs Source Drift". O `cstk` resolve
-isso via manifest + hash_dir.
+Directly copying the directories still works (`cp -r global/skills/
+~/.claude/skills/`), but **does not track versions or detect drift** — see
+[`CLAUDE.md`](./CLAUDE.md) §"Installed vs Source Drift". `cstk` solves
+this via manifest + hash_dir.
 
-### Documentação completa do cstk
+### Complete cstk documentation
 
-- [`cli/README.md`](./cli/README.md) — visão técnica, convenções, processo de release
+- [`cli/README.md`](./cli/README.md) — technical overview, conventions, release process
 - [`docs/specs/_archived/cstk-cli/`](docs/specs/_archived/cstk-cli/) — spec, plan, contracts, quickstart
 <!-- --8<-- [end:install-section] -->
 
 <!-- --8<-- [start:profiles-section] -->
-### Perfis de instalação (resumo)
+### Installation profiles (summary)
 
-| Perfil | Conteúdo | Uso típico |
+| Profile | Content | Typical use |
 |--------|----------|------------|
-| `sdd` | 17 skills: pipeline Spec-Driven Development completa (briefing → review-features) + runtime interno, model-selector e os 4 gates de qualidade dos orquestradores | Instalação global default |
-| `complementary` | 13 skills independentes (advisor, bugfix, e2e-integration-flow, etc.) | Complementa o pipeline SDD |
-| `all` | Todas as 31 skills (sdd + complementary + language-go) | Instalação completa |
-| `language-go` | Skills + hooks específicos para Go | Apenas em projetos Go |
+| `sdd` | 17 skills: complete Spec-Driven Development pipeline (briefing → review-features) + internal runtime, model-selector and the orchestrators' 4 quality gates | Default global installation |
+| `complementary` | 13 independent skills (advisor, bugfix, e2e-integration-flow, etc.) | Complements the SDD pipeline |
+| `all` | All 31 skills (sdd + complementary + language-go) | Full installation |
+| `language-go` | Go-specific skills + hooks | Only in Go projects |
 
-Profile padrão quando nada é informado: `sdd`. Detalhes em `cstk install --help`.
+Default profile when none is given: `sdd`. Details in `cstk install --help`.
 <!-- --8<-- [end:profiles-section] -->
 
-## Documentação por tópicos
+## Documentation by topic
 
-| Tópico | Documento |
+| Topic | Document |
 |--------|-----------|
-| Pipeline SDD: fluxo completo, quando usar cada skill, atalhos, specs vivas | [docs/sdd-pipeline.md](./docs/sdd-pipeline.md) |
-| Orquestrador autônomo (agente-00c / feature-00c) | [docs/agente-00c.md](./docs/agente-00c.md) |
-| Sessões paralelas (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.md) |
-| Memória de conhecimento (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.md) |
-| Painel web (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.md) |
-| Skills e hooks para Go | [docs/go-toolkit.md](./docs/go-toolkit.md) |
-| Convenções de nomenclatura e hierarquia de docs | [docs/conventions.md](./docs/conventions.md) |
-| Manual navegável (site) | [jotjunior.github.io/cstk](https://jotjunior.github.io/cstk/) |
+| SDD Pipeline: full flow, when to use each skill, shortcuts, living specs | [docs/sdd-pipeline.md](./docs/sdd-pipeline.md) |
+| Autonomous orchestrator (agente-00c / feature-00c) | [docs/agente-00c.md](./docs/agente-00c.md) |
+| Parallel sessions (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.md) |
+| Knowledge memory (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.md) |
+| Web panel (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.md) |
+| Go skills and hooks | [docs/go-toolkit.md](./docs/go-toolkit.md) |
+| Naming conventions and docs hierarchy | [docs/conventions.md](./docs/conventions.md) |
+| Browsable manual (site) | [jotjunior.github.io/cstk](https://jotjunior.github.io/cstk/) |
 
-## Contribuindo
+## Contributing
 
-Contribuições são bem-vindas. O guia completo — modelo mental do sistema,
-fluxo de desenvolvimento, política de versionamento e o **princípio de escopo
-do toolkit global** (skills publicadas aqui não devem nomear clientes,
-empresas ou projetos específicos) — está em
-[CONTRIBUTING.md](./CONTRIBUTING.md). Resumo para adicionar uma skill:
+Contributions are welcome. The complete guide — the system's mental model,
+development flow, versioning policy and the **global toolkit scope principle**
+(skills published here must not name specific clients, companies or projects) —
+is in [CONTRIBUTING.md](./CONTRIBUTING.md). Summary for adding a skill:
 
-1. Siga a estrutura de pasta de uma skill existente (ver [Anatomia de uma skill](#anatomia-de-uma-skill))
-2. `SKILL.md` enxuto como ponto de entrada; conteúdo pesado em subpastas
-3. **description** como trigger condition, não resumo
-4. **Gotchas** documentados — o conteúdo mais valioso de uma skill
-5. Scripts em POSIX sh para operações determinísticas; todo `.sh` novo exige `tests/test_<nome>.sh`
-6. Generalize: se referencia algo de um projeto específico, pertence ao `<projeto>/.claude/skills/`, não a este toolkit
-7. Teste com o Claude Code antes de submeter
+1. Follow the folder structure of an existing skill (see [Anatomy of a skill](#anatomy-of-a-skill))
+2. Lean `SKILL.md` as the entry point; heavy content in subfolders
+3. **description** as a trigger condition, not a summary
+4. **Gotchas** documented — the most valuable content of a skill
+5. Scripts in POSIX sh for deterministic operations; every new `.sh` requires `tests/test_<name>.sh`
+6. Generalize: if it references something from a specific project, it belongs in `<project>/.claude/skills/`, not in this toolkit
+7. Test with Claude Code before submitting
 
-## Versionamento
+## Versioning
 
-Este projeto segue [Semantic Versioning](https://semver.org/) e mantém um
-[CHANGELOG.md](./CHANGELOG.md) com o histórico de mudanças.
+This project follows [Semantic Versioning](https://semver.org/) and keeps a
+[CHANGELOG.md](./CHANGELOG.md) with the change history.
 
-## Créditos & Atribuições
+## Credits & Attributions
 
-Parte do pipeline SDD é adaptada do [GitHub Spec Kit](https://github.com/github/spec-kit)
-(MIT) — em especial o vocabulário de etapas e o template de constituição. O
-modelo de specs vivas com delta requirements foi inspirado no
-[OpenSpec](https://github.com/Fission-AI/OpenSpec). Outras skills tiveram
-inspiração conceitual de [obra/superpowers](https://github.com/obra/superpowers)
-e das convenções do Claude Code. Padrões públicos (OWASP, NIST, IETF, W3C,
-MITRE) são citados como referência. Detalhes e avisos de licença em
+Part of the SDD pipeline is adapted from the [GitHub Spec Kit](https://github.com/github/spec-kit)
+(MIT) — in particular the step vocabulary and the constitution template. The
+living-specs model with delta requirements was inspired by
+[OpenSpec](https://github.com/Fission-AI/OpenSpec). Other skills had conceptual
+inspiration from [obra/superpowers](https://github.com/obra/superpowers)
+and from Claude Code conventions. Public standards (OWASP, NIST, IETF, W3C,
+MITRE) are cited as reference. Details and license notices in
 [THIRD-PARTY-NOTICES.md](./THIRD-PARTY-NOTICES.md).
 
-## Licença
+## License
 
-Distribuído sob a licença MIT. Veja o arquivo [LICENSE](./LICENSE) para o
-texto completo.
+Distributed under the MIT license. See the [LICENSE](./LICENSE) file for the
+full text.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,314 @@
+[English](./README.md) · **Português (pt-BR)**
+
+# Claude Code Toolkit
+
+[![Latest Release](https://img.shields.io/github/v/release/JotJunior/cstk?label=latest%20release&color=blue)](https://github.com/JotJunior/cstk/releases/latest)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
+[![SemVer](https://img.shields.io/badge/SemVer-5.x-orange.svg)](./CHANGELOG.md)
+[![Docs Site](https://img.shields.io/badge/docs-jotjunior.github.io/cstk-blue?logo=readthedocs)](https://jotjunior.github.io/cstk/)
+[![Publish Site](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml/badge.svg?branch=main)](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml)
+
+Conjunto de ferramentas para aumentar a produtividade no desenvolvimento do dia a dia com
+o [Claude Code](https://claude.ai/code): **skills** e **hooks** para
+documentação, desenvolvimento, segurança e qualidade de código.
+
+> **Quem mantém / para quem é.** Mantido por uma pessoa, otimizado primeiro
+> para o fluxo do mantenedor (microserviços em Go). As partes concretas —
+> skills, hooks, CLI — são de uso geral; a **trilha avançada** (orquestrador
+> autônomo) é mais experimental.
+
+> **Versão atual:** [release mais recente](https://github.com/JotJunior/cstk/releases/latest)
+> · histórico no [CHANGELOG.md](./CHANGELOG.md). Instalação recomendada via
+> `cstk` CLI (ver [Instalação](#instalação)).
+
+## Comece aqui
+
+Duas trilhas, dependendo do que você procura:
+
+| Trilha | Para quem | Onde ir |
+|--------|-----------|---------|
+| **Básico** | Quer produtividade no dia a dia — especificar, revisar, corrigir, documentar com algumas skills | Esta seção + [Skills Globais](#skills-globais) |
+| **Avançado** | Quer o orquestrador autônomo rodando o pipeline SDD inteiro sozinho | [Trilha avançada](#trilha-avançada-orquestrador-autônomo) |
+
+### Trilha básica em 3 passos
+
+```bash
+# 1. Instale (uma vez por máquina)
+curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh | sh
+```
+
+```text
+# 2. Abra o Claude Code no seu projeto e invoque uma skill pelo gatilho:
+#    "especifica essa feature: ..."   → specify  (ideia → spec)
+#    "revisa a segurança desse código" → owasp-security
+#    "corrige esse bug: ..."          → bugfix   (investigação multi-camada)
+#    "me aconselhe sobre esse plano"  → advisor  (crítica estratégica)
+```
+
+```text
+# 3. Pronto. As skills são auto-invocadas por contexto — você descreve a
+#    intenção em linguagem natural e o gatilho dispara a skill certa.
+```
+
+> Não precisa do orquestrador autônomo para começar. Ele é a trilha avançada
+> — adote quando quiser que o pipeline SDD rode de ponta a ponta sem você
+> conduzir cada etapa.
+
+## Estrutura
+
+```
+├── global/                     # Skills globais (independentes de linguagem)
+│   └── skills/                 # 24 skills globais (cada skill é uma pasta)
+│       ├── advisor/
+│       ├── agente-00c-runtime/ # runtime POSIX interno (não user-invocável)
+│       ├── analyze/
+│       ├── apply-insights/
+│       ├── briefing/
+│       ├── bugfix/
+│       ├── checklist/
+│       ├── clarify/
+│       ├── constitution/
+│       ├── converge/           # reconcilia spec/plan/tasks vs código real
+│       ├── create-tasks/
+│       ├── decision-tree/      # ⚠️ DEPRECATED (remove_in 6.0.0) — use cstk-panel (cstk serve)
+│       ├── e2e-integration-flow/ # testes E2E de integração full-stack (Playwright)
+│       ├── execute-task/
+│       ├── image-generation/   # ⚠️ DEPRECATED (remove_in 6.0.0) — fora do escopo do toolkit
+│       ├── initialize-docs/
+│       ├── model-selector/     # heurística de roteamento de modelo (sugestor)
+│       ├── owasp-security/
+│       ├── plan/
+│       ├── review-features/
+│       ├── review-task/
+│       ├── specify/
+│       ├── validate-docs-rendered/
+│       └── validate-documentation/
+├── language-related/           # Skills e hooks específicos por linguagem
+│   └── go/                     # Go — ver docs/go-toolkit.md
+├── cli/                        # Binário cstk + libs POSIX
+└── docs/                       # Documentação por tópicos (ver índice abaixo)
+```
+
+### Anatomia de uma skill
+
+Cada skill é uma pasta com um `SKILL.md` (ponto de entrada) e, conforme o
+caso, subpastas consultadas sob demanda (*progressive disclosure* — o modelo
+paga só o contexto necessário no momento da invocação):
+
+```
+skills/<nome>/
+├── SKILL.md             # Quando invocar, regras de alto nível, gotchas
+├── templates/           # Templates preenchíveis
+├── examples/            # Casos concretos (good.md vs bad.md)
+├── references/          # Documentação de apoio
+├── scripts/             # Scripts POSIX determinísticos
+└── config.json          # Configuração por projeto (opcional)
+```
+
+Nem toda skill usa todas as subpastas — skills simples são só um `SKILL.md`.
+
+## Skills Globais
+
+Skills em `global/skills/`, independentes de linguagem ou framework.
+
+### Pipeline SDD (Spec-Driven Development)
+
+Sequência recomendada para levar uma ideia do discovery à implementação.
+Detalhes, diagrama do fluxo e atalhos em
+[docs/sdd-pipeline.md](./docs/sdd-pipeline.pt-BR.md).
+
+| Skill | Trigger | Descrição |
+|-------|---------|-----------|
+| **briefing** | "briefing", "discovery", "novo projeto" | Entrevista estruturada de discovery (visão, usuários, restrições, stack) |
+| **constitution** | "constitution", "princípios do projeto" | Princípios imutáveis de governança que guiam decisões |
+| **specify** | "specify", "criar spec", "nova feature" | Descrição natural → feature spec SDD (stories, requisitos, success criteria). Gate: todo requisito exige >=1 cenário; seção opcional Delta Requirements (specs vivas) |
+| **clarify** | "clarify", "resolver ambiguidades" | Resolve ambiguidades da spec via perguntas estruturadas (max 5) |
+| **plan** | "plan", "plano técnico" | Plano de implementação: pesquisa, modelo de dados, contratos |
+| **checklist** | "checklist", "quality gate" | "Unit Tests for English" — valida qualidade dos REQUISITOS; gaps viram tarefas |
+| **create-tasks** | "criar tarefas", "criar backlog" | Backlog de tarefas por fases com dependências e criticidade |
+| **analyze** | "analyze", "analisar consistência" | Análise read-only de consistência cross-artifact |
+| **execute-task** | "executar tarefa", "execute task" | Executa tarefa seguindo workflow obrigatório de 9 etapas |
+| **review-task** | "revisar tarefas", "status das tarefas" | Relatório de status com progresso e recomendações |
+
+### Skills Complementares
+
+| Skill | Trigger | Descrição |
+|-------|---------|-----------|
+| **advisor** | "me aconselhe", "analise estratégica" | Conselheiro brutalmente honesto que disseca raciocínio e gera planos de ação |
+| **bugfix** | "bugfix", "fix bug", "debug" | Protocolo estruturado de correção de bugs multi-camada |
+| **converge** | "converge", "o código bate com a spec?" | Reconcilia spec/plan/tasks contra o código ATUAL e apenda gaps como nova fase de tasks. Gate incondicional entre execute-task e review-task nos orquestradores |
+| **e2e-integration-flow** | "e2e", "playwright", "validar fluxo completo" | Testes E2E de integração full-stack (UI → API → banco → fila → efeitos colaterais) |
+| **initialize-docs** | "inicializar docs", "setup documentação" | Cria hierarquia padrão de documentação com 9 níveis |
+| **apply-insights** | "aplicar insights", "melhorar claude.md" | Aplica insights de uso comprovados ao CLAUDE.md, hooks e workflows — ver [Insights de uso](#insights-de-uso) |
+| **owasp-security** | Ao revisar segurança | Revisão guiada por checklist (OWASP Top 10:2025, ASVS 5.0, LLM/Agentic, NIST, OAuth 2.1...). Não substitui auditoria/pentest |
+| **review-features** | "status global", "comparar features" | Relatório cross-feature com sugestão de arquivar/abandonar/priorizar; a ação de archive aplica os deltas ao corpus de specs vivas |
+| **validate-documentation** | "validar documentação", "verificar UC" | Valida documentos individuais contra padrões estruturais |
+| **validate-docs-rendered** | "validar renderização", "verificar diagramas" | Valida que o Markdown renderiza (Mermaid, links, frontmatter, tabelas) |
+| **image-generation** | Ao gerar imagens | ⚠️ DEPRECATED (remove_in 6.0.0) |
+
+## Trilha avançada (orquestrador autônomo)
+
+> **Experimental** — funcional e em uso pelo mantenedor, sem garantias de
+> suporte para adoção externa.
+
+O `/agente-00c` conduz a pipeline SDD inteira sobre um projeto-alvo, pausando
+apenas em bloqueios reais; o `/feature-00c` faz o mesmo para UMA feature em
+projeto existente. Subsistemas: roteamento de modelos por onda, modo
+atomic-commit (commits automáticos + push/PR no finalize), guardas enforced
+(hook fail-closed), sessões paralelas em worktrees e memória de conhecimento
+cross-feature consultada antes de decidir.
+
+| Tópico | Documento |
+|--------|-----------|
+| Orquestradores `/agente-00c` + `/feature-00c`, model-routing, atomic-commit, guardas | [docs/agente-00c.md](./docs/agente-00c.pt-BR.md) |
+| Sessões paralelas (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.pt-BR.md) |
+| Memória de conhecimento (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.pt-BR.md) |
+| Painel web de métricas (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.pt-BR.md) |
+
+## Insights de uso
+
+A skill `apply-insights` é **prescritiva**: lê seu playbook
+(`~/.claude/insights/usage-insights.md`, por usuário — gere via `/insights`
+nativo do Claude Code) e o aplica ao projeto. Distinta do `/insights` nativo,
+que é **introspectivo** (analisa suas sessões).
+
+<!-- --8<-- [start:install-section] -->
+## Instalação
+
+### Via cstk CLI (recomendado)
+
+O toolkit é instalado via `cstk` — CLI POSIX shell que baixa, valida
+(SHA-256), instala e atualiza skills sem exigir clone do repositório.
+
+**One-liner de bootstrap** (instala `cstk` em `~/.local/bin/`):
+
+```bash
+curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh | sh
+```
+
+Depois disso, comandos típicos:
+
+```bash
+cstk --version                       # confirma instalação
+cstk install                         # instala perfil 'sdd' em ~/.claude/skills/
+cstk install --profile all           # instala TODAS as 31 skills (inclui language-go)
+cstk install advisor bugfix          # cherry-pick por nome
+cstk update                          # aplica novas releases preservando edits locais
+cstk update --force                  # sobrescreve skills com edição local
+cstk list                            # lista skills instaladas + status
+cstk doctor                          # detecta drift entre manifest e disco
+cstk self-update                     # atualiza o próprio binário cstk + cli/lib
+```
+
+> **`install`/`update` tocam só o catálogo** (skills/commands/agents em
+> `~/.claude/`); o runtime (`cli/lib/*.sh` + binário) atualiza via
+> **`cstk self-update`**.
+
+**Perfis disponíveis:**
+
+| Perfil | Conteúdo | Uso típico |
+|--------|----------|------------|
+| `sdd` | 17 skills: pipeline Spec-Driven Development completa (briefing → review-features) + runtime interno, model-selector e os 4 gates de qualidade dos orquestradores | Instalação global default |
+| `complementary` | 13 skills independentes (advisor, bugfix, e2e-integration-flow, etc.) | Complementa o pipeline SDD |
+| `all` | Todas as 31 skills (sdd + complementary + language-go) | Instalação completa |
+| `language-go` | Skills + hooks específicos para Go | Apenas em projetos Go |
+
+Profile padrão quando nada é informado: `sdd`.
+
+**Escopo de projeto** (`./.claude/skills/` no CWD em vez de `~/.claude/skills/`):
+
+```bash
+# Em um projeto Go: instala skills + hooks + merge de settings.json
+cd ~/projetos/meu-app-go
+cstk install --scope project --profile language-go
+
+# Cherry-pick em escopo de projeto
+cstk install --scope project advisor owasp-security
+
+# Hooks de language-* SÃO instalados apenas em --scope project
+# (em --scope global, hooks são omitidos com aviso no summary — FR-009c)
+```
+
+**Modo interativo** (seletor numerado em TTY) e **dry-run**:
+
+```bash
+cstk install --interactive   # lista perfis + skills numerados; seleção via toggle
+cstk install --dry-run --profile all
+cstk update --dry-run
+```
+
+### Instalação manual (deprecated, ainda suportada)
+
+Copia direta dos diretórios continua funcionando (`cp -r global/skills/
+~/.claude/skills/`), mas **não rastreia versões nem detecta drift** — ver
+[`CLAUDE.md`](./CLAUDE.md) §"Installed vs Source Drift". O `cstk` resolve
+isso via manifest + hash_dir.
+
+### Documentação completa do cstk
+
+- [`cli/README.md`](./cli/README.pt-BR.md) — visão técnica, convenções, processo de release
+- [`docs/specs/_archived/cstk-cli/`](docs/specs/_archived/cstk-cli/) — spec, plan, contracts, quickstart
+<!-- --8<-- [end:install-section] -->
+
+<!-- --8<-- [start:profiles-section] -->
+### Perfis de instalação (resumo)
+
+| Perfil | Conteúdo | Uso típico |
+|--------|----------|------------|
+| `sdd` | 17 skills: pipeline Spec-Driven Development completa (briefing → review-features) + runtime interno, model-selector e os 4 gates de qualidade dos orquestradores | Instalação global default |
+| `complementary` | 13 skills independentes (advisor, bugfix, e2e-integration-flow, etc.) | Complementa o pipeline SDD |
+| `all` | Todas as 31 skills (sdd + complementary + language-go) | Instalação completa |
+| `language-go` | Skills + hooks específicos para Go | Apenas em projetos Go |
+
+Profile padrão quando nada é informado: `sdd`. Detalhes em `cstk install --help`.
+<!-- --8<-- [end:profiles-section] -->
+
+## Documentação por tópicos
+
+| Tópico | Documento |
+|--------|-----------|
+| Pipeline SDD: fluxo completo, quando usar cada skill, atalhos, specs vivas | [docs/sdd-pipeline.md](./docs/sdd-pipeline.pt-BR.md) |
+| Orquestrador autônomo (agente-00c / feature-00c) | [docs/agente-00c.md](./docs/agente-00c.pt-BR.md) |
+| Sessões paralelas (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.pt-BR.md) |
+| Memória de conhecimento (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.pt-BR.md) |
+| Painel web (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.pt-BR.md) |
+| Skills e hooks para Go | [docs/go-toolkit.md](./docs/go-toolkit.pt-BR.md) |
+| Convenções de nomenclatura e hierarquia de docs | [docs/conventions.md](./docs/conventions.pt-BR.md) |
+| Manual navegável (site) | [jotjunior.github.io/cstk](https://jotjunior.github.io/cstk/) |
+
+## Contribuindo
+
+Contribuições são bem-vindas. O guia completo — modelo mental do sistema,
+fluxo de desenvolvimento, política de versionamento e o **princípio de escopo
+do toolkit global** (skills publicadas aqui não devem nomear clientes,
+empresas ou projetos específicos) — está em
+[CONTRIBUTING.md](./CONTRIBUTING.pt-BR.md). Resumo para adicionar uma skill:
+
+1. Siga a estrutura de pasta de uma skill existente (ver [Anatomia de uma skill](#anatomia-de-uma-skill))
+2. `SKILL.md` enxuto como ponto de entrada; conteúdo pesado em subpastas
+3. **description** como trigger condition, não resumo
+4. **Gotchas** documentados — o conteúdo mais valioso de uma skill
+5. Scripts em POSIX sh para operações determinísticas; todo `.sh` novo exige `tests/test_<nome>.sh`
+6. Generalize: se referencia algo de um projeto específico, pertence ao `<projeto>/.claude/skills/`, não a este toolkit
+7. Teste com o Claude Code antes de submeter
+
+## Versionamento
+
+Este projeto segue [Semantic Versioning](https://semver.org/) e mantém um
+[CHANGELOG.md](./CHANGELOG.md) com o histórico de mudanças.
+
+## Créditos & Atribuições
+
+Parte do pipeline SDD é adaptada do [GitHub Spec Kit](https://github.com/github/spec-kit)
+(MIT) — em especial o vocabulário de etapas e o template de constituição. O
+modelo de specs vivas com delta requirements foi inspirado no
+[OpenSpec](https://github.com/Fission-AI/OpenSpec). Outras skills tiveram
+inspiração conceitual de [obra/superpowers](https://github.com/obra/superpowers)
+e das convenções do Claude Code. Padrões públicos (OWASP, NIST, IETF, W3C,
+MITRE) são citados como referência. Detalhes e avisos de licença em
+[THIRD-PARTY-NOTICES.md](./THIRD-PARTY-NOTICES.pt-BR.md).
+
+## Licença
+
+Distribuído sob a licença MIT. Veja o arquivo [LICENSE](./LICENSE) para o
+texto completo.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,30 +1,32 @@
+**English** · [Português (pt-BR)](./THIRD-PARTY-NOTICES.pt-BR.md)
+
 # Third-Party Notices & Acknowledgments
 
-`cstk` é distribuído sob a licença MIT (ver [LICENSE](./LICENSE)). Este arquivo
-reconhece trabalhos de terceiros que inspiraram ou foram parcialmente adaptados
-neste toolkit, e reproduz os avisos de licença exigidos.
+`cstk` is distributed under the MIT license (see [LICENSE](./LICENSE)). This file
+acknowledges third-party works that inspired or were partially adapted in this
+toolkit, and reproduces the required license notices.
 
-O agrupamento abaixo é por **nível de obrigação**: obrigatório (a licença exige
-preservar o aviso), cortesia (inspiração conceitual, sem exigência legal) e
-referências factuais (padrões públicos citados, sem reprodução de texto
-protegido).
+The grouping below is by **level of obligation**: mandatory (the license requires
+preserving the notice), courtesy (conceptual inspiration, no legal requirement)
+and factual references (public standards cited, with no reproduction of protected
+text).
 
 ---
 
-## 1. Obrigatório — código/templates adaptados
+## 1. Mandatory — adapted code/templates
 
 ### GitHub Spec Kit
 
-Partes do pipeline de Spec-Driven Development deste toolkit — o vocabulário de
-etapas (`constitution` → `specify` → `clarify` → `plan` → `tasks` → `analyze`) e,
-em particular, o **template de constituição** em
-`global/skills/constitution/templates/constitution.md` (estrutura
-`## Core Principles` / `### [PRINCIPLE_N_NAME]`, rodapé
-`**Version** | **Ratified** | **Last Amended**`, marcadores `[NEEDS CLARIFICATION]`
-e "Sync Impact Report") — são **adaptados** do projeto **GitHub Spec Kit**.
+Parts of this toolkit's Spec-Driven Development pipeline — the vocabulary of steps
+(`constitution` → `specify` → `clarify` → `plan` → `tasks` → `analyze`) and, in
+particular, the **constitution template** in
+`global/skills/constitution/templates/constitution.md` (structure
+`## Core Principles` / `### [PRINCIPLE_N_NAME]`, footer
+`**Version** | **Ratified** | **Last Amended**`, `[NEEDS CLARIFICATION]` markers
+and "Sync Impact Report") — are **adapted** from the **GitHub Spec Kit** project.
 
-- Projeto: <https://github.com/github/spec-kit>
-- Licença: MIT
+- Project: <https://github.com/github/spec-kit>
+- License: MIT
 
 ```
 MIT License
@@ -50,40 +52,41 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-> Reproduzido verbatim do `LICENSE` upstream
-> (<https://github.com/github/spec-kit/blob/main/LICENSE>), que não declara ano.
+> Reproduced verbatim from the upstream `LICENSE`
+> (<https://github.com/github/spec-kit/blob/main/LICENSE>), which declares no year.
 
 ---
 
-## 2. Cortesia — inspiração conceitual (sem exigência legal)
+## 2. Courtesy — conceptual inspiration (no legal requirement)
 
-Estes projetos influenciaram o **design** de skills/convenções, sem reprodução
-de código ou texto. O reconhecimento é por boa-fé, não por obrigação de licença.
+These projects influenced the **design** of skills/conventions, with no
+reproduction of code or text. The acknowledgment is made in good faith, not out of
+a license obligation.
 
 - **obra/superpowers** (Jesse Vincent) — <https://github.com/obra/superpowers> —
-  inspirou padrões de `description`/anti-atalho e estrutura de skills. Licença MIT.
-- **Anthropic Claude Code** — convenções de scaffolding de skills, commands e
-  agents (formato `SKILL.md`, frontmatter, triggers). Documentação pública.
-- O framework de prompt "Subject-Context-Style" da skill `image-generation`
-  segue o guia público de prompting do Google Imagen.
+  inspired `description`/anti-shortcut patterns and skill structure. MIT license.
+- **Anthropic Claude Code** — scaffolding conventions for skills, commands and
+  agents (`SKILL.md` format, frontmatter, triggers). Public documentation.
+- The "Subject-Context-Style" prompt framework of the `image-generation` skill
+  follows Google Imagen's public prompting guide.
 
 ---
 
-## 3. Referências factuais — padrões públicos citados
+## 3. Factual references — public standards cited
 
-A skill `owasp-security` **não reproduz texto protegido** desses padrões: usa
-nomes de categorias e rankings (fatos) com prosa e exemplos de código próprios,
-e já cita cada fonte nas seções `## Sources` dos arquivos de referência. Listados
-aqui por transparência:
+The `owasp-security` skill **does not reproduce protected text** from these
+standards: it uses category names and rankings (facts) with its own prose and code
+examples, and already cites each source in the `## Sources` sections of the
+reference files. Listed here for transparency:
 
 - OWASP Top 10:2025, API Security Top 10:2023, CI/CD Top 10, ASVS 5.0, Top 10 for
   LLM Applications 2025, Top 10 for Agentic Applications 2026, Mobile/Kubernetes/
-  Docker Top 10 — © OWASP Foundation (conteúdo original sob CC BY-SA; aqui apenas
-  taxonomias factuais são referenciadas).
+  Docker Top 10 — © OWASP Foundation (original content under CC BY-SA; here only
+  factual taxonomies are referenced).
 - MITRE CWE Top 25:2025 · NIST SP 800-63B-4, FIPS 203/204/205, IR 8547 ·
   IETF OAuth 2.1, RFC 9449/9126/9101 · W3C WebAuthn L3 · OpenID FAPI 2.0 ·
   Cloud Security Alliance MAESTRO · EU AI Act.
 
 ---
 
-*Encontrou uma atribuição faltante ou incorreta? Abra uma issue — corrigimos.*
+*Found a missing or incorrect attribution? Open an issue — we'll fix it.*

--- a/THIRD-PARTY-NOTICES.pt-BR.md
+++ b/THIRD-PARTY-NOTICES.pt-BR.md
@@ -1,0 +1,91 @@
+[English](./THIRD-PARTY-NOTICES.md) · **Português (pt-BR)**
+
+# Third-Party Notices & Acknowledgments
+
+`cstk` é distribuído sob a licença MIT (ver [LICENSE](./LICENSE)). Este arquivo
+reconhece trabalhos de terceiros que inspiraram ou foram parcialmente adaptados
+neste toolkit, e reproduz os avisos de licença exigidos.
+
+O agrupamento abaixo é por **nível de obrigação**: obrigatório (a licença exige
+preservar o aviso), cortesia (inspiração conceitual, sem exigência legal) e
+referências factuais (padrões públicos citados, sem reprodução de texto
+protegido).
+
+---
+
+## 1. Obrigatório — código/templates adaptados
+
+### GitHub Spec Kit
+
+Partes do pipeline de Spec-Driven Development deste toolkit — o vocabulário de
+etapas (`constitution` → `specify` → `clarify` → `plan` → `tasks` → `analyze`) e,
+em particular, o **template de constituição** em
+`global/skills/constitution/templates/constitution.md` (estrutura
+`## Core Principles` / `### [PRINCIPLE_N_NAME]`, rodapé
+`**Version** | **Ratified** | **Last Amended**`, marcadores `[NEEDS CLARIFICATION]`
+e "Sync Impact Report") — são **adaptados** do projeto **GitHub Spec Kit**.
+
+- Projeto: <https://github.com/github/spec-kit>
+- Licença: MIT
+
+```
+MIT License
+
+Copyright GitHub, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+> Reproduzido verbatim do `LICENSE` upstream
+> (<https://github.com/github/spec-kit/blob/main/LICENSE>), que não declara ano.
+
+---
+
+## 2. Cortesia — inspiração conceitual (sem exigência legal)
+
+Estes projetos influenciaram o **design** de skills/convenções, sem reprodução
+de código ou texto. O reconhecimento é por boa-fé, não por obrigação de licença.
+
+- **obra/superpowers** (Jesse Vincent) — <https://github.com/obra/superpowers> —
+  inspirou padrões de `description`/anti-atalho e estrutura de skills. Licença MIT.
+- **Anthropic Claude Code** — convenções de scaffolding de skills, commands e
+  agents (formato `SKILL.md`, frontmatter, triggers). Documentação pública.
+- O framework de prompt "Subject-Context-Style" da skill `image-generation`
+  segue o guia público de prompting do Google Imagen.
+
+---
+
+## 3. Referências factuais — padrões públicos citados
+
+A skill `owasp-security` **não reproduz texto protegido** desses padrões: usa
+nomes de categorias e rankings (fatos) com prosa e exemplos de código próprios,
+e já cita cada fonte nas seções `## Sources` dos arquivos de referência. Listados
+aqui por transparência:
+
+- OWASP Top 10:2025, API Security Top 10:2023, CI/CD Top 10, ASVS 5.0, Top 10 for
+  LLM Applications 2025, Top 10 for Agentic Applications 2026, Mobile/Kubernetes/
+  Docker Top 10 — © OWASP Foundation (conteúdo original sob CC BY-SA; aqui apenas
+  taxonomias factuais são referenciadas).
+- MITRE CWE Top 25:2025 · NIST SP 800-63B-4, FIPS 203/204/205, IR 8547 ·
+  IETF OAuth 2.1, RFC 9449/9126/9101 · W3C WebAuthn L3 · OpenID FAPI 2.0 ·
+  Cloud Security Alliance MAESTRO · EU AI Act.
+
+---
+
+*Encontrou uma atribuição faltante ou incorreta? Abra uma issue — corrigimos.*

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,127 +1,127 @@
+**English** · [Português (pt-BR)](./README.pt-BR.md)
+
 # cstk — Claude Specs Toolkit CLI
 
-CLI em POSIX sh para instalar, atualizar e auditar skills do toolkit. Este
-diretorio contem o codigo fonte do CLI; a documentacao de design completa
-vive em [`../docs/specs/cstk-cli/`](../docs/specs/_archived/cstk-cli/).
+A POSIX sh CLI to install, update and audit the toolkit's skills. This directory
+contains the CLI's source code; the full design documentation lives in
+[`../docs/specs/cstk-cli/`](../docs/specs/_archived/cstk-cli/).
 
-**Status atual**: FASES 0-9.2 do backlog concluidas — todos os subcomandos
-(`install`, `update`, `self-update`, `list`, `doctor`, `serve`) implementados e
-testados, com pipeline de release automatizado. Pendentes: FASES 9.3
-(coverage check), 10 (testes de integracao end-to-end) e 11 (docs +
-primeira release publica).
+**Current status**: PHASES 0-9.2 of the backlog complete — all subcommands
+(`install`, `update`, `self-update`, `list`, `doctor`, `serve`) implemented and
+tested, with an automated release pipeline. Pending: PHASES 9.3 (coverage check),
+10 (end-to-end integration tests) and 11 (docs + first public release).
 
 ## Layout
 
 ```
 cli/
-├── cstk         # executavel principal (POSIX sh)
-├── VERSION      # tag de versao (dev: "0.0.0-dev"; release: preenchida pelo build)
-├── lib/         # bibliotecas modulares por subcomando
-└── README.md    # este arquivo
+├── cstk         # main executable (POSIX sh)
+├── VERSION      # version tag (dev: "0.0.0-dev"; release: filled in by the build)
+├── lib/         # modular libraries per subcommand
+└── README.md    # this file
 ```
 
-## Uso em dev (antes de release)
+## Dev usage (before a release)
 
 ```sh
-# Da raiz do repo:
+# From the repo root:
 ./cli/cstk --version        # → cstk 0.0.0-dev
 ./cli/cstk --help
-./cli/cstk help install     # aponta para o contrato
+./cli/cstk help install     # points to the contract
 ```
 
-## Instalacao via one-liner
+## Installation via one-liner
 
-Apos uma release publica estar disponivel, instalar o `cstk` em uma maquina
-nova com:
+Once a public release is available, install `cstk` on a new machine with:
 
 ```sh
 curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh | sh
 ```
 
-O bootstrap baixa o tarball da ultima release, valida o SHA-256 (FR-010a),
-copia `cstk` para `~/.local/bin/` e `cli/lib/` para `~/.local/share/cstk/lib/`.
-Depois disso:
+The bootstrap downloads the latest release tarball, validates the SHA-256
+(FR-010a), copies `cstk` to `~/.local/bin/` and `cli/lib/` to
+`~/.local/share/cstk/lib/`. After that:
 
 ```sh
-cstk --version           # confirma instalacao
-cstk install             # instala perfil sdd em ~/.claude/skills/
-cstk self-update         # atualiza o proprio binario quando houver release nova
+cstk --version           # confirms installation
+cstk install             # installs the sdd profile into ~/.claude/skills/
+cstk self-update         # updates its own binary when a new release exists
 ```
 
-## Processo de release
+## Release process
 
-A pipeline em [`.github/workflows/release.yml`](../.github/workflows/release.yml)
-publica releases automaticamente quando uma tag SemVer e empurrada.
+The pipeline in [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+publishes releases automatically when a SemVer tag is pushed.
 
 ```sh
-# Local: criar e empurrar a tag
+# Local: create and push the tag
 git tag -a v0.1.0 -m "cstk v0.1.0"
 git push origin v0.1.0
 ```
 
-A pipeline (em `ubuntu-latest`):
+The pipeline (on `ubuntu-latest`):
 
-1. Valida o formato da tag (`vX.Y.Z[-suffix]`)
-2. Roda `./tests/run.sh` (suite global) — falha aborta o release
-3. Roda cada `tests/cstk/test_*.sh` — falha aborta o release
-4. Executa `./scripts/build-release.sh <tag>` (build deterministico —
-   ver [scripts/build-release.sh](../scripts/build-release.sh))
-5. Cria o GitHub Release via `gh release create` com upload de:
+1. Validates the tag format (`vX.Y.Z[-suffix]`)
+2. Runs `./tests/run.sh` (global suite) — failure aborts the release
+3. Runs each `tests/cstk/test_*.sh` — failure aborts the release
+4. Executes `./scripts/build-release.sh <tag>` (deterministic build —
+   see [scripts/build-release.sh](../scripts/build-release.sh))
+5. Creates the GitHub Release via `gh release create`, uploading:
    - `cstk-<bare-version>.tar.gz`
    - `cstk-<bare-version>.tar.gz.sha256`
-   - `cli/install.sh` (asset standalone para o one-liner)
+   - `cli/install.sh` (standalone asset for the one-liner)
 
-Release notes sao geradas automaticamente pelo `gh release create
---generate-notes` (lista de PRs/commits desde a ultima tag).
+Release notes are generated automatically by `gh release create
+--generate-notes` (list of PRs/commits since the last tag).
 
-**Re-rodar uma release ja publicada falha** — `gh release create` nao
-sobrescreve. Para corrigir, deletar o release no GitHub UI e re-empurrar
-a tag (ou usar uma nova tag, preferencial).
+**Re-running an already-published release fails** — `gh release create` does not
+overwrite. To fix it, delete the release in the GitHub UI and re-push the tag (or
+use a new tag, preferred).
 
-## Subcomandos
+## Subcommands
 
-| Subcomando | Descricao | Lib |
+| Subcommand | Description | Lib |
 |------------|-----------|-----|
-| `install` | Instala perfis/skills em `~/.claude/` | `lib/install.sh` |
-| `update` | Aplica novas releases preservando edits locais | `lib/install.sh` |
-| `self-update` | Atualiza o binario `cstk` + `cli/lib/` | `lib/self-update.sh` |
-| `list` | Lista skills instaladas + status | `lib/list.sh` |
-| `doctor` | Detecta drift entre manifest e disco | `lib/doctor.sh` |
-| `session` | Cria/lista/encerra sessoes com worktree isolado | `lib/session.sh` |
-| `recall` | Memoria cross-feature: busca/ingestao/reindex | `lib/recall.sh` |
-| `serve` | Inicia o painel web local (lazy-install + npm start) | `lib/serve.sh` |
+| `install` | Installs profiles/skills into `~/.claude/` | `lib/install.sh` |
+| `update` | Applies new releases while preserving local edits | `lib/install.sh` |
+| `self-update` | Updates the `cstk` binary + `cli/lib/` | `lib/self-update.sh` |
+| `list` | Lists installed skills + status | `lib/list.sh` |
+| `doctor` | Detects drift between manifest and disk | `lib/doctor.sh` |
+| `session` | Creates/lists/ends sessions with an isolated worktree | `lib/session.sh` |
+| `recall` | Cross-feature memory: search/ingest/reindex | `lib/recall.sh` |
+| `serve` | Starts the local web panel (lazy-install + npm start) | `lib/serve.sh` |
 
 ### `cstk serve`
 
-Baixa e executa a interface web do cstk panel. Na primeira execucao, consulta
-a GitHub Releases API, baixa o tarball mais recente de
-`JotJunior/cstk-panel`, extrai e roda `npm install`. Execucoes subsequentes
-reutilizam o cache (sem download).
+Downloads and runs the cstk panel web interface. On the first run it queries the
+GitHub Releases API, downloads the latest tarball from `JotJunior/cstk-panel`,
+extracts it and runs `npm install`. Subsequent runs reuse the cache (no
+download).
 
 ```sh
-cstk serve                   # inicia na porta padrao 5173
-cstk serve --port 8080       # porta customizada
-cstk serve --reinstall       # forcca reinstalacao
-PORT=4000 cstk serve         # porta via variavel de ambiente
+cstk serve                   # starts on the default port 5173
+cstk serve --port 8080       # custom port
+cstk serve --reinstall       # force reinstall
+PORT=4000 cstk serve         # port via environment variable
 ```
 
-Opcoes: `--port PORT` (1024-65535), `--host HOST` (default: 127.0.0.1),
-`--reinstall`, `--help`. Override do diretorio via `$CSTK_PANEL_DIR`.
+Options: `--port PORT` (1024-65535), `--host HOST` (default: 127.0.0.1),
+`--reinstall`, `--help`. Override the directory via `$CSTK_PANEL_DIR`.
 
-## Convencoes
+## Conventions
 
-- POSIX sh: `#!/bin/sh`, `set -eu`, sem bash-isms (Constitution 1.1.0 §II).
-- Saida de dados em stdout; mensagens humanas + summaries em stderr.
-- Exit codes: 0 OK, 1 erro geral, 2 uso, 3 lock, 4 edit local, 10 check-available.
-- `$CSTK_LIB` override localiza lib/ durante testes.
-- `$CSTK_VERSION_FILE` override localiza VERSION durante testes.
+- POSIX sh: `#!/bin/sh`, `set -eu`, no bash-isms (Constitution 1.1.0 §II).
+- Data output on stdout; human messages + summaries on stderr.
+- Exit codes: 0 OK, 1 general error, 2 usage, 3 lock, 4 local edit, 10 check-available.
+- `$CSTK_LIB` override locates lib/ during tests.
+- `$CSTK_VERSION_FILE` override locates VERSION during tests.
 
-## Desenvolvimento
+## Development
 
-Veja [`../docs/specs/cstk-cli/tasks.md`](../docs/specs/_archived/cstk-cli/tasks.md) para
-o backlog. Rodar testes:
+See [`../docs/specs/cstk-cli/tasks.md`](../docs/specs/_archived/cstk-cli/tasks.md) for
+the backlog. Running tests:
 
 ```sh
-sh tests/cstk/test_cstk-main.sh    # direto (FASE 1.1)
-./tests/run.sh cstk                # via suite (apos FASE 9.3.1)
+sh tests/cstk/test_cstk-main.sh    # direct (PHASE 1.1)
+./tests/run.sh cstk                # via the suite (after PHASE 9.3.1)
 ```

--- a/cli/README.pt-BR.md
+++ b/cli/README.pt-BR.md
@@ -1,0 +1,129 @@
+[English](./README.md) · **Português (pt-BR)**
+
+# cstk — Claude Specs Toolkit CLI
+
+CLI em POSIX sh para instalar, atualizar e auditar skills do toolkit. Este
+diretorio contem o codigo fonte do CLI; a documentacao de design completa
+vive em [`../docs/specs/cstk-cli/`](../docs/specs/_archived/cstk-cli/).
+
+**Status atual**: FASES 0-9.2 do backlog concluidas — todos os subcomandos
+(`install`, `update`, `self-update`, `list`, `doctor`, `serve`) implementados e
+testados, com pipeline de release automatizado. Pendentes: FASES 9.3
+(coverage check), 10 (testes de integracao end-to-end) e 11 (docs +
+primeira release publica).
+
+## Layout
+
+```
+cli/
+├── cstk         # executavel principal (POSIX sh)
+├── VERSION      # tag de versao (dev: "0.0.0-dev"; release: preenchida pelo build)
+├── lib/         # bibliotecas modulares por subcomando
+└── README.md    # este arquivo
+```
+
+## Uso em dev (antes de release)
+
+```sh
+# Da raiz do repo:
+./cli/cstk --version        # → cstk 0.0.0-dev
+./cli/cstk --help
+./cli/cstk help install     # aponta para o contrato
+```
+
+## Instalacao via one-liner
+
+Apos uma release publica estar disponivel, instalar o `cstk` em uma maquina
+nova com:
+
+```sh
+curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh | sh
+```
+
+O bootstrap baixa o tarball da ultima release, valida o SHA-256 (FR-010a),
+copia `cstk` para `~/.local/bin/` e `cli/lib/` para `~/.local/share/cstk/lib/`.
+Depois disso:
+
+```sh
+cstk --version           # confirma instalacao
+cstk install             # instala perfil sdd em ~/.claude/skills/
+cstk self-update         # atualiza o proprio binario quando houver release nova
+```
+
+## Processo de release
+
+A pipeline em [`.github/workflows/release.yml`](../.github/workflows/release.yml)
+publica releases automaticamente quando uma tag SemVer e empurrada.
+
+```sh
+# Local: criar e empurrar a tag
+git tag -a v0.1.0 -m "cstk v0.1.0"
+git push origin v0.1.0
+```
+
+A pipeline (em `ubuntu-latest`):
+
+1. Valida o formato da tag (`vX.Y.Z[-suffix]`)
+2. Roda `./tests/run.sh` (suite global) — falha aborta o release
+3. Roda cada `tests/cstk/test_*.sh` — falha aborta o release
+4. Executa `./scripts/build-release.sh <tag>` (build deterministico —
+   ver [scripts/build-release.sh](../scripts/build-release.sh))
+5. Cria o GitHub Release via `gh release create` com upload de:
+   - `cstk-<bare-version>.tar.gz`
+   - `cstk-<bare-version>.tar.gz.sha256`
+   - `cli/install.sh` (asset standalone para o one-liner)
+
+Release notes sao geradas automaticamente pelo `gh release create
+--generate-notes` (lista de PRs/commits desde a ultima tag).
+
+**Re-rodar uma release ja publicada falha** — `gh release create` nao
+sobrescreve. Para corrigir, deletar o release no GitHub UI e re-empurrar
+a tag (ou usar uma nova tag, preferencial).
+
+## Subcomandos
+
+| Subcomando | Descricao | Lib |
+|------------|-----------|-----|
+| `install` | Instala perfis/skills em `~/.claude/` | `lib/install.sh` |
+| `update` | Aplica novas releases preservando edits locais | `lib/install.sh` |
+| `self-update` | Atualiza o binario `cstk` + `cli/lib/` | `lib/self-update.sh` |
+| `list` | Lista skills instaladas + status | `lib/list.sh` |
+| `doctor` | Detecta drift entre manifest e disco | `lib/doctor.sh` |
+| `session` | Cria/lista/encerra sessoes com worktree isolado | `lib/session.sh` |
+| `recall` | Memoria cross-feature: busca/ingestao/reindex | `lib/recall.sh` |
+| `serve` | Inicia o painel web local (lazy-install + npm start) | `lib/serve.sh` |
+
+### `cstk serve`
+
+Baixa e executa a interface web do cstk panel. Na primeira execucao, consulta
+a GitHub Releases API, baixa o tarball mais recente de
+`JotJunior/cstk-panel`, extrai e roda `npm install`. Execucoes subsequentes
+reutilizam o cache (sem download).
+
+```sh
+cstk serve                   # inicia na porta padrao 5173
+cstk serve --port 8080       # porta customizada
+cstk serve --reinstall       # forcca reinstalacao
+PORT=4000 cstk serve         # porta via variavel de ambiente
+```
+
+Opcoes: `--port PORT` (1024-65535), `--host HOST` (default: 127.0.0.1),
+`--reinstall`, `--help`. Override do diretorio via `$CSTK_PANEL_DIR`.
+
+## Convencoes
+
+- POSIX sh: `#!/bin/sh`, `set -eu`, sem bash-isms (Constitution 1.1.0 §II).
+- Saida de dados em stdout; mensagens humanas + summaries em stderr.
+- Exit codes: 0 OK, 1 erro geral, 2 uso, 3 lock, 4 edit local, 10 check-available.
+- `$CSTK_LIB` override localiza lib/ durante testes.
+- `$CSTK_VERSION_FILE` override localiza VERSION durante testes.
+
+## Desenvolvimento
+
+Veja [`../docs/specs/cstk-cli/tasks.md`](../docs/specs/_archived/cstk-cli/tasks.md) para
+o backlog. Rodar testes:
+
+```sh
+sh tests/cstk/test_cstk-main.sh    # direto (FASE 1.1)
+./tests/run.sh cstk                # via suite (apos FASE 9.3.1)
+```

--- a/docs/agente-00c.md
+++ b/docs/agente-00c.md
@@ -1,191 +1,193 @@
-# Agente-00C — orquestrador autônomo da pipeline SDD
+**English** · [Português (pt-BR)](./agente-00c.pt-BR.md)
 
-> **Trilha avançada.** Não é necessário para o uso básico do toolkit (ver
-> [Comece aqui](../README.md#comece-aqui)). Subsistemas de suporte:
-> [Sessões paralelas](./cstk-session.md) e
-> [Memória de conhecimento](./cstk-recall.md).
+# Agente-00C — autonomous orchestrator of the SDD pipeline
 
-> **Status: funcional e em uso pelo mantenedor** — porém **sem suíte de
-> testes automatizada dos agentes custom** (validação por execuções reais,
-> decisão consciente do briefing). Para adoção externa, trate como
-> **experimental**: é um experimento pessoal de orquestração autônoma, não
-> um produto com garantias de suporte. O backlog original (já concluído) está
-> em [`specs/_archived/agente-00c/`](./specs/_archived/agente-00c/)
-> (44 tarefas, 9 fases); a feature evoluiu muito desde então — ver
-> feature-00c, model-routing e a memória de conhecimento.
+> **Advanced track.** Not required for basic use of the toolkit (see
+> [Start here](../README.md#start-here)). Supporting subsystems:
+> [Parallel sessions](./cstk-session.md) and
+> [Knowledge memory](./cstk-recall.md).
 
-O `agente-00C` é um **orquestrador autônomo** da pipeline SDD do toolkit:
-você invoca `/agente-00c` com uma descrição curta de POC/MVP e ele conduz
+> **Status: functional and in use by the maintainer** — but **without an
+> automated test suite for the custom agents** (validated by real runs, a
+> conscious decision from the briefing). For external adoption, treat it as
+> **experimental**: it is a personal experiment in autonomous orchestration,
+> not a product with support guarantees. The original backlog (already
+> completed) is in [`specs/_archived/agente-00c/`](./specs/_archived/agente-00c/)
+> (44 tasks, 9 phases); the feature has evolved a lot since then — see
+> feature-00c, model-routing and the knowledge memory.
+
+`agente-00C` is an **autonomous orchestrator** of the toolkit's SDD pipeline:
+you invoke `/agente-00c` with a short POC/MVP description and it runs
 `briefing → constitution → specify → clarify → plan → checklist →
-create-tasks → execute-task → review-task → review-features`, **pausando
-apenas em bloqueios reais** (decisões que exigem um humano) e entre ondas
-agendadas — **não** é "dispare-e-esqueça". O entregável-mor é um **relatório
-auditável** rico em decisões, bloqueios e lições aprendidas: ele existe
-justamente para você revisar a rota, em vez de confiar cegamente na cadeia
-de etapas.
+create-tasks → execute-task → review-task → review-features`, **pausing only
+on real blocks** (decisions that require a human) and between scheduled waves
+— it is **not** "fire-and-forget". The primary deliverable is an **auditable
+report** rich in decisions, blocks and lessons learned: it exists precisely so
+you can review the route, instead of blindly trusting the chain of steps.
 
-> **Dica — prompt ideal para o briefing**: quanto mais completa a descrição
-> inicial, menos perguntas o agente faz na etapa `briefing`. Use o template
-> preenchível em
+> **Tip — ideal briefing prompt**: the more complete the initial description,
+> the fewer questions the agent asks in the `briefing` step. Use the fillable
+> template at
 > [`templates/briefing-prompt-ideal.md`](./templates/briefing-prompt-ideal.md)
-> — mapeado 1:1 com as seções do briefing e com blocos extras para
-> arquiteturas complexas, com guia de poda para entregas simples.
+> — mapped 1:1 with the briefing sections, with extra blocks for complex
+> architectures and a pruning guide for simple deliverables.
 
-## Comandos expostos
+## Exposed commands
 
-| Comando | Função |
-|---------|--------|
-| `cstk 00c <path>` | **Atalho recomendado**: bootstrap interativo (cria diretório, coleta parâmetros e invoca `claude` já com `/agente-00c` montada) |
-| `/agente-00c <descricao> [--stack ...] [--whitelist ...] [--projeto-alvo-path ...]` | Invocação direta no claude (alternativa ao `cstk 00c`) |
-| `/agente-00c-resume [--projeto-alvo-path ...] [--resposta-bloqueio <id>:<resp>]` | Retoma após pausa ou schedule |
-| `/agente-00c-abort [--projeto-alvo-path ...]` | Aborto manual |
+| Command | Function |
+|---------|----------|
+| `cstk 00c <path>` | **Recommended shortcut**: interactive bootstrap (creates the directory, collects parameters and invokes `claude` with `/agente-00c` already assembled) |
+| `/agente-00c <descricao> [--stack ...] [--whitelist ...] [--projeto-alvo-path ...]` | Direct invocation in claude (alternative to `cstk 00c`) |
+| `/agente-00c-resume [--projeto-alvo-path ...] [--resposta-bloqueio <id>:<resp>]` | Resume after a pause or schedule |
+| `/agente-00c-abort [--projeto-alvo-path ...]` | Manual abort |
 
-> **`cstk 00c <path>`** é o caminho preferido para iniciar um POC/MVP novo:
-> ele valida o path, cria o diretório, coleta descrição/stack/whitelist via
-> prompts e dá `exec claude` com a slash command auto-submetida. Requer
-> TTY interativo e só opera em paths novos ou vazios — para retomar execução
-> existente, use `/agente-00c-resume` diretamente no claude. Detalhes em
+> **`cstk 00c <path>`** is the preferred path to start a new POC/MVP: it
+> validates the path, creates the directory, collects description/stack/whitelist
+> via prompts and runs `exec claude` with the slash command auto-submitted. It
+> requires an interactive TTY and only operates on new or empty paths — to
+> resume an existing run, use `/agente-00c-resume` directly in claude. Details in
 > [`specs/_archived/cstk-cli/contracts/cstk-00c.md`](./specs/_archived/cstk-cli/contracts/cstk-00c.md).
 
-## Pré-requisitos
+## Prerequisites
 
-- **Claude Code** (Opus 4.x ou Sonnet 4.6 recomendado), **Auto mode**
-  ativo para reduzir interrupções.
-- **`gh` CLI autenticado** (necessário para abertura automática de issue
-  no toolkit em caso de bug em skill global — FR-021).
-- **`git` no PATH** (commit local entre ondas).
-- **Docker local** (apenas se a stack-sugerida usar containers; orquestrador
-  recusa qualquer `docker push`/deploy externo — Princípio V da feature).
-- **Toolkit instalado via `cstk install`** para que os slash commands e
-  agentes custom estejam disponíveis.
+- **Claude Code** (Opus 4.x or Sonnet 4.6 recommended), **Auto mode**
+  enabled to reduce interruptions.
+- **Authenticated `gh` CLI** (required for automatic issue opening on the
+  toolkit in case of a bug in a global skill — FR-021).
+- **`git` on the PATH** (local commit between waves).
+- **Local Docker** (only if the suggested stack uses containers; the
+  orchestrator refuses any `docker push`/external deploy — Principle V of the
+  feature).
+- **Toolkit installed via `cstk install`** so the slash commands and custom
+  agents are available.
 
-## Limitações conhecidas
+## Known limitations
 
-- **Schedule limitado a 60-3600s via `ScheduleWakeup`**: continuação
-  cross-sessão usa `ScheduleWakeup`; para pausas longas (>=1h ou
-  bloqueios que só serão respondidos em horas/dias), o relatório
-  parcial sugere criar uma routine manual via `/schedule` que sobrevive
-  laptop suspend/restart (cloud Anthropic).
-- **Sem observabilidade nativa de tokens consumidos**: o orçamento de
-  sessão usa proxies (tool calls da onda, wallclock, tamanho do estado).
-- **Sem `git push` cru, sem deploy externo, sem `sudo`**: por constituição da
-  feature, blast radius é confinado ao `--projeto-alvo-path`. O caminho
-  confinado de push+PR existe apenas no finalize do modo atomic-commit.
-- **Suíte de testes automatizada**: validação ocorre via execuções reais
-  com cenários manuais
+- **Schedule limited to 60-3600s via `ScheduleWakeup`**: cross-session
+  continuation uses `ScheduleWakeup`; for long pauses (>=1h or blocks that
+  will only be answered in hours/days), the partial report suggests creating a
+  manual routine via `/schedule` that survives laptop suspend/restart
+  (Anthropic cloud).
+- **No native observability of consumed tokens**: the session budget uses
+  proxies (wave tool calls, wallclock, state size).
+- **No raw `git push`, no external deploy, no `sudo`**: by the feature's
+  constitution, the blast radius is confined to `--projeto-alvo-path`. The
+  confined push+PR path exists only in the atomic-commit mode finalize.
+- **Automated test suite**: validation happens through real runs with manual
+  scenarios
   ([`specs/_archived/agente-00c/quickstart.md`](./specs/_archived/agente-00c/quickstart.md)).
-- **Schema de estado sem migração automática entre versões maiores**:
-  execuções pendentes precisam ser concluídas ou abortadas antes de upgrade.
+- **State schema without automatic migration across major versions**: pending
+  runs must be completed or aborted before upgrading.
 
-Detalhamento completo (briefing, constitution, spec com 31 FRs, plan,
-research, threat-model, contracts, quickstart) em
+Full details (briefing, constitution, spec with 31 FRs, plan, research,
+threat-model, contracts, quickstart) in
 [`specs/_archived/agente-00c/`](./specs/_archived/agente-00c/).
 
-## Feature-00C — variante de escopo de feature individual
+## Feature-00C — individual-feature scope variant
 
-A partir de v3.13.0, o toolkit oferece `/feature-00c` como variante do
-agente-00c focada em **uma feature** dentro de projeto que JÁ possui
-`briefing.md` + `docs/constitution.md` ratificados. Pipeline reduzida:
+Since v3.13.0, the toolkit offers `/feature-00c` as a variant of agente-00c
+focused on **one feature** within a project that ALREADY has ratified
+`briefing.md` + `docs/constitution.md`. Reduced pipeline:
 `specify → clarify → plan → checklist → create-tasks → execute-task →
-review-task` (sem briefing/constitution/review-features, que são
-pré-requisitos validados em FR-PRE-001..004).
+review-task` (without briefing/constitution/review-features, which are
+prerequisites validated in FR-PRE-001..004).
 
-| Comando | Quando usar |
+| Command | When to use |
 |---------|-------------|
-| `/feature-00c "<descricao>" [<short-name>]` | Adicionar feature nova em projeto existente |
-| `/feature-00c-resume <short-name> [--resposta-bloqueio "..."]` | Retomar após pausa ou schedule |
-| `/feature-00c-abort <short-name> [--purge-backups]` | Aborto manual (SIGTERM + grace period 60s) |
+| `/feature-00c "<descricao>" [<short-name>]` | Add a new feature to an existing project |
+| `/feature-00c-resume <short-name> [--resposta-bloqueio "..."]` | Resume after a pause or schedule |
+| `/feature-00c-abort <short-name> [--purge-backups]` | Manual abort (SIGTERM + 60s grace period) |
 
-Co-existência com `/agente-00c`: namespaces isolados
-(`agente-00c-state/` vs `feature-00c-state/<short_name>/`). Features
-paralelas no mesmo projeto são permitidas; concorrência com agente-00c
-ativo é bloqueada (FR-026). Reuso integral do runtime POSIX
-compartilhado (`agente-00c-runtime`). Detalhamento em
+Co-existence with `/agente-00c`: isolated namespaces
+(`agente-00c-state/` vs `feature-00c-state/<short_name>/`). Parallel features
+in the same project are allowed; concurrency with an active agente-00c is
+blocked (FR-026). Full reuse of the shared POSIX runtime
+(`agente-00c-runtime`). Details in
 [`specs/_archived/feature-00c/`](./specs/_archived/feature-00c/).
 
-## Roteamento de modelos por onda (model-routing)
+## Per-wave model routing (model-routing)
 
-> **BREAKING v4.0.0** — o model-routing **deixou de ser audit-only**
-> (premissa da v3.15.0, revogada): o harness atual aceita `model` no spawn
-> de subagente, e o modelo agora **É APLICADO** a cada onda.
+> **BREAKING v4.0.0** — model-routing **is no longer audit-only** (the v3.15.0
+> premise, revoked): the current harness accepts `model` on subagent spawn, and
+> the model is now **APPLIED** on every wave.
 
-No início de cada onda, o **command pai** (`/agente-00c`, `/feature-00c` e
-resumes) chama `model-routing.sh wave-select` e aplica o modelo retornado no
-spawn do orquestrador. A base é um mapa determinístico fase→modelo
-(`references/phase-model-map.txt`, POSIX puro):
+At the start of each wave, the **parent command** (`/agente-00c`, `/feature-00c`
+and their resumes) calls `model-routing.sh wave-select` and applies the returned
+model on the orchestrator's spawn. The base is a deterministic phase→model map
+(`references/phase-model-map.txt`, pure POSIX):
 
-| Fase | Faixa | Modelo-piso |
-|------|-------|-------------|
-| `plan`, `analyze`, `constitution` | profunda | **opus** |
-| `specify`, `clarify`, `checklist`, `create-tasks`, `briefing` | média | **sonnet** |
-| `execute-task` | rasa | **sonnet** (piso; refinável ↑opus / ↓haiku) |
-| `validate-docs`, `review-task` | rasa | **haiku** |
-| fase não listada | — | `manter-atual` (nunca erro) |
+| Phase | Tier | Floor model |
+|-------|------|-------------|
+| `plan`, `analyze`, `constitution` | deep | **opus** |
+| `specify`, `clarify`, `checklist`, `create-tasks`, `briefing` | medium | **sonnet** |
+| `execute-task` | shallow | **sonnet** (floor; refinable ↑opus / ↓haiku) |
+| `validate-docs`, `review-task` | shallow | **haiku** |
+| phase not listed | — | `manter-atual` (never an error) |
 
-Precedência de resolução:
-`override manual do operador > escalada mid-onda (opus) > refino model-selector > mapa fase→modelo`.
+Resolution precedence:
+`operator manual override > mid-wave escalation (opus) > model-selector refinement > phase→model map`.
 
-A skill **model-selector** virou camada de refino opcional (só em
-`execute-task` com `--task-text`): pode elevar para opus ou rebaixar para
-haiku sobre o piso do mapa, citando sinais. Contrato **suggest-only**
-preservado: a skill nunca troca modelo sozinha — quem aplica é o command pai.
-Auditoria sugerido-vs-aplicado via `model-routing-report.sh aggregate`
-(consumida pelo `review-task` §4.5).
+The **model-selector** skill became an optional refinement layer (only in
+`execute-task` with `--task-text`): it can raise to opus or lower to haiku over
+the map's floor, citing signals. The **suggest-only** contract is preserved:
+the skill never switches the model on its own — the parent command applies it.
+Suggested-vs-applied auditing via `model-routing-report.sh aggregate`
+(consumed by `review-task` §4.5).
 
 Specs: [`specs/_archived/model-routing-por-onda/`](./specs/_archived/model-routing-por-onda/)
-(mecanismo atual) e
+(current mechanism) and
 [`specs/_archived/agente-00c-model-routing/`](./specs/_archived/agente-00c-model-routing/)
-(feature original, audit-only revogado).
+(original feature, revoked audit-only).
 
-## Modo atomic-commit (opt-in)
+## Atomic-commit mode (opt-in)
 
-A partir de v5.12.0, os orquestradores oferecem modo **atomic-commit**
-opt-in: cada etapa de artefato gera um commit Conventional Commits
-automático, e cada grupo de tasks `execute-task` com `outcome=pass` gera
-um commit ranged ao final da onda. O finalize terminal dispara push + PR via
-`cstk session pr` (push direto permanece bloqueado pelo `bash-guard.sh`).
+Since v5.12.0, the orchestrators offer an opt-in **atomic-commit** mode: each
+artifact step generates an automatic Conventional Commits commit, and each
+group of `execute-task` tasks with `outcome=pass` generates a ranged commit at
+the end of the wave. The terminal finalize triggers push + PR via
+`cstk session pr` (direct push remains blocked by `bash-guard.sh`).
 
-Desde v5.23.0, o staging é **por allowlist derivada** do diff da onda
-(subcomandos `snapshot`/`stage-derived` do `commit-mode.sh`) — nunca
-`git add -A`: arquivos untracked alheios à execução jamais entram nos
-commits automáticos.
+Since v5.23.0, staging is **by a derived allowlist** from the wave's diff
+(`snapshot`/`stage-derived` subcommands of `commit-mode.sh`) — never
+`git add -A`: untracked files unrelated to the run never enter the automatic
+commits.
 
-| Componente | Localização |
-|------------|-------------|
-| Helper POSIX (`is-enabled`, `set-enabled`, `guard-branch`, `stage-message`, `task-message`, `snapshot`, `stage-derived`, `finalize`) | `global/skills/agente-00c-runtime/scripts/commit-mode.sh` |
-| Testes | `tests/test_commit-mode.sh` |
+| Component | Location |
+|-----------|----------|
+| POSIX helper (`is-enabled`, `set-enabled`, `guard-branch`, `stage-message`, `task-message`, `snapshot`, `stage-derived`, `finalize`) | `global/skills/agente-00c-runtime/scripts/commit-mode.sh` |
+| Tests | `tests/test_commit-mode.sh` |
 | Spec | [`specs/_archived/atomic-commit-pr/`](./specs/_archived/atomic-commit-pr/) |
 
-## Guardas enforced (hook PreToolUse + integridade + allowlist de hosts)
+## Enforced guards (PreToolUse hook + integrity + host allowlist)
 
-As guardas de segurança do runtime (`bash-guard.sh`, checksum do painel,
-esquema de URL) eram **advisory**. Três frentes passaram a ser **enforced**
-(não dependem do orquestrador lembrar):
+The runtime's security guards (`bash-guard.sh`, panel checksum, URL scheme)
+used to be **advisory**. Three fronts became **enforced** (they no longer
+depend on the orchestrator remembering):
 
-1. **Hook `PreToolUse`/`Bash` fail-closed**: intercepta todo comando Bash
-   de uma execução `agente-00c`/`feature-00c` ativa e delega a
-   `bash-guard.sh check` — nunca reimplementa a regra. Falha do próprio
-   mecanismo também bloqueia (`MECANISMO_FALHOU`, distinguível de
-   `REGRA_VIOLADA`). Sessões manuais do operador ficam intactas. Decisões
-   auditáveis em `.claude/enforcement-log.jsonl` (scrub de segredos antes
-   de truncar).
-2. **`cstk serve` fail-closed por padrão**: ausência de `.sha256` do pacote
-   bloqueia (`unverifiable-blocked`); bypass explícito e auditado via
-   `--allow-unverified`/`CSTK_SERVE_ALLOW_UNVERIFIED=1`; divergência de
-   checksum bloqueia sempre, sem bypass.
-3. **Allowlist de hosts confiáveis** (`CSTK_TRUSTED_RELEASE_HOSTS`, match
-   exato case-insensitive, `file://` isento) aplicada em `cstk serve`,
-   `cstk install --from` e `cstk self-update --from`.
+1. **Fail-closed `PreToolUse`/`Bash` hook**: intercepts every Bash command of
+   an active `agente-00c`/`feature-00c` run and delegates to
+   `bash-guard.sh check` — it never reimplements the rule. Failure of the
+   mechanism itself also blocks (`MECANISMO_FALHOU`, distinguishable from
+   `REGRA_VIOLADA`). The operator's manual sessions stay intact. Auditable
+   decisions in `.claude/enforcement-log.jsonl` (secrets scrubbed before
+   truncation).
+2. **`cstk serve` fail-closed by default**: absence of the package's `.sha256`
+   blocks (`unverifiable-blocked`); explicit and audited bypass via
+   `--allow-unverified`/`CSTK_SERVE_ALLOW_UNVERIFIED=1`; a checksum mismatch
+   always blocks, with no bypass.
+3. **Trusted-host allowlist** (`CSTK_TRUSTED_RELEASE_HOSTS`, exact
+   case-insensitive match, `file://` exempt) applied in `cstk serve`,
+   `cstk install --from` and `cstk self-update --from`.
 
-| Componente | Localização |
-|------------|-------------|
-| Hook + snippet de settings | `global/skills/agente-00c-runtime/hooks/pretooluse-bash-guard.sh` + `settings.snippet.json` |
-| Provisionamento automático | `apply_guard_hooks()` em `cli/lib/hooks.sh` (escopo `project`) |
-| Allowlist de hosts compartilhada | `cli/lib/trusted-hosts.sh` |
-| Log auditável | `.claude/enforcement-log.jsonl` (por projeto-alvo) |
+| Component | Location |
+|-----------|----------|
+| Hook + settings snippet | `global/skills/agente-00c-runtime/hooks/pretooluse-bash-guard.sh` + `settings.snippet.json` |
+| Automatic provisioning | `apply_guard_hooks()` in `cli/lib/hooks.sh` (`project` scope) |
+| Shared host allowlist | `cli/lib/trusted-hosts.sh` |
+| Auditable log | `.claude/enforcement-log.jsonl` (per target project) |
 | Spec | [`specs/enforced-guards/`](./specs/enforced-guards/) |
 
-Complementos do runtime: hook `PostToolUse` de métrica de tool calls
-(sidecar append-only, v5.21.0) e envelope diagnóstico
-`DIAG|severity|code|message|fix` nos helpers POSIX (`_diag.sh`, v5.22.0)
-— o campo `fix` diz o próximo passo acionável para o agente.
+Runtime complements: `PostToolUse` tool-call metric hook (append-only sidecar,
+v5.21.0) and the `DIAG|severity|code|message|fix` diagnostic envelope in the
+POSIX helpers (`_diag.sh`, v5.22.0) — the `fix` field states the next
+actionable step for the agent.

--- a/docs/agente-00c.pt-BR.md
+++ b/docs/agente-00c.pt-BR.md
@@ -1,0 +1,193 @@
+[English](./agente-00c.md) · **Português (pt-BR)**
+
+# Agente-00C — orquestrador autônomo da pipeline SDD
+
+> **Trilha avançada.** Não é necessário para o uso básico do toolkit (ver
+> [Comece aqui](../README.pt-BR.md#comece-aqui)). Subsistemas de suporte:
+> [Sessões paralelas](./cstk-session.pt-BR.md) e
+> [Memória de conhecimento](./cstk-recall.pt-BR.md).
+
+> **Status: funcional e em uso pelo mantenedor** — porém **sem suíte de
+> testes automatizada dos agentes custom** (validação por execuções reais,
+> decisão consciente do briefing). Para adoção externa, trate como
+> **experimental**: é um experimento pessoal de orquestração autônoma, não
+> um produto com garantias de suporte. O backlog original (já concluído) está
+> em [`specs/_archived/agente-00c/`](./specs/_archived/agente-00c/)
+> (44 tarefas, 9 fases); a feature evoluiu muito desde então — ver
+> feature-00c, model-routing e a memória de conhecimento.
+
+O `agente-00C` é um **orquestrador autônomo** da pipeline SDD do toolkit:
+você invoca `/agente-00c` com uma descrição curta de POC/MVP e ele conduz
+`briefing → constitution → specify → clarify → plan → checklist →
+create-tasks → execute-task → review-task → review-features`, **pausando
+apenas em bloqueios reais** (decisões que exigem um humano) e entre ondas
+agendadas — **não** é "dispare-e-esqueça". O entregável-mor é um **relatório
+auditável** rico em decisões, bloqueios e lições aprendidas: ele existe
+justamente para você revisar a rota, em vez de confiar cegamente na cadeia
+de etapas.
+
+> **Dica — prompt ideal para o briefing**: quanto mais completa a descrição
+> inicial, menos perguntas o agente faz na etapa `briefing`. Use o template
+> preenchível em
+> [`templates/briefing-prompt-ideal.md`](./templates/briefing-prompt-ideal.md)
+> — mapeado 1:1 com as seções do briefing e com blocos extras para
+> arquiteturas complexas, com guia de poda para entregas simples.
+
+## Comandos expostos
+
+| Comando | Função |
+|---------|--------|
+| `cstk 00c <path>` | **Atalho recomendado**: bootstrap interativo (cria diretório, coleta parâmetros e invoca `claude` já com `/agente-00c` montada) |
+| `/agente-00c <descricao> [--stack ...] [--whitelist ...] [--projeto-alvo-path ...]` | Invocação direta no claude (alternativa ao `cstk 00c`) |
+| `/agente-00c-resume [--projeto-alvo-path ...] [--resposta-bloqueio <id>:<resp>]` | Retoma após pausa ou schedule |
+| `/agente-00c-abort [--projeto-alvo-path ...]` | Aborto manual |
+
+> **`cstk 00c <path>`** é o caminho preferido para iniciar um POC/MVP novo:
+> ele valida o path, cria o diretório, coleta descrição/stack/whitelist via
+> prompts e dá `exec claude` com a slash command auto-submetida. Requer
+> TTY interativo e só opera em paths novos ou vazios — para retomar execução
+> existente, use `/agente-00c-resume` diretamente no claude. Detalhes em
+> [`specs/_archived/cstk-cli/contracts/cstk-00c.md`](./specs/_archived/cstk-cli/contracts/cstk-00c.md).
+
+## Pré-requisitos
+
+- **Claude Code** (Opus 4.x ou Sonnet 4.6 recomendado), **Auto mode**
+  ativo para reduzir interrupções.
+- **`gh` CLI autenticado** (necessário para abertura automática de issue
+  no toolkit em caso de bug em skill global — FR-021).
+- **`git` no PATH** (commit local entre ondas).
+- **Docker local** (apenas se a stack-sugerida usar containers; orquestrador
+  recusa qualquer `docker push`/deploy externo — Princípio V da feature).
+- **Toolkit instalado via `cstk install`** para que os slash commands e
+  agentes custom estejam disponíveis.
+
+## Limitações conhecidas
+
+- **Schedule limitado a 60-3600s via `ScheduleWakeup`**: continuação
+  cross-sessão usa `ScheduleWakeup`; para pausas longas (>=1h ou
+  bloqueios que só serão respondidos em horas/dias), o relatório
+  parcial sugere criar uma routine manual via `/schedule` que sobrevive
+  laptop suspend/restart (cloud Anthropic).
+- **Sem observabilidade nativa de tokens consumidos**: o orçamento de
+  sessão usa proxies (tool calls da onda, wallclock, tamanho do estado).
+- **Sem `git push` cru, sem deploy externo, sem `sudo`**: por constituição da
+  feature, blast radius é confinado ao `--projeto-alvo-path`. O caminho
+  confinado de push+PR existe apenas no finalize do modo atomic-commit.
+- **Suíte de testes automatizada**: validação ocorre via execuções reais
+  com cenários manuais
+  ([`specs/_archived/agente-00c/quickstart.md`](./specs/_archived/agente-00c/quickstart.md)).
+- **Schema de estado sem migração automática entre versões maiores**:
+  execuções pendentes precisam ser concluídas ou abortadas antes de upgrade.
+
+Detalhamento completo (briefing, constitution, spec com 31 FRs, plan,
+research, threat-model, contracts, quickstart) em
+[`specs/_archived/agente-00c/`](./specs/_archived/agente-00c/).
+
+## Feature-00C — variante de escopo de feature individual
+
+A partir de v3.13.0, o toolkit oferece `/feature-00c` como variante do
+agente-00c focada em **uma feature** dentro de projeto que JÁ possui
+`briefing.md` + `docs/constitution.md` ratificados. Pipeline reduzida:
+`specify → clarify → plan → checklist → create-tasks → execute-task →
+review-task` (sem briefing/constitution/review-features, que são
+pré-requisitos validados em FR-PRE-001..004).
+
+| Comando | Quando usar |
+|---------|-------------|
+| `/feature-00c "<descricao>" [<short-name>]` | Adicionar feature nova em projeto existente |
+| `/feature-00c-resume <short-name> [--resposta-bloqueio "..."]` | Retomar após pausa ou schedule |
+| `/feature-00c-abort <short-name> [--purge-backups]` | Aborto manual (SIGTERM + grace period 60s) |
+
+Co-existência com `/agente-00c`: namespaces isolados
+(`agente-00c-state/` vs `feature-00c-state/<short_name>/`). Features
+paralelas no mesmo projeto são permitidas; concorrência com agente-00c
+ativo é bloqueada (FR-026). Reuso integral do runtime POSIX
+compartilhado (`agente-00c-runtime`). Detalhamento em
+[`specs/_archived/feature-00c/`](./specs/_archived/feature-00c/).
+
+## Roteamento de modelos por onda (model-routing)
+
+> **BREAKING v4.0.0** — o model-routing **deixou de ser audit-only**
+> (premissa da v3.15.0, revogada): o harness atual aceita `model` no spawn
+> de subagente, e o modelo agora **É APLICADO** a cada onda.
+
+No início de cada onda, o **command pai** (`/agente-00c`, `/feature-00c` e
+resumes) chama `model-routing.sh wave-select` e aplica o modelo retornado no
+spawn do orquestrador. A base é um mapa determinístico fase→modelo
+(`references/phase-model-map.txt`, POSIX puro):
+
+| Fase | Faixa | Modelo-piso |
+|------|-------|-------------|
+| `plan`, `analyze`, `constitution` | profunda | **opus** |
+| `specify`, `clarify`, `checklist`, `create-tasks`, `briefing` | média | **sonnet** |
+| `execute-task` | rasa | **sonnet** (piso; refinável ↑opus / ↓haiku) |
+| `validate-docs`, `review-task` | rasa | **haiku** |
+| fase não listada | — | `manter-atual` (nunca erro) |
+
+Precedência de resolução:
+`override manual do operador > escalada mid-onda (opus) > refino model-selector > mapa fase→modelo`.
+
+A skill **model-selector** virou camada de refino opcional (só em
+`execute-task` com `--task-text`): pode elevar para opus ou rebaixar para
+haiku sobre o piso do mapa, citando sinais. Contrato **suggest-only**
+preservado: a skill nunca troca modelo sozinha — quem aplica é o command pai.
+Auditoria sugerido-vs-aplicado via `model-routing-report.sh aggregate`
+(consumida pelo `review-task` §4.5).
+
+Specs: [`specs/_archived/model-routing-por-onda/`](./specs/_archived/model-routing-por-onda/)
+(mecanismo atual) e
+[`specs/_archived/agente-00c-model-routing/`](./specs/_archived/agente-00c-model-routing/)
+(feature original, audit-only revogado).
+
+## Modo atomic-commit (opt-in)
+
+A partir de v5.12.0, os orquestradores oferecem modo **atomic-commit**
+opt-in: cada etapa de artefato gera um commit Conventional Commits
+automático, e cada grupo de tasks `execute-task` com `outcome=pass` gera
+um commit ranged ao final da onda. O finalize terminal dispara push + PR via
+`cstk session pr` (push direto permanece bloqueado pelo `bash-guard.sh`).
+
+Desde v5.23.0, o staging é **por allowlist derivada** do diff da onda
+(subcomandos `snapshot`/`stage-derived` do `commit-mode.sh`) — nunca
+`git add -A`: arquivos untracked alheios à execução jamais entram nos
+commits automáticos.
+
+| Componente | Localização |
+|------------|-------------|
+| Helper POSIX (`is-enabled`, `set-enabled`, `guard-branch`, `stage-message`, `task-message`, `snapshot`, `stage-derived`, `finalize`) | `global/skills/agente-00c-runtime/scripts/commit-mode.sh` |
+| Testes | `tests/test_commit-mode.sh` |
+| Spec | [`specs/_archived/atomic-commit-pr/`](./specs/_archived/atomic-commit-pr/) |
+
+## Guardas enforced (hook PreToolUse + integridade + allowlist de hosts)
+
+As guardas de segurança do runtime (`bash-guard.sh`, checksum do painel,
+esquema de URL) eram **advisory**. Três frentes passaram a ser **enforced**
+(não dependem do orquestrador lembrar):
+
+1. **Hook `PreToolUse`/`Bash` fail-closed**: intercepta todo comando Bash
+   de uma execução `agente-00c`/`feature-00c` ativa e delega a
+   `bash-guard.sh check` — nunca reimplementa a regra. Falha do próprio
+   mecanismo também bloqueia (`MECANISMO_FALHOU`, distinguível de
+   `REGRA_VIOLADA`). Sessões manuais do operador ficam intactas. Decisões
+   auditáveis em `.claude/enforcement-log.jsonl` (scrub de segredos antes
+   de truncar).
+2. **`cstk serve` fail-closed por padrão**: ausência de `.sha256` do pacote
+   bloqueia (`unverifiable-blocked`); bypass explícito e auditado via
+   `--allow-unverified`/`CSTK_SERVE_ALLOW_UNVERIFIED=1`; divergência de
+   checksum bloqueia sempre, sem bypass.
+3. **Allowlist de hosts confiáveis** (`CSTK_TRUSTED_RELEASE_HOSTS`, match
+   exato case-insensitive, `file://` isento) aplicada em `cstk serve`,
+   `cstk install --from` e `cstk self-update --from`.
+
+| Componente | Localização |
+|------------|-------------|
+| Hook + snippet de settings | `global/skills/agente-00c-runtime/hooks/pretooluse-bash-guard.sh` + `settings.snippet.json` |
+| Provisionamento automático | `apply_guard_hooks()` em `cli/lib/hooks.sh` (escopo `project`) |
+| Allowlist de hosts compartilhada | `cli/lib/trusted-hosts.sh` |
+| Log auditável | `.claude/enforcement-log.jsonl` (por projeto-alvo) |
+| Spec | [`specs/enforced-guards/`](./specs/enforced-guards/) |
+
+Complementos do runtime: hook `PostToolUse` de métrica de tool calls
+(sidecar append-only, v5.21.0) e envelope diagnóstico
+`DIAG|severity|code|message|fix` nos helpers POSIX (`_diag.sh`, v5.22.0)
+— o campo `fix` diz o próximo passo acionável para o agente.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,50 +1,52 @@
-# Convenções de nomenclatura e hierarquia de documentação
+**English** · [Português (pt-BR)](./conventions.pt-BR.md)
 
-## Convenções de Nomenclatura
+# Naming conventions and documentation hierarchy
 
-| Tipo | Padrão | Exemplo |
-|------|--------|---------|
-| Casos de Uso | `UC-{DOMÍNIO}-{NNN}` | UC-CAD-001 |
-| Decisões de Arquitetura | `ADR-{NNN}-{título}` | ADR-001-database |
-| Regras de Negócio | `RN{NN}` | RN01 |
-| Casos de Teste | `CT{NN}` | CT01 |
-| Exceções | `E{NNN}` | E001 |
+## Naming Conventions
 
-### Códigos de Domínio
+| Type | Pattern | Example |
+|------|---------|---------|
+| Use Cases | `UC-{DOMAIN}-{NNN}` | UC-CAD-001 |
+| Architecture Decisions | `ADR-{NNN}-{title}` | ADR-001-database |
+| Business Rules | `RN{NN}` | RN01 |
+| Test Cases | `CT{NN}` | CT01 |
+| Exceptions | `E{NNN}` | E001 |
 
-Os códigos de domínio são **definidos por projeto**, não universais. A partir
-de 1.1.0, as skills consultam os domínios reais via:
+### Domain Codes
 
-1. Campo `domains` em `config.json` (quando o projeto define explicitamente)
-2. Glob de UCs existentes (quando o projeto já tem documentação)
-3. Pergunta ao usuário via AskUserQuestion (quando ambos ausentes)
+Domain codes are **defined per project**, not universal. Since 1.1.0, the
+skills look up the real domains via:
 
-Exemplos comuns em projetos de negócio: `AUTH` (autenticação), `CAD`
-(cadastros), `PED` (pedidos), `FIN` (financeiro). Use o que faz sentido no
-seu domínio.
+1. `domains` field in `config.json` (when the project defines it explicitly)
+2. Glob of existing UCs (when the project already has documentation)
+3. Asking the user via AskUserQuestion (when both are absent)
 
-## Hierarquia de Documentação
+Common examples in business projects: `AUTH` (authentication), `CAD`
+(registration), `PED` (orders), `FIN` (financial). Use whatever makes sense in
+your domain.
 
-O skill `initialize-docs` cria a seguinte estrutura:
+## Documentation Hierarchy
+
+The `initialize-docs` skill creates the following structure:
 
 ```
 docs/
-├── 01-briefing-discovery/      # Requisitos iniciais, PDFs
-├── 02-requisitos-casos-uso/    # Casos de uso (UC-*)
+├── 01-briefing-discovery/      # Initial requirements, PDFs
+├── 02-requisitos-casos-uso/    # Use cases (UC-*)
 ├── 03-modelagem-dados/         # DERs, schemas
-├── 04-arquitetura-sistema/     # ADRs, diagramas
+├── 04-arquitetura-sistema/     # ADRs, diagrams
 ├── 05-definicao-apis/          # REST, gRPC, Webhooks, Messaging
 ├── 06-ui-ux-design/            # Wireframes, mockups
-├── 07-plano-testes/            # Planos de teste
+├── 07-plano-testes/            # Test plans
 ├── 08-operacoes/               # Runbooks
 └── 09-entregaveis/             # Release notes
 ```
 
-## Specs de feature (SDD)
+## Feature specs (SDD)
 
-Specs de feature vivem em `docs/specs/<feature>/` (spec.md, plan.md, tasks.md,
-checklists/, contracts/). Ao concluir, a feature é arquivada em
-`docs/specs/_archived/YYYY-MM-DD-<feature>/` (prefixo de data desde v5.22.0;
-diretórios arquivados antes disso mantêm o nome sem data) e seu delta é
-aplicado ao corpus de specs vivas em `docs/specs/current/` — ver
-[Pipeline SDD](./sdd-pipeline.md#specs-vivas-e-delta-requirements-v5230).
+Feature specs live in `docs/specs/<feature>/` (spec.md, plan.md, tasks.md,
+checklists/, contracts/). Once completed, the feature is archived under
+`docs/specs/_archived/YYYY-MM-DD-<feature>/` (date prefix since v5.22.0;
+directories archived before that keep the name without a date) and its delta is
+applied to the living-specs corpus in `docs/specs/current/` — see
+[SDD Pipeline](./sdd-pipeline.md#living-specs-and-delta-requirements-v5230).

--- a/docs/conventions.pt-BR.md
+++ b/docs/conventions.pt-BR.md
@@ -1,0 +1,52 @@
+[English](./conventions.md) · **Português (pt-BR)**
+
+# Convenções de nomenclatura e hierarquia de documentação
+
+## Convenções de Nomenclatura
+
+| Tipo | Padrão | Exemplo |
+|------|--------|---------|
+| Casos de Uso | `UC-{DOMÍNIO}-{NNN}` | UC-CAD-001 |
+| Decisões de Arquitetura | `ADR-{NNN}-{título}` | ADR-001-database |
+| Regras de Negócio | `RN{NN}` | RN01 |
+| Casos de Teste | `CT{NN}` | CT01 |
+| Exceções | `E{NNN}` | E001 |
+
+### Códigos de Domínio
+
+Os códigos de domínio são **definidos por projeto**, não universais. A partir
+de 1.1.0, as skills consultam os domínios reais via:
+
+1. Campo `domains` em `config.json` (quando o projeto define explicitamente)
+2. Glob de UCs existentes (quando o projeto já tem documentação)
+3. Pergunta ao usuário via AskUserQuestion (quando ambos ausentes)
+
+Exemplos comuns em projetos de negócio: `AUTH` (autenticação), `CAD`
+(cadastros), `PED` (pedidos), `FIN` (financeiro). Use o que faz sentido no
+seu domínio.
+
+## Hierarquia de Documentação
+
+O skill `initialize-docs` cria a seguinte estrutura:
+
+```
+docs/
+├── 01-briefing-discovery/      # Requisitos iniciais, PDFs
+├── 02-requisitos-casos-uso/    # Casos de uso (UC-*)
+├── 03-modelagem-dados/         # DERs, schemas
+├── 04-arquitetura-sistema/     # ADRs, diagramas
+├── 05-definicao-apis/          # REST, gRPC, Webhooks, Messaging
+├── 06-ui-ux-design/            # Wireframes, mockups
+├── 07-plano-testes/            # Planos de teste
+├── 08-operacoes/               # Runbooks
+└── 09-entregaveis/             # Release notes
+```
+
+## Specs de feature (SDD)
+
+Specs de feature vivem em `docs/specs/<feature>/` (spec.md, plan.md, tasks.md,
+checklists/, contracts/). Ao concluir, a feature é arquivada em
+`docs/specs/_archived/YYYY-MM-DD-<feature>/` (prefixo de data desde v5.22.0;
+diretórios arquivados antes disso mantêm o nome sem data) e seu delta é
+aplicado ao corpus de specs vivas em `docs/specs/current/` — ver
+[Pipeline SDD](./sdd-pipeline.pt-BR.md#specs-vivas-e-delta-requirements-v5230).

--- a/docs/cstk-recall.md
+++ b/docs/cstk-recall.md
@@ -1,99 +1,101 @@
-# Memória de conhecimento (`cstk recall`)
+**English** · [Português (pt-BR)](./cstk-recall.pt-BR.md)
 
-> **Trilha avançada** — subsistema do [orquestrador autônomo](./agente-00c.md).
+# Knowledge memory (`cstk recall`)
 
-Camada **aditiva** de memória cross-feature: um índice SQLite global
-(`~/.claude/cstk/knowledge.db`, full-text via FTS5) alimentado automaticamente
-no fim de cada onda dos orquestradores `agente-00c`/`feature-00c`. Permite
-buscar decisões, bloqueios, retro-execuções, skills invocadas e **memorias**
-(arquivos `.md` do Claude Code) de **qualquer projeto ou feature já executados**,
-com proveniência (projeto / feature / onda / data).
+> **Advanced track** — subsystem of the [autonomous orchestrator](./agente-00c.md).
 
-Desde o **schema v2** (índice retro-compatível, migração aditiva e silenciosa),
-a ingestão também deriva **métricas de dashboard** do `state.json` em tabelas
-dedicadas: `executions` (status / motivo / duração por execução), `waves`
-(ciclo de vida, `tool_calls`, `wallclock` por onda), `alert_signals` (sinais de
-circular / budget breach), `tasks` (outcome pass|fail, testes, lint,
-arquivos tocados) e `events`. Métricas como latência humana, clarify-rate e mix
-de modelos são **deriváveis** dessas tabelas — consumidas pelo
-[`cstk serve`](./cstk-serve.md) (dashboard read-only). As 4 tabelas textuais
-originais (`decisions`/`bloqueios`/`retros`/`skills`) seguem inalteradas.
+An **additive** cross-feature memory layer: a global SQLite index
+(`~/.claude/cstk/knowledge.db`, full-text via FTS5) fed automatically at the end
+of each wave of the `agente-00c`/`feature-00c` orchestrators. It lets you search
+decisions, blockers, retro-executions, invoked skills, and **memories**
+(Claude Code `.md` files) from **any project or feature already executed**, with
+provenance (project / feature / wave / date).
 
-O índice é puramente **derivado** — o `state.json` transacional permanece a
-fonte de verdade, intacto e fora do caminho crítico (a ingestão o lê em modo
-**somente leitura**, nunca escreve). A base inteira é descartável: pode ser
-reconstruída a qualquer momento via `--reindex` a partir dos
-`state.json`/`state-history` existentes.
+Since **schema v2** (backward-compatible index, additive and silent migration),
+ingestion also derives **dashboard metrics** from `state.json` into dedicated
+tables: `executions` (status / reason / duration per execution), `waves`
+(lifecycle, `tool_calls`, `wallclock` per wave), `alert_signals` (circular /
+budget breach signals), `tasks` (outcome pass|fail, tests, lint, touched files),
+and `events`. Metrics such as human latency, clarify-rate, and model mix are
+**derivable** from these tables — consumed by [`cstk serve`](./cstk-serve.md)
+(read-only dashboard). The 4 original textual tables
+(`decisions`/`bloqueios`/`retros`/`skills`) remain unchanged.
+
+The index is purely **derived** — the transactional `state.json` remains the
+source of truth, intact and off the critical path (ingestion reads it in
+**read-only** mode, never writes). The whole database is disposable: it can be
+rebuilt at any time via `--reindex` from the existing
+`state.json`/`state-history`.
 
 ```bash
-# Buscar (full-text, ordenado por relevância bm25)
+# Search (full-text, ordered by bm25 relevance)
 cstk recall "lock contention"
 
-# Filtrar por projeto, tipo de registro e limitar resultados
+# Filter by project, record type, and limit results
 cstk recall "secrets-filter" --project cstk --type decision --limit 5
 
-# Filtrar só memorias (.md do Claude Code)
+# Filter only memories (Claude Code .md files)
 cstk recall "setup" --type memory
 
-# Filtrar só sugestões (aprendizado de meta-padrão: diagnóstico + proposta)
+# Filter only suggestions (meta-pattern learning: diagnosis + proposal)
 cstk recall "websocket auth" --type suggestion
 
-# Reconstruir o índice do zero a partir dos states existentes (inclui memorias)
+# Rebuild the index from scratch from existing states (includes memories)
 cstk recall --reindex
 
-# Ingestão manual de uma feature específica (normalmente o hook faz isto)
+# Manual ingestion of a specific feature (normally the hook does this)
 cstk recall --ingest --state-dir .claude/feature-00c-state/<short-name>
 
-# Leitura-para-contexto (read-back loop): bloco markdown pronto para injeção
+# Read-for-context (read-back loop): markdown block ready for injection
 cstk recall --context "cache fts query" --limit 4 \
   --exclude-feature minha-feature-corrente --max-bytes 2000
 
-# Listar memorias indexadas (slug + description, sem body)
+# List indexed memories (slug + description, no body)
 cstk recall --list-memories [--project P]
 ```
 
-## Flags do modo busca
+## Search-mode flags
 
-- `--project P` — filtra pelo projeto de origem
+- `--project P` — filters by source project
 - `--type T` — `decision` | `bloqueio` | `retro` | `skill` | `memory` | `suggestion`
-- `--limit N` — máximo de resultados (inteiro positivo; default 20)
-- `--db PATH` — índice alternativo (default `$CSTK_KNOWLEDGE_DB` ou
+- `--limit N` — maximum results (positive integer; default 20)
+- `--db PATH` — alternative index (default `$CSTK_KNOWLEDGE_DB` or
   `~/.claude/cstk/knowledge.db`)
 
-## Modo `--context` (read-back loop)
+## `--context` mode (read-back loop)
 
-Fecha o ciclo da memória — em vez de exibir resultados para leitura humana,
-retorna um **bloco markdown enxuto** pronto para injeção no contexto de um
-prompt. Os orquestradores `agente-00c`/`feature-00c` o invocam automaticamente
-no início das fases `specify` e `plan` (passo PRE-DECISAO), injetando
-aprendizado de execuções passadas **antes** de decidir. Diferenças face ao modo
-busca: composição **OR** entre termos (maior recall sobre keywords kebab da
-feature), anti-eco `--exclude-feature` (omite a feature corrente para não ecoar
-suas próprias escritas), e teto duro de bytes.
+Closes the memory loop — instead of showing results for human reading, it
+returns a **lean markdown block** ready for injection into a prompt's context.
+The `agente-00c`/`feature-00c` orchestrators invoke it automatically at the start
+of the `specify` and `plan` phases (PRE-DECISION step), injecting learning from
+past executions **before** deciding. Differences from search mode: **OR**
+composition between terms (higher recall over the feature's kebab keywords),
+anti-echo `--exclude-feature` (omits the current feature so it does not echo its
+own writes), and a hard byte ceiling.
 
-- `--exclude-feature NAME` — anti-eco: omite achados da feature `NAME` (no SQL)
-- `--limit N` — máximo de achados (default **4**; faixa recomendada 3-5)
-- `--max-bytes N` — teto de bytes do bloco (default **2000**; corta por achado
-  inteiro, nunca no meio)
-- `--type T` / `--project P` / `--db PATH` — iguais ao modo busca
+- `--exclude-feature NAME` — anti-echo: omits findings from feature `NAME` (in SQL)
+- `--limit N` — maximum findings (default **4**; recommended range 3-5)
+- `--max-bytes N` — byte ceiling for the block (default **2000**; cuts by whole
+  finding, never in the middle)
+- `--type T` / `--project P` / `--db PATH` — same as search mode
 
-É **read-only** e **best-effort**: toda degradação (sem `sqlite3`, índice
-ausente/corrompido, zero achados) resulta em **no-op silencioso** (stdout vazio,
-exit 0) — nunca gateia uma onda. Contra prompt-injection via memória recuperada
-há **duas camadas** (ASI09/LLM01): (1) *scrubbing* de segredos na **ingestão**
-(controle técnico real) e (2) injeção com rótulo **UNTRUSTED / não-autoritativo**
-— uma **mitigação** defense-in-depth, **não uma garantia**. O risco residual de
-um registro antigo *instruir* o modelo permanece; por isso o conteúdo nunca é
-tratado como instrução.
+It is **read-only** and **best-effort**: any degradation (no `sqlite3`, missing/
+corrupted index, zero findings) results in a **silent no-op** (empty stdout,
+exit 0) — it never gates a wave. Against prompt-injection via retrieved memory
+there are **two layers** (ASI09/LLM01): (1) secret *scrubbing* at **ingestion**
+(a real technical control) and (2) injection with an **UNTRUSTED /
+non-authoritative** label — a defense-in-depth **mitigation**, **not a
+guarantee**. The residual risk of an old record *instructing* the model remains;
+that is why the content is never treated as an instruction.
 
-**Degradação graciosa**: a ausência de `sqlite3` ou `jq` **nunca** aborta uma
-onda — o hook de ingestão e o `recall` saem com status 0 emitindo apenas um
-aviso. O índice fica isolado em `~/.claude/cstk/`, separado do estado
-transacional por projeto.
+**Graceful degradation**: the absence of `sqlite3` or `jq` **never** aborts a
+wave — the ingestion hook and `recall` exit with status 0 emitting only a
+warning. The index is isolated in `~/.claude/cstk/`, separate from the
+per-project transactional state.
 
-## Documentação completa
+## Full documentation
 
 - [`specs/_archived/cstk-knowledge-db/spec.md`](./specs/_archived/cstk-knowledge-db/spec.md) — user stories, FRs, success criteria
-- [`specs/_archived/cstk-knowledge-db/contracts/cstk-recall.md`](./specs/_archived/cstk-knowledge-db/contracts/cstk-recall.md) — modos, flags, exit codes, esquema FTS5
-- [`specs/_archived/knowledge-db-metrics/spec.md`](./specs/_archived/knowledge-db-metrics/spec.md) — ingestão de métricas (schema v2)
-- [`specs/_archived/knowledge-db-metrics/data-model.md`](./specs/_archived/knowledge-db-metrics/data-model.md) — DDL das tabelas e chaves naturais
+- [`specs/_archived/cstk-knowledge-db/contracts/cstk-recall.md`](./specs/_archived/cstk-knowledge-db/contracts/cstk-recall.md) — modes, flags, exit codes, FTS5 schema
+- [`specs/_archived/knowledge-db-metrics/spec.md`](./specs/_archived/knowledge-db-metrics/spec.md) — metrics ingestion (schema v2)
+- [`specs/_archived/knowledge-db-metrics/data-model.md`](./specs/_archived/knowledge-db-metrics/data-model.md) — table DDL and natural keys

--- a/docs/cstk-recall.pt-BR.md
+++ b/docs/cstk-recall.pt-BR.md
@@ -1,0 +1,101 @@
+[English](./cstk-recall.md) · **Português (pt-BR)**
+
+# Memória de conhecimento (`cstk recall`)
+
+> **Trilha avançada** — subsistema do [orquestrador autônomo](./agente-00c.pt-BR.md).
+
+Camada **aditiva** de memória cross-feature: um índice SQLite global
+(`~/.claude/cstk/knowledge.db`, full-text via FTS5) alimentado automaticamente
+no fim de cada onda dos orquestradores `agente-00c`/`feature-00c`. Permite
+buscar decisões, bloqueios, retro-execuções, skills invocadas e **memorias**
+(arquivos `.md` do Claude Code) de **qualquer projeto ou feature já executados**,
+com proveniência (projeto / feature / onda / data).
+
+Desde o **schema v2** (índice retro-compatível, migração aditiva e silenciosa),
+a ingestão também deriva **métricas de dashboard** do `state.json` em tabelas
+dedicadas: `executions` (status / motivo / duração por execução), `waves`
+(ciclo de vida, `tool_calls`, `wallclock` por onda), `alert_signals` (sinais de
+circular / budget breach), `tasks` (outcome pass|fail, testes, lint,
+arquivos tocados) e `events`. Métricas como latência humana, clarify-rate e mix
+de modelos são **deriváveis** dessas tabelas — consumidas pelo
+[`cstk serve`](./cstk-serve.pt-BR.md) (dashboard read-only). As 4 tabelas textuais
+originais (`decisions`/`bloqueios`/`retros`/`skills`) seguem inalteradas.
+
+O índice é puramente **derivado** — o `state.json` transacional permanece a
+fonte de verdade, intacto e fora do caminho crítico (a ingestão o lê em modo
+**somente leitura**, nunca escreve). A base inteira é descartável: pode ser
+reconstruída a qualquer momento via `--reindex` a partir dos
+`state.json`/`state-history` existentes.
+
+```bash
+# Buscar (full-text, ordenado por relevância bm25)
+cstk recall "lock contention"
+
+# Filtrar por projeto, tipo de registro e limitar resultados
+cstk recall "secrets-filter" --project cstk --type decision --limit 5
+
+# Filtrar só memorias (.md do Claude Code)
+cstk recall "setup" --type memory
+
+# Filtrar só sugestões (aprendizado de meta-padrão: diagnóstico + proposta)
+cstk recall "websocket auth" --type suggestion
+
+# Reconstruir o índice do zero a partir dos states existentes (inclui memorias)
+cstk recall --reindex
+
+# Ingestão manual de uma feature específica (normalmente o hook faz isto)
+cstk recall --ingest --state-dir .claude/feature-00c-state/<short-name>
+
+# Leitura-para-contexto (read-back loop): bloco markdown pronto para injeção
+cstk recall --context "cache fts query" --limit 4 \
+  --exclude-feature minha-feature-corrente --max-bytes 2000
+
+# Listar memorias indexadas (slug + description, sem body)
+cstk recall --list-memories [--project P]
+```
+
+## Flags do modo busca
+
+- `--project P` — filtra pelo projeto de origem
+- `--type T` — `decision` | `bloqueio` | `retro` | `skill` | `memory` | `suggestion`
+- `--limit N` — máximo de resultados (inteiro positivo; default 20)
+- `--db PATH` — índice alternativo (default `$CSTK_KNOWLEDGE_DB` ou
+  `~/.claude/cstk/knowledge.db`)
+
+## Modo `--context` (read-back loop)
+
+Fecha o ciclo da memória — em vez de exibir resultados para leitura humana,
+retorna um **bloco markdown enxuto** pronto para injeção no contexto de um
+prompt. Os orquestradores `agente-00c`/`feature-00c` o invocam automaticamente
+no início das fases `specify` e `plan` (passo PRE-DECISAO), injetando
+aprendizado de execuções passadas **antes** de decidir. Diferenças face ao modo
+busca: composição **OR** entre termos (maior recall sobre keywords kebab da
+feature), anti-eco `--exclude-feature` (omite a feature corrente para não ecoar
+suas próprias escritas), e teto duro de bytes.
+
+- `--exclude-feature NAME` — anti-eco: omite achados da feature `NAME` (no SQL)
+- `--limit N` — máximo de achados (default **4**; faixa recomendada 3-5)
+- `--max-bytes N` — teto de bytes do bloco (default **2000**; corta por achado
+  inteiro, nunca no meio)
+- `--type T` / `--project P` / `--db PATH` — iguais ao modo busca
+
+É **read-only** e **best-effort**: toda degradação (sem `sqlite3`, índice
+ausente/corrompido, zero achados) resulta em **no-op silencioso** (stdout vazio,
+exit 0) — nunca gateia uma onda. Contra prompt-injection via memória recuperada
+há **duas camadas** (ASI09/LLM01): (1) *scrubbing* de segredos na **ingestão**
+(controle técnico real) e (2) injeção com rótulo **UNTRUSTED / não-autoritativo**
+— uma **mitigação** defense-in-depth, **não uma garantia**. O risco residual de
+um registro antigo *instruir* o modelo permanece; por isso o conteúdo nunca é
+tratado como instrução.
+
+**Degradação graciosa**: a ausência de `sqlite3` ou `jq` **nunca** aborta uma
+onda — o hook de ingestão e o `recall` saem com status 0 emitindo apenas um
+aviso. O índice fica isolado em `~/.claude/cstk/`, separado do estado
+transacional por projeto.
+
+## Documentação completa
+
+- [`specs/_archived/cstk-knowledge-db/spec.md`](./specs/_archived/cstk-knowledge-db/spec.md) — user stories, FRs, success criteria
+- [`specs/_archived/cstk-knowledge-db/contracts/cstk-recall.md`](./specs/_archived/cstk-knowledge-db/contracts/cstk-recall.md) — modos, flags, exit codes, esquema FTS5
+- [`specs/_archived/knowledge-db-metrics/spec.md`](./specs/_archived/knowledge-db-metrics/spec.md) — ingestão de métricas (schema v2)
+- [`specs/_archived/knowledge-db-metrics/data-model.md`](./specs/_archived/knowledge-db-metrics/data-model.md) — DDL das tabelas e chaves naturais

--- a/docs/cstk-serve.md
+++ b/docs/cstk-serve.md
@@ -1,86 +1,85 @@
-# Painel Web (`cstk serve`)
+**English** · [Português (pt-BR)](./cstk-serve.pt-BR.md)
 
-Inicia a interface web do cstk panel localmente. Na primeira execução, baixa
-automaticamente a release mais recente de
-[JotJunior/cstk-panel](https://github.com/JotJunior/cstk-panel) e instala em
-`~/.local/share/cstk/panel`. Execuções subsequentes reutilizam a instalação em
-cache.
+# Web panel (`cstk serve`)
 
-O `cstk serve` compila os workspaces (`npm run build` — shared-types, server e
-web) e então sobe um **único processo Fastify** (`npm run start`) que serve a
-**API e o SPA buildado** (`apps/web/dist`) na **mesma porta**. Não há modo
-dev nem proxy do Vite. Abra **http://127.0.0.1:5173** (ou a porta de `--port`)
-no navegador. Requer `cstk-panel >= 0.2.0`.
+Starts the cstk panel web interface locally. On first run, it automatically
+downloads the latest release of
+[JotJunior/cstk-panel](https://github.com/JotJunior/cstk-panel) and installs it
+in `~/.local/share/cstk/panel`. Subsequent runs reuse the cached installation.
 
-**Dependências**: `curl` sempre; `npm` e `node` (Node.js) apenas no modo nativo
-(padrão). Com `--docker` (abaixo), `npm`/`node` **não** são necessários no
-host: só é preciso Docker Engine/Desktop instalado **e** o daemon rodando.
+`cstk serve` builds the workspaces (`npm run build` — shared-types, server, and
+web) and then starts a **single Fastify process** (`npm run start`) that serves
+the **API and the built SPA** (`apps/web/dist`) on the **same port**. There is
+no dev mode nor Vite proxy. Open **http://127.0.0.1:5173** (or the `--port` port)
+in the browser. Requires `cstk-panel >= 0.2.0`.
+
+**Dependencies**: `curl` always; `npm` and `node` (Node.js) only in native mode
+(default). With `--docker` (below), `npm`/`node` are **not** required on the
+host: you only need Docker Engine/Desktop installed **and** the daemon running.
 
 ```bash
-cstk serve                      # compila e inicia o painel (API + SPA na mesma porta)
-cstk serve --update             # atualiza o painel se houver release nova, depois inicia
-cstk serve --reinstall          # remove e reinstala do zero, depois inicia
-cstk serve --docker             # roda o painel num container Docker local (sem npm/node no host)
+cstk serve                      # builds and starts the panel (API + SPA on the same port)
+cstk serve --update             # updates the panel if there is a new release, then starts
+cstk serve --reinstall          # removes and reinstalls from scratch, then starts
+cstk serve --docker             # runs the panel in a local Docker container (no npm/node on host)
 ```
 
-## Opções
+## Options
 
-| Flag | Padrão | Descrição |
-|------|--------|-----------|
-| `--update` | — | Consulta o GitHub e reinstala o painel **somente** se houver release mais nova (best-effort: falha de rede/API mantém a versão instalada). Com `--docker`, reconstrói a **imagem** local. |
-| `--reinstall` | — | Remove a instalação existente e reinstala do GitHub (incondicional; vence `--update`). Com `--docker`, reconstrói a **imagem** do zero. |
-| `--port PORT` | `5173` | Porta onde o servidor Fastify escuta (inteiro 1024–65535; também lê `$PORT`). |
-| `--host HOST` | `127.0.0.1` | Host de bind (apenas loopback tem suporte completo). |
-| `--docker` | — | Roda o painel dentro de um container Docker local (opt-in; ausente = comportamento nativo 100% preservado). |
-| `--help`, `-h` | — | Exibe ajuda e sai. |
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--update` | — | Queries GitHub and reinstalls the panel **only** if there is a newer release (best-effort: a network/API failure keeps the installed version). With `--docker`, rebuilds the local **image**. |
+| `--reinstall` | — | Removes the existing installation and reinstalls from GitHub (unconditional; wins over `--update`). With `--docker`, rebuilds the **image** from scratch. |
+| `--port PORT` | `5173` | Port the Fastify server listens on (integer 1024–65535; also reads `$PORT`). |
+| `--host HOST` | `127.0.0.1` | Bind host (only loopback is fully supported). |
+| `--docker` | — | Runs the panel inside a local Docker container (opt-in; absent = native behavior 100% preserved). |
+| `--help`, `-h` | — | Prints help and exits. |
 
-## Variáveis de ambiente
+## Environment variables
 
-- `CSTK_PANEL_DIR` — Substitui o diretório de instalação (padrão:
+- `CSTK_PANEL_DIR` — Overrides the installation directory (default:
   `~/.local/share/cstk/panel`).
-- `PORT` — Porta padrão quando `--port` não é informado.
-- `CSTK_KNOWLEDGE_DB` — Caminho do `knowledge.db`; com `--docker`, o
-  **diretório** deste arquivo é montado somente leitura no container
-  (padrão: `~/.claude/cstk/knowledge.db`).
+- `PORT` — Default port when `--port` is not provided.
+- `CSTK_KNOWLEDGE_DB` — Path to `knowledge.db`; with `--docker`, the
+  **directory** of this file is mounted read-only in the container
+  (default: `~/.claude/cstk/knowledge.db`).
 
-**Exit codes**: `0` sucesso · `1` erro geral (prereq ausente, download/build
-falhou, instalação corrompida; com `--docker` também: Docker ausente/daemon
-inacessível, build da imagem falhou, container remanescente irreconciliável) ·
-`2` erro de uso (porta inválida, flag desconhecida).
+**Exit codes**: `0` success · `1` general error (missing prereq, download/build
+failed, corrupted installation; with `--docker` also: Docker missing/daemon
+unreachable, image build failed, unreconcilable leftover container) ·
+`2` usage error (invalid port, unknown flag).
 
-**Segurança**: apenas URLs de `api.github.com`, `github.com`,
-`codeload.github.com` e `objects.githubusercontent.com` são autorizadas no
-download (SSRF allowlist). Integridade **fail-closed por padrão**: pacote sem
-`.sha256` bloqueia (`unverifiable-blocked`); bypass explícito e auditado via
-`--allow-unverified`/`CSTK_SERVE_ALLOW_UNVERIFIED=1`; divergência de checksum
-bloqueia sempre. Host `127.0.0.1` é o único com suporte completo.
+**Security**: only URLs from `api.github.com`, `github.com`,
+`codeload.github.com`, and `objects.githubusercontent.com` are authorized for
+the download (SSRF allowlist). Integrity is **fail-closed by default**: a package
+without `.sha256` blocks (`unverifiable-blocked`); explicit and audited bypass
+via `--allow-unverified`/`CSTK_SERVE_ALLOW_UNVERIFIED=1`; a checksum mismatch
+always blocks. Host `127.0.0.1` is the only fully supported one.
 
-## Modo Docker (`cstk serve --docker`)
+## Docker mode (`cstk serve --docker`)
 
-Roda o painel dentro de um **container Docker local** em vez de nativamente no
-host — útil quando `npm`/`node` não estão disponíveis (ou não são desejados)
-na máquina.
+Runs the panel inside a **local Docker container** instead of natively on the
+host — useful when `npm`/`node` are not available (or not wanted) on the machine.
 
-**Pré-requisitos**: Docker Engine ou Docker Desktop instalado **e** o daemon
-rodando. Ambos são checados antes de qualquer acesso à rede, com mensagens
-distintas para "Docker não instalado" vs "daemon parado/inacessível".
+**Prerequisites**: Docker Engine or Docker Desktop installed **and** the daemon
+running. Both are checked before any network access, with distinct messages for
+"Docker not installed" vs "daemon stopped/unreachable".
 
-**O que acontece**: na primeira execução (ou em `--reinstall`, ou em
-`--update` quando há release nova), constrói uma imagem local
-(`cstk-panel:<versão>`, **nunca** publicada em registry) a partir da mesma
-árvore-fonte verificada usada no modo nativo — mesmo mecanismo de integridade
-fail-closed. Builds subsequentes reusam a imagem já construída. O container
-roda com hardening por padrão (usuário não-root, `--cap-drop ALL`,
-`--security-opt no-new-privileges`, rootfs somente leitura) e nome
-determinístico (`cstk-panel`) — um container remanescente de uma execução
-anterior é automaticamente reconciliado.
+**What happens**: on the first run (or on `--reinstall`, or on `--update` when
+there is a new release), it builds a local image (`cstk-panel:<version>`,
+**never** published to a registry) from the same verified source tree used in
+native mode — same fail-closed integrity mechanism. Subsequent builds reuse the
+already-built image. The container runs with hardening by default (non-root user,
+`--cap-drop ALL`, `--security-opt no-new-privileges`, read-only rootfs) and a
+deterministic name (`cstk-panel`) — a leftover container from a previous run is
+automatically reconciled.
 
-**Paridade de dados com o modo nativo**: o diretório do `~/.claude/cstk/`
-(ou o diretório de `$CSTK_KNOWLEDGE_DB`, se definida) é montado **somente
-leitura** dentro do container — o painel containerizado lê o **mesmo**
-`knowledge.db` do modo nativo, byte a byte. Gravações concorrentes no host
-ficam visíveis na próxima requisição, **sem precisar reiniciar** o container.
+**Data parity with native mode**: the `~/.claude/cstk/` directory (or the
+directory of `$CSTK_KNOWLEDGE_DB`, if set) is mounted **read-only** inside the
+container — the containerized panel reads the **same** `knowledge.db` as native
+mode, byte for byte. Concurrent writes on the host become visible on the next
+request, **without needing to restart** the container.
 
-`Ctrl+C` encerra o container graciosamente (`docker stop`, mesmo grace
-period do modo nativo). Detalhes completos:
+`Ctrl+C` shuts down the container gracefully (`docker stop`, same grace period
+as native mode). Full details:
 [`specs/panel-docker/spec.md`](./specs/panel-docker/spec.md).

--- a/docs/cstk-serve.pt-BR.md
+++ b/docs/cstk-serve.pt-BR.md
@@ -1,0 +1,88 @@
+[English](./cstk-serve.md) · **Português (pt-BR)**
+
+# Painel Web (`cstk serve`)
+
+Inicia a interface web do cstk panel localmente. Na primeira execução, baixa
+automaticamente a release mais recente de
+[JotJunior/cstk-panel](https://github.com/JotJunior/cstk-panel) e instala em
+`~/.local/share/cstk/panel`. Execuções subsequentes reutilizam a instalação em
+cache.
+
+O `cstk serve` compila os workspaces (`npm run build` — shared-types, server e
+web) e então sobe um **único processo Fastify** (`npm run start`) que serve a
+**API e o SPA buildado** (`apps/web/dist`) na **mesma porta**. Não há modo
+dev nem proxy do Vite. Abra **http://127.0.0.1:5173** (ou a porta de `--port`)
+no navegador. Requer `cstk-panel >= 0.2.0`.
+
+**Dependências**: `curl` sempre; `npm` e `node` (Node.js) apenas no modo nativo
+(padrão). Com `--docker` (abaixo), `npm`/`node` **não** são necessários no
+host: só é preciso Docker Engine/Desktop instalado **e** o daemon rodando.
+
+```bash
+cstk serve                      # compila e inicia o painel (API + SPA na mesma porta)
+cstk serve --update             # atualiza o painel se houver release nova, depois inicia
+cstk serve --reinstall          # remove e reinstala do zero, depois inicia
+cstk serve --docker             # roda o painel num container Docker local (sem npm/node no host)
+```
+
+## Opções
+
+| Flag | Padrão | Descrição |
+|------|--------|-----------|
+| `--update` | — | Consulta o GitHub e reinstala o painel **somente** se houver release mais nova (best-effort: falha de rede/API mantém a versão instalada). Com `--docker`, reconstrói a **imagem** local. |
+| `--reinstall` | — | Remove a instalação existente e reinstala do GitHub (incondicional; vence `--update`). Com `--docker`, reconstrói a **imagem** do zero. |
+| `--port PORT` | `5173` | Porta onde o servidor Fastify escuta (inteiro 1024–65535; também lê `$PORT`). |
+| `--host HOST` | `127.0.0.1` | Host de bind (apenas loopback tem suporte completo). |
+| `--docker` | — | Roda o painel dentro de um container Docker local (opt-in; ausente = comportamento nativo 100% preservado). |
+| `--help`, `-h` | — | Exibe ajuda e sai. |
+
+## Variáveis de ambiente
+
+- `CSTK_PANEL_DIR` — Substitui o diretório de instalação (padrão:
+  `~/.local/share/cstk/panel`).
+- `PORT` — Porta padrão quando `--port` não é informado.
+- `CSTK_KNOWLEDGE_DB` — Caminho do `knowledge.db`; com `--docker`, o
+  **diretório** deste arquivo é montado somente leitura no container
+  (padrão: `~/.claude/cstk/knowledge.db`).
+
+**Exit codes**: `0` sucesso · `1` erro geral (prereq ausente, download/build
+falhou, instalação corrompida; com `--docker` também: Docker ausente/daemon
+inacessível, build da imagem falhou, container remanescente irreconciliável) ·
+`2` erro de uso (porta inválida, flag desconhecida).
+
+**Segurança**: apenas URLs de `api.github.com`, `github.com`,
+`codeload.github.com` e `objects.githubusercontent.com` são autorizadas no
+download (SSRF allowlist). Integridade **fail-closed por padrão**: pacote sem
+`.sha256` bloqueia (`unverifiable-blocked`); bypass explícito e auditado via
+`--allow-unverified`/`CSTK_SERVE_ALLOW_UNVERIFIED=1`; divergência de checksum
+bloqueia sempre. Host `127.0.0.1` é o único com suporte completo.
+
+## Modo Docker (`cstk serve --docker`)
+
+Roda o painel dentro de um **container Docker local** em vez de nativamente no
+host — útil quando `npm`/`node` não estão disponíveis (ou não são desejados)
+na máquina.
+
+**Pré-requisitos**: Docker Engine ou Docker Desktop instalado **e** o daemon
+rodando. Ambos são checados antes de qualquer acesso à rede, com mensagens
+distintas para "Docker não instalado" vs "daemon parado/inacessível".
+
+**O que acontece**: na primeira execução (ou em `--reinstall`, ou em
+`--update` quando há release nova), constrói uma imagem local
+(`cstk-panel:<versão>`, **nunca** publicada em registry) a partir da mesma
+árvore-fonte verificada usada no modo nativo — mesmo mecanismo de integridade
+fail-closed. Builds subsequentes reusam a imagem já construída. O container
+roda com hardening por padrão (usuário não-root, `--cap-drop ALL`,
+`--security-opt no-new-privileges`, rootfs somente leitura) e nome
+determinístico (`cstk-panel`) — um container remanescente de uma execução
+anterior é automaticamente reconciliado.
+
+**Paridade de dados com o modo nativo**: o diretório do `~/.claude/cstk/`
+(ou o diretório de `$CSTK_KNOWLEDGE_DB`, se definida) é montado **somente
+leitura** dentro do container — o painel containerizado lê o **mesmo**
+`knowledge.db` do modo nativo, byte a byte. Gravações concorrentes no host
+ficam visíveis na próxima requisição, **sem precisar reiniciar** o container.
+
+`Ctrl+C` encerra o container graciosamente (`docker stop`, mesmo grace
+period do modo nativo). Detalhes completos:
+[`specs/panel-docker/spec.md`](./specs/panel-docker/spec.md).

--- a/docs/cstk-session.md
+++ b/docs/cstk-session.md
@@ -1,47 +1,50 @@
-# Sessões paralelas (`cstk session`)
+**English** · [Português (pt-BR)](./cstk-session.pt-BR.md)
 
-> **Trilha avançada** — suporte ao [orquestrador autônomo](./agente-00c.md).
+# Parallel sessions (`cstk session`)
 
-Permite trabalhar em múltiplas features simultaneamente no mesmo repositório sem
-colisão de working tree, branch HEAD ou `.claude/agente-00c-state/`. Isola cada
-sessão em uma worktree git irmã do repo principal.
+> **Advanced track** — support for the [autonomous orchestrator](./agente-00c.md).
+
+Lets you work on multiple features simultaneously in the same repository without
+colliding on the working tree, HEAD branch, or `.claude/agente-00c-state/`. It
+isolates each session in a git worktree that is a sibling of the main repo.
 
 ```bash
-# Iniciar nova sessão (cria worktree + branch + .claude/ filtrado)
+# Start a new session (creates worktree + branch + filtered .claude/)
 cstk session start iniciacao-membro
-# → cria <parent>/<repo>-iniciacao-membro/ com branch iniciacao-membro
+# → creates <parent>/<repo>-iniciacao-membro/ with branch iniciacao-membro
 
-# Listar sessões ativas
+# List active sessions
 cstk session list
 # NAME              BRANCH              IDLE  STATUS   PATH
 # iniciacao-membro  iniciacao-membro    0d    CURRENT  /home/jot/Projects/meta-gob-ms-iniciacao-membro
 # oauth2-refresh    feat/oauth2         2d    *        /home/jot/Projects/meta-gob-ms-oauth2-refresh
 
-# Abrir PR via gh (idempotente)
+# Open a PR via gh (idempotent)
 cstk session pr iniciacao-membro
 
-# Encerrar sessão (com guards para dirty/unpushed/PR aberto)
+# End the session (with guards for dirty/unpushed/open PR)
 cstk session end iniciacao-membro
-# Ou forçar sem prompts:
+# Or force without prompts:
 cstk session end iniciacao-membro --force
 ```
 
-## Subcomandos
+## Subcommands
 
-- `start <name> [--reset|--reuse] [--force]` — cria worktree + branch + `.claude/`
-  filtrado (exclui `agente-00c-state/`, `agente-00c-archive/`, `insights/`,
+- `start <name> [--reset|--reuse] [--force]` — creates worktree + branch + filtered
+  `.claude/` (excludes `agente-00c-state/`, `agente-00c-archive/`, `insights/`,
   `settings.local.json`, `agente-00c-whitelist`, `agente-00c-report.md`,
   `agente-00c-suggestions.md`, `.agente-00c-state.lock`)
-- `list [--json]` — tabela com `NAME BRANCH IDLE STATUS PATH`; marcadores
-  combináveis `CURRENT,*,STALE`
-- `end <name> [--force]` — remove worktree + branch local; prompt se há
-  mudanças não commitadas, commits não pushados ou PR aberto
-- `pr <name> [--draft] [--title T] [--body B] [--reviewer USER]` — push + abre
-  PR via `gh pr create`; idempotente (retorna URL existente se PR já criado)
+- `list [--json]` — table with `NAME BRANCH IDLE STATUS PATH`; combinable
+  markers `CURRENT,*,STALE`
+- `end <name> [--force]` — removes worktree + local branch; prompts if there are
+  uncommitted changes, unpushed commits, or an open PR
+- `pr <name> [--draft] [--title T] [--body B] [--reviewer USER]` — push + opens
+  a PR via `gh pr create`; idempotent (returns the existing URL if the PR is
+  already created)
 
-**Requisitos**: `git >= 2.36`, `gh` (obrigatório só para `pr`; opcional em `end`).
+**Requirements**: `git >= 2.36`, `gh` (required only for `pr`; optional for `end`).
 
-## Documentação completa
+## Full documentation
 
 - [`specs/_archived/cstk-session/spec.md`](./specs/_archived/cstk-session/spec.md) — user stories, FRs, success criteria
 - [`specs/_archived/cstk-session/contracts/cli-session.md`](./specs/_archived/cstk-session/contracts/cli-session.md) — exit codes (5-15), flags, output formats

--- a/docs/cstk-session.pt-BR.md
+++ b/docs/cstk-session.pt-BR.md
@@ -1,0 +1,49 @@
+[English](./cstk-session.md) · **Português (pt-BR)**
+
+# Sessões paralelas (`cstk session`)
+
+> **Trilha avançada** — suporte ao [orquestrador autônomo](./agente-00c.pt-BR.md).
+
+Permite trabalhar em múltiplas features simultaneamente no mesmo repositório sem
+colisão de working tree, branch HEAD ou `.claude/agente-00c-state/`. Isola cada
+sessão em uma worktree git irmã do repo principal.
+
+```bash
+# Iniciar nova sessão (cria worktree + branch + .claude/ filtrado)
+cstk session start iniciacao-membro
+# → cria <parent>/<repo>-iniciacao-membro/ com branch iniciacao-membro
+
+# Listar sessões ativas
+cstk session list
+# NAME              BRANCH              IDLE  STATUS   PATH
+# iniciacao-membro  iniciacao-membro    0d    CURRENT  /home/jot/Projects/meta-gob-ms-iniciacao-membro
+# oauth2-refresh    feat/oauth2         2d    *        /home/jot/Projects/meta-gob-ms-oauth2-refresh
+
+# Abrir PR via gh (idempotente)
+cstk session pr iniciacao-membro
+
+# Encerrar sessão (com guards para dirty/unpushed/PR aberto)
+cstk session end iniciacao-membro
+# Ou forçar sem prompts:
+cstk session end iniciacao-membro --force
+```
+
+## Subcomandos
+
+- `start <name> [--reset|--reuse] [--force]` — cria worktree + branch + `.claude/`
+  filtrado (exclui `agente-00c-state/`, `agente-00c-archive/`, `insights/`,
+  `settings.local.json`, `agente-00c-whitelist`, `agente-00c-report.md`,
+  `agente-00c-suggestions.md`, `.agente-00c-state.lock`)
+- `list [--json]` — tabela com `NAME BRANCH IDLE STATUS PATH`; marcadores
+  combináveis `CURRENT,*,STALE`
+- `end <name> [--force]` — remove worktree + branch local; prompt se há
+  mudanças não commitadas, commits não pushados ou PR aberto
+- `pr <name> [--draft] [--title T] [--body B] [--reviewer USER]` — push + abre
+  PR via `gh pr create`; idempotente (retorna URL existente se PR já criado)
+
+**Requisitos**: `git >= 2.36`, `gh` (obrigatório só para `pr`; opcional em `end`).
+
+## Documentação completa
+
+- [`specs/_archived/cstk-session/spec.md`](./specs/_archived/cstk-session/spec.md) — user stories, FRs, success criteria
+- [`specs/_archived/cstk-session/contracts/cli-session.md`](./specs/_archived/cstk-session/contracts/cli-session.md) — exit codes (5-15), flags, output formats

--- a/docs/go-toolkit.md
+++ b/docs/go-toolkit.md
@@ -1,38 +1,40 @@
-# Skills e hooks para Go
+**English** · [Português (pt-BR)](./go-toolkit.pt-BR.md)
 
-Skills em `language-related/go/skills/` para projetos Go:
+# Skills and hooks for Go
 
-| Skill | Trigger | Descrição |
-|-------|---------|-----------|
-| **commit** | "commit", "commitar" | Commits com conventional commits, suporte a submodules e mudanças multi-serviço |
-| **go-add-entity** | "criar entidade", "novo agregado" | Adiciona CRUD vertical slice completo (domain, DTO, repo, service, handler, migration, wiring) |
-| **go-add-migration** | "nova migration", "criar tabela" | Cria nova migration SQL com naming/numeração corretos |
-| **go-add-test** | "adicionar testes", "cobertura" | Gera testes para handler/service seguindo convenções do projeto |
-| **go-add-consumer** | "novo consumer", "subscribe evento" | Adiciona consumer de mensagens RabbitMQ |
-| **go-review-pr** | "review pr", "quality gate" | Quality gate pré-PR, diff-aware, com revisão em 8 etapas |
-| **go-review-service** | "review service", "auditar serviço" | Audita microserviço Go contra todas as convenções do projeto |
+Skills in `language-related/go/skills/` for Go projects:
 
-Estas skills são acionadas automaticamente pelos orchestrators quando o stack
-detectado for Go — ver seção 4.2.1 de `execute-task` e "Atalhos de auditoria
-por stack" em `review-task`.
+| Skill | Trigger | Description |
+|-------|---------|-------------|
+| **commit** | "commit", "commitar" | Commits following conventional commits, with submodule support and multi-service changes |
+| **go-add-entity** | "criar entidade", "novo agregado" | Adds a complete vertical-slice CRUD (domain, DTO, repo, service, handler, migration, wiring) |
+| **go-add-migration** | "nova migration", "criar tabela" | Creates a new SQL migration with correct naming/numbering |
+| **go-add-test** | "adicionar testes", "cobertura" | Generates tests for handler/service following the project's conventions |
+| **go-add-consumer** | "novo consumer", "subscribe evento" | Adds a RabbitMQ message consumer |
+| **go-review-pr** | "review pr", "quality gate" | Pre-PR quality gate, diff-aware, with an 8-step review |
+| **go-review-service** | "review service", "auditar serviço" | Audits a Go microservice against all of the project's conventions |
 
-## Hooks para Go
+These skills are triggered automatically by the orchestrators when the detected
+stack is Go — see section 4.2.1 of `execute-task` and "Audit shortcuts by
+stack" in `review-task`.
 
-Hooks em `language-related/go/hooks/` para validações automáticas:
+## Hooks for Go
 
-| Hook | Descrição |
-|------|-----------|
-| **go-build-gate.sh** | Valida build antes de operações |
-| **check-uncommitted.sh** | Verifica alterações não commitadas |
-| **check-schema-prefix.sh** | Valida prefixo de schema nas migrations |
-| **check-route-order.sh** | Verifica ordenação de rotas no router |
+Hooks in `language-related/go/hooks/` for automatic validations:
 
-Instalação em projeto Go (skills + hooks + merge de settings.json):
+| Hook | Description |
+|------|-------------|
+| **go-build-gate.sh** | Validates the build before operations |
+| **check-uncommitted.sh** | Checks for uncommitted changes |
+| **check-schema-prefix.sh** | Validates the schema prefix in migrations |
+| **check-route-order.sh** | Checks route ordering in the router |
+
+Installation in a Go project (skills + hooks + settings.json merge):
 
 ```bash
 cd ~/projetos/meu-app-go
 cstk install --scope project --profile language-go
 ```
 
-Hooks de language-* são instalados **apenas** em `--scope project` (em
-`--scope global` são omitidos com aviso no summary — FR-009c).
+language-* hooks are installed **only** with `--scope project` (with
+`--scope global` they are omitted with a warning in the summary — FR-009c).

--- a/docs/go-toolkit.pt-BR.md
+++ b/docs/go-toolkit.pt-BR.md
@@ -1,0 +1,40 @@
+[English](./go-toolkit.md) · **Português (pt-BR)**
+
+# Skills e hooks para Go
+
+Skills em `language-related/go/skills/` para projetos Go:
+
+| Skill | Trigger | Descrição |
+|-------|---------|-----------|
+| **commit** | "commit", "commitar" | Commits com conventional commits, suporte a submodules e mudanças multi-serviço |
+| **go-add-entity** | "criar entidade", "novo agregado" | Adiciona CRUD vertical slice completo (domain, DTO, repo, service, handler, migration, wiring) |
+| **go-add-migration** | "nova migration", "criar tabela" | Cria nova migration SQL com naming/numeração corretos |
+| **go-add-test** | "adicionar testes", "cobertura" | Gera testes para handler/service seguindo convenções do projeto |
+| **go-add-consumer** | "novo consumer", "subscribe evento" | Adiciona consumer de mensagens RabbitMQ |
+| **go-review-pr** | "review pr", "quality gate" | Quality gate pré-PR, diff-aware, com revisão em 8 etapas |
+| **go-review-service** | "review service", "auditar serviço" | Audita microserviço Go contra todas as convenções do projeto |
+
+Estas skills são acionadas automaticamente pelos orchestrators quando o stack
+detectado for Go — ver seção 4.2.1 de `execute-task` e "Atalhos de auditoria
+por stack" em `review-task`.
+
+## Hooks para Go
+
+Hooks em `language-related/go/hooks/` para validações automáticas:
+
+| Hook | Descrição |
+|------|-----------|
+| **go-build-gate.sh** | Valida build antes de operações |
+| **check-uncommitted.sh** | Verifica alterações não commitadas |
+| **check-schema-prefix.sh** | Valida prefixo de schema nas migrations |
+| **check-route-order.sh** | Verifica ordenação de rotas no router |
+
+Instalação em projeto Go (skills + hooks + merge de settings.json):
+
+```bash
+cd ~/projetos/meu-app-go
+cstk install --scope project --profile language-go
+```
+
+Hooks de language-* são instalados **apenas** em `--scope project` (em
+`--scope global` são omitidos com aviso no summary — FR-009c).

--- a/docs/sdd-pipeline.md
+++ b/docs/sdd-pipeline.md
@@ -1,144 +1,146 @@
-# Pipeline SDD (Spec-Driven Development)
+**English** · [Português (pt-BR)](./sdd-pipeline.pt-BR.md)
 
-> Documento por tópico do [README](../README.md). Catálogo resumido das skills
-> na seção [Skills Globais](../README.md#skills-globais).
+# SDD Pipeline (Spec-Driven Development)
 
-O pipeline SDD é a sequência recomendada para levar uma ideia desde o discovery
-até a implementação. Cada skill consome os artefatos do anterior e alimenta o
-próximo.
+> Topic document from the [README](../README.md). Condensed skill catalog in
+> the [Global Skills](../README.md#global-skills) section.
+
+The SDD pipeline is the recommended sequence to take an idea from discovery all
+the way to implementation. Each skill consumes the previous one's artifacts and
+feeds the next.
 
 ```text
  ┌──────────────┐
  │  DISCOVERY   │
  └──────┬───────┘
         │
-   ① briefing          Entrevista de discovery → docs/01-briefing-discovery/briefing.md
-        │                Coleta visão, usuários, escopo, restrições e stack.
-        │                Pergunta UMA pergunta por vez (max 10).
+   ① briefing          Discovery interview → docs/01-briefing-discovery/briefing.md
+        │                Gathers vision, users, scope, constraints and stack.
+        │                Asks ONE question at a time (max 10).
         ▼
    ② constitution      Briefing → docs/constitution.md
-        │                Define princípios MUST/SHOULD que governam todas as decisões.
-        │                Validado contra artefatos existentes (propagação).
+        │                Defines MUST/SHOULD principles that govern every decision.
+        │                Validated against existing artifacts (propagation).
         ▼
  ┌──────────────┐
- │ ESPECIFICAÇÃO│
+ │ SPECIFICATION│
  └──────┬───────┘
         │
-   ③ specify            Descrição natural → docs/specs/{feature}/spec.md
-        │                Gera user stories priorizadas, requisitos funcionais,
-        │                critérios de aceite e success criteria mensuráveis.
-        │                Foco no QUE e POR QUÊ — nunca no COMO.
-        │                Gate determinístico: todo requisito exige >=1 cenário
-        │                (requirement-coverage.sh, v5.22.0). Seção opcional
-        │                "## Delta Requirements" declara o delta a aplicar no
-        │                corpus de specs vivas no archive (v5.23.0).
+   ③ specify            Natural description → docs/specs/{feature}/spec.md
+        │                Produces prioritized user stories, functional requirements,
+        │                acceptance criteria and measurable success criteria.
+        │                Focus on WHAT and WHY — never on HOW.
+        │                Deterministic gate: every requirement needs >=1 scenario
+        │                (requirement-coverage.sh, v5.22.0). Optional
+        │                "## Delta Requirements" section declares the delta to apply
+        │                to the living-specs corpus at archive time (v5.23.0).
         ▼
-   ④ clarify            Spec → Spec refinada (in-place)
-        │                Escaneia ambiguidades por taxonomia (10 categorias).
-        │                Faz max 5 perguntas com opções e recomendação.
-        │                Integra respostas diretamente na spec.
+   ④ clarify            Spec → Refined spec (in-place)
+        │                Scans for ambiguities by taxonomy (10 categories).
+        │                Asks max 5 questions with options and a recommendation.
+        │                Integrates answers directly into the spec.
         ▼
  ┌──────────────┐
- │ PLANEJAMENTO │
+ │   PLANNING   │
  └──────┬───────┘
         │
    ⑤ plan              Spec → docs/specs/{feature}/plan.md + research.md + data-model.md
-        │                Pesquisa tecnologias, define modelo de dados,
-        │                contratos de API e cenários de teste.
-        │                Valida contra constitution (gate obrigatório).
+        │                Researches technologies, defines the data model,
+        │                API contracts and test scenarios.
+        │                Validates against the constitution (mandatory gate).
         ▼
    ⑥ checklist          Plan + Spec → docs/specs/{feature}/checklists/{domain}.md
-        │                "Unit Tests for English" — valida QUALIDADE dos requisitos,
-        │                não da implementação. Domínios: ux, api, security, performance.
-        │                Itens com dono {auto}/{humano}; gaps abertos viram
-        │                tarefas no create-tasks (loop gap → ação).
+        │                "Unit Tests for English" — validates requirement QUALITY,
+        │                not the implementation. Domains: ux, api, security, performance.
+        │                Items with owner {auto}/{humano}; open gaps become
+        │                tasks in create-tasks (gap → action loop).
         ▼
  ┌──────────────┐
- │ IMPLEMENTAÇÃO│
+ │IMPLEMENTATION│
  └──────┬───────┘
         │
-   ⑦ create-tasks      Plan → Backlog de tarefas estruturado por fases
-        │                Tarefas com IDs, criticidade e matriz de dependências.
+   ⑦ create-tasks      Plan → Task backlog structured by phases
+        │                Tasks with IDs, criticality and dependency matrix.
         ▼
-   ⑧ analyze           Spec + Plan + Tasks + Constitution → Relatório de consistência
-        │                Detecta duplicações, ambiguidades, gaps de cobertura
-        │                e violações de princípios. Estritamente READ-ONLY.
+   ⑧ analyze           Spec + Plan + Tasks + Constitution → Consistency report
+        │                Detects duplications, ambiguities, coverage gaps
+        │                and principle violations. Strictly READ-ONLY.
         ▼
-   ⑨ execute-task      Task → Código implementado (workflow de 9 etapas)
-        │                Análise → Localização → Planejamento → Implementação →
-        │                Testes → Validação → Lint → Conclusão → Atualização.
+   ⑨ execute-task      Task → Implemented code (9-step workflow)
+        │                Analysis → Localization → Planning → Implementation →
+        │                Tests → Validation → Lint → Conclusion → Update.
         ▼
-   ⑩ review-task       Tasks → Relatório de status com métricas e próximas ações
+   ⑩ review-task       Tasks → Status report with metrics and next actions
 ```
 
-## Quando usar cada skill
+## When to use each skill
 
-| Momento | Skill | Entrada | Saída |
-|---------|-------|---------|-------|
-| Projeto novo ou feature grande | `briefing` | Conversa interativa | `briefing.md` |
-| Após briefing | `constitution` | Briefing + contexto | `constitution.md` |
-| Nova feature | `specify` | Descrição em linguagem natural | `spec.md` |
-| Spec com dúvidas | `clarify` | `spec.md` existente | `spec.md` atualizada |
-| Spec pronta | `plan` | `spec.md` | `plan.md`, `data-model.md`, `contracts/` |
-| Antes de implementar | `checklist` | Spec + Plan | `checklists/{domain}.md` |
-| Plan pronto | `create-tasks` | `plan.md` | Backlog estruturado |
-| Tasks criadas | `analyze` | Todos os artefatos | Relatório de consistência |
-| Task específica | `execute-task` | ID da tarefa | Código + relatório |
-| Implementação "pronta" | `converge` | Spec + Plan + Tasks + código real | Gaps acionáveis como nova fase de tasks |
-| Acompanhamento | `review-task` | Arquivo de tasks | Relatório de progresso |
+| Moment | Skill | Input | Output |
+|--------|-------|-------|--------|
+| New project or large feature | `briefing` | Interactive conversation | `briefing.md` |
+| After briefing | `constitution` | Briefing + context | `constitution.md` |
+| New feature | `specify` | Natural-language description | `spec.md` |
+| Spec with open questions | `clarify` | Existing `spec.md` | Updated `spec.md` |
+| Spec ready | `plan` | `spec.md` | `plan.md`, `data-model.md`, `contracts/` |
+| Before implementing | `checklist` | Spec + Plan | `checklists/{domain}.md` |
+| Plan ready | `create-tasks` | `plan.md` | Structured backlog |
+| Tasks created | `analyze` | All artifacts | Consistency report |
+| Specific task | `execute-task` | Task ID | Code + report |
+| Implementation "done" | `converge` | Spec + Plan + Tasks + real code | Actionable gaps as a new task phase |
+| Tracking | `review-task` | Tasks file | Progress report |
 
-## Atalhos — nem sempre é preciso percorrer todo o pipeline
+## Shortcuts — you don't always need the full pipeline
 
-- **Feature simples**: `specify` → `plan` → `create-tasks` → `execute-task`
-- **Bug fix**: `bugfix` (skill independente, não requer pipeline)
-- **Projeto existente sem docs**: `initialize-docs` → `briefing` → `constitution`
-- **Só precisa de tasks**: `create-tasks` direto (se já tem contexto suficiente)
+- **Simple feature**: `specify` → `plan` → `create-tasks` → `execute-task`
+- **Bug fix**: `bugfix` (standalone skill, no pipeline required)
+- **Existing project without docs**: `initialize-docs` → `briefing` → `constitution`
+- **Only need tasks**: `create-tasks` directly (if you already have enough context)
 
-A `specify` também traz um guia de triagem "atualizar spec existente vs abrir
-feature nova" (v5.22.0): mesma intenção/refino → atualizar a spec; intenção
-mudou ou escopo explodiu → nova feature.
+`specify` also brings a triage guide "update an existing spec vs. open a new
+feature" (v5.22.0): same intent/refinement → update the spec; intent changed
+or scope exploded → new feature.
 
-## Specs vivas e Delta Requirements (v5.23.0)
+## Living Specs and Delta Requirements (v5.23.0)
 
-As specs de feature descrevem MUDANÇAS e são arquivadas em
-`docs/specs/_archived/YYYY-MM-DD-<feature>/` quando concluídas. Para o
-conhecimento "como o sistema se comporta AGORA" não evaporar no archive,
-existe um **corpus canônico de specs vivas** em `docs/specs/current/`
-(um arquivo por capability):
+Feature specs describe CHANGES and are archived under
+`docs/specs/_archived/YYYY-MM-DD-<feature>/` once completed. So that the
+knowledge of "how the system behaves NOW" does not evaporate into the archive,
+there is a **canonical living-specs corpus** in `docs/specs/current/`
+(one file per capability):
 
-- A spec de feature pode declarar uma seção opcional `## Delta Requirements`
-  com subseções `ADDED/MODIFIED/REMOVED/RENAMED Requirements`.
-- No momento do archive (ação da `review-features`), o delta é validado por
-  `delta-gate.sh` (estrutura do corpus, referências, "feature sem delta é
-  inválida salvo skip explícito") e aplicado ao corpus por `delta-merge.sh`
-  (merge atômico por capability).
-- Conflito NUNCA é mergeado silenciosamente — vira bloqueio com diagnóstico
-  (no fluxo autônomo, registro via `bloqueios.sh`).
+- A feature spec may declare an optional `## Delta Requirements` section
+  with `ADDED/MODIFIED/REMOVED/RENAMED Requirements` subsections.
+- At archive time (a `review-features` action), the delta is validated by
+  `delta-gate.sh` (corpus structure, references, "a feature without a delta is
+  invalid unless explicitly skipped") and applied to the corpus by `delta-merge.sh`
+  (atomic per-capability merge).
+- A conflict is NEVER merged silently — it becomes a block with a diagnostic
+  (in the autonomous flow, recorded via `bloqueios.sh`).
 
-Origem do modelo: benchmark do [OpenSpec](https://github.com/Fission-AI/OpenSpec)
-(separação `specs/` = comportamento atual vs `changes/` = deltas propostos).
+Origin of the model: benchmark of [OpenSpec](https://github.com/Fission-AI/OpenSpec)
+(separation `specs/` = current behavior vs `changes/` = proposed deltas).
 
 ## Workflow: execute-task
 
-O skill `execute-task` impõe um workflow completo de 9 etapas:
+The `execute-task` skill enforces a complete 9-step workflow:
 
-1. **Análise** - Detectar contexto e ler documentação
-2. **Localização** - Encontrar tarefa no arquivo de tarefas
-3. **Planejamento** - Definir escopo e identificar padrões
-4. **Implementação** - Executar a tarefa
-5. **Testes** - Rodar testes se aplicável
-6. **Validação** - Verificar qualidade e consistência
-7. **Lint** - Checar formatação e padrões
-8. **Conclusão** - Gerar relatório de execução
-9. **Atualização** - Marcar tarefa como concluída
+1. **Analysis** - Detect context and read documentation
+2. **Localization** - Find the task in the tasks file
+3. **Planning** - Define scope and identify patterns
+4. **Implementation** - Execute the task
+5. **Tests** - Run tests if applicable
+6. **Validation** - Verify quality and consistency
+7. **Lint** - Check formatting and standards
+8. **Conclusion** - Generate execution report
+9. **Update** - Mark the task as completed
 
-## Protocolo: bugfix
+## Protocol: bugfix
 
-O skill `bugfix` implementa um protocolo de 8 etapas destilado da prática de
-corrigir bugs em arquiteturas multi-serviço, com foco em eliminar ciclos de
-"corrige-revela-corrige":
+The `bugfix` skill implements an 8-step protocol distilled from the practice of
+fixing bugs in multi-service architectures, focused on eliminating
+"fix-reveals-fix" cycles:
 
-- Classifica complexidade (simples vs. multi-camada)
-- Rastreia o fluxo de dados completo antes de qualquer alteração
-- Mapeia DTOs, enums e nomes de campo em todas as fronteiras
-- Implementa correções em todas as camadas afetadas de uma vez
+- Classifies complexity (simple vs. multi-layer)
+- Traces the full data flow before any change
+- Maps DTOs, enums and field names across every boundary
+- Implements fixes across all affected layers at once

--- a/docs/sdd-pipeline.pt-BR.md
+++ b/docs/sdd-pipeline.pt-BR.md
@@ -1,0 +1,146 @@
+[English](./sdd-pipeline.md) · **Português (pt-BR)**
+
+# Pipeline SDD (Spec-Driven Development)
+
+> Documento por tópico do [README](../README.pt-BR.md). Catálogo resumido das skills
+> na seção [Skills Globais](../README.pt-BR.md#skills-globais).
+
+O pipeline SDD é a sequência recomendada para levar uma ideia desde o discovery
+até a implementação. Cada skill consome os artefatos do anterior e alimenta o
+próximo.
+
+```text
+ ┌──────────────┐
+ │  DISCOVERY   │
+ └──────┬───────┘
+        │
+   ① briefing          Entrevista de discovery → docs/01-briefing-discovery/briefing.md
+        │                Coleta visão, usuários, escopo, restrições e stack.
+        │                Pergunta UMA pergunta por vez (max 10).
+        ▼
+   ② constitution      Briefing → docs/constitution.md
+        │                Define princípios MUST/SHOULD que governam todas as decisões.
+        │                Validado contra artefatos existentes (propagação).
+        ▼
+ ┌──────────────┐
+ │ ESPECIFICAÇÃO│
+ └──────┬───────┘
+        │
+   ③ specify            Descrição natural → docs/specs/{feature}/spec.md
+        │                Gera user stories priorizadas, requisitos funcionais,
+        │                critérios de aceite e success criteria mensuráveis.
+        │                Foco no QUE e POR QUÊ — nunca no COMO.
+        │                Gate determinístico: todo requisito exige >=1 cenário
+        │                (requirement-coverage.sh, v5.22.0). Seção opcional
+        │                "## Delta Requirements" declara o delta a aplicar no
+        │                corpus de specs vivas no archive (v5.23.0).
+        ▼
+   ④ clarify            Spec → Spec refinada (in-place)
+        │                Escaneia ambiguidades por taxonomia (10 categorias).
+        │                Faz max 5 perguntas com opções e recomendação.
+        │                Integra respostas diretamente na spec.
+        ▼
+ ┌──────────────┐
+ │ PLANEJAMENTO │
+ └──────┬───────┘
+        │
+   ⑤ plan              Spec → docs/specs/{feature}/plan.md + research.md + data-model.md
+        │                Pesquisa tecnologias, define modelo de dados,
+        │                contratos de API e cenários de teste.
+        │                Valida contra constitution (gate obrigatório).
+        ▼
+   ⑥ checklist          Plan + Spec → docs/specs/{feature}/checklists/{domain}.md
+        │                "Unit Tests for English" — valida QUALIDADE dos requisitos,
+        │                não da implementação. Domínios: ux, api, security, performance.
+        │                Itens com dono {auto}/{humano}; gaps abertos viram
+        │                tarefas no create-tasks (loop gap → ação).
+        ▼
+ ┌──────────────┐
+ │ IMPLEMENTAÇÃO│
+ └──────┬───────┘
+        │
+   ⑦ create-tasks      Plan → Backlog de tarefas estruturado por fases
+        │                Tarefas com IDs, criticidade e matriz de dependências.
+        ▼
+   ⑧ analyze           Spec + Plan + Tasks + Constitution → Relatório de consistência
+        │                Detecta duplicações, ambiguidades, gaps de cobertura
+        │                e violações de princípios. Estritamente READ-ONLY.
+        ▼
+   ⑨ execute-task      Task → Código implementado (workflow de 9 etapas)
+        │                Análise → Localização → Planejamento → Implementação →
+        │                Testes → Validação → Lint → Conclusão → Atualização.
+        ▼
+   ⑩ review-task       Tasks → Relatório de status com métricas e próximas ações
+```
+
+## Quando usar cada skill
+
+| Momento | Skill | Entrada | Saída |
+|---------|-------|---------|-------|
+| Projeto novo ou feature grande | `briefing` | Conversa interativa | `briefing.md` |
+| Após briefing | `constitution` | Briefing + contexto | `constitution.md` |
+| Nova feature | `specify` | Descrição em linguagem natural | `spec.md` |
+| Spec com dúvidas | `clarify` | `spec.md` existente | `spec.md` atualizada |
+| Spec pronta | `plan` | `spec.md` | `plan.md`, `data-model.md`, `contracts/` |
+| Antes de implementar | `checklist` | Spec + Plan | `checklists/{domain}.md` |
+| Plan pronto | `create-tasks` | `plan.md` | Backlog estruturado |
+| Tasks criadas | `analyze` | Todos os artefatos | Relatório de consistência |
+| Task específica | `execute-task` | ID da tarefa | Código + relatório |
+| Implementação "pronta" | `converge` | Spec + Plan + Tasks + código real | Gaps acionáveis como nova fase de tasks |
+| Acompanhamento | `review-task` | Arquivo de tasks | Relatório de progresso |
+
+## Atalhos — nem sempre é preciso percorrer todo o pipeline
+
+- **Feature simples**: `specify` → `plan` → `create-tasks` → `execute-task`
+- **Bug fix**: `bugfix` (skill independente, não requer pipeline)
+- **Projeto existente sem docs**: `initialize-docs` → `briefing` → `constitution`
+- **Só precisa de tasks**: `create-tasks` direto (se já tem contexto suficiente)
+
+A `specify` também traz um guia de triagem "atualizar spec existente vs abrir
+feature nova" (v5.22.0): mesma intenção/refino → atualizar a spec; intenção
+mudou ou escopo explodiu → nova feature.
+
+## Specs vivas e Delta Requirements (v5.23.0)
+
+As specs de feature descrevem MUDANÇAS e são arquivadas em
+`docs/specs/_archived/YYYY-MM-DD-<feature>/` quando concluídas. Para o
+conhecimento "como o sistema se comporta AGORA" não evaporar no archive,
+existe um **corpus canônico de specs vivas** em `docs/specs/current/`
+(um arquivo por capability):
+
+- A spec de feature pode declarar uma seção opcional `## Delta Requirements`
+  com subseções `ADDED/MODIFIED/REMOVED/RENAMED Requirements`.
+- No momento do archive (ação da `review-features`), o delta é validado por
+  `delta-gate.sh` (estrutura do corpus, referências, "feature sem delta é
+  inválida salvo skip explícito") e aplicado ao corpus por `delta-merge.sh`
+  (merge atômico por capability).
+- Conflito NUNCA é mergeado silenciosamente — vira bloqueio com diagnóstico
+  (no fluxo autônomo, registro via `bloqueios.sh`).
+
+Origem do modelo: benchmark do [OpenSpec](https://github.com/Fission-AI/OpenSpec)
+(separação `specs/` = comportamento atual vs `changes/` = deltas propostos).
+
+## Workflow: execute-task
+
+O skill `execute-task` impõe um workflow completo de 9 etapas:
+
+1. **Análise** - Detectar contexto e ler documentação
+2. **Localização** - Encontrar tarefa no arquivo de tarefas
+3. **Planejamento** - Definir escopo e identificar padrões
+4. **Implementação** - Executar a tarefa
+5. **Testes** - Rodar testes se aplicável
+6. **Validação** - Verificar qualidade e consistência
+7. **Lint** - Checar formatação e padrões
+8. **Conclusão** - Gerar relatório de execução
+9. **Atualização** - Marcar tarefa como concluída
+
+## Protocolo: bugfix
+
+O skill `bugfix` implementa um protocolo de 8 etapas destilado da prática de
+corrigir bugs em arquiteturas multi-serviço, com foco em eliminar ciclos de
+"corrige-revela-corrige":
+
+- Classifica complexidade (simples vs. multi-camada)
+- Rastreia o fluxo de dados completo antes de qualquer alteração
+- Mapeia DTOs, enums e nomes de campo em todas as fronteiras
+- Implementa correções em todas as camadas afetadas de uma vez

--- a/tests/test_doc-counts.sh
+++ b/tests/test_doc-counts.sh
@@ -33,14 +33,16 @@ _count_skills() {
   find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' '
 }
 
-# O numero "<N> skills globais" no README bate com a contagem real de pastas.
+# O numero "<N> global skills" no README bate com a contagem real de pastas.
+# (README.md e o primario em ingles desde a virada bilingue; a copia pt-BR e
+# README.pt-BR.md e nao e guardada aqui.)
 # README e versionado -> esta guarda e ativa tambem em CI.
 scenario_skills_count_matches_readme() {
   [ -f "$README" ] || { _error missing "README.md ausente"; return 2; }
   _real=$(_count_skills)
-  _doc=$(grep -oE '[0-9]+ skills globais' "$README" | head -1 | grep -oE '^[0-9]+')
+  _doc=$(grep -oE '[0-9]+ global skills' "$README" | head -1 | grep -oE '^[0-9]+')
   if [ -z "$_doc" ]; then
-    printf 'README.md nao declara "<N> skills globais"\n' >&2
+    printf 'README.md nao declara "<N> global skills"\n' >&2
     return 1
   fi
   if [ "$_doc" != "$_real" ]; then


### PR DESCRIPTION
## Resumo

Documentação passa a ter o **inglês como idioma principal**, com a leitura em pt-BR a um clique. Cada documento vira o par `X.md` (inglês, primário) + `X.pt-BR.md` (português), com troca de idioma no topo e links cruzados resolvendo para o sibling do mesmo idioma.

**Conjunto (11 pares → 22 arquivos):** `README`, `CONTRIBUTING`, `THIRD-PARTY-NOTICES`, `cli/README` e os 7 docs de tópico (`sdd-pipeline`, `agente-00c`, `cstk-session`, `cstk-recall`, `cstk-serve`, `go-toolkit`, `conventions`).

## Preservado byte-a-byte
Comandos, paths, nomes de skill/flag, contagens, URLs, marcadores de snippet mkdocs (`<!-- --8<-- -->`) e gatilhos de skill (frases literais em pt-BR — traduzi-las quebraria o disparo).

## Higiene de links (verificada)
- `.pt-BR.md` linka para siblings pt-BR; primários linkam para primários em inglês.
- Âncoras reescritas para os novos slugs em inglês (ex.: `#instalação`→`#installation`, `#skills-globais`→`#global-skills`).
- `scripts/check-links.py`: 0 erros. Todos os 22 arquivos presentes, switcher correto, zero links relativos quebrados.

## Impacto no site (mkdocs)
As páginas geradas a partir de `README.md` (snippets install/profiles) e `cli/README.md` passam a renderizar em inglês — consistente com inglês-primário. Marcadores de snippet preservados; build não quebra.

## Teste ajustado
`tests/test_doc-counts.sh` passa a casar a frase em inglês (`"<N> global skills"`) do README primário.

Mudança puramente documental — nenhum comportamento de skill, CLI ou runtime alterado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHNTDcvUeuhsVbJY2Uk4kG