### PR TITLE
feat: wave-token-metrics — captura de tokens/tool-uses/duração por spawn de subagente

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.25.0] - 2026-07-26
+
+Métricas de consumo por spawn de subagente (feature `wave-token-metrics`,
+PR #46): os totais de tokens/tool-uses/duração que o harness registra ao fim
+de cada spawn agora são capturados, agregados por onda e expostos nos
+relatórios — fechando o gap "quanto custou cada onda e em qual modelo".
+
+### Added
+
+- **Hook `PostToolUse` `posttooluse-agent-usage.sh`** (agente-00c-runtime):
+  captura o `tool_response` de spawns da tool `Agent` (totalTokens + breakdown
+  input/output/cache-read/cache-creation, tool uses, duração, modelo) num
+  sidecar append-only `wave-agent-usage.jsonl` — fail-open absoluto, permissão
+  `0600`, cap de 500 linhas, nunca toca o `state.json`; spawns em background
+  (`async_launched`, ~50% dos casos reais) viram `indisponivel` (`null` ≠ `0`,
+  nunca estimado — Princípio VI). Provisionado por `apply_guard_hooks()`.
+- **Agregação por onda**: `state-ondas.sh start/end` consome o sidecar →
+  `.waves[N].agent_usage` + `.waves[N].agent_spawns[]` +
+  `.accumulated_metrics.agent_*`, com `spawns_total` separado de
+  `spawns_with_usage` e resiliência a linhas corrompidas.
+- **`wave-usage-report.sh`** (novo helper read-only): `aggregate` (Markdown
+  canônico + `--json`, distribuição de tokens por modelo incluindo
+  `nao-aplicavel`) e `backfill` (reconstrói métricas de execuções passadas a
+  partir do transcript JSONL, correlacionando `tool_use`↔`toolUseResult` via
+  `tool_use_id`; opt-in, idempotente, exit 3 quando sem cobertura).
+- **knowledge.db v9→v10**: 9 colunas `agent_*` na tabela `waves`; migração
+  idempotente; `--ingest`/`--reindex` leem `.waves[].agent_usage` com retrofit
+  `NULL` para dados antigos.
+- **Consumo nos relatórios**: `report.sh` §1/§2 (linhas de spawns/tokens/
+  cobertura da métrica) e `review-task` §4.5 (cruzamento custo×roteamento —
+  join `wave-usage-report` × `model-routing-report` por onda).
+- Testes: `tests/test_posttooluse-agent-usage.sh` (18 cenários) +
+  `tests/test_wave-usage-report.sh` (31) + extensões em `test_state-ondas.sh`
+  (+9), `test_report.sh` (+3), `tests/cstk/test_recall.sh` (+4) e
+  `tests/cstk/test_hooks.sh` (+2).
+
+### Changed
+
+- `docs/specs/wave-token-metrics/` — spec/plan/contratos/checklists/tasks da
+  feature (pipeline feature-00c completa: 14 ondas, 76 decisões auditadas,
+  backlog 59/59).
+
 ## [5.24.0] - 2026-07-24
 
 Documentação passa a ter o **inglês como idioma principal**, com a leitura em
@@ -3906,6 +3948,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.25.0]: https://github.com/JotJunior/cstk/releases/tag/v5.25.0
 [5.24.0]: https://github.com/JotJunior/cstk/releases/tag/v5.24.0
 [5.23.0]: https://github.com/JotJunior/cstk/releases/tag/v5.23.0
 [5.22.0]: https://github.com/JotJunior/cstk/releases/tag/v5.22.0

--- a/cli/lib/hooks.sh
+++ b/cli/lib/hooks.sh
@@ -167,6 +167,10 @@ print_paste_block() {
 #      calls por onda, sidecar tool-call-ticks.log) quando presente no
 #      catalogo. BEST-EFFORT: ausencia (catalogo antigo) ou falha de cp
 #      NAO muda a palavra de estado nem aborta — e metrica, nao guarda.
+#   1c. Copia <src_dir>/posttooluse-agent-usage.sh (metrica de uso de
+#      tokens/tool-uses/duracao por spawn de subagente, sidecar
+#      wave-agent-usage.jsonl — wave-token-metrics FASE 2) quando presente
+#      no catalogo. Mesma politica BEST-EFFORT do item 1b.
 #   2. Mescla <src_dir>/settings.snippet.json em
 #      <dest_claude_root>/settings.json via merge_settings (jq) ou
 #      print_paste_block (fallback sem jq) — mesma mecanica ja testada dos
@@ -218,11 +222,15 @@ apply_guard_hooks() {
   fi
 
   _agh_tick_script="$_agh_src/posttooluse-tool-call-tick.sh"
+  _agh_usage_script="$_agh_src/posttooluse-agent-usage.sh"
 
   if [ "$_agh_dry_run" = 1 ]; then
     log_info "[dry-run] guard-hooks: copiaria $_agh_hook_script -> $_agh_hooks_dst/pretooluse-bash-guard.sh"
     if [ -f "$_agh_tick_script" ]; then
       log_info "[dry-run] guard-hooks: copiaria $_agh_tick_script -> $_agh_hooks_dst/posttooluse-tool-call-tick.sh"
+    fi
+    if [ -f "$_agh_usage_script" ]; then
+      log_info "[dry-run] guard-hooks: copiaria $_agh_usage_script -> $_agh_hooks_dst/posttooluse-agent-usage.sh"
     fi
     if [ -f "$_agh_snippet" ]; then
       if detect_jq; then
@@ -259,6 +267,17 @@ apply_guard_hooks() {
       log_info "hooks: posttooluse-tool-call-tick.sh provisionado em $_agh_hooks_dst"
     else
       log_warn "hooks: cp de posttooluse-tool-call-tick.sh falhou — metrica de tool calls indisponivel (guard intacto)"
+    fi
+  fi
+
+  # Hook de metrica de uso de tokens por spawn (best-effort, mesma politica
+  # do item acima — wave-token-metrics FASE 2).
+  if [ -f "$_agh_usage_script" ]; then
+    if cp -- "$_agh_usage_script" "$_agh_hooks_dst/posttooluse-agent-usage.sh" 2>/dev/null; then
+      chmod +x -- "$_agh_hooks_dst/posttooluse-agent-usage.sh" 2>/dev/null || :
+      log_info "hooks: posttooluse-agent-usage.sh provisionado em $_agh_hooks_dst"
+    else
+      log_warn "hooks: cp de posttooluse-agent-usage.sh falhou — metrica de uso de tokens indisponivel (guard intacto)"
     fi
   fi
 

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -608,6 +608,25 @@ recall_ensure_db_dir() {
   return 0
 }
 
+# recall_normalize_db_perms DB_PATH -> best-effort: garante permissao 0600 no
+# arquivo do indice (~/.claude/cstk/knowledge.db ou --db custom). Fecha o gap
+# CHK017 (feature wave-token-metrics, subtarefas 1.2.2/1.2.4): o DB e criado
+# pelo processo do operador (mesma politica ja documentada para o sidecar
+# irmao wave-agent-usage.jsonl, data-model.md §Sidecar). NAO altera um DB ja
+# existente com permissao mais aberta silenciosamente sem log — normaliza via
+# chmod 600 e avisa uma vez via log_warn. Nunca bloqueia o caller: ausencia de
+# `stat` portavel, arquivo inexistente ou chmod negado degradam para no-op.
+recall_normalize_db_perms() {
+  [ -f "$1" ] || return 0
+  _ndp_mode=$(stat -f '%Lp' -- "$1" 2>/dev/null) || _ndp_mode=$(stat -c '%a' -- "$1" 2>/dev/null) || _ndp_mode=""
+  [ -n "$_ndp_mode" ] || return 0
+  [ "$_ndp_mode" = "600" ] && return 0
+  if chmod 600 -- "$1" 2>/dev/null; then
+    log_warn "recall: permissao do indice ($1) era $_ndp_mode, normalizada para 600"
+  fi
+  return 0
+}
+
 # recall_apply_schema DB_PATH -> aplica pragmas + (migracao v7 one-time) + DDL.
 # Roteado pelo retry/backoff (FR-016) porque CREATE TABLE/VIRTUAL TABLE sao
 # escritas e podem contender com outra ingestao concorrente no mesmo DB
@@ -1813,6 +1832,7 @@ recall_mode_ingest() {
     log_warn "recall: falha ao aplicar schema em $_ing_db; ingestao pulada"
     return "$RECALL_EXIT_OK"
   }
+  recall_normalize_db_perms "$_ing_db"
 
   RECALL_TOTAL_DEC=0; RECALL_TOTAL_BLOQ=0; RECALL_TOTAL_RETRO=0; RECALL_TOTAL_SKILL=0
   RECALL_TOTAL_EXEC=0; RECALL_TOTAL_WAVE=0; RECALL_TOTAL_ALERT=0
@@ -2211,6 +2231,7 @@ recall_mode_reindex() {
     log_warn "recall: falha ao recriar schema em $_rx_db; reindex pulado"
     return "$RECALL_EXIT_OK"
   }
+  recall_normalize_db_perms "$_rx_db"
 
   # Raiz de varredura: --states-root ou descoberta padrao (HOME + cwd).
   if [ -z "$_rx_states_root" ]; then

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -103,7 +103,16 @@ RECALL_EXIT_USAGE=2
 # TABLE ADD COLUMN idempotente guardado por PRAGMA table_info (padrao
 # v2/v5/v8); re-ingestao backfilla linhas ja existentes via upsert pela
 # chave natural. waves e knowledge_fts INTOCADAS.
-RECALL_SCHEMA_VERSION=9
+# v10 (wave-token-metrics): 9 colunas aditivas INTEGER em waves
+# (agent_spawns_total, agent_spawns_with_usage, agent_total_tokens,
+# agent_input_tokens, agent_output_tokens, agent_cache_read_tokens,
+# agent_cache_creation_tokens, agent_tool_use_count, agent_duration_ms) —
+# origem .waves[].agent_usage do state.json (agregado por onda, FR-006).
+# Migracao v9->v10 = ALTER TABLE ADD COLUMN idempotente guardado por PRAGMA
+# table_info (mesmo padrao v2/v5/v8/v9); SEM drop, dados v9 preservados.
+# Onda antiga ou sem .agent_usage -> todas as 9 colunas NULL, nunca 0
+# (recall_int_or_null; Principio VI — nao fabricar dado nao observado).
+RECALL_SCHEMA_VERSION=10
 # Enum interno (canonico): valores EN. 'bloqueio' permanece aceito como ALIAS
 # DEPRECADO em --type (normalizado para 'block' com aviso) — ver recall_normalize_type.
 RECALL_TYPE_ENUM="decision block retro skill memory suggestion"
@@ -501,6 +510,15 @@ CREATE TABLE IF NOT EXISTS waves (
   n_stages INTEGER,
   n_skills INTEGER,
   session TEXT,
+  agent_spawns_total INTEGER,
+  agent_spawns_with_usage INTEGER,
+  agent_total_tokens INTEGER,
+  agent_input_tokens INTEGER,
+  agent_output_tokens INTEGER,
+  agent_cache_read_tokens INTEGER,
+  agent_cache_creation_tokens INTEGER,
+  agent_tool_use_count INTEGER,
+  agent_duration_ms INTEGER,
   ingested_at TEXT NOT NULL,
   UNIQUE(project, feature, wave, source_id)
 );
@@ -709,6 +727,25 @@ ALTER TABLE waves ADD COLUMN session TEXT;" ;;
         ''|*'|target_project_path|'*) : ;;  # tabela inexistente (DDL cria) ou ja migrada
         *) _as_extra="$_as_extra
 ALTER TABLE executions ADD COLUMN target_project_path TEXT;" ;;
+      esac
+      # ---- Migracao v9->v10 (wave-token-metrics): 9 colunas aditivas
+      # INTEGER em waves para o agregado de uso de agentes por onda
+      # (agent_usage). Mesmo padrao idempotente acima; reusa _as_wcols (PRAGMA
+      # ja lido antes de qualquer ALTER neste batch — os ALTERs so executam
+      # em conjunto no final). Sem DEFAULT explicito -> NULL na criacao da
+      # coluna, coerente com onda antiga sem agent_usage (FR-009: nunca 0).
+      case "$_as_wcols" in
+        ''|*'|agent_spawns_total|'*) : ;;  # tabela inexistente (DDL cria) ou ja migrada
+        *) _as_extra="$_as_extra
+ALTER TABLE waves ADD COLUMN agent_spawns_total INTEGER;
+ALTER TABLE waves ADD COLUMN agent_spawns_with_usage INTEGER;
+ALTER TABLE waves ADD COLUMN agent_total_tokens INTEGER;
+ALTER TABLE waves ADD COLUMN agent_input_tokens INTEGER;
+ALTER TABLE waves ADD COLUMN agent_output_tokens INTEGER;
+ALTER TABLE waves ADD COLUMN agent_cache_read_tokens INTEGER;
+ALTER TABLE waves ADD COLUMN agent_cache_creation_tokens INTEGER;
+ALTER TABLE waves ADD COLUMN agent_tool_use_count INTEGER;
+ALTER TABLE waves ADD COLUMN agent_duration_ms INTEGER;" ;;
       esac
     fi
   fi
@@ -1025,6 +1062,10 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
   # Deriva etapas (join ","), inicio/fim, wallclock_seconds, tool_calls,
   # motivo_termino (texto livre filtrado), n_etapas, n_skills (derivados via
   # length). Onda aberta (fim null) -> fim vazio, sem erro (1.3.5).
+  # v10 (wave-token-metrics): +9 campos de .agent_usage (agregado por onda).
+  # .agent_usage ausente/null -> cada subcampo "" via `//` -> recall_int_or_null
+  # produz NULL (nunca 0 fabricado; 0 legitimo de fato observado e preservado,
+  # pois `//` do jq so trata false/null/vazio como falsy, nao 0).
   _isj_n_wave=0
   _isj_wave_lines=$(jq -r '
     ((.waves // .ondas) // [])
@@ -1042,7 +1083,16 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
        ($stages | length | tostring),
        (($w.skills_invoked // [])
         | map(select((.kind // "skill") != "gate"))
-        | length | tostring)]
+        | length | tostring),
+       (($w.agent_usage.spawns_total // "")|tostring),
+       (($w.agent_usage.spawns_with_usage // "")|tostring),
+       (($w.agent_usage.total_tokens // "")|tostring),
+       (($w.agent_usage.input_tokens // "")|tostring),
+       (($w.agent_usage.output_tokens // "")|tostring),
+       (($w.agent_usage.cache_read_input_tokens // "")|tostring),
+       (($w.agent_usage.cache_creation_input_tokens // "")|tostring),
+       (($w.agent_usage.tool_use_count // "")|tostring),
+       (($w.agent_usage.duration_ms // "")|tostring)]
     | @base64' "$_isj_state" 2>/dev/null) || _isj_wave_lines=""
   if [ -n "$_isj_wave_lines" ]; then
     _isj_OLDIFS="$IFS"; IFS='
@@ -1058,16 +1108,34 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
       _f_mt=$(printf '%s' "$_isj_decoded" | jq -r '.[6]' 2>/dev/null | strip_nul)
       _f_ne=$(printf '%s' "$_isj_decoded" | jq -r '.[7]' 2>/dev/null | strip_nul)
       _f_ns=$(printf '%s' "$_isj_decoded" | jq -r '.[8]' 2>/dev/null | strip_nul)
+      _f_ast=$(printf '%s' "$_isj_decoded" | jq -r '.[9]' 2>/dev/null | strip_nul)
+      _f_asu=$(printf '%s' "$_isj_decoded" | jq -r '.[10]' 2>/dev/null | strip_nul)
+      _f_att=$(printf '%s' "$_isj_decoded" | jq -r '.[11]' 2>/dev/null | strip_nul)
+      _f_ait=$(printf '%s' "$_isj_decoded" | jq -r '.[12]' 2>/dev/null | strip_nul)
+      _f_aot=$(printf '%s' "$_isj_decoded" | jq -r '.[13]' 2>/dev/null | strip_nul)
+      _f_acr=$(printf '%s' "$_isj_decoded" | jq -r '.[14]' 2>/dev/null | strip_nul)
+      _f_acc=$(printf '%s' "$_isj_decoded" | jq -r '.[15]' 2>/dev/null | strip_nul)
+      _f_atu=$(printf '%s' "$_isj_decoded" | jq -r '.[16]' 2>/dev/null | strip_nul)
+      _f_adm=$(printf '%s' "$_isj_decoded" | jq -r '.[17]' 2>/dev/null | strip_nul)
       [ -n "$_f_wid" ] || continue
       _f_mt=$(recall_scrub "$_f_mt")
       _isj_wc_sql=$(recall_int_or_null "$_f_wc")
       _isj_tc_sql=$(recall_int_or_null "$_f_tc")
       _isj_ne_sql=$(recall_int_or_null "$_f_ne")
       _isj_ns_sql=$(recall_int_or_null "$_f_ns")
+      _isj_ast_sql=$(recall_int_or_null "$_f_ast")
+      _isj_asu_sql=$(recall_int_or_null "$_f_asu")
+      _isj_att_sql=$(recall_int_or_null "$_f_att")
+      _isj_ait_sql=$(recall_int_or_null "$_f_ait")
+      _isj_aot_sql=$(recall_int_or_null "$_f_aot")
+      _isj_acr_sql=$(recall_int_or_null "$_f_acr")
+      _isj_acc_sql=$(recall_int_or_null "$_f_acc")
+      _isj_atu_sql=$(recall_int_or_null "$_f_atu")
+      _isj_adm_sql=$(recall_int_or_null "$_f_adm")
       _isj_sql="$_isj_sql
-INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,started_at,finished_at,wallclock_seconds,tool_calls,termination_reason,n_stages,n_skills,session,ingested_at)
-VALUES('$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','$(sql_escape "$_f_wid")','$(sql_escape "$_isj_exec_id")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_wid")','$(sql_escape "$_f_etp")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_fim")',$_isj_wc_sql,$_isj_tc_sql,'$(sql_escape "$_f_mt")',$_isj_ne_sql,$_isj_ns_sql,$_isj_session_sql,'$(sql_escape "$_isj_now")')
-ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,stages=excluded.stages,started_at=excluded.started_at,finished_at=excluded.finished_at,wallclock_seconds=excluded.wallclock_seconds,tool_calls=excluded.tool_calls,termination_reason=excluded.termination_reason,n_stages=excluded.n_stages,n_skills=excluded.n_skills,session=excluded.session,ingested_at=excluded.ingested_at;"
+INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,started_at,finished_at,wallclock_seconds,tool_calls,termination_reason,n_stages,n_skills,session,agent_spawns_total,agent_spawns_with_usage,agent_total_tokens,agent_input_tokens,agent_output_tokens,agent_cache_read_tokens,agent_cache_creation_tokens,agent_tool_use_count,agent_duration_ms,ingested_at)
+VALUES('$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','$(sql_escape "$_f_wid")','$(sql_escape "$_isj_exec_id")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_wid")','$(sql_escape "$_f_etp")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_fim")',$_isj_wc_sql,$_isj_tc_sql,'$(sql_escape "$_f_mt")',$_isj_ne_sql,$_isj_ns_sql,$_isj_session_sql,$_isj_ast_sql,$_isj_asu_sql,$_isj_att_sql,$_isj_ait_sql,$_isj_aot_sql,$_isj_acr_sql,$_isj_acc_sql,$_isj_atu_sql,$_isj_adm_sql,'$(sql_escape "$_isj_now")')
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,stages=excluded.stages,started_at=excluded.started_at,finished_at=excluded.finished_at,wallclock_seconds=excluded.wallclock_seconds,tool_calls=excluded.tool_calls,termination_reason=excluded.termination_reason,n_stages=excluded.n_stages,n_skills=excluded.n_skills,session=excluded.session,agent_spawns_total=excluded.agent_spawns_total,agent_spawns_with_usage=excluded.agent_spawns_with_usage,agent_total_tokens=excluded.agent_total_tokens,agent_input_tokens=excluded.agent_input_tokens,agent_output_tokens=excluded.agent_output_tokens,agent_cache_read_tokens=excluded.agent_cache_read_tokens,agent_cache_creation_tokens=excluded.agent_cache_creation_tokens,agent_tool_use_count=excluded.agent_tool_use_count,agent_duration_ms=excluded.agent_duration_ms,ingested_at=excluded.ingested_at;"
       _isj_n_wave=$((_isj_n_wave + 1))
     done
     IFS="$_isj_OLDIFS"

--- a/docs/specs/wave-token-metrics/checklists/requirements.md
+++ b/docs/specs/wave-token-metrics/checklists/requirements.md
@@ -1,0 +1,105 @@
+# Requirements Checklist: wave-token-metrics
+
+**Purpose**: validar qualidade, clareza, completude e rastreabilidade dos
+requisitos de `spec.md` e do desenho tecnico de `plan.md` — nao valida
+implementacao (ainda inexistente).
+**Created**: 2026-07-25
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md)
+
+## Completude de Requisitos
+
+- [x] CHK001 - Os requisitos funcionais cobrem tokens (total + 4 categorias), tool-uses e duracao para cada spawn concluido? [Completude, Spec §FR-001, §FR-002] {auto}
+  - Satisfeito: FR-001 exige "total agregado e um breakdown por categoria (input, output, cache-read, cache-creation)"; FR-002 exige "contagem de tool-uses" e "duracao" — ambos MUST.
+- [x] CHK002 - Requisitos nao-funcionais (seguranca/zero-egress/observabilidade) estao cobertos? [Completude] {auto}
+  - Satisfeito: Plan §Constitution Check, Principio IV — "todo dado permanece local... Nenhum egress, nenhum endpoint, nenhum identificador enviado a lugar algum. O hook nao faz rede."
+- [ ] CHK003 - Existe uma secao explicita de "Fora de Escopo" na spec? [Completude] {auto} [Gap]
+  - Nao satisfeito: `spec.md` nao tem heading dedicado de fora-de-escopo. Ha apenas fronteiras implicitas em "Assumptions & Dependencies" (linha 308-309: "Esta feature nao especifica o schema de armazenamento nem o formato exato dos campos de captura — isso e decisao tecnica de `/plan`"). O plan.md preenche a lacuna tecnica (Data Model, contracts), mas a spec em si carece do heading formal.
+- [x] CHK004 - Dependencias externas (harness `PostToolUse` matcher `Agent`, `jq`, `sqlite3`) estao documentadas? [Completude, Spec §Assumptions & Dependencies] {auto}
+  - Satisfeito: Spec §Assumptions cita as duas fontes de dados observadas; Plan §Technical Context declara `jq`/`sqlite3` como deps opcionais ja confinadas, "Nenhuma dep nova e introduzida."
+- [x] CHK005 - Premissas de fonte de dados sao apoiadas por evidencia observada (nao suposicao)? [Completude, Spec §Assumptions & Dependencies] {auto}
+  - Satisfeito: Spec linhas 274-289 cita transcript real com correspondencia numerica (`tokens=106664, tool-uses=38`) contra o que foi exibido ao operador na mesma onda — evidencia citavel, nao suposicao.
+- [x] CHK006 - Ha fallback definido para dependencia/fonte indisponivel (hook nao provisionado, `jq` ausente)? [Completude, Spec §FR-008] {auto}
+  - Satisfeito: FR-008 MUST best-effort; Plan §Riscos R2 antecipa explicitamente "o hook de `tool_calls` nao esta provisionado" neste proprio repo e define a mitigacao (relatorio distingue "0 spawns" de "metrica nao coletada").
+
+## Clareza de Requisitos
+
+- [x] CHK007 - Cada requisito funcional usa verbo MUST/SHOULD testavel? [Clareza, Spec §Functional Requirements] {auto}
+  - Satisfeito: 12/12 FRs usam MUST, exceto FR-010 (SHOULD, justificado por prioridade P4/fase separada — nao e ambiguidade, e escolha deliberada de escopo).
+- [x] CHK008 - Os termos de status ("indisponivel", "parcial", "nao-aplicavel") estao definidos com semantica exata (nao apenas rotulo vago)? [Clareza, Spec §FR-009, §FR-012, §Key Entities] {auto}
+  - Satisfeito: §Key Entities enumera o enum fechado — "completo, parcial (dado ate o momento de uma falha, apenas quando observavel) ou indisponivel (nenhum dado observavel) — nunca estimada".
+- [x] CHK009 - Todas as marcacoes de clarificacao/placeholder (`[NEEDS CLARIFICATION]`, TODO) foram resolvidas? [Clareza] {auto}
+  - Satisfeito: `grep -ni 'NEEDS CLARIFICATION\|TODO\|TKTK'` sobre spec.md retornou zero ocorrencias; secao "## Clarifications / Session 2026-07-25" registra 5 perguntas, todas com resposta objetiva.
+- [x] CHK010 - "Best-effort" (FR-008) esta operacionalmente definido, nao apenas rotulado? [Clareza, Spec §FR-008] {auto}
+  - Satisfeito: FR-008 define o comportamento exato — "a ausencia ou malformacao da fonte de dados de uso subjacente MUST NOT abortar nem bloquear a onda".
+
+## Consistencia de Requisitos
+
+- [x] CHK011 - Os requisitos sao consistentes com os principios da constitution do projeto? [Constitution Alignment] {auto}
+  - Satisfeito: Plan §Constitution Check lista os 6 principios — todos `PASS` ou `PASS parcial/N/A` justificado, nenhuma violacao aberta (confirmado por "Veredito: mantido PASS em todos os principios" no re-check pos-Phase 1).
+- [x] CHK012 - A terminologia e consistente entre spec (Key Entities) e o desenho tecnico (plan/data-model)? [Consistencia] {auto}
+  - Satisfeito: `data-model.md` §"Mapeamento requisito -> campo" traduz 1:1 "Metrica de Uso de Spawn" (spec) para a entidade tecnica `SpawnUsage` (plan/data-model), sem introduzir conceito paralelo.
+- [x] CHK013 - FR-010 (SHOULD, prioridade menor) nao contradiz os MUST de captura ao vivo (FR-001/002/003)? [Consistencia, Spec §FR-010] {auto}
+  - Satisfeito: Plan §"Fases de implementacao sugeridas" declara F1-F3 (US1, captura ao vivo) "independentes de F4-F6"; F6 (backfill/FR-010) e isolado e nao bloqueia nem e bloqueado pelos MUST.
+
+## Mensurabilidade / Success Criteria
+
+- [x] CHK014 - Cada Success Criterion e objetivamente verificavel, sem termo vago? [Mensurabilidade, Spec §Success Criteria] {auto}
+  - Satisfeito: SC-001 ("100% dos spawns... quando a fonte estava disponivel"), SC-004 ("100% dos relatorios marcam... explicitamente") e SC-003 ("sem precisar fazer calculo manual fora do toolkit") sao todos criterios binarios/verificaveis, sem adjetivo vago.
+- [x] CHK015 - SC-004 (nunca inventar) tem criterio de verificacao concreto, alem da intencao? [Mensurabilidade, Spec §SC-004] {auto}
+  - Satisfeito: redacao e binaria e auditavel — "100% dos relatorios marcam a metrica... nunca exibem um numero inventado ou um zero apresentado como valor real" e diretamente checavel contra a saida de qualquer relatorio gerado.
+- [ ] CHK016 - A meta "100%" de SC-001/SC-004 e realista/aceitavel dado que ~50% dos spawns reais nao tem `usage` (`async_launched`, achado do plan)? [Risco, Spec §SC-001, Plan §Summary "achado que molda o desenho"] {humano}
+  - Depende de julgamento de risco/expectativa do dono do produto: o 100% e formalmente correto (esta condicionado a "quando a fonte de dados de uso estava disponivel"), mas comunicar essa condicional aos stakeholders sem gerar percepcao de metrica "quebrada" e decisao de produto, nao de qualidade textual do requisito.
+
+## Cobertura de Cenarios
+
+- [x] CHK017 - O happy path (spawn unico concluido normalmente) esta coberto? [Cobertura, Spec §US1 AS1] {auto}
+  - Satisfeito: US1 Acceptance Scenario 1 cobre exatamente esse caso; Quickstart Cenario 1 (§"Captura ao vivo de um spawn concluido (SC-001)") da o teste executavel correspondente.
+- [x] CHK018 - O cenario de multiplos spawns paralelos na mesma onda esta coberto (atribuicao individual + agregado)? [Cobertura, Spec §US1 AS2, §Edge Cases] {auto}
+  - Satisfeito: US1 AS2 e a 3a pergunta de Edge Cases tratam exatamente disso; Quickstart Cenario 3 ("Onda mista: metade dos spawns sem usage") exercita o caso real observado no proprio projeto.
+- [x] CHK019 - O cenario de falha/aborto parcial de spawn esta coberto (dado parcial vs indisponivel)? [Cobertura, Spec §FR-012, §Edge Cases] {auto}
+  - Satisfeito: FR-012 e o 1o item de Edge Cases descrevem o comportamento exato (parcial se observavel, indisponivel senao); resolvido nesta sessao (marcado "RESOLVIDO" no bloco Clarifications).
+- [x] CHK020 - O cenario de execucoes concorrentes no mesmo projeto (atribuicao sem mistura entre execucoes) esta coberto? [Cobertura, Spec §Edge Cases] {auto}
+  - Satisfeito: ultimo item de Edge Cases + Clarifications Q3 exigem identificador de execucao explicito na Metrica de Uso de Spawn, precedente citado (coluna `session` do knowledge.db v8).
+- [x] CHK021 - O cenario de reconstrucao retroativa com dados ja removidos do disco (recusa explicita) esta coberto? [Cobertura, Spec §FR-011, §US4 AS2] {auto}
+  - Satisfeito: FR-011 MUST + US4 Acceptance Scenario 2 definem a recusa explicita; Quickstart Cenario 10 ("Backfill recusa explicita (FR-011)") da o teste correspondente.
+- [x] CHK022 - O gate deterministico de cobertura de cenarios (`requirement-coverage.sh`) confirma que todo FR tem cenario associado? [Cobertura] {auto}
+  - Satisfeito: `RESULT|docs/specs/wave-token-metrics/spec.md|requirements=12|covered=12|errors=0` (exit 0) — registrado como Decisao dec-033 nesta onda.
+
+## Requisitos Nao-Funcionais
+
+- [x] CHK023 - O requisito de nao-bloqueio (fail-open) tem restricao qualitativa explicita, mesmo sem alvo numerico de latencia? [Nao-Funcional, Plan §Technical Context "Constraints"] {auto}
+  - Satisfeito: Plan declara restricao dura "(a) hook MUST NOT escrever no state.json... " e "o hook MUST NOT bloquear, atrasar ou reprovar uma tool call (fail-open)", reusando o teto `timeout: 5` ja praticado pelos hooks existentes.
+- [ ] CHK024 - A ausencia deliberada de alvo numerico de performance/latencia (plan declara "N/A quantitativo") e aceitavel para este release, ou o operador quer um teto explicito adicional? [Risco, Plan §Technical Context "Performance Goals"] {humano}
+  - Depende de apetite de risco do dono do produto — a spec/plan documentam a ausencia honestamente (nao fabricam um numero), mas decidir se isso e suficiente para aprovar o release e julgamento de negocio.
+
+## Dependencias e Premissas
+
+- [x] CHK025 - A fonte de dados do payload do hook foi verificada contra doc oficial, nao suposta? [Assumption, Spec §Assumptions & Dependencies, Plan §Constitution Check Principio VI] {auto}
+  - Satisfeito: Plan cita fonte primaria rastreavel — "Todo campo do payload do harness citado nos contratos foi extraido da doc oficial baixada e lida (`https://code.claude.com/docs/en/hooks.md`, 2026-07-25) e cruzado com transcripts reais."
+- [x] CHK026 - O "risco em aberto" declarado na spec (payload exato do hook nao verificado) foi endereçado antes do plan avancar para o design? [Assumption, Spec §Assumptions & Dependencies "Risco em aberto"] {auto}
+  - Satisfeito: Plan §Summary confirma que "o unknown central da spec... foi resolvido com fonte oficial" no Phase 0 (`research.md` Decision 1), fechando o risco antes da Fase 1 (design).
+- [x] CHK027 - A spec distingue corretamente entre a decisao historica anterior ("harness nao expoe tokens a scripts/env") e o canal novo assumido por esta feature (transcript/tool_response)? [Consistencia, Spec §Assumptions & Dependencies "Nao contradiz decisao historica"] {auto}
+  - Satisfeito: paragrafo dedicado explica que a conclusao anterior vale so para o canal de env vars testado, e que o canal desta feature (dado persistido em disco / tool_response) e diferente e nao testado por aquela decisao — evita contradicao aparente.
+
+## Rastreabilidade
+
+- [x] CHK028 - Cada User Story se liga a Requisitos Funcionais especificos? [Traceability] {auto}
+  - Satisfeito: `data-model.md` §"Mapeamento requisito -> campo" cobre os 12/12 FRs com campo tecnico correspondente, e cada FR ja cita a User Story de origem no proprio corpo da spec (US1: FR-001/002/003/004/005/008/009; US2: FR-007; US3: FR-006; US4: FR-010/011).
+- [x] CHK029 - Os Success Criteria se ligam a Requisitos/User Stories de forma rastreavel (nao numeros soltos)? [Traceability, Spec §Success Criteria] {auto}
+  - Satisfeito: `quickstart.md` amarra cada cenario executavel a um par explicito FR+SC (ex.: "Cenario 1 — Captura ao vivo de um spawn concluido (SC-001)", "Cenario 6 — Custo x modelo roteado (SC-003, FR-007)").
+
+## Ambiguidades e Conflitos
+
+- [x] CHK030 - Todas as ambiguidades levantadas na sessao de clarify foram resolvidas com decisao explicita (nao "manter em aberto")? [Ambiguity, Spec §Clarifications] {auto}
+  - Satisfeito: 5/5 perguntas da sessao 2026-07-25 tem resposta objetiva (`→ A:`); nenhuma ficou com resposta ambigua ou "a definir depois".
+- [x] CHK031 - Ha conflito entre o MUST de FR-009 (nunca fabricar) e alguma pressao de completude (ex.: exibir 100% de cobertura)? [Conflict] {auto}
+  - Nao satisfeito nao se aplica — verificado, sem conflito: SC-001/SC-004 condicionam explicitamente o 100% a disponibilidade da fonte ("quando a fonte de dados de uso estava disponivel"), preservando FR-009 sem criar pressao para fabricar dado ausente.
+
+## Notes
+
+- Items `{auto}` ja vem resolvidos pelo agente (`[x]` com citacao, ou marcador `[Gap]`).
+- Items `{humano}` ficam `[ ]` aguardando decisao do dono do produto.
+- **{auto} resolvidos**: 27
+- **{humano} aguardando decisao**: 2 (CHK016, CHK024)
+- **Gaps abertos**: 1 (CHK003 — `[Gap]`, secao "Fora de Escopo" ausente na spec)
+- Gate `requirement-coverage.sh`: `requirements=12|covered=12|errors=0` (exit 0) — nenhum `[Gap]` adicional de cenario-por-FR foi necessario (ver CHK022).

--- a/docs/specs/wave-token-metrics/checklists/security.md
+++ b/docs/specs/wave-token-metrics/checklists/security.md
@@ -1,0 +1,82 @@
+# Security Checklist: wave-token-metrics
+
+**Purpose**: validar qualidade dos requisitos de seguranca (nao a
+implementacao — inexistente ainda) do hook `PostToolUse`/matcher `Agent` que
+captura telemetria de uso por spawn de subagente, e da cadeia
+sidecar->state.json->knowledge.db que a persiste/expoe. Adaptado ao
+dominio real da feature (CLI local, sem rede/auth/PII) — os items de
+authN/RBAC/TLS/LGPD do catalogo generico de `security.md` nao se aplicam
+aqui e sao marcados N/A com justificativa, nao copiados as cegas.
+**Created**: 2026-07-25
+**Feature**: [spec.md](../spec.md) · [plan.md](../plan.md) ·
+[contracts/hook-posttooluse-agent-usage.md](../contracts/hook-posttooluse-agent-usage.md)
+
+## Vazamento de Dados / Protecao de Segredos
+
+- [x] CHK001 - O requisito de nao-vazamento de texto livre (prompt/resposta do subagente) no sidecar esta explicito e nao apenas implicito? [Protecao de Dados, Contract §2 "Restricoes duras da linha"] {auto}
+  - Satisfeito: `contracts/hook-posttooluse-agent-usage.md` §2, item 1 — "MUST NOT conter `content`, `prompt` ou `description` — texto livre e proibido (tamanho + vazamento de segredo)"; §1.3 tabela marca `prompt`/`description` explicitamente "NAO" consumidos.
+- [x] CHK002 - Ha teste de cenario dedicado que garante essa restricao anti-vazamento na pratica (nao so na intencao do requisito)? [Cobertura, Contract §6 cenario 11] {auto}
+  - Satisfeito: Contract §6, cenario #11 — "anti-vazamento: `content`/`prompt` presentes na entrada nunca aparecem na linha".
+- [x] CHK003 - O requisito de nao-fabricacao de dado (FR-009/FR-012) tambem previne o risco inverso — um `null` real sendo mascarado como `0` (o que poderia esconder uma falha de captura)? [Clareza, Spec §FR-009, Plan §Constitution Check Principio VI] {auto}
+  - Satisfeito: Plan detalha isso como o risco #2 do Principio VI — "um `0` no lugar de um `null` transforma 'nao medi' em 'medi e deu zero'" — tratado como invariante replicada em todas as camadas (sidecar -> state.json -> SQLite -> relatorio).
+- [x] CHK004 - O canal de persistencia (knowledge.db) usa o mesmo helper de nulos ja auditado em vez de logica nova sujeita a regressao? [Consistencia, Plan §Principio VI] {auto}
+  - Satisfeito: Plan cita reuso do helper existente `recall_int_or_null` para propagar `NULL` no SQLite, em vez de introduzir tratamento de nulo paralelo.
+
+## Least Privilege / Superficie de Acesso (ASI02 — Tool Misuse)
+
+- [x] CHK005 - O hook consome apenas os campos estritamente necessarios do payload do harness (nao um dump irrestrito de `tool_response`)? [ASI02 Tool Misuse — "validar todos os inputs/outputs de tool", Contract §1.4] {auto}
+  - Satisfeito: Contract §1.3/§1.4 listam campo-a-campo o que e consumido (`SIM`) vs explicitamente descartado (`NAO`) — `prompt`, `description`, `content` marcados NAO; apenas 11 campos numericos/identificadores curtos sao lidos.
+- [x] CHK006 - O acesso do hook ao sistema de arquivos e de escrita confinada (append-only, um unico arquivo por state-dir), sem escrita arbitraria fora do escopo da execucao? [ASI02 Least Privilege, Research §Decision 5] {auto}
+  - Satisfeito: Decision 5 — hook escreve "UMA linha JSON por spawn em `<state-dir>/wave-agent-usage.jsonl`, append-only" e "nunca toca `state.json`"; nenhum outro caminho de escrita e requisitado.
+- [x] CHK007 - Todo campo lido do payload do harness tem tratamento de ausencia/malformacao explicito (validacao de input), em vez de assumir presenca? [ASI02 "Validate all tool inputs and outputs", Contract §3] {auto}
+  - Satisfeito: Contract §3 tabela "Politica de falha" cobre `jq` ausente, stdin vazio/invalido, `cwd` vazio, `tool_name != Agent`, `tool_response` malformado — cada condicao com comportamento definido (`exit 0` ou `status=indisponivel`), nunca um crash ou leitura nao validada.
+- [x] CHK008 - A deteccao de "execucao ativa" (decidir para qual state-dir a metrica vai) reusa um algoritmo ja auditado, em vez de introduzir logica nova de resolucao de escopo? [ASI02 Escopo/Privilegio, Contract §4] {auto}
+  - Satisfeito: Contract §4 exige algoritmo "**identico** ao de `posttooluse-tool-call-tick.sh:68-100`" com regra dura "MUST NOT divergir desse algoritmo" — reuso deliberado em vez de reimplementacao paralela, reduzindo superficie nova de erro/escopo incorreto.
+
+## Disponibilidade / Fail-Open como Vetor (nao-funcional de seguranca)
+
+- [x] CHK009 - O requisito de fail-open esta especificado por condicao, nao como principio generico vago? [Clareza, Contract §3] {auto}
+  - Satisfeito: Contract §3 enumera 7 condicoes de falha distintas com o comportamento exato para cada uma (nao um "deve falhar graciosamente" generico).
+- [x] CHK010 - Existe restricao dura contra o hook usar `set -e` ou escrever em stdout (vetores que fariam o harness expor stderr/ruido ao operador ou interromper o fluxo)? [Clareza, Contract §3] {auto}
+  - Satisfeito: Contract §3 — "MUST NOT usar `set -e`... MUST NOT escrever em stdout... MUST NOT bloquear, atrasar ou reprovar a tool call".
+- [x] CHK011 - O crescimento do sidecar (potencial vetor de esgotamento de disco sob spawns repetidos) tem limite de ciclo de vida definido? [Cobertura, Research §Decision 5 "Ciclo de vida"] {auto}
+  - Satisfeito: Decision 5 — "reset em `start` e em `end`... Janela de contagem = start->end" — o sidecar nao acumula indefinidamente entre ondas, limitando o vetor a uma unica onda.
+- [x] CHK012 - O tamanho maximo de linha do sidecar (relevante para atomicidade E para limitar o que pode ser escrito) esta quantificado, nao apenas qualificado como "curto"? [Clareza, Contract §2 item 2] {auto}
+  - Satisfeito: Contract §2 — "MUST caber em uma linha curta (< PIPE_BUF)"; Research §Decision 5 reforca que a restricao de tamanho e "load-bearing" tanto para atomicidade do append quanto para banir campos de texto livre.
+
+## Auditoria / Rastreabilidade de Uso
+
+- [x] CHK013 - Cada metrica de spawn capturada carrega proveniencia suficiente para auditoria (execucao, onda, feature/projeto, modelo)? [ASI02 "Log all tool invocations for audit", Spec §FR-003] {auto}
+  - Satisfeito: FR-003 MUST — associa a metrica "a onda, ao identificador de execucao, a feature/projeto e ao modelo que foi roteado para aquele spawn", com o campo de modelo sempre presente (nunca omitido).
+- [x] CHK014 - A auditoria de custo x modelo roteado (FR-007/US2) tem requisito de qualidade equivalente ao dos demais tipos de registro auditavel do toolkit (Decisoes, bloqueios)? [Consistencia, Spec §FR-007] {auto}
+  - Satisfeito: FR-007 explicitamente reusa "auditoria de custo x roteamento ja existente no toolkit" em vez de propor um mecanismo de auditoria paralelo — consistente com o padrao ja estabelecido para `model-routing-report.sh`.
+
+## Zero Coleta Remota (Principio IV — escopo de confianca)
+
+- [x] CHK015 - A spec/plan garantem explicitamente que nenhum dado de uso (potencialmente sensivel a nivel de padrao de consumo) sai do disco local? [ASI04-adjacente / Principio IV, Plan §Constitution Check] {auto}
+  - Satisfeito: Plan §Constitution Check, linha IV — "todo dado permanece local... Nenhum egress, nenhum endpoint, nenhum identificador enviado a lugar algum. O hook nao faz rede." — marcado "Ponto de maior atencao desta feature", nao tratado como obvio.
+- [x] CHK016 - Os 3 destinos de persistencia (sidecar, state.json, knowledge.db) sao todos explicitamente locais, sem introduzir um servico/API novo? [Completude, Plan §Storage] {auto}
+  - Satisfeito: Plan §Technical Context "Storage" — `state.json` por execucao + sidecar JSONL por onda + `~/.claude/cstk/knowledge.db` (SQLite local) — os 3 sao arquivo-em-disco, nenhum servidor.
+
+## Achados do Gate owasp-security (dec-035)
+
+- [ ] CHK020 - Ha um teto explicito de numero de linhas/spawns por onda no sidecar, para o caso de um loop anomalo gerar muitos spawns ANTES do proximo `end` resetar o arquivo? [Cobertura, Research §Decision 5 "Ciclo de vida"] {auto} [Gap]
+  - Nao satisfeito: o desenho limita o vetor pelo ciclo de vida (reset em `start`/`end`, janela = 1 onda) e pelo `Scale/Scope` do plan ("poucos spawns por onda, ordem de unidades"), mas nenhum artefato define um teto explicito de linhas dentro de uma unica onda antes do reset — diferente de `budget.sh`, que ja vigia `state_size_threshold_bytes` para o `state.json`, o sidecar `wave-agent-usage.jsonl` em si nao e observado por nenhum threshold dedicado. Risco residual classificado INFO/LOW pelo gate `owasp-security` (dec-035): nao bloqueia, mas fica registrado para `/create-tasks` avaliar um contador leve (ex.: `wc -l` best-effort em `state-ondas.sh end` antes do reset, so para log/aviso, sem bloquear).
+
+## Gaps / Itens Nao Cobertos
+
+- [ ] CHK017 - Ha requisito explicito de permissoes de arquivo (umask/chmod) para o sidecar `wave-agent-usage.jsonl` e para `~/.claude/cstk/knowledge.db`, dado que ambos passam a conter contagens de tokens/duracao por feature (sinal de padrao de uso, ainda que nao PII)? [Protecao de Dados] {auto} [Gap]
+  - Nao satisfeito: nenhum artefato (spec/plan/research/contracts) especifica permissoes de arquivo para o sidecar ou para o knowledge.db. **Contexto atenuante, nao dispensa o Gap**: o hook irmao pre-existente (`posttooluse-tool-call-tick.sh`) e o `~/.claude/cstk/knowledge.db` ja em producao tambem nao tem requisito de permissao documentado — ou seja, este e um gap **herdado do padrao ja estabelecido no toolkit**, nao introduzido de novo por esta feature. Ainda assim, como esta feature adiciona dado novo (consumo por feature/projeto) ao mesmo arquivo compartilhado, vale registrar o gap para consumo por `/create-tasks` em vez de ignora-lo.
+- [ ] CHK018 - A superficie de ameaca ASI05 (Unexpected Code Execution) se aplica a este hook — ha algum caminho em que dado do `tool_response` e interpretado/executado (nao apenas lido como valor)? [ASI05, Contract §1] {auto}
+  - Satisfeito (N/A justificado, nao Gap): revisado campo-a-campo no Contract §1.4 — todos os 11 campos consumidos sao valores escalares (string/number) lidos via `jq` e gravados verbatim; nenhum e usado como comando, template ou caminho de `eval`. ASI05 nao se aplica a este componente por desenho (metrica pura, sem execucao de conteudo dinamico).
+- [ ] CHK019 - Os requisitos generico-catalogo de authN/RBAC/TLS/LGPD-PCI-HIPAA se aplicam a esta feature? [Compliance] {auto}
+  - Nao aplicavel, justificado: feature e um mecanismo local de telemetria de uso dentro de um CLI de execucao autonoma single-user, sem superficie de rede, sem conta de usuario, sem dado de terceiro/PII — os mesmos motivos ja documentados no Constitution Check Principio IV. Item generico do catalogo `references/security.md` descartado deliberadamente (nao copiado as cegas), conforme instrucao da propria skill checklist §3.3.
+
+## Notes
+
+- Items `{auto}` ja vem resolvidos pelo agente (`[x]` com citacao, ou marcador `[Gap]`).
+- Items `{humano}` ficam `[ ]` aguardando decisao do dono do produto.
+- **{auto} resolvidos**: 18 (15 satisfeitos + 2 N/A justificados: CHK018/CHK019 — nao sao Gap, sao aplicabilidade descartada com evidencia; CHK020 conta como item auto-resolvido que revelou Gap)
+- **{humano} aguardando decisao**: 0
+- **Gaps abertos**: 2 (CHK017 — permissoes de arquivo do sidecar/knowledge.db, herdado do padrao pre-existente do toolkit, nao introduzido por esta feature; CHK020 — sem teto explicito de linhas/spawns por onda no sidecar antes do reset, achado do gate `owasp-security`)
+- Gate `owasp-security` (dec-035): 0 findings `critical`/`high` (nenhum bloqueio humano obrigatorio); 3 findings INFO/LOW registrados (CHK017, CHK020, e nota defensiva sobre renderizacao futura em painel — esta ultima sem acao, ja mitigada porque knowledge.db v10 so recebe colunas INTEGER agregadas, nenhum campo string novo).

--- a/docs/specs/wave-token-metrics/contracts/hook-posttooluse-agent-usage.md
+++ b/docs/specs/wave-token-metrics/contracts/hook-posttooluse-agent-usage.md
@@ -1,0 +1,222 @@
+# Contract: hook `posttooluse-agent-usage.sh`
+
+**Feature**: `wave-token-metrics` | **Status**: `[PROPOSTA — a validar na implementacao]`
+**Arquivo alvo**: `global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh`
+
+> Este contrato tem duas metades com estatutos diferentes:
+> **§1 (entrada)** e um contrato **EXISTENTE do harness Claude Code**, extraido
+> da doc oficial `https://code.claude.com/docs/en/hooks.md` (baixada e lida em
+> 2026-07-25) e confirmado em transcripts reais — nao foi inventado.
+> **§2 em diante** e o contrato **NOVO** desta feature.
+
+---
+
+## 1. Entrada — payload do harness (CONTRATO EXISTENTE, verificado)
+
+O hook recebe um objeto JSON no **stdin**.
+
+### 1.1 Campos comuns a todo hook event
+
+| Campo | Tipo | Uso neste hook |
+|-------|------|----------------|
+| `session_id` | string | nao usado |
+| `prompt_id` | string | nao usado |
+| `transcript_path` | string | **nao usado ao vivo** — escrito assincronamente, pode ter lag no instante do hook (doc L617). Reservado ao backfill offline. |
+| `cwd` | string | **usado** — raiz para deteccao de execucao ativa (mesmo uso de `posttooluse-tool-call-tick.sh:53`) |
+| `permission_mode` | string | nao usado |
+| `hook_event_name` | string | `"PostToolUse"` |
+
+### 1.2 Campos especificos de `PostToolUse`
+
+| Campo | Tipo | Uso |
+|-------|------|-----|
+| `tool_name` | string | **usado** — deve ser `"Agent"` (guarda defensiva mesmo com matcher) |
+| `tool_use_id` | string | nao usado (o `agentId` e a chave do spawn) |
+| `tool_input` | object | **usado** — so `subagent_type` |
+| `tool_response` | object | **usado** — portador da telemetria |
+
+### 1.3 `tool_input` da tool `Agent` (doc, secao `##### Agent`)
+
+| Campo | Tipo | Consumido? |
+|-------|------|-----------|
+| `prompt` | string | **NAO** — texto livre, proibido no sidecar |
+| `description` | string | NAO |
+| `subagent_type` | string | SIM -> `agent_type` |
+| `model` | string | NAO — usa-se `resolvedModel` do response (modelo efetivo) |
+
+### 1.4 `tool_response` com `status = "completed"` (doc L1483-1495)
+
+Citacao literal do doc (L1483):
+
+> In `PostToolUse`, `tool_response` for a completed Agent call carries the
+> subagent's final text along with usage telemetry. Read these fields to record
+> per-subagent cost from a hook:
+
+| Campo | Tipo | Consumido? | Destino |
+|-------|------|-----------|---------|
+| `status` | string | SIM | deriva `SpawnUsage.status` |
+| `agentId` | string | SIM | `agent_id` |
+| `content` | array | **NAO** — texto livre, proibido no sidecar | — |
+| `resolvedModel` | string | SIM | `model` (requer harness >= 2.1.174) |
+| `modelsUsed` | array | SIM | `models_used` (requer harness >= 2.1.212) |
+| `totalTokens` | number | SIM | `total_tokens` |
+| `totalDurationMs` | number | SIM | `duration_ms` |
+| `totalToolUseCount` | number | SIM | `tool_use_count` |
+| `usage.input_tokens` | number | SIM | `input_tokens` |
+| `usage.output_tokens` | number | SIM | `output_tokens` |
+| `usage.cache_creation_input_tokens` | number | SIM | `cache_creation_input_tokens` |
+| `usage.cache_read_input_tokens` | number | SIM | `cache_read_input_tokens` |
+
+### 1.5 `tool_response` com `status = "async_launched"` (doc L1497)
+
+Citacao literal:
+
+> For background subagents, the tool returns when the task moves to the
+> background, so `tool_response` carries no usage fields (...) It has
+> `status: "async_launched"`, `agentId`, `description`, `prompt`, `outputFile`,
+> and `resolvedModel`.
+
+Chaves observadas empiricamente num transcript real deste projeto:
+
+```json
+["agentId","canReadOutputFile","description","isAsync","outputFile","prompt","resolvedModel","status"]
+```
+
+**Consequencia contratual**: neste caso o hook grava `status = "indisponivel"`
+com **todos** os campos numericos em `null`. NUNCA `0`.
+
+> **Frequencia real, nao suposta**: contagem nos transcripts deste projeto =
+> **52 `async_launched` vs 51 `completed`**. O caminho "indisponivel" e tao
+> comum quanto o caminho feliz e MUST ser tratado como fluxo normal.
+
+---
+
+## 2. Saida — linha do sidecar `[PROPOSTA]`
+
+**Destino**: `<state-dir>/wave-agent-usage.jsonl`, append-only.
+
+Uma linha JSON compacta (`jq -c`) por spawn:
+
+```json
+{"agent_id":"a1b598e5d8f9a0318","agent_type":"agente-00c-feature-orchestrator","status":"completo","model":"claude-sonnet-5","models_used":null,"total_tokens":131692,"input_tokens":2,"output_tokens":1097,"cache_read_input_tokens":130176,"cache_creation_input_tokens":417,"tool_use_count":45,"duration_ms":681768,"source":"live","observed_at":"2026-07-25T21:04:49Z"}
+```
+
+> Os valores acima nao sao ilustrativos inventados: `agent_id`, `agent_type`
+> (do `subagent_type` do `tool_use` correlato), `model`, `total_tokens`,
+> `tool_use_count`, `duration_ms` e os 4 campos de breakdown derivam de um
+> `toolUseResult` real observado no transcript
+> `01d83125-e6c0-4c7d-859a-a1b94d6de09e.jsonl` desta sessao. Apenas `status`,
+> `source` e `observed_at` sao campos DERIVADOS pelo desenho novo (nao existem
+> na fonte).
+
+Exemplo do caso indisponivel (tambem de registro real do mesmo diretorio de
+transcripts — spawn background, `status = "async_launched"`):
+
+```json
+{"agent_id":"a35a086e9e6589c0b","agent_type":"general-purpose","status":"indisponivel","model":"claude-opus-4-8[1m]","models_used":null,"total_tokens":null,"input_tokens":null,"output_tokens":null,"cache_read_input_tokens":null,"cache_creation_input_tokens":null,"tool_use_count":null,"duration_ms":null,"source":"live","observed_at":"2026-07-25T21:05:10Z"}
+```
+
+**Restricoes duras da linha**:
+
+1. **MUST NOT** conter `content`, `prompt` ou `description` — texto livre e
+   proibido (tamanho + vazamento de segredo).
+2. **MUST** caber em uma linha curta (< PIPE_BUF) para preservar a atomicidade
+   do append O_APPEND — a mesma premissa documentada em
+   `posttooluse-tool-call-tick.sh:39-41`.
+3. **MUST NOT** conter `null` disfarcado de `0` em nenhum campo numerico.
+
+---
+
+## 3. Politica de falha: fail-OPEN absoluto
+
+Identica a de `posttooluse-tool-call-tick.sh` (cabecalho L21-27) e **oposta** a
+do `pretooluse-bash-guard.sh` (que e fail-closed por ser guarda, nao metrica).
+
+| Condicao | Comportamento |
+|----------|---------------|
+| `jq` ausente | `exit 0` silencioso |
+| stdin vazio/invalido | `exit 0` silencioso |
+| `cwd` vazio | `exit 0` silencioso |
+| `tool_name != "Agent"` | `exit 0` silencioso |
+| nenhuma execucao 00c ativa | `exit 0` silencioso, zero interferencia |
+| append negado (permissao/disco) | `exit 0` silencioso |
+| `tool_response` malformado | grava `status = "indisponivel"`, ou `exit 0` se nem `agentId` houver |
+
+**MUST NOT** usar `set -e` (mesma justificativa do hook irmao: um erro nao
+tratado viraria exit != 0 e o harness exporia stderr ao operador).
+**MUST NOT** escrever em stdout. **MUST NOT** bloquear, atrasar ou reprovar a
+tool call — este hook e metrica, nunca guarda.
+
+---
+
+## 4. Deteccao de execucao ativa (REUSO, nao reimplementacao)
+
+Algoritmo **identico** ao de `posttooluse-tool-call-tick.sh:68-100`, que por sua
+vez espelha `pretooluse-bash-guard.sh`:
+
+1. `<cwd>/.claude/agente-00c-state/state.json` com
+   `.execution.status ∈ {em_andamento, aguardando_humano}` -> vence.
+2. Senao, varrer `<cwd>/.claude/feature-00c-state/*/state.json` com o mesmo
+   filtro de status; desempate pelo **menor short-name em ordem lexicografica
+   byte-wise** (`LC_ALL=C sort`).
+3. Nenhuma ativa -> `exit 0`.
+
+**MUST NOT** divergir desse algoritmo: divergencia entre os dois hooks faria a
+metrica de uso e a de tool calls apontarem para state dirs diferentes na mesma
+sessao.
+
+---
+
+## 5. Provisionamento
+
+`cli/lib/hooks.sh::apply_guard_hooks()` (L193) `[EXISTE]` ganha um terceiro `cp`
+best-effort, simetrico ao de `posttooluse-tool-call-tick.sh` (L256-263): falha
+de copia emite `log_warn` e **nao** altera o state word retornado
+(`merged | paste-instructed | hooks-only | not-applicable | error`).
+
+`global/skills/agente-00c-runtime/hooks/settings.snippet.json` `[EXISTE]` ganha
+uma terceira entrada `[PROPOSTA]`:
+
+```json
+{
+  "matcher": "Agent",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/posttooluse-agent-usage.sh",
+      "timeout": 5
+    }
+  ]
+}
+```
+
+Escopo `project` apenas — nunca `global`, mesma regra ja aplicada aos hooks
+existentes.
+
+---
+
+## 6. Testes
+
+`tests/test_posttooluse-agent-usage.sh` `[PROPOSTA]`.
+
+**Atencao a convencao** (verificado em `tests/run.sh`): hooks vivem em
+`.../hooks/`, fora do `_find_scripts()`, logo um teste novo seria marcado como
+*teste orfao* por `--check-coverage`. E necessario adicionar isencao
+existence-guarded em `_is_internal_test`, replicando o precedente literal de
+`tests/run.sh:298-303`.
+
+Cenarios minimos:
+
+| # | Cenario | Assercao |
+|---|---------|----------|
+| 1 | `status=completed` completo | linha com todos os campos; `status=completo` |
+| 2 | `status=async_launched` | `status=indisponivel`; todos numericos `null` |
+| 3 | `completed` sem `usage` | `status=parcial`; observados preenchidos, resto `null` |
+| 4 | `resolvedModel` ausente | `model == "nao-aplicavel"` |
+| 5 | `jq` ausente | exit 0, sidecar nao criado |
+| 6 | sem execucao ativa | exit 0, sidecar nao criado |
+| 7 | `tool_name != Agent` | exit 0, sidecar nao criado |
+| 8 | 2 features ativas | escreve no menor short-name lexicografico |
+| 9 | stdin malformado | exit 0, sem crash |
+| 10 | append repetido | 2 spawns => 2 linhas, ordem preservada |
+| 11 | anti-vazamento | `content`/`prompt` presentes na entrada nunca aparecem na linha |

--- a/docs/specs/wave-token-metrics/contracts/wave-usage-report.md
+++ b/docs/specs/wave-token-metrics/contracts/wave-usage-report.md
@@ -32,8 +32,10 @@ wave-usage-report.sh aggregate --state-dir DIR [--json]
 | `--state-dir DIR` | sim | diretorio contendo `state.json` |
 | `--json` | nao | emite JSON em vez de Markdown |
 
-**Exit codes** (espelham `model-routing-report.sh`): `0` sucesso;
-`2` uso invalido / `--state-dir` ausente / `state.json` inexistente.
+**Exit codes** (espelham `model-routing-report.sh`, `_mrr_die "aggregate:
+state.json nao encontrado..." 1`): `0` sucesso; `2` uso invalido (flag
+ausente/desconhecida); `1` erro generico, inclusive `state.json`
+inexistente.
 
 **Read-only**: MUST NOT escrever no `state.json`.
 

--- a/docs/specs/wave-token-metrics/contracts/wave-usage-report.md
+++ b/docs/specs/wave-token-metrics/contracts/wave-usage-report.md
@@ -1,0 +1,220 @@
+# Contract: `wave-usage-report.sh` + extensoes de agregacao
+
+**Feature**: `wave-token-metrics` | **Status**: `[PROPOSTA — a validar na implementacao]`
+**Arquivo alvo**: `global/skills/agente-00c-runtime/scripts/wave-usage-report.sh`
+
+> Contratos EXISTENTES citados com `arquivo:linha`. Tudo o mais e novo.
+
+---
+
+## 1. Por que um helper novo (e nao estender `model-routing-report.sh`)
+
+`model-routing-report.sh` le **somente** `.decisions[]` e nao le `.waves` — e
+uma decisao registrada no cabecalho do proprio script (L5-6: "agregacao
+real-time derivada de `.decisions[]` (sem campo agregado em `.waves`)"). Fazer
+esse script ler `.waves` quebraria o invariante que ele documenta.
+
+Beneficio colateral: por viver em `global/skills/*/scripts/`, o helper novo cai
+na regra 1:1 de `tests/run.sh::_expected_test_for_script` e ganha
+`tests/test_wave-usage-report.sh` **sem** precisar de isencao em
+`_is_internal_test` (ao contrario do hook).
+
+---
+
+## 2. Subcomando `aggregate`
+
+```
+wave-usage-report.sh aggregate --state-dir DIR [--json]
+```
+
+| Flag | Obrigatoria | Descricao |
+|------|-------------|-----------|
+| `--state-dir DIR` | sim | diretorio contendo `state.json` |
+| `--json` | nao | emite JSON em vez de Markdown |
+
+**Exit codes** (espelham `model-routing-report.sh`): `0` sucesso;
+`2` uso invalido / `--state-dir` ausente / `state.json` inexistente.
+
+**Read-only**: MUST NOT escrever no `state.json`.
+
+### 2.1 Saida Markdown (default)
+
+```markdown
+## Consumo por onda (tokens / tool-uses / duracao)
+
+| onda | spawns | com uso | tokens | input | output | cache-read | cache-creation | tool-uses | duracao |
+|------|--------|---------|--------|-------|--------|------------|----------------|-----------|---------|
+| onda-004 | 3 | 2 | 254.0k | 4 | 1975 | 250.9k | 1049 | 72 | 923s |
+| onda-005 | 2 | 0 | indisponivel | indisponivel | indisponivel | indisponivel | indisponivel | indisponivel | indisponivel |
+
+**Sumario**:
+- Ondas com metrica: 1 de 2
+- Spawns observados: 5 (com uso: 2; indisponiveis: 3)
+- Tokens totais: 254.0k (input 4 / output 1975 / cache-read 250.9k / cache-creation 1049)
+- Cobertura da metrica: 40.0% dos spawns
+```
+
+**Regras de renderizacao (nao-negociaveis, FR-009/SC-004)**:
+
+1. Campo sem dado renderiza a palavra `indisponivel` — **nunca** `0`, `-` ou
+   celula vazia.
+2. A coluna `com uso` **MUST** sempre acompanhar `spawns`. Exibir tokens sem o
+   denominador apresentaria um total parcial como se fosse completo.
+3. A linha `Cobertura da metrica` **MUST** aparecer sempre que
+   `spawns_indisponiveis > 0`.
+4. Quando o sidecar/hook nunca produziu dado em nenhuma onda, a saida **MUST**
+   dizer explicitamente que a metrica **nao foi coletada** — e nao que o consumo
+   foi zero (research Decision 10).
+
+### 2.2 Saida `--json`
+
+```json
+{
+  "waves_total": 2,
+  "waves_with_usage": 1,
+  "spawns_total": 5,
+  "spawns_with_usage": 2,
+  "spawns_unavailable": 3,
+  "coverage_pct": "40.0%",
+  "total_tokens": 254000,
+  "input_tokens": 4,
+  "output_tokens": 1975,
+  "cache_read_input_tokens": 250900,
+  "cache_creation_input_tokens": 1049,
+  "tool_use_count": 72,
+  "duration_ms": 923000,
+  "por_onda": [],
+  "por_modelo": {}
+}
+```
+
+`por_modelo` agrupa consumo pelo `resolvedModel` observado — e o insumo direto
+de FR-007 (custo x modelo). Campos sem dado sao `null`, nunca `0`.
+
+---
+
+## 3. Subcomando `backfill` (US4 / FR-010 / FR-011)
+
+```
+wave-usage-report.sh backfill --state-dir DIR --transcript PATH [--dry-run]
+```
+
+| Flag | Obrigatoria | Descricao |
+|------|-------------|-----------|
+| `--state-dir DIR` | sim | execucao alvo |
+| `--transcript PATH` | sim | transcript `.jsonl` da sessao original |
+| `--dry-run` | nao | reporta o que faria sem escrever |
+
+**Algoritmo**: extrai do transcript os registros cujo `toolUseResult` tem
+`totalTokens` (correlacionados a `tool_use` com `name == "Agent"` — verificado
+6/6 nesta sessao), e atribui cada spawn a onda cuja janela
+`started_at <= ts < finished_at` o contem.
+
+**Proveniencia obrigatoria**: todo registro gravado por backfill leva
+`source = "backfill"` (vs `"live"`). A atribuicao por janela temporal e
+**heuristica**, nao chave — o transcript nao carrega id de onda. Spawns na
+fronteira entre ondas podem ser mal atribuidos, e o operador precisa saber
+disso pela proveniencia.
+
+**Exit codes**:
+
+| Code | Significado |
+|------|-------------|
+| 0 | backfill aplicado (ou dry-run OK) |
+| 2 | uso invalido |
+| 3 | **transcript ausente/ilegivel** — FR-011: recusa explicita nomeando a execucao que nao pode ser reconstruida. **MUST NOT** preencher com valor estimado. |
+
+**Idempotencia**: re-executar sobre o mesmo transcript **MUST NOT** duplicar
+spawns — dedup pela chave natural `(wave_id, agent_id)`.
+
+---
+
+## 4. Extensao de `state-ondas.sh end` (contrato EXISTENTE estendido)
+
+`end` `[EXISTE]` (`state-ondas.sh:337`) hoje agrega o sidecar de ticks em
+`:373-377` e grava em `:391-410`. A extensao adiciona, **no mesmo `jq`
+transacional**, os campos definidos em `data-model.md`.
+
+**Flags inalteradas** `[EXISTE]`: `--state-dir`, `--motivo-termino`
+(`etapa_concluida_avancando|threshold_proxy_atingido|bloqueio_humano|aborto|concluido`),
+`--proxima-agendada-para`, `--add-etapa` (repetivel). **Nenhuma flag nova.**
+
+**Reset do sidecar**: `_so_ticks_reset` `[EXISTE]` (`:235`, chamado em `:282` e
+`:417`) ganha um irmao para `wave-agent-usage.jsonl`, nos mesmos dois pontos.
+
+**Herdado sem trabalho novo**: `_so_backup_current` + `_so_atomic_write` +
+`_so_update_sha` (`:412-418`) ja cobrem backup, escrita atomica e recomputo de
+hash. `reconcile-wave` (`:928`) e no-op idempotente em onda fechada
+(`:947-956`), logo ondas recuperadas pelo comando pai herdam a agregacao.
+
+---
+
+## 5. Consumo em `review-task` §4.5 (contrato EXISTENTE estendido)
+
+`global/skills/review-task/SKILL.md` §4.5 `[EXISTE]` (L138-206) hoje invoca:
+
+```bash
+~/.claude/skills/agente-00c-runtime/scripts/model-routing-report.sh \
+  aggregate --state-dir "$STATE_DIR"
+```
+
+e cola a saida **verbatim** (invariante INV-RT-1, L458 — reformatar quebra o
+contrato). A extensao adiciona uma segunda invocacao, mesma disciplina:
+
+```bash
+~/.claude/skills/agente-00c-runtime/scripts/wave-usage-report.sh \
+  aggregate --state-dir "$STATE_DIR"
+```
+
+**Posicionamento**: imediatamente apos o bloco de model-routing (que fica entre
+"Progresso por Fase" e "Recomendacoes"), para que modelo roteado e consumo
+observado sejam lidos lado a lado — e o que torna FR-007/SC-003 verificavel sem
+calculo manual.
+
+**Regra de inclusao** (espelha a existente): incluir quando exit 0 e ha >= 1
+linha de tabela; omitir quando nao ha nenhuma onda com metrica; registrar "skip
+auditavel" em "Recomendacoes" quando exit != 0.
+
+---
+
+## 6. Extensao de `report.sh` (contrato EXISTENTE estendido)
+
+`report.sh` `[EXISTE]` emite 6 secoes: `## 1. Resumo Executivo` (L80),
+`## 2. Linha do Tempo` (L109), `## 3. Decisoes` (L130), `## 4. Bloqueios
+Humanos` (L182), `## 5. Sugestoes para Skills Globais` (L246),
+`## 6. Licoes Aprendidas` (L317).
+
+**§1 Resumo Executivo** — hoje tem a linha `| Tool calls totais | ... |`
+(L93). Ganha linhas irmas `[PROPOSTA]`: `Spawns de subagente`,
+`Tokens totais (observados)`, `Cobertura da metrica`. A linha de cobertura e o
+que impede ler um total parcial como completo.
+
+**§2 Linha do Tempo** — a tabela por onda (L118) hoje tem colunas
+`id | inicio | fim | etapas | tool_calls | wallclock | motivo`. Ganha
+`spawns` e `tokens` `[PROPOSTA]`, com `indisponivel` onde nao ha dado.
+
+**Retro-compatibilidade**: usar o padrao `(.campo // default)` ja adotado no
+arquivo, de modo que state antigo renderize `indisponivel` sem erro.
+
+---
+
+## 7. Extensao da ingestao (`cli/lib/recall.sh`)
+
+Ver `data-model.md` §"Extensao do knowledge.db: v9 -> v10" para as 9 colunas.
+
+Pontos de toque `[EXISTE]`:
+
+| Ponto | Linha | Mudanca |
+|-------|-------|---------|
+| `RECALL_SCHEMA_VERSION` | 106 | `9` -> `10` |
+| DDL da tabela `waves` | 487-506 | +9 colunas |
+| Migracao idempotente | 677-694 | +`case` com `PRAGMA table_info(waves)` |
+| Bloco de ingestao de waves | 1005-1055 | +9 campos no array `@base64` e no `INSERT ... ON CONFLICT` |
+
+**MUST** usar `recall_int_or_null` `[EXISTE]` em todas as colunas novas — onda
+sem dado => `NULL`, jamais `0` (FR-009).
+
+**MUST NOT** alterar a chave `UNIQUE(project, feature, wave, source_id)`.
+
+Cobertura: `tests/cstk/test_recall.sh` `[EXISTE]`, com cenarios de migracao
+v9->v10 preservando dados e de `NULL` para onda antiga.

--- a/docs/specs/wave-token-metrics/data-model.md
+++ b/docs/specs/wave-token-metrics/data-model.md
@@ -1,0 +1,256 @@
+# Data Model: wave-token-metrics
+
+**Feature**: `wave-token-metrics` | **Date**: 2026-07-25 | **Spec**: [spec.md](./spec.md)
+
+> **Legenda de veracidade (Constitution VI)**
+> `[EXISTE]` — campo/coluna ja presente no codigo, com arquivo:linha.
+> `[PROPOSTA]` — contrato novo desenhado aqui, a validar na implementacao.
+
+---
+
+## Visao geral do fluxo de dados
+
+```
+tool Agent completa
+        |
+        v
+[hook PostToolUse matcher="Agent"]        <- le tool_response do stdin
+        |
+        v
+<state-dir>/wave-agent-usage.jsonl        [PROPOSTA] sidecar append-only
+        |                                    (hook NUNCA toca state.json)
+        v
+[state-ondas.sh end]                      <- agrega no fechamento da onda
+        |
+        v
+state.json  .waves[].agent_usage          [PROPOSTA]
+            .waves[].agent_spawns[]       [PROPOSTA]
+            .accumulated_metrics.agent_*  [PROPOSTA]
+        |
+        +---> [report.sh]                 -> relatorio de execucao (FR-005)
+        +---> [wave-usage-report.sh]      -> review-task §4.5 (FR-007)
+        +---> [cstk recall --ingest]      -> knowledge.db waves.* (FR-006)
+```
+
+---
+
+## Entity: Metrica de Uso de Spawn (`SpawnUsage`)
+
+Registro do consumo observado de UM spawn de subagente. E a entidade central da
+spec ("Metrica de Uso de Spawn"). Materializa-se em duas representacoes: uma
+linha do sidecar JSONL (transitoria, por onda) e uma entrada de
+`.waves[].agent_spawns[]` (persistente).
+
+### Campos
+
+| Campo | Tipo | Obrigatorio | Origem | Notas |
+|-------|------|-------------|--------|-------|
+| `agent_id` | string | sim | `tool_response.agentId` `[EXISTE no harness]` | Identificador da run do subagente. Chave natural do spawn. |
+| `agent_type` | string \| null | nao | `tool_input.subagent_type` `[EXISTE no harness]` | Ex.: `feature-00c-clarify-asker`. Null se ausente. |
+| `status` | enum | sim | derivado de `tool_response.status` | `completo` \| `parcial` \| `indisponivel`. Ver "State transitions". |
+| `model` | string | sim | `tool_response.resolvedModel` | **Sempre presente** (FR-003). Quando ausente na fonte => literal `"nao-aplicavel"`, nunca omitido. |
+| `models_used` | array\<string\> \| null | nao | `tool_response.modelsUsed` | So quando houve swap mid-run. Requer harness >= 2.1.212. Null = sem swap ou harness antigo. |
+| `total_tokens` | int \| null | sim (nullable) | `tool_response.totalTokens` | **null = nao observado**. NUNCA 0 como substituto (FR-009). |
+| `input_tokens` | int \| null | sim (nullable) | `tool_response.usage.input_tokens` | Breakdown FR-001. |
+| `output_tokens` | int \| null | sim (nullable) | `tool_response.usage.output_tokens` | Breakdown FR-001. |
+| `cache_read_input_tokens` | int \| null | sim (nullable) | `tool_response.usage.cache_read_input_tokens` | Breakdown FR-001. |
+| `cache_creation_input_tokens` | int \| null | sim (nullable) | `tool_response.usage.cache_creation_input_tokens` | Breakdown FR-001. |
+| `tool_use_count` | int \| null | sim (nullable) | `tool_response.totalToolUseCount` | FR-002. |
+| `duration_ms` | int \| null | sim (nullable) | `tool_response.totalDurationMs` | FR-002. |
+| `source` | enum | sim | gerado | `live` \| `backfill` `[PROPOSTA]`. Proveniencia (Decision 9 do research). |
+| `observed_at` | string (ISO 8601 UTC) | sim | `date -u +%Y-%m-%dT%H:%M:%SZ` | Momento da captura. |
+
+**Campos deliberadamente NAO capturados** (Decision 5 do research):
+`tool_response.content` (texto final do subagente) e `tool_input.prompt` (texto
+da tarefa). Motivo duplo: (a) estourariam PIPE_BUF e quebrariam a atomicidade
+do append no sidecar; (b) texto livre = superficie de vazamento de segredo.
+
+### State transitions (campo `status`)
+
+```
+                  tool_response.status == "completed"
+                  E totalTokens presente
+   [spawn] ---------------------------------------------> completo
+
+                  tool_response.status == "completed"
+                  MAS algum campo de uso ausente
+           ---------------------------------------------> parcial
+
+                  tool_response.status == "async_launched"
+                  (background; sem campos de usage)
+           ---------------------------------------------> indisponivel
+
+                  tool_response ausente/malformado
+           ---------------------------------------------> indisponivel
+```
+
+Regras duras:
+
+- `indisponivel` **MUST** ter todos os campos numericos de uso em `null`.
+  Gravar `0` seria afirmar "medido e deu zero" — fabricacao (FR-009/SC-004).
+- `parcial` grava os campos observados e mantem `null` nos nao observados
+  (FR-012: parcial **somente se observavel**).
+- Nenhuma transicao produz valor estimado. Nao existe caminho de codigo que
+  derive um numero de uso por heuristica.
+
+### Chave natural
+
+`(project, feature, execution_id, wave_id, agent_id)`.
+
+O `execution_id` explicito atende a Clarification ratificada ("identificador de
+execucao explicito, precedente da coluna `session` do knowledge.db v8") e o edge
+case de duas execucoes concorrentes sobre o mesmo projeto.
+
+---
+
+## Entity: Consumo Agregado da Onda (`WaveUsage`)
+
+Soma das `SpawnUsage` de uma mesma onda. Persistida em
+`.waves[].agent_usage` `[PROPOSTA]`.
+
+| Campo | Tipo | Notas |
+|-------|------|-------|
+| `spawns_total` | int | Total de spawns observados na onda (todos os status). |
+| `spawns_with_usage` | int | Quantos tinham dado de uso (`completo` + `parcial`). |
+| `spawns_unavailable` | int | Quantos ficaram `indisponivel`. **Load-bearing**: ~50% dos spawns reais (research Decision 2). |
+| `total_tokens` | int \| null | Soma sobre spawns com dado. `null` quando `spawns_with_usage == 0`. |
+| `input_tokens` | int \| null | idem |
+| `output_tokens` | int \| null | idem |
+| `cache_read_input_tokens` | int \| null | idem |
+| `cache_creation_input_tokens` | int \| null | idem |
+| `tool_use_count` | int \| null | idem |
+| `duration_ms` | int \| null | idem |
+
+**Invariante de honestidade (SC-004)**: `spawns_total`, `spawns_with_usage` e
+`spawns_unavailable` **MUST** ser exibidos junto do total sempre que
+`spawns_unavailable > 0`. Um total sem esse denominador seria apresentado como
+completo quando e parcial. `spawns_total = spawns_with_usage + spawns_unavailable`.
+
+**Distincao critica**: `spawns_total == 0` significa "nenhum subagente foi
+spawnado nesta onda". NAO significa "hook ausente". O segundo caso e detectado
+pela ausencia do sidecar somada a evidencia de spawn — e reportado como
+"metrica nao coletada", nunca como zero (research Decision 10).
+
+---
+
+## Extensoes ao `state.json`
+
+Todas ADITIVAS. Nenhum campo existente muda de semantica.
+
+### `.waves[]` — entrada de onda
+
+Campos ja existentes `[EXISTE]` (`state-ondas.sh:259-273`, 9 campos criados por
+`start`): `id`, `started_at`, `finished_at`, `executed_stages`, `tool_calls`,
+`wallclock_seconds`, `termination_reason`, `next_wave_scheduled_for`,
+`skills_invoked`.
+
+Campos novos `[PROPOSTA]`:
+
+| Campo | Tipo | Escrito por |
+|-------|------|-------------|
+| `agent_usage` | objeto `WaveUsage` \| null | `state-ondas.sh end` |
+| `agent_spawns` | array\<`SpawnUsage`\> | `state-ondas.sh end` |
+
+`null` / `[]` quando nenhum spawn foi observado — coerente com o comportamento
+de onda antiga (retro-compatibilidade, ver abaixo).
+
+### `.accumulated_metrics` — totais da execucao
+
+Campos ja existentes `[EXISTE]` (`state-ondas.sh:400-406`): `waves_total`,
+`tool_calls_total`, `wallclock_total_seconds`.
+
+Campos novos `[PROPOSTA]`, incrementados no mesmo `jq` de `end`:
+
+| Campo | Tipo |
+|-------|------|
+| `agent_spawns_total` | int |
+| `agent_spawns_with_usage_total` | int |
+| `agent_tokens_total` | int \| null |
+| `agent_tool_use_count_total` | int \| null |
+| `agent_duration_ms_total` | int \| null |
+
+### Retro-compatibilidade
+
+State de execucao anterior a esta feature nao tem os campos novos. Todo leitor
+**MUST** usar o padrao ja adotado no repo — `(.campo // default)` no jq, como
+em `state-ondas.sh:373` (`(.budgets.tool_calls_current_wave // ...) // 0`) — de
+modo que ausencia produza `null`/`0 spawns`, nunca erro. Nenhuma migracao de
+`state.json` e necessaria.
+
+---
+
+## Sidecar: `<state-dir>/wave-agent-usage.jsonl` `[PROPOSTA]`
+
+Espelha o contrato ja existente de `<state-dir>/tool-call-ticks.log`
+(`state-ondas.sh:219-235`).
+
+| Propriedade | Valor |
+|-------------|-------|
+| Formato | JSON Lines — 1 objeto `SpawnUsage` por linha, sem `content`/`prompt` |
+| Escrita | Append-only (`>>`), O_APPEND atomico para linha < PIPE_BUF |
+| Escritor | Somente o hook `posttooluse-agent-usage.sh` |
+| Leitor | Somente `state-ondas.sh end` (e `wave-usage-report.sh` para leitura mid-onda) |
+| Reset | `start` e `end`, espelhando `_so_ticks_reset` (`state-ondas.sh:235`, chamado em `:282` e `:417`) |
+| Janela | start -> end da onda corrente |
+| Perda aceita | Spawns na fronteira exata start/end — mesma tolerancia ja documentada para o sidecar de ticks |
+
+---
+
+## Extensao do knowledge.db: v9 -> v10
+
+`RECALL_SCHEMA_VERSION` `[EXISTE]` = 9 (`cli/lib/recall.sh:106`) -> 10
+`[PROPOSTA]`.
+
+### Tabela `waves` — colunas existentes `[EXISTE]`
+
+`cli/lib/recall.sh:487-506`: `id`, `project`, `feature`, `wave`, `execution_id`,
+`source_ts`, `source_id`, `stages`, `started_at`, `finished_at`,
+`wallclock_seconds`, `tool_calls`, `termination_reason`, `n_stages`,
+`n_skills`, `session`, `ingested_at`, `UNIQUE(project, feature, wave, source_id)`.
+
+### Colunas novas `[PROPOSTA]`
+
+| Coluna | Tipo | Fonte em `state.json` |
+|--------|------|------------------------|
+| `agent_spawns_total` | INTEGER | `.waves[].agent_usage.spawns_total` |
+| `agent_spawns_with_usage` | INTEGER | `.waves[].agent_usage.spawns_with_usage` |
+| `agent_total_tokens` | INTEGER | `.waves[].agent_usage.total_tokens` |
+| `agent_input_tokens` | INTEGER | `.waves[].agent_usage.input_tokens` |
+| `agent_output_tokens` | INTEGER | `.waves[].agent_usage.output_tokens` |
+| `agent_cache_read_tokens` | INTEGER | `.waves[].agent_usage.cache_read_input_tokens` |
+| `agent_cache_creation_tokens` | INTEGER | `.waves[].agent_usage.cache_creation_input_tokens` |
+| `agent_tool_use_count` | INTEGER | `.waves[].agent_usage.tool_use_count` |
+| `agent_duration_ms` | INTEGER | `.waves[].agent_usage.duration_ms` |
+
+**Regra de nulidade (FR-009)**: todas usam `recall_int_or_null` `[EXISTE]`, o
+mesmo helper ja aplicado a `wallclock_seconds` e `tool_calls`
+(`cli/lib/recall.sh:1005-1055`). Onda antiga ou sem dado => `NULL`, jamais `0`.
+
+**Migracao**: aditiva idempotente via `PRAGMA table_info(waves)` + `case`, no
+padrao literal ja usado em v7->v8 e v8->v9 (`cli/lib/recall.sh:677-694`). Sem
+`DROP`, dados v9 preservados. Retrofit por `recall_mode_reindex()`
+(`cli/lib/recall.sh:2175`).
+
+**Granularidade**: a knowledge.db recebe o AGREGADO por onda, nao o detalhe por
+spawn. Motivo: a tabela `waves` tem grao de onda (`UNIQUE(project, feature,
+wave, source_id)`), e o detalhe por spawn permanece consultavel no `state.json`
+da execucao. Uma tabela `spawns` dedicada seria a extensao natural caso o
+detalhe cross-projeto vire requisito — fora do escopo desta feature.
+
+---
+
+## Mapeamento requisito -> campo
+
+| FR | Onde e satisfeito |
+|----|-------------------|
+| FR-001 (total + 4 categorias) | `SpawnUsage.total_tokens` + `input/output/cache_read/cache_creation` |
+| FR-002 (tool-uses + duracao) | `SpawnUsage.tool_use_count`, `.duration_ms` |
+| FR-003 (onda/execucao/feature/modelo; modelo sempre presente) | chave natural + `SpawnUsage.model` (`"nao-aplicavel"` quando ausente) |
+| FR-004 (consultavel apos a sessao) | persistencia em `state.json` + knowledge.db |
+| FR-005 (relatorios existentes) | `report.sh` §1 e §2 |
+| FR-006 (cross-feature) | colunas novas em `waves` (knowledge.db v10) |
+| FR-007 (custo x roteamento) | `wave-usage-report.sh` + `model-routing-report.sh` em review-task §4.5 |
+| FR-008 (best-effort) | hook fail-open; sidecar ausente => agregado nulo |
+| FR-009 (nao fabricar) | `null` em vez de `0`; `status = indisponivel` |
+| FR-010/FR-011 (backfill + recusa) | `source = backfill`; recusa explicita quando transcript ausente |
+| FR-012 (parcial so se observavel) | `status = parcial` com campos observados; resto `null` |

--- a/docs/specs/wave-token-metrics/data-model.md
+++ b/docs/specs/wave-token-metrics/data-model.md
@@ -194,6 +194,34 @@ Espelha o contrato ja existente de `<state-dir>/tool-call-ticks.log`
 | Janela | start -> end da onda corrente |
 | Perda aceita | Spawns na fronteira exata start/end — mesma tolerancia ja documentada para o sidecar de ticks |
 
+### Permissao de arquivo `[PROPOSTA]` (CHK017)
+
+O sidecar `wave-agent-usage.jsonl` **MUST** ser criado com permissao `0600`
+(leitura/escrita apenas do dono do processo) — dado numerico agregavel por
+onda, sem `content`/`prompt`, mas ainda assim superficie a minimizar por
+padrao (defesa em profundidade, nao porque o conteudo seja sensivel por si).
+O hook `posttooluse-agent-usage.sh` aplica `umask 077` imediatamente antes do
+primeiro append de cada arquivo (o primeiro append cria o arquivo se ausente;
+`umask` so afeta a criacao, nao um arquivo ja existente). Mesma politica
+retroativa se aplica ao sidecar irmao `<state-dir>/tool-call-ticks.log` — gap
+herdado do padrao pre-existente do toolkit, resolvido aqui porque esta
+feature adiciona dado novo ao mesmo mecanismo compartilhado.
+
+### Teto de linhas `[PROPOSTA]` (CHK020)
+
+O sidecar aceita no maximo **500 linhas** por onda (ver `research.md`
+§Decision 5 para a justificativa do numero). Ao atingir o teto, o hook
+`posttooluse-agent-usage.sh` **pula** o append de qualquer linha adicional
+(fail-open — a tool call do spawn nunca e bloqueada) e emite um aviso unico
+por onda via arquivo-sentinela `<state-dir>/.wave-agent-usage-cap-warned`
+(criado/removido no mesmo ciclo `start`/`end` do sidecar). Consequencia
+direta para o consumidor: spawns alem do teto ficam fora do agregado da
+onda — undercounting silencioso conhecido, analogo a tolerancia ja
+documentada acima para a fronteira exata start/end. `state-ondas.sh end`
+reporta `spawns_total` (e os demais campos de `.waves[].agent_usage`) apenas
+com base nas linhas de fato observadas no sidecar; nunca fabrica ou estima o
+excedente pulado (Principio VI).
+
 ---
 
 ## Extensao do knowledge.db: v9 -> v10
@@ -236,6 +264,18 @@ spawn. Motivo: a tabela `waves` tem grao de onda (`UNIQUE(project, feature,
 wave, source_id)`), e o detalhe por spawn permanece consultavel no `state.json`
 da execucao. Uma tabela `spawns` dedicada seria a extensao natural caso o
 detalhe cross-projeto vire requisito — fora do escopo desta feature.
+
+### Permissao de arquivo `[PROPOSTA]` (CHK017)
+
+`~/.claude/cstk/knowledge.db` **MUST** ser criado com permissao `0600` — mesma
+politica do sidecar acima, ja que o DB agrega, entre outras colunas
+pre-existentes, dado novo de uso de tokens por onda. Aplicado em
+`recall_apply_schema()`/`recall_ensure_db_dir()` (`cli/lib/recall.sh`), na
+mesma sequencia ja usada para as `PRAGMA` de abertura. **Nao altera** a
+permissao de um DB ja existente com modo mais aberto silenciosamente: normaliza
+via `chmod 600` best-effort e loga via `log_warn` (nunca falha a ingestao/
+reindex por causa disso) — evita quebrar setups locais existentes com um erro
+inesperado, ao mesmo tempo que corrige o desvio na proxima escrita.
 
 ---
 

--- a/docs/specs/wave-token-metrics/plan.md
+++ b/docs/specs/wave-token-metrics/plan.md
@@ -1,0 +1,276 @@
+# Implementation Plan: Metricas de Tokens por Spawn de Subagente
+
+**Feature**: `wave-token-metrics` | **Date**: 2026-07-25 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Substituir `tool_calls` — hoje o unico proxy de custo do toolkit, e um proxy
+grosseiro (uma tool call de 50 tokens conta igual a uma de 50.000) — por consumo
+real de tokens, tool-uses e duracao **por spawn de subagente**, capturado ao
+vivo, agregado por onda, persistido no `state.json`, indexado na knowledge.db e
+exibido nos relatorios que ja existem.
+
+**Abordagem tecnica** (resolvida no Phase 0, ver [research.md](./research.md)):
+o unknown central da spec — "qual payload um hook recebe quando um spawn
+completa" — foi resolvido com fonte oficial. A doc do Claude Code documenta
+**exatamente este caso de uso**: um hook `PostToolUse` com matcher `Agent`
+recebe, em `tool_response`, `totalTokens`, `totalDurationMs`, `totalToolUseCount`,
+`usage{input,output,cache_read,cache_creation}` e `resolvedModel`. Nao e preciso
+ler o transcript ao vivo.
+
+O desenho reusa integralmente o padrao ja provado do hook de `tool_calls`:
+**fail-open absoluto, sidecar append-only por onda, hook nunca toca o
+`state.json`**; a agregacao acontece em `state-ondas.sh end`, que ja e o ponto
+transacional de fechamento com backup + escrita atomica + rehash.
+
+**Achado que molda o desenho**: medicao nos transcripts reais deste projeto
+mostra **52 spawns `async_launched` contra 51 `completed`** — desde a v2.1.198
+subagentes rodam em background por default, e o `tool_response` de background
+**nao carrega campos de uso**. Ou seja, "metrica indisponivel" nao e edge case
+raro: e ~metade dos spawns. Por isso o desenho separa `spawns_total` de
+`spawns_with_usage` em todo agregado e trata `null != 0` como invariante de
+primeira classe, e nao como detalhe de implementacao.
+
+## Technical Context
+
+**Language/Version**: POSIX `sh` puro (sem bash-isms), conforme Constitution
+Principio II. Verificado no repo: todos os scripts sob `global/skills/*/scripts/`
+e `cli/lib/` seguem essa disciplina.
+**Primary Dependencies**: `jq` (dep opcional confinada, ja usada por hooks e por
+`cli/lib/recall.sh`); `sqlite3` (dep opcional confinada a `cli/lib/recall.sh`).
+Nenhuma dep nova e introduzida.
+**Storage**: `state.json` por execucao (fonte de verdade transacional) + sidecar
+JSONL por onda (transitorio) + `~/.claude/cstk/knowledge.db` (SQLite, indice
+derivado e reconstruivel).
+**Testing**: harness POSIX proprio — `./tests/run.sh` (~1678 cenarios). Convencao
+1:1 imposta por `--check-coverage`.
+**Target Platform**: macOS + Linux (CI Ubuntu). Sem GNU-only.
+**Project Type**: CLI/toolkit — single-layer, sem servidor nem frontend.
+**Performance Goals**: N/A quantitativo — nao ha alvo numerico de latencia
+definido para esta feature e nenhum sera inventado. A restricao qualitativa e
+dura: o hook **MUST NOT** bloquear, atrasar ou reprovar uma tool call
+(fail-open). O `timeout: 5` do snippet de settings e o teto ja praticado pelos
+hooks existentes.
+**Constraints**: (a) hook **MUST NOT** escrever no `state.json` (concorrencia
+com writes transacionais); (b) linha do sidecar **MUST** ser curta (< PIPE_BUF)
+para manter a atomicidade do append O_APPEND; (c) nenhum dado de uso pode ser
+estimado.
+**Scale/Scope**: poucos spawns por onda (ordem de unidades); dezenas a centenas
+de ondas por execucao. `budget.sh` ja vigia `state_size_threshold_bytes`
+(default `1048576`, `budget.sh:97-100`).
+
+## Constitution Check
+
+*GATE: passou antes do Phase 0. Re-checado apos Phase 1 (secao "Re-check").*
+
+Constitution v1.2.0 (`docs/constitution.md`, ratificada 2026-04-20, ultima
+emenda 2026-06-18).
+
+| Principio | Status | Notas |
+|-----------|--------|-------|
+| **I. SDD aplica-se recursivamente** (NON-NEGOTIABLE) | PASS | A feature esta sendo desenvolvida pela propria pipeline SDD: `spec.md` -> `clarify` -> este `plan.md` -> `checklist` -> `create-tasks`. Artefatos versionados em `docs/specs/wave-token-metrics/`. |
+| **II. Scripts POSIX sh puros, zero dep externa** (NON-NEGOTIABLE) | PASS (via carve-out 1.1.0) | Ver analise das 3 condicoes cumulativas abaixo. Nenhuma dep nova; `jq`/`sqlite3` ja sao deps opcionais confinadas e pre-existentes. Zero bash-isms. |
+| **III. Formato canonico de skill** | N/A / PASS parcial | A feature nao cria skill nova. Toca `review-task/SKILL.md` §4.5 apenas para adicionar uma invocacao de helper, preservando o invariante INV-RT-1 (saida colada verbatim). |
+| **IV. Zero coleta remota de uso ou dados** (NON-NEGOTIABLE) | PASS | **Ponto de maior atencao desta feature**: ela mede consumo, que e exatamente o tipo de dado que telemetria coletaria. Mitigacao arquitetural: todo dado permanece **local** — sidecar no state dir do projeto, agregado no `state.json` do projeto, indice em `~/.claude/cstk/knowledge.db`. Nenhum egress, nenhum endpoint, nenhum identificador enviado a lugar algum. O hook nao faz rede. |
+| **V. Profundidade e reducao de retrabalho acima de metricas de adocao** | PASS | O objetivo e reduzir retrabalho de decisao (escolher modelo/roteamento com base em custo real em vez de proxy grosseiro), nao produzir numero de vaidade. |
+| **VI. Veracidade de dados — zero fabricacao** (NON-NEGOTIABLE) | PASS | E o principio estruturante do desenho, nao um checkbox. Ver detalhamento abaixo. |
+
+### Detalhamento do Principio II (carve-out 1.1.0 — 3 condicoes CUMULATIVAS)
+
+| Condicao | Atendimento |
+|----------|-------------|
+| (a) uso opcional com fallback graceful documentado **e coberto por teste** | `jq` ausente => hook faz `exit 0` silencioso e a onda segue sem a metrica (fail-open). Coberto pelo Cenario 4 do quickstart e pelo cenario de teste #5 do contrato do hook. `sqlite3` ausente => `cstk recall` ja degrada com aviso e exit 0 (comportamento pre-existente, inalterado). |
+| (b) codigo que referencia a dep confinado em UM arquivo identificavel | `jq` no hook novo: confinado a `posttooluse-agent-usage.sh` — mesmo confinamento do hook irmao. `sqlite3`: permanece exclusivo de `cli/lib/recall.sh` (a feature nao o espalha). O helper `wave-usage-report.sh` usa `jq` no mesmo padrao dos demais helpers de runtime ja existentes. |
+| (c) dep declarada na documentacao da feature | Declarada aqui (Technical Context + esta tabela) e nos contratos, com caminho confinado e descricao do fallback. |
+
+**Ferramentas banidas** (`ripgrep`, `fd`, `bats`): nenhuma e usada.
+
+### Detalhamento do Principio VI (estruturante)
+
+O risco de fabricacao nesta feature e concreto e de dois tipos, ambos endereçados:
+
+1. **Fabricar o contrato de interface.** Todo campo do payload do harness citado
+   nos contratos foi extraido da doc oficial baixada e lida
+   (`https://code.claude.com/docs/en/hooks.md`, 2026-07-25) e cruzado com
+   transcripts reais. Nenhum nome de campo foi suposto. Contratos EXISTENTES do
+   repo citam `arquivo:linha`; contratos NOVOS estao marcados
+   `[PROPOSTA — a validar na implementacao]`.
+2. **Fabricar o dado medido.** Esta e a superficie mais perigosa: um `0` no
+   lugar de um `null` transforma "nao medi" em "medi e deu zero". O desenho
+   trata isso como invariante dura, replicada em todas as camadas:
+   `null` no sidecar -> `null` no `state.json` -> `NULL` no SQLite (via o helper
+   ja existente `recall_int_or_null`) -> a palavra `indisponivel` no relatorio.
+   Nao existe caminho de codigo que derive um valor de uso por heuristica.
+
+**Numeros nao inventados**: este plano nao afirma nenhum alvo de performance,
+custo em $ ou taxa de overhead. Onde a spec pediria um numero que nao temos, o
+plano diz N/A e explica por que.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+docs/specs/wave-token-metrics/
+├── spec.md
+├── plan.md                                   # This file
+├── research.md                               # Phase 0 output
+├── data-model.md                             # Phase 1 output
+├── quickstart.md                             # Phase 1 output
+└── contracts/
+    ├── hook-posttooluse-agent-usage.md       # contrato do hook (entrada = harness)
+    └── wave-usage-report.md                  # helper + extensoes de agregacao/relatorio
+```
+
+### Source Code (repository root)
+
+Arvore real (verificada no repo), com os pontos de toque marcados:
+
+```
+cstk/
+├── cli/
+│   ├── cstk                                  # binario (dispatch) — sem mudanca
+│   └── lib/
+│       ├── recall.sh                         # MODIFICAR: schema v9->v10, +9 colunas em waves
+│       └── hooks.sh                          # MODIFICAR: apply_guard_hooks() copia o hook novo
+├── global/
+│   └── skills/
+│       ├── agente-00c-runtime/
+│       │   ├── hooks/
+│       │   │   ├── pretooluse-bash-guard.sh          # inalterado
+│       │   │   ├── posttooluse-tool-call-tick.sh     # inalterado (padrao de referencia)
+│       │   │   ├── posttooluse-agent-usage.sh        # CRIAR
+│       │   │   └── settings.snippet.json             # MODIFICAR: +entrada matcher "Agent"
+│       │   └── scripts/
+│       │       ├── state-ondas.sh                    # MODIFICAR: agregacao no end + reset do sidecar
+│       │       ├── budget.sh                         # inalterado (sem dimensao de token)
+│       │       ├── report.sh                         # MODIFICAR: secoes 1 e 2
+│       │       ├── model-routing-report.sh           # inalterado (invariante: so le .decisions[])
+│       │       └── wave-usage-report.sh              # CRIAR
+│       └── review-task/
+│           └── SKILL.md                              # MODIFICAR: §4.5 +invocacao do helper
+└── tests/
+    ├── run.sh                                # MODIFICAR: isencao do teste do hook
+    ├── test_posttooluse-agent-usage.sh       # CRIAR
+    ├── test_wave-usage-report.sh             # CRIAR
+    ├── test_state-ondas.sh                   # ESTENDER
+    ├── test_report.sh                        # ESTENDER (se existente)
+    └── cstk/
+        ├── test_recall.sh                    # ESTENDER (migracao v9->v10)
+        └── test_hooks.sh                     # ESTENDER (provisionamento do hook novo)
+```
+
+**Structure Decision**: nenhuma estrutura nova. A feature se encaixa nos tres
+diretorios que ja tratam do assunto — `hooks/` para captura, `scripts/` para
+agregacao/relatorio, `cli/lib/` para indexacao — e reusa os pontos de extensao
+existentes em vez de criar caminho paralelo. Duas escolhas merecem registro:
+
+1. **Hook novo dedicado (matcher `Agent`) em vez de estender o hook de ticks
+   (matcher `*`)**: o filtro por matcher e feito pelo harness, entao o hook novo
+   so roda em spawns, sem custo no caminho quente de toda tool call. Custo
+   aceito e declarado: mais uma entrada no snippet de settings e mais uma
+   isencao existence-guarded em `tests/run.sh::_is_internal_test` (hooks vivem
+   fora de `scripts/` e por isso quebram a regra 1:1 do `--check-coverage` —
+   precedente literal ja existe em `tests/run.sh:298-303`).
+2. **Helper de relatorio novo em vez de estender `model-routing-report.sh`**:
+   aquele script documenta no proprio cabecalho (L5-6) que le **somente**
+   `.decisions[]` e nao `.waves`. Fazer-lhe ler `.waves` quebraria o invariante
+   que ele publica. Como bonus, um script em `scripts/` ganha teste 1:1
+   automatico, sem isencao.
+
+## Convencoes de Borda
+
+**N/A parcial — feature single-layer.** Nao ha borda backend↔frontend, DTO
+serializado entre servicos, nem case-style negociavel entre camadas de
+aplicacao. As bordas reais sao de dado, e valem estas convencoes:
+
+| Borda | Convencao | Validacao | Fonte da verdade |
+|-------|-----------|-----------|------------------|
+| Harness -> hook (stdin JSON) | camelCase (`totalTokens`, `resolvedModel`, `agentId`) — **imposto pelo harness, nao negociavel** | `jq` com default (`// null`) em todo acesso | doc oficial `code.claude.com/docs/en/hooks.md` |
+| Hook -> sidecar JSONL | snake_case (`total_tokens`, `agent_id`) | linha unica `jq -c` | `contracts/hook-posttooluse-agent-usage.md` §2 |
+| Sidecar -> `state.json` | snake_case, EN | `state-validate.sh` + sha256 | `data-model.md` |
+| `state.json` -> knowledge.db | snake_case, EN, prefixo `agent_` | `PRAGMA table_info` na migracao | `cli/lib/recall.sh` DDL |
+| CLI (flags) | kebab-case (`--state-dir`, `--transcript`, `--dry-run`) | parser do proprio script | helpers existentes do runtime |
+
+**Mapper layer**: a traducao camelCase (harness) -> snake_case (toolkit)
+acontece em **um unico lugar** — a expressao `jq` do hook. Nenhuma outra camada
+ve os nomes do harness. Isso e deliberado: se o harness renomear um campo, o
+raio de mudanca e um arquivo.
+
+**Idioma**: identificadores em ingles (regra global do repo); comentarios e
+mensagens ao operador em portugues, como no restante do runtime.
+
+## Fases de implementacao sugeridas
+
+Ordem derivada das prioridades da spec. Detalhamento fica para `/create-tasks`.
+
+| Fase | Escopo | Stories | Entrega verificavel |
+|------|--------|---------|---------------------|
+| F1 | Hook + sidecar + provisionamento + testes | base de US1 | Cenarios 1, 2, 4 do quickstart |
+| F2 | Agregacao em `state-ondas.sh end` + `state.json` | US1 | Cenarios 1, 3 |
+| F3 | `wave-usage-report.sh aggregate` + `report.sh` §1/§2 | US1 (FR-005) | Cenarios 3, 5, 11 |
+| F4 | knowledge.db v9->v10 + ingestao + migracao | US3 (FR-006) | Cenarios 7, 8 |
+| F5 | `review-task` §4.5 (custo x roteamento) | US2 (FR-007) | Cenario 6 |
+| F6 | Backfill de transcripts | US4 (FR-010/011) | Cenarios 9, 10 |
+
+F1-F3 entregam o valor central (US1) e sao independentes de F4-F6. F6 e a fase
+mais isolada e a unica que depende da heuristica de janela temporal — coerente
+com sua prioridade P4 na spec.
+
+## Complexity Tracking
+
+> Preencher APENAS se Constitution Check tem violacoes que precisam justificativa.
+
+**Nenhuma violacao de Constitution.** Todos os principios PASS ou N/A; o carve-out
+usado (Principio II, amendment 1.1.0) e um mecanismo previsto na propria
+constitution, com as 3 condicoes cumulativas satisfeitas e documentadas acima —
+nao e excecao nem trade-off pendente. Nenhuma `Constitution Exception` e
+necessaria.
+
+## Riscos
+
+Consolidados em [research.md](./research.md) §"Riscos residuais". Os dois de
+maior severidade:
+
+- **R1 — ~50% dos spawns sem usage** (`async_launched`). Nao e mitigavel no
+  codigo desta feature: e comportamento default do harness. Mitigacao e de
+  *apresentacao*: separar `spawns_total` de `spawns_with_usage` e nunca exibir
+  total sem cobertura.
+- **R2 — hook nao provisionado no projeto-alvo.** Risco herdado, ja materializado:
+  neste proprio repo o hook de `tool_calls` nao esta provisionado, e por isso as
+  ondas 001-004 desta execucao registram `tool_calls: 0`. A feature nova herda a
+  mesma exposicao. Mitigacao: o relatorio distingue "0 spawns" de "metrica nao
+  coletada", e `cstk doctor` e o lugar natural para sinalizar a ausencia.
+
+## Re-check pos-Phase 1
+
+Revalidacao apos o design (Etapa 7):
+
+- **Complexidade introduzida**: 2 arquivos novos (1 hook, 1 helper) + extensoes
+  em 6 arquivos existentes. Nenhuma camada, servico ou abstracao nova. Nenhum
+  mecanismo de provisionamento, lock ou scheduling novo.
+- **Principio II**: o design nao adicionou dep alguma; `sqlite3` continua
+  confinado a `cli/lib/recall.sh`.
+- **Principio IV**: o design confirma-se local-only — nenhum contrato desenhado
+  em Phase 1 tem egress.
+- **Principio VI**: reforcado no design (`null` propagado ponta a ponta;
+  `recall_int_or_null` obrigatorio; palavra `indisponivel` no relatorio).
+- **Veredito**: mantido PASS em todos os principios. Nenhuma violacao nova
+  introduzida pelo design.
+
+## Artefatos
+
+| Arquivo | Status |
+|---------|--------|
+| `docs/specs/wave-token-metrics/plan.md` | Criado |
+| `docs/specs/wave-token-metrics/research.md` | Criado |
+| `docs/specs/wave-token-metrics/data-model.md` | Criado |
+| `docs/specs/wave-token-metrics/quickstart.md` | Criado |
+| `docs/specs/wave-token-metrics/contracts/hook-posttooluse-agent-usage.md` | Criado |
+| `docs/specs/wave-token-metrics/contracts/wave-usage-report.md` | Criado |
+
+## Proximos Passos
+
+1. `/checklist` — quality gate dos requisitos antes de implementar
+2. `/create-tasks` — decompor as fases F1-F6 em backlog executavel
+3. `/analyze` — consistencia cross-artifact apos as tasks existirem

--- a/docs/specs/wave-token-metrics/plan.md
+++ b/docs/specs/wave-token-metrics/plan.md
@@ -242,6 +242,32 @@ maior severidade:
   mesma exposicao. Mitigacao: o relatorio distingue "0 spawns" de "metrica nao
   coletada", e `cstk doctor` e o lugar natural para sinalizar a ausencia.
 
+### Decisoes aguardando dono do produto (CHK016/CHK024 `{humano}`)
+
+Registro apenas — nenhuma resposta hipotetica foi implementada para os dois
+itens abaixo (checklists/requirements.md CHK016 e CHK024). A resolucao fica
+para o operador decidir antes ou durante `review-task` final desta feature:
+
+- **CHK016**: a meta de 100% de SC-001/SC-004 (todo spawn concluido gera uma
+  metrica no relatorio, e todo spawn sem dado observavel e marcado
+  explicitamente `indisponivel`) permanece formalmente correta mesmo sabendo
+  que ~50% dos spawns reais de hoje nao tem `usage` (`status = async_launched`,
+  ver R1 acima) — o "100%" e sobre cobertura de MARCACAO (nunca um numero
+  fabricado no lugar de um dado ausente), nao sobre cobertura de DADO REAL.
+  Pergunta em aberto: essa condicional precisa ser comunicada de forma mais
+  explicita no relatorio da feature (ex: "100% marcado, X% com dado real") para
+  nao parecer uma metrica quebrada ao operador que le so o resumo?
+- **CHK024**: a spec/plano nao definem um alvo numerico de
+  performance/latencia para a captura (hook `PostToolUse` + agregacao em
+  `state-ondas.sh end`) — ausencia deliberada, documentada honestamente em vez
+  de inventada. Pergunta em aberto: essa ausencia e aceitavel para este
+  release, ou o operador quer um teto explicito (ex: hook `MUST` completar em
+  <N ms fail-open) antes de `execute-task` seguir para as fases de codigo?
+
+Nenhuma das duas perguntas bloqueia o inicio de `execute-task` (FASE 1 apenas
+registra o texto e o estado atual); ambas precisam de resposta humana antes do
+fechamento de `review-task`.
+
 ## Re-check pos-Phase 1
 
 Revalidacao apos o design (Etapa 7):

--- a/docs/specs/wave-token-metrics/quickstart.md
+++ b/docs/specs/wave-token-metrics/quickstart.md
@@ -1,0 +1,238 @@
+# Quickstart: wave-token-metrics
+
+**Feature**: `wave-token-metrics` | **Date**: 2026-07-25 | **Spec**: [spec.md](./spec.md)
+
+Cenarios de validacao end-to-end. Cada um mapeia a um Success Criteria da spec.
+Todos rodam sobre o repo do proprio toolkit (`cstk`), que ja e projeto-alvo de
+execucoes `feature-00c`.
+
+> **Nota sobre roundtrip backend↔frontend**: N/A — feature single-layer
+> (hooks + scripts POSIX + SQLite local). Nao ha borda HTTP nem DTO
+> serializado entre servicos. A borda real aqui e **harness -> hook (stdin
+> JSON)**, coberta pelo Cenario 1, que le o payload REAL do harness, nao um
+> fixture.
+
+---
+
+## Cenario 1 — Captura ao vivo de um spawn concluido (SC-001)
+
+**Objetivo**: provar que o hook captura tokens/tool-uses/duracao de um spawn
+real, com dado do harness e nao de mock.
+
+1. Garantir o hook provisionado no projeto-alvo:
+   `cstk update` (ou `apply_guard_hooks()` via install) e confirmar que
+   `<projeto>/.claude/hooks/posttooluse-agent-usage.sh` existe e e executavel,
+   e que `.claude/settings.json` tem a entrada `PostToolUse` com matcher
+   `"Agent"`.
+2. Iniciar uma execucao autonoma (`/feature-00c <short-name>`) cuja onda
+   spawne pelo menos um subagente em **foreground**
+   (`run_in_background: false` — ver Cenario 3 para o caso background).
+3. Ao fim da onda, inspecionar o sidecar antes do reset:
+   `cat <state-dir>/wave-agent-usage.jsonl`
+4. Fechar a onda e inspecionar o state:
+   `jq '.waves[-1].agent_usage, .waves[-1].agent_spawns' <state-dir>/state.json`
+
+**Expected**:
+- O sidecar tem 1 linha JSON por spawn, com `status: "completo"`,
+  `total_tokens` > 0 e os 4 campos de breakdown preenchidos.
+- A linha **nao** contem `content`, `prompt` nem `description`.
+- `.waves[-1].agent_usage.spawns_total` == numero de spawns da onda.
+- `.waves[-1].agent_usage.total_tokens` == soma dos `total_tokens` dos spawns
+  com dado.
+- O sidecar foi removido apos o `end` (reset da janela).
+
+---
+
+## Cenario 2 — Metrica indisponivel nunca vira zero (SC-004, FR-009)
+
+**Objetivo**: provar a regra central de nao-fabricacao.
+
+1. Simular o payload de um spawn background alimentando o hook diretamente:
+
+```sh
+printf '%s' '{"cwd":"<projeto>","tool_name":"Agent","tool_input":{"subagent_type":"Explore"},"tool_response":{"status":"async_launched","agentId":"abc123","resolvedModel":"claude-sonnet-5","outputFile":"/tmp/x","prompt":"...","description":"..."}}' \
+  | <projeto>/.claude/hooks/posttooluse-agent-usage.sh
+echo "exit=$?"
+```
+
+2. Inspecionar a linha gravada:
+   `tail -1 <state-dir>/wave-agent-usage.jsonl | jq .`
+3. Fechar a onda e rodar o relatorio:
+   `wave-usage-report.sh aggregate --state-dir <state-dir>`
+
+**Expected**:
+- `exit=0` (fail-open).
+- A linha tem `status: "indisponivel"` e **todos** os campos numericos em
+  `null` — nenhum `0`.
+- O relatorio renderiza a palavra `indisponivel` naquela celula, nunca `0`
+  nem celula vazia.
+- O sumario mostra `spawns` e `com uso` separados, mais a linha
+  `Cobertura da metrica`.
+
+---
+
+## Cenario 3 — Onda mista: metade dos spawns sem usage (Edge case real)
+
+**Objetivo**: cobrir o caso medido como ~50% da realidade (research Decision 2),
+garantindo que o total parcial nao seja apresentado como completo.
+
+1. Rodar uma onda que spawne 2 subagentes em foreground e 2 em background.
+2. `wave-usage-report.sh aggregate --state-dir <state-dir> --json | jq .`
+
+**Expected**:
+- `spawns_total == 4`, `spawns_with_usage == 2`, `spawns_unavailable == 2`.
+- `coverage_pct == "50.0%"`.
+- `total_tokens` reflete **apenas** os 2 spawns observados, e a saida deixa
+  explicito que 2 spawns nao tem dado.
+- Em nenhum ponto os 2 spawns sem dado somam `0` ao total silenciosamente.
+
+---
+
+## Cenario 4 — Best-effort: hook nunca quebra a onda (FR-008)
+
+**Objetivo**: provar o contrato fail-open em todas as degradacoes.
+
+1. Rodar o hook com `jq` fora do PATH:
+   `PATH=/usr/bin:/bin env -u HOME sh -c 'printf "{}" | <hook>'`
+2. Rodar com stdin vazio: `printf '' | <hook>; echo $?`
+3. Rodar com JSON malformado: `printf '{oops' | <hook>; echo $?`
+4. Rodar fora de qualquer execucao ativa (nenhum `state.json` com status
+   `em_andamento`).
+5. Tornar o state dir somente-leitura e disparar o hook.
+
+**Expected**:
+- Todos retornam `exit 0`, stdout vazio.
+- Nenhum caso cria sidecar parcial ou corrompido.
+- Em nenhum caso o `state.json` e tocado pelo hook.
+- Uma onda executada com o hook quebrado conclui normalmente, apenas sem a
+  metrica.
+
+---
+
+## Cenario 5 — Persistencia apos a sessao (SC-002, FR-004)
+
+1. Concluir uma execucao com metricas capturadas.
+2. Encerrar a sessao do Claude Code.
+3. Em sessao nova: `report.sh emit --flavor feature-00c --state-dir <state-dir>`
+
+**Expected**:
+- §1 do relatorio mostra `Spawns de subagente`, `Tokens totais (observados)` e
+  `Cobertura da metrica`.
+- §2 (Linha do Tempo) mostra as colunas `spawns` e `tokens` por onda.
+- Nenhuma consulta depende da conversa original estar aberta.
+
+---
+
+## Cenario 6 — Custo x modelo roteado (SC-003, FR-007)
+
+1. Rodar duas ondas que roteiem modelos diferentes (ex.: uma `plan` -> opus,
+   uma `review-task` -> haiku).
+2. Rodar a skill `review-task` e ler §4.5.
+
+**Expected**:
+- O bloco de `model-routing-report.sh` (modelo **roteado**) e o de
+  `wave-usage-report.sh` (consumo **observado**, agrupado por
+  `resolvedModel`) aparecem lado a lado.
+- O operador compara tokens por modelo sem calculo manual fora do toolkit.
+- Divergencia entre modelo roteado e `resolvedModel` observado aparece como
+  sinal legivel (ex.: swap mid-run via `models_used`), nao como erro de captura.
+
+---
+
+## Cenario 7 — Consulta cross-feature (SC-002/FR-006)
+
+1. `cstk recall --ingest --state-dir <state-dir>`
+2. ```sh
+   sqlite3 ~/.claude/cstk/knowledge.db \
+     "SELECT project, feature, wave, agent_spawns_total, agent_total_tokens
+      FROM waves WHERE agent_total_tokens IS NOT NULL LIMIT 5;"
+   ```
+3. Conferir a versao do schema:
+   `sqlite3 ~/.claude/cstk/knowledge.db "SELECT value FROM schema_meta WHERE key='schema_version';"`
+
+**Expected**:
+- `schema_version == 10`.
+- Ondas com metrica trazem valores; ondas antigas trazem `NULL` (nao `0`).
+- A proveniencia (`project`, `feature`, `wave`, `execution_id`, `session`)
+  acompanha o registro, igual aos demais tipos ja indexados.
+
+---
+
+## Cenario 8 — Migracao v9 -> v10 preserva dados (FR-006)
+
+1. Partir de uma knowledge.db v9 existente; anotar
+   `SELECT COUNT(*) FROM waves;` e alguns `tool_calls`.
+2. Rodar um `cstk recall --ingest` com o codigo novo.
+3. Repetir as contagens e conferir `PRAGMA table_info(waves);`.
+
+**Expected**:
+- `schema_version` passa a `10`; as 9 colunas novas existem.
+- `COUNT(*)` inalterado e `tool_calls` preservados — **sem `DROP`**.
+- Colunas novas em `NULL` para as linhas pre-existentes.
+- Rodar a ingestao 2x nao duplica linhas nem falha (idempotencia do
+  `ADD COLUMN` guardado por `PRAGMA`).
+
+---
+
+## Cenario 9 — Backfill retroativo (SC-005, FR-010)
+
+1. Escolher uma execucao concluida antes desta feature, com transcript ainda
+   em `~/.claude/projects/<encoded>/<session>.jsonl`.
+2. `wave-usage-report.sh backfill --state-dir <state-dir> --transcript <path> --dry-run`
+3. Repetir sem `--dry-run`; depois `cstk recall --ingest`.
+
+**Expected**:
+- O dry-run lista os spawns e a onda a que cada um seria atribuido.
+- Apos aplicar, os spawns aparecem com `source: "backfill"` (nunca `"live"`).
+- Re-executar o backfill **nao** duplica registros (dedup por
+  `(wave_id, agent_id)`).
+- O consumo passa a aparecer nos mesmos lugares que um dado ao vivo.
+
+---
+
+## Cenario 10 — Backfill recusa explicita (FR-011)
+
+1. `wave-usage-report.sh backfill --state-dir <state-dir> --transcript /caminho/inexistente.jsonl`
+
+**Expected**:
+- Exit code `3`.
+- Mensagem nomeia explicitamente a execucao que **nao pode ser reconstruida**.
+- Nenhum campo de metrica e escrito — nem `0`, nem estimativa.
+
+---
+
+## Cenario 11 — Hook nao provisionado != consumo zero (research Decision 10)
+
+**Objetivo**: o modo de falha silencioso mais provavel na pratica — e o unico
+que pode enganar o operador.
+
+1. Rodar uma onda com spawns num projeto **sem** o hook provisionado
+   (estado atual do proprio repo `cstk`: `.claude/settings.local.json` so tem
+   matchers `Edit|Write`, e as ondas 001-004 registram `tool_calls: 0`).
+2. `wave-usage-report.sh aggregate --state-dir <state-dir>`
+
+**Expected**:
+- A saida diz explicitamente que a metrica **nao foi coletada** (hook ausente),
+  e **nao** que o consumo foi zero.
+- `cstk doctor` sinaliza a ausencia do hook no projeto.
+
+---
+
+## Regressao — suite completa
+
+```sh
+./tests/run.sh test_posttooluse-agent-usage.sh
+./tests/run.sh test_wave-usage-report.sh
+./tests/run.sh test_state-ondas.sh
+./tests/run.sh cstk/test_recall.sh
+./tests/run.sh cstk/test_hooks.sh
+./tests/run.sh --check-coverage
+./tests/run.sh            # suite completa antes de fechar a feature
+```
+
+**Expected**: tudo verde; `--check-coverage` sem orfaos (exige a isencao
+existence-guarded do teste do hook em `_is_internal_test`).
+
+> **Nota de tempo**: a suite completa leva ~12 min (memoria
+> `feedback_full_suite_slow_background_parent`) — rodar em background preso ao
+> processo pai, nao em foreground com timeout curto.

--- a/docs/specs/wave-token-metrics/research.md
+++ b/docs/specs/wave-token-metrics/research.md
@@ -264,6 +264,22 @@ agregar.
 `_so_ticks_reset` (`state-ondas.sh:235`, chamado em `:282` no start e `:417`
 no end). Janela de contagem = start→end, igual ao sidecar de ticks.
 
+**Teto de linhas (CHK020, achado do gate `owasp-security`, dec-035,
+severidade INFO/LOW)**: o sidecar aceita no maximo **500 linhas** por onda.
+Numero magico deliberado — ordem de grandeza generosa acima do "poucos
+spawns por onda" ja descrito em `plan.md` §Scale/Scope, revisitavel se a
+experiencia real mostrar insuficiencia (mesmo espirito do cap de 10
+invocacoes de model-routing por onda, ja precedente no toolkit). O hook
+checa a contagem atual (`wc -l` best-effort) ANTES de cada append: se ja
+`>= 500`, pula o append desta linha (fail-open — nunca bloqueia a tool
+call) e emite um `log_out` de aviso uma unica vez por onda, guardado por
+um arquivo-sentinela `<state-dir>/.wave-agent-usage-cap-warned` criado no
+`start` e removido no `end` (mesmo ciclo de vida do sidecar). Spawns alem
+do teto ficam fora do agregado da onda — undercounting silencioso
+conhecido e aceito, analogo a tolerancia ja documentada acima para a
+fronteira exata start/end. `state-ondas.sh end` reporta `spawns_total`
+apenas dos observados no sidecar, nunca fabrica o excedente (Principio VI).
+
 ---
 
 ## Decision 6 — Agregacao em `state-ondas.sh end` (ponto ja existente)

--- a/docs/specs/wave-token-metrics/research.md
+++ b/docs/specs/wave-token-metrics/research.md
@@ -1,0 +1,438 @@
+# Phase 0 Research: wave-token-metrics
+
+**Feature**: `wave-token-metrics` | **Date**: 2026-07-25 | **Spec**: [spec.md](./spec.md)
+
+> **Convencao de veracidade (Constitution Principio VI)**: cada fato abaixo
+> carrega sua fonte. `[VERIFICADO]` = extraido de fonte rastreavel (doc oficial
+> baixada e lida, codigo do repo com arquivo:linha, ou output observado nesta
+> sessao). `[PROPOSTA]` = desenho novo, ainda nao existente, a validar na
+> implementacao. Nenhum numero de performance ou custo em $ e estimado.
+
+---
+
+## Unknown central da feature
+
+A spec (secao "Assumptions & Dependencies") deixou explicitamente em aberto:
+
+> **Risco em aberto — mecanismo exato de captura**: nao foi verificado ainda o
+> payload exato que um hook de pos-execucao de tool call recebe no momento em
+> que um spawn de subagente completa (qual identificador de tool chega, e se os
+> totais de uso vem diretamente nesse payload ou exigem acesso ao arquivo de
+> transcript por um caminho fornecido separadamente).
+
+Este research resolve esse unknown por completo. **Resultado: os totais de uso
+vem DIRETAMENTE no payload do hook** — nao e necessario ler o transcript ao
+vivo. O caminho por transcript fica reservado ao backfill offline (US4).
+
+---
+
+## Decision 1 — Fonte de captura: hook `PostToolUse` com matcher `Agent`
+
+**Decision**: capturar via hook `PostToolUse` filtrado pelo matcher `Agent`,
+lendo os campos de uso diretamente de `tool_response` no stdin do hook.
+
+**Rationale** `[VERIFICADO]`:
+
+Fonte: `https://code.claude.com/docs/en/hooks.md` (baixada em 2026-07-25 e lida
+localmente; 238174 bytes).
+
+1. **A tool de spawn se chama `Agent`, nao `Task`.** Linha 2049 do doc, literal:
+
+   > To inject context into the parent session after a subagent returns, use a
+   > [`PostToolUse`](#posttooluse) hook on the `Agent` tool instead.
+
+   O doc tem uma secao dedicada `##### Agent` (L1472-1480) descrevendo o
+   `tool_input` (`prompt`, `description`, `subagent_type`, `model`).
+
+   Confirmacao empirica independente: no transcript
+   `~/.claude/projects/-Users-jot-Projects--lab-Jot-misc-cstk/01d83125-e6c0-4c7d-859a-a1b94d6de09e.jsonl`,
+   os 6 `tool_use_id` cujo resultado carrega `toolUseResult.totalTokens`
+   correlacionam 6/6 com `tool_use` de `name = "Agent"`.
+
+2. **O payload do hook JA carrega a telemetria de uso.** Linha 1483, literal:
+
+   > In `PostToolUse`, `tool_response` for a completed Agent call carries the
+   > subagent's final text along with usage telemetry. Read these fields to
+   > record per-subagent cost from a hook:
+
+   Ou seja: o doc oficial documenta **exatamente o caso de uso desta feature**.
+   Campos de `tool_response` para `status = "completed"` (tabela L1485-1495):
+
+   | Campo | Tipo | Observacao do doc |
+   |-------|------|-------------------|
+   | `status` | string | `"completed"` (foreground) ou `"async_launched"` (background) |
+   | `agentId` | string | identificador da run do subagente |
+   | `content` | array | blocos de texto finais do subagente |
+   | `resolvedModel` | string | modelo em que o subagente iniciou; requer Claude Code >= v2.1.174 |
+   | `modelsUsed` | array | modelos usados em ordem, so quando houve swap mid-run; requer >= v2.1.212 |
+   | `totalTokens` | number | total de tokens faturados nos turnos do subagente |
+   | `totalDurationMs` | number | duracao wall-clock da run |
+   | `totalToolUseCount` | number | contagem de tool calls do subagente |
+   | `usage` | object | breakdown: `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens` |
+
+   Isso cobre FR-001 (total + breakdown por 4 categorias), FR-002 (tool-uses +
+   duracao) e FR-003 (modelo, via `resolvedModel`) numa unica leitura.
+
+3. **Campos comuns do stdin do hook** (doc, secao "Common input fields"):
+   `session_id`, `prompt_id`, `transcript_path`, `cwd`, `permission_mode`,
+   `hook_event_name`; e especificos do PostToolUse: `tool_name`, `tool_use_id`,
+   `tool_input`, `tool_response`. O campo `cwd` e o mesmo ja consumido por
+   `posttooluse-tool-call-tick.sh:53` para detectar execucao ativa — a
+   deteccao existente e reusavel sem mudanca.
+
+**Alternatives considered**:
+
+- **Hook `SubagentStop`** — REJEITADO. Doc L2028: recebe `stop_hook_active`,
+  `agent_id`, `agent_type`, `agent_transcript_path`, `last_assistant_message`.
+  **Nenhum campo de usage.** Daria identidade do subagente mas nao o consumo,
+  exigindo um segundo passo de leitura de transcript (que sofre o lag da
+  Decision 3). Descartado como fonte primaria.
+- **Ler `transcript_path` dentro do hook** — REJEITADO (ver Decision 3).
+- **Capturar no proprio orquestrador, do tool result inline** — REJEITADO. O
+  orquestrador ve o resumo de uso no retorno da tool Agent, mas depender da
+  prosa do orquestrador para registrar metrica e exatamente o modo de falha
+  "mecanismo advisory" que o cabecalho de `posttooluse-tool-call-tick.sh:5-13`
+  documenta como causa raiz do gap anterior (`tool_calls` nunca avancava
+  porque nenhum mecanismo automatico invocava o tick). Hook e deterministico;
+  prosa nao e.
+
+---
+
+## Decision 2 — ~50% dos spawns reais NAO tem usage (`status = async_launched`)
+
+**Decision**: tratar `async_launched` como o caso **"indisponivel"** da FR-009 /
+FR-012, registrando o spawn com os campos de uso NULOS e um status explicito —
+nunca zero, nunca estimado. Nao alterar a semantica de execucao do orquestrador
+para "forcar" foreground.
+
+**Rationale** `[VERIFICADO]`:
+
+1. Doc L1497, literal:
+
+   > For background subagents, the tool returns when the task moves to the
+   > background, so `tool_response` carries no usage fields: a background launch
+   > returns immediately, and a foreground task that Claude Code backgrounds
+   > mid-run returns at that transition. It has `status: "async_launched"`,
+   > `agentId`, `description`, `prompt`, `outputFile`, and `resolvedModel`.
+
+2. Doc L1487 (nota de versao na linha do campo `status`):
+
+   > As of v2.1.198, subagents run in the background by default, so an omitted
+   > `run_in_background` also produces `"async_launched"`
+
+3. **Medicao real** (nao estimativa) nos transcripts deste projeto,
+   `~/.claude/projects/-Users-jot-Projects--lab-Jot-misc-cstk/*.jsonl`:
+
+   ```
+   52 async_launched
+   51 completed
+   ```
+
+   Keys observadas num `toolUseResult` com `status = "async_launched"`:
+
+   ```json
+   ["agentId","canReadOutputFile","description","isAsync","outputFile","prompt","resolvedModel","status"]
+   ```
+
+   — sem `totalTokens`, sem `usage`. Confirma o doc.
+
+**Consequencia de desenho (importante)**: o caso "metrica indisponivel" da
+FR-009/SC-004 **nao e um edge case raro** — na pratica observada e ~metade dos
+spawns. O relatorio precisa exibir "indisponivel" de forma legivel e rotineira,
+e o agregado da onda precisa distinguir `spawns_total` de
+`spawns_com_usage`, senao o operador le um total parcial como se fosse total.
+
+**Ambiente local** `[VERIFICADO]`: `claude --version` => `2.1.220 (Claude Code)`
+— acima dos pisos de `resolvedModel` (2.1.174) e `modelsUsed` (2.1.212), logo
+os dois campos estao disponiveis aqui. O desenho trata ambos como opcionais
+(ausencia => campo nulo) para nao quebrar em harness mais antigo.
+
+**Alternatives considered**:
+
+- **Forcar `run_in_background: false` em todos os spawns do orquestrador** —
+  REJEITADO como requisito desta feature. Aumentaria a cobertura da metrica,
+  mas muda a semantica de execucao da orquestracao (paralelismo de subagentes)
+  para servir a observabilidade — o rabo abanando o cachorro. Fica registrado
+  como **recomendacao aditiva e opcional** ao orquestrador, fora do escopo.
+- **Ler `outputFile` do spawn background para extrair uso** — REJEITADO: o doc
+  descreve `outputFile` como o destino da saida da task, nao como portador de
+  telemetria; nao ha campo de uso documentado ali. Supor que teria seria
+  fabricacao (Principio VI).
+- **Estimar o consumo do spawn background** — PROIBIDO por FR-009.
+
+---
+
+## Decision 3 — `transcript_path` serve so para backfill offline, nunca ao vivo
+
+**Decision**: nao ler `transcript_path` de dentro do hook. O caminho por
+transcript e reservado a US4 (reconstrucao retroativa, FR-010/FR-011), que
+opera sobre transcripts de sessoes ja encerradas.
+
+**Rationale** `[VERIFICADO]`: doc L617, literal:
+
+> Path to conversation JSON. The transcript file is written asynchronously and
+> may lag the in-memory conversation, so it may not yet include the current
+> turn's most recent messages when a hook fires.
+
+Ler o transcript no instante do hook seria nao-deterministico: a entrada do
+proprio spawn que acabou de completar pode ainda nao estar no arquivo. Para
+backfill, o lag e irrelevante (a sessao ja terminou e o arquivo esta estavel).
+
+**Nota sobre a spec**: a secao "Assumptions & Dependencies" da spec levantou as
+duas fontes possiveis (transcript persistido vs resultado da tool call) e
+deixou a escolha para o `/plan`. A escolha e: **tool call para captura ao vivo
+(US1-US3), transcript para reconstrucao retroativa (US4)** — as duas fontes
+sao usadas, cada uma onde e deterministica.
+
+---
+
+## Decision 4 — Hook novo dedicado (matcher `Agent`), nao extensao do hook de ticks
+
+**Decision**: criar `global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh`
+`[PROPOSTA]`, registrado com matcher `"Agent"`, em vez de estender
+`posttooluse-tool-call-tick.sh` (matcher `"*"`).
+
+**Rationale**:
+
+- O matcher `"Agent"` faz o harness filtrar antes de invocar o processo: o hook
+  novo so roda em spawns de subagente, nao a cada tool call. Estender o hook de
+  ticks (que roda em `"*"`) adicionaria trabalho no caminho quente de toda tool
+  call.
+- Separacao de responsabilidade: o hook de ticks conta; o hook novo mede uso.
+  Cada um mantem seu proprio contrato fail-open simples.
+- O provisionamento ja tem o padrao pronto: `cli/lib/hooks.sh:256-263`
+  (`apply_guard_hooks()`) ja copia `posttooluse-tool-call-tick.sh` em modo
+  best-effort (falha so emite `log_warn`, nao muda o state word). Um terceiro
+  `cp` no mesmo bloco e simetrico.
+
+**Custo aceito (declarado, nao escondido)**:
+
+1. Mais uma entrada em `global/skills/agente-00c-runtime/hooks/settings.snippet.json`
+   (hoje tem 2: PreToolUse matcher `"Bash"` L3-14; PostToolUse matcher `"*"`
+   L15-26).
+2. Mais uma isencao em `tests/run.sh::_is_internal_test`. **Verificado**: hooks
+   vivem em `.../hooks/`, fora do `_find_scripts()` (que varre
+   `global/skills/*/scripts/*.sh` e `cli/lib/*.sh`), entao um
+   `tests/test_posttooluse-agent-usage.sh` seria sinalizado como *teste orfao*.
+   O precedente exato ja existe em `tests/run.sh:298-303`, que isenta
+   `test_posttooluse-tool-call-tick.sh` de forma existence-guarded:
+
+   ```sh
+   test_posttooluse-tool-call-tick.sh)
+     # cobre global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh
+     [ -f "$REPO_ROOT/global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh" ] && return 0
+   ```
+
+   O hook novo replica esse padrao.
+
+**Alternative considered**: estender o hook de ticks com um `case` em
+`tool_name`. Menos arquivos e um unico caminho de provisionamento, mas paga
+custo em toda tool call e mistura duas metricas num script cujo contrato
+fail-open depende de ser trivialmente auditavel. Rejeitado por margem estreita
+— e uma escolha reversivel se o provisionamento duplo se mostrar fragil.
+
+---
+
+## Decision 5 — Sidecar append-only, state.json intocado pelo hook
+
+**Decision**: o hook escreve UMA linha JSON por spawn em
+`<state-dir>/wave-agent-usage.jsonl` `[PROPOSTA]`, append-only, e **nunca**
+toca `state.json`. A agregacao para o `state.json` acontece em
+`state-ondas.sh end`, que ja e o ponto transacional de fechamento de onda.
+
+**Rationale** `[VERIFICADO]`: o cabecalho de `posttooluse-tool-call-tick.sh:28-37`
+documenta a regra dura e o motivo, e vale identicamente aqui:
+
+> REGRA DURA — NAO tocar o state.json: PostToolUse dispara CONCORRENTE as tool
+> calls do orquestrador (batches paralelos do harness). Um read-modify-write do
+> state.json aqui (...) poderia clobberar um write transacional
+> (Decisao/bloqueio/onda) gravado entre o read e o `mv` do tick.
+
+**Restricao de tamanho de linha (load-bearing)**: o mesmo cabecalho (L39-41)
+justifica a atomicidade do append por a linha ser curta:
+
+> Append com O_APPEND e atomico para linhas curtas (< PIPE_BUF).
+
+Consequencia direta de desenho: a linha JSONL **MUST** conter apenas os campos
+numericos e identificadores curtos. `content` (texto final do subagente) e
+`prompt` (texto da tarefa) **MUST NOT** ser gravados — por tamanho (estourariam
+PIPE_BUF e quebrariam a atomicidade do append) e por conteudo (texto livre =
+superficie de vazamento de segredo). Isso tambem mantem o sidecar barato de
+agregar.
+
+**Ciclo de vida**: reset em `start` e em `end`, espelhando
+`_so_ticks_reset` (`state-ondas.sh:235`, chamado em `:282` no start e `:417`
+no end). Janela de contagem = start→end, igual ao sidecar de ticks.
+
+---
+
+## Decision 6 — Agregacao em `state-ondas.sh end` (ponto ja existente)
+
+**Decision**: `end` le o sidecar, agrega, e grava no mesmo `jq` transacional que
+ja escreve o fechamento da onda.
+
+**Rationale** `[VERIFICADO]`: `state-ondas.sh:373-377` ja faz exatamente esse
+padrao para os ticks:
+
+```sh
+_tc_field=$(jq -r '(.budgets.tool_calls_current_wave // .orcamentos.tool_calls_onda_corrente) // 0' "$_sf")
+_tc_side=$(_so_ticks_count "$_sdir")
+_tc=$((_tc_field + _tc_side))
+```
+
+e grava em `:391-410` via `.waves[-1] |= (...)` mais incrementos em
+`.accumulated_metrics`. O caminho ja e coberto por `_so_backup_current` +
+`_so_atomic_write` + `_so_update_sha` (`:412-418`) — a metrica nova herda
+backup, escrita atomica e recomputo de hash sem mecanismo novo.
+
+**Rede de seguranca**: `reconcile-wave` (`state-ondas.sh:928`) so age em onda
+ABERTA e e no-op idempotente em onda fechada (`:947-956`) — ondas recuperadas
+pelo comando pai passam pelo mesmo `end`, logo herdam a agregacao sem trabalho
+extra.
+
+---
+
+## Decision 7 — knowledge.db v9 -> v10 por colunas aditivas em `waves`
+
+**Decision**: bump `RECALL_SCHEMA_VERSION` 9 -> 10 (`cli/lib/recall.sh:106`) e
+adicionar colunas aditivas a tabela `waves`, seguindo o padrao idempotente ja
+usado nas migracoes v7->v8 e v8->v9.
+
+**Rationale** `[VERIFICADO]`: o padrao existe literalmente em
+`cli/lib/recall.sh:677-694` — `PRAGMA table_info(<tabela>)` + `case` que so
+emite o `ALTER TABLE ... ADD COLUMN` se a coluna faltar (SQLite nao tem
+`ADD COLUMN IF NOT EXISTS`). **Sem DROP** — dados v9 preservados. Exemplo
+literal da v8->v9 no arquivo:
+
+```sh
+case "$_as_ecols" in
+  ''|*'|target_project_path|'*) : ;;
+  *) _as_extra="$_as_extra
+ALTER TABLE executions ADD COLUMN target_project_path TEXT;" ;;
+esac
+```
+
+**Retrofit**: `recall_mode_reindex()` (`cli/lib/recall.sh:2175`) reconstroi do
+zero a partir dos `state.json` encontrados — execucoes cujo state.json ja tenha
+os campos novos passam a popular as colunas novas sem trabalho manual.
+
+**Regra de nao-fabricacao na ingestao** `[VERIFICADO]`: o bloco de waves usa
+`recall_int_or_null` para `wallclock_seconds` e `tool_calls`
+(`cli/lib/recall.sh:1005-1055`). As colunas novas **MUST** usar o mesmo helper:
+onda antiga (sem o campo) => `NULL`, jamais `0`. `NULL` significa "nao medido";
+`0` significaria "medido e deu zero" — confundir os dois viola FR-009/SC-004.
+
+---
+
+## Decision 8 — Helper de relatorio novo, sem contaminar `model-routing-report.sh`
+
+**Decision**: criar
+`global/skills/agente-00c-runtime/scripts/wave-usage-report.sh` `[PROPOSTA]`
+com subcomando `aggregate --state-dir DIR [--json]`, e consumi-lo em
+`review-task` (§4.5) ao lado do agregado de model-routing.
+
+**Rationale** `[VERIFICADO]`: `model-routing-report.sh` le **somente**
+`.decisions[]` e nao le `.waves` — e uma decisao registrada e explicita no
+cabecalho do proprio script (L5-6, "agregacao real-time derivada de
+`.decisions[]` (sem campo agregado em `.waves`)"). Fazer esse script ler
+`.waves` quebraria o invariante que ele documenta. Helper separado preserva os
+dois contratos.
+
+**Beneficio colateral de convencao** `[VERIFICADO]`: por viver em
+`global/skills/*/scripts/`, o helper novo cai na regra 1:1 de
+`tests/run.sh::_expected_test_for_script` e ganha
+`tests/test_wave-usage-report.sh` **sem** precisar de isencao em
+`_is_internal_test` — o oposto do caso do hook (Decision 4).
+
+**Correlacao custo x modelo (US2/FR-007)**: o cruzamento se da por onda —
+`wave-usage-report.sh` traz consumo por onda/spawn (incluindo `resolvedModel`
+observado) e `model-routing-report.sh` traz o modelo *roteado* por onda. A
+distincao importa e esta documentada em data-model.md: `resolvedModel` e o
+modelo **aplicado observado no harness**, enquanto a Decisao de model-routing e
+o modelo **escolhido pelo toolkit**. Divergencia entre os dois e sinal util
+(ex.: swap mid-run via `modelsUsed`), nao um bug de captura.
+
+---
+
+## Decision 9 — Backfill (US4/P4) por janela temporal, com recusa explicita
+
+**Decision**: subcomando `wave-usage-report.sh backfill` `[PROPOSTA]` que le um
+transcript ja encerrado, extrai os `toolUseResult` de tool calls `Agent` e os
+atribui a ondas por **janela temporal** (`started_at` <= ts < `finished_at` de
+cada entrada de `.waves[]`). Quando o transcript nao existe mais em disco,
+retorna recusa explicita — nunca preenche.
+
+**Rationale** `[VERIFICADO]`: a estrutura do transcript foi confirmada
+empiricamente nesta sessao (ver Decision 1). O transcript **nao carrega
+identificador de onda** — nao ha chave direta de juncao, entao a janela
+temporal e a unica correlacao disponivel a partir de dados reais. Os campos
+`started_at`/`finished_at` existem em toda entrada de `.waves[]`
+(`state-ondas.sh:259-273` cria `started_at`; `:391-410` grava `finished_at`).
+
+**Risco declarado**: a atribuicao por janela temporal e uma **heuristica**, nao
+uma chave. Spawns exatamente na fronteira entre ondas podem ser mal atribuidos.
+Mitigacao: marcar a proveniencia do registro como `backfill` (vs `live`) para
+que o operador saiba que aquele numero veio de correlacao temporal. Esta e a
+razao de US4 ser P4 e candidata a fase separada — o dado ao vivo (US1) nao
+depende dessa heuristica.
+
+**FR-011** (transcript ausente): retorno de recusa explicita com exit code
+distinto e mensagem nomeando a execucao que nao pode ser reconstruida.
+
+---
+
+## Decision 10 — Provisionamento e o elo fraco (risco herdado, nao introduzido)
+
+**Decision**: reusar `apply_guard_hooks()` e adicionar uma verificacao de
+diagnostico, tratando o gap de provisionamento como risco explicito com task
+propria — nao como pressuposto silencioso.
+
+**Rationale** `[VERIFICADO]` — estado real observado neste proprio repo:
+
+```
+find .claude -name tool-call-ticks.log   => (vazio)
+jq .hooks .claude/settings.local.json    => apenas matchers Edit|Write
+state.json .waves[].tool_calls (001-004) => 0, 0, 0, 0
+```
+
+Ou seja: **o hook de metrica de tool calls nao esta provisionado no repo do
+proprio toolkit**, e por isso todas as ondas desta execucao registram
+`tool_calls: 0`. Isso corrobora o comportamento degradado ja documentado
+(`agente-00c-feature-orchestrator.md`, passo 4 do Loop: "Sem o hook provisionado
+a metrica degrada para 0 — best-effort, nunca gateia").
+
+A feature nova herda exatamente o mesmo risco: hook perfeito + provisionamento
+ausente = metrica vazia. A mitigacao NAO e mudar o desenho (o fail-open e
+correto e constitucional), e sim tornar o gap **visivel**: o relatorio deve
+distinguir "0 spawns nesta onda" de "hook nao provisionado / metrica nao
+coletada", e `cstk doctor` e o lugar natural para sinalizar a ausencia do hook.
+
+---
+
+## Riscos residuais consolidados
+
+| # | Risco | Severidade | Mitigacao |
+|---|-------|-----------|-----------|
+| R1 | ~50% dos spawns sao `async_launched` sem usage (Decision 2) | Alta | Status explicito `indisponivel`; separar `spawns_total` de `spawns_com_usage` no agregado |
+| R2 | Hook nao provisionado no projeto-alvo (Decision 10) | Alta | Diagnostico explicito; nunca apresentar ausencia como zero |
+| R3 | Linha do sidecar > PIPE_BUF quebra atomicidade do append (Decision 5) | Media | Proibir `content`/`prompt` na linha; so numeros + ids curtos |
+| R4 | Backfill por janela temporal pode mal-atribuir spawn de fronteira (Decision 9) | Media | Marcar proveniencia `backfill` vs `live`; US4 e P4, isolada |
+| R5 | Campos `resolvedModel`/`modelsUsed` exigem harness >= 2.1.174 / >= 2.1.212 | Baixa | Tratar como opcionais; ausencia => campo nulo, nunca inventado |
+| R6 | Crescimento do `state.json` com detalhe por spawn | Baixa | `budget.sh` ja monitora `state_size_threshold_bytes` (default 1048576, `budget.sh:97-100`); spawns por onda sao poucos |
+
+---
+
+## Fontes
+
+| Fonte | Tipo | Uso |
+|-------|------|-----|
+| `https://code.claude.com/docs/en/hooks.md` (baixada 2026-07-25) | Doc oficial | Decisions 1, 2, 3 |
+| `~/.claude/projects/-Users-jot-Projects--lab-Jot-misc-cstk/*.jsonl` | Transcript real | Decisions 1, 2, 9 |
+| `global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh` | Codigo do repo | Decisions 4, 5 |
+| `global/skills/agente-00c-runtime/scripts/state-ondas.sh` | Codigo do repo | Decisions 5, 6, 9 |
+| `global/skills/agente-00c-runtime/scripts/budget.sh` | Codigo do repo | R6 |
+| `cli/lib/recall.sh` | Codigo do repo | Decision 7 |
+| `cli/lib/hooks.sh` | Codigo do repo | Decisions 4, 10 |
+| `global/skills/agente-00c-runtime/scripts/model-routing-report.sh` | Codigo do repo | Decision 8 |
+| `tests/run.sh` | Codigo do repo | Decisions 4, 8 |
+| `claude --version` => `2.1.220 (Claude Code)` | Ambiente local | Decision 2 |

--- a/docs/specs/wave-token-metrics/spec.md
+++ b/docs/specs/wave-token-metrics/spec.md
@@ -9,6 +9,10 @@
 ### Session 2026-07-25
 
 - Q: Esta feature deve ESTENDER a infraestrutura de metricas por onda ja existente no toolkit (adicionando granularidade por spawn) ou introduzir um mecanismo de captura/armazenamento novo e independente? → A: Estender a infraestrutura ja existente, adicionando granularidade por spawn — mesmo padrao ja usado para tool_calls (fail-open, sidecar por onda, nunca bloqueia a orquestracao).
+- Q: Quando um spawn de subagente falha/aborta antes de completar, a metrica de tokens desse spawn deve ser capturada parcialmente (ate o ponto da falha, marcada explicitamente "parcial") ou sempre marcada como indisponivel? → A: Parcial somente se observavel no transcript/tool result (marcada explicitamente "parcial"); sem dado observavel = "indisponivel". Nunca estimar/fabricar (Constitution Principio VI).
+- Q: A Metrica de Uso de Spawn precisa de um identificador de execucao explicito (alem de onda/feature/projeto) para garantir atribuicao correta sob execucoes concorrentes no mesmo projeto? → A: Sim, incluir identificador de execucao explicito na Metrica de Uso de Spawn — precedente: coluna `session` do knowledge.db v8 (feature `recall-worktree-identity`).
+- Q: Quando um spawn nao teve nenhum modelo roteado via model-routing (ex.: mediacao inline degradada, sem spawn real), a metrica de tokens desse spawn deve ser capturada mesmo assim (so sem correlacao de modelo) ou fica fora do escopo desta feature? → A: Capturar sempre, com o campo de modelo marcado explicitamente como "nao-aplicavel" quando nao houve roteamento — alinhado a FR-001/FR-002 (MUST incondicionais).
+- Q: A metrica de tokens por spawn deve ser um total unico agregado, ou detalhada por categoria (input/output/cache-read/cache-write)? → A: Total agregado + breakdown por categoria (input, output, cache-read, cache-creation), a partir do campo `usage` ja presente no `toolUseResult` — custos por categoria diferem significativamente entre si.
 
 ## User Scenarios & Testing
 
@@ -137,10 +141,13 @@ capturado ao vivo.
 
 ### Edge Cases
 
-- O que acontece quando um spawn de subagente falha/aborta antes de
-  retornar (nunca completa)? O consumo parcial ate o momento da falha deve
-  ser capturado, ou a metrica fica marcada como indisponivel para esse
-  spawn especifico?
+- Quando um spawn de subagente falha/aborta antes de retornar (nunca
+  completa): o consumo parcial ate o momento da falha e capturado somente
+  se estiver observavel na fonte de dados (transcript/tool result), sendo
+  marcado explicitamente como "parcial"; quando nenhum dado observavel
+  existe, a metrica fica marcada como "indisponivel" para esse spawn
+  especifico — nunca estimada (RESOLVIDO nesta sessao, ver bloco
+  "Clarifications").
 - O que acontece quando o dado de uso do subagente simplesmente nao esta
   disponivel para captura (ambiente degradado, fonte de dados ausente)? A
   onda continua normalmente, so sem aquela metrica (ver FR-008)?
@@ -150,9 +157,11 @@ capturado ao vivo.
 - O que acontece quando o operador tenta reconstruir retroativamente
   (US4) uma execucao cujos dados de sessao originais ja foram removidos do
   disco? (ver Acceptance Scenario 2 da US4)
-- O que acontece quando duas execucoes rodam concorrentemente sobre o
-  mesmo projeto — a atribuicao de consumo por onda continua correta sem
-  misturar spawns de execucoes diferentes?
+- Quando duas execucoes rodam concorrentemente sobre o mesmo projeto: a
+  Metrica de Uso de Spawn carrega um identificador de execucao explicito
+  (alem de onda/feature/projeto), garantindo que a atribuicao de consumo
+  por onda nao mistura spawns de execucoes diferentes (RESOLVIDO nesta
+  sessao, ver bloco "Clarifications").
 
 ## Requirements
 
@@ -160,13 +169,19 @@ capturado ao vivo.
 
 - **FR-001**: O sistema MUST capturar, para cada spawn de subagente que
   completa dentro de uma onda de orquestracao autonoma, uma metrica de
-  tokens consumidos associada aquele spawn.
+  tokens consumidos associada aquele spawn, composta por um total agregado
+  e um breakdown por categoria (input, output, cache-read,
+  cache-creation), a partir do campo `usage` do resultado da tool call de
+  spawn quando disponivel.
 - **FR-002**: O sistema MUST capturar, para cada spawn de subagente que
   completa dentro de uma onda, uma metrica de contagem de tool-uses e uma
   metrica de duracao associadas aquele spawn.
 - **FR-003**: O sistema MUST associar cada metrica de spawn capturada a
-  onda, a feature/projeto e, quando aplicavel, ao modelo que foi roteado
-  para aquele spawn.
+  onda, ao identificador de execucao, a feature/projeto e ao modelo que
+  foi roteado para aquele spawn. O campo de modelo MUST estar sempre
+  presente na metrica; quando o spawn nao teve nenhum modelo roteado
+  (ex.: mediacao inline degradada), o campo MUST ser preenchido com o
+  valor explicito "nao-aplicavel", nunca omitido.
 - **FR-004**: As metricas de spawn capturadas MUST permanecer consultaveis
   apos o encerramento da sessao de orquestracao (nao apenas visiveis
   durante a conversa ao vivo).
@@ -197,6 +212,13 @@ capturado ao vivo.
   execucao cujos dados de sessao originais ja nao existem mais em disco, o
   sistema MUST informar explicitamente que aquela execucao nao pode ser
   reconstruida, em vez de preencher a metrica com um valor estimado.
+- **FR-012**: Quando um spawn de subagente falha/aborta antes de completar,
+  o sistema MUST capturar a metrica parcial de tokens/tool-uses/duracao
+  daquele spawn somente se esse dado parcial estiver observavel na fonte
+  de dados subjacente (transcript/resultado da tool call), marcando-a
+  explicitamente como "parcial"; caso nenhum dado observavel exista, a
+  metrica MUST ser marcada como "indisponivel" — nunca estimada
+  (Constitution Principio VI).
 
 > Decisoes de infraestrutura: N/A alem do already-coberto por FR-008/FR-009
 > (best-effort + nao-fabricacao) — a feature nao introduz scheduling,
@@ -208,10 +230,16 @@ capturado ao vivo.
 ### Key Entities
 
 - **Metrica de Uso de Spawn**: registro do consumo observado de um spawn de
-  subagente concluido — tokens consumidos, contagem de tool-uses, duracao,
-  e a associacao com a onda, a feature/projeto e o modelo roteado para
-  aquele spawn. Pode ter campos individuais marcados como indisponiveis
-  quando a fonte de dados subjacente nao permitiu captura-los (FR-009).
+  subagente — tokens consumidos (total agregado e breakdown por categoria:
+  input, output, cache-read, cache-creation), contagem de tool-uses,
+  duracao, e a associacao com a onda, o identificador de execucao, a
+  feature/projeto e o modelo roteado para aquele spawn (campo de modelo
+  sempre presente; "nao-aplicavel" quando nao houve roteamento — FR-003).
+  Carrega um status de completude — completo, parcial (dado ate o momento
+  de uma falha, apenas quando observavel) ou indisponivel (nenhum dado
+  observavel) — nunca estimada (FR-009, FR-012). Pode ter campos
+  individuais marcados como indisponiveis quando a fonte de dados
+  subjacente nao permitiu captura-los (FR-009).
 - **Consumo Agregado da Onda**: soma das Metricas de Uso de Spawn de todos
   os subagentes de uma mesma onda, exibida nos relatorios de execucao
   (FR-005).
@@ -222,8 +250,10 @@ capturado ao vivo.
 
 - **SC-001**: Para 100% dos spawns de subagente concluidos com sucesso
   dentro de uma onda orquestrada (quando a fonte de dados de uso estava
-  disponivel), o relatorio da onda exibe tokens/tool-uses/duracao em vez de
-  apenas uma contagem de tool_calls como proxy.
+  disponivel), o relatorio da onda exibe tokens (total agregado e
+  breakdown por categoria: input/output/cache-read/cache-creation)/
+  tool-uses/duracao em vez de apenas uma contagem de tool_calls como
+  proxy.
 - **SC-002**: O operador consegue consultar retroativamente, para qualquer
   onda concluida, o consumo de tokens associado, sem precisar reabrir a
   sessao original de conversa.

--- a/docs/specs/wave-token-metrics/spec.md
+++ b/docs/specs/wave-token-metrics/spec.md
@@ -1,0 +1,273 @@
+# Feature Specification: Metricas de Tokens por Spawn de Subagente
+
+**Feature**: `wave-token-metrics`
+**Created**: 2026-07-25
+**Status**: Draft
+
+## User Scenarios & Testing
+
+### User Story 1 - Ver tokens/tool-uses/duracao por onda no relatorio de execucao (Priority: P1)
+
+Como operador que revisa uma execucao autonoma (`agente-00c`/`feature-00c`), ao
+abrir o relatorio de uma onda concluida, quero ver o consumo real de tokens,
+a contagem de tool-uses e a duracao de cada spawn de subagente daquela onda —
+nao apenas a contagem de tool_calls que o toolkit usa hoje como proxy de
+custo.
+
+**Why this priority**: e o valor central da feature — sem isso, a metrica
+"tool_calls" continua sendo a unica leitura de custo disponivel, que e um
+proxy grosseiro (uma tool call de 50 tokens e uma de 50.000 tokens contam
+igual). Sozinha, esta story ja entrega valor mensuravel ao operador.
+
+**Independent Test**: concluir uma onda de uma execucao autonoma com pelo
+menos um spawn de subagente e verificar que o relatorio da onda exibe
+tokens/tool-uses/duracao daquele spawn (ou marca explicitamente a metrica
+como indisponivel, nunca inventada — ver FR-009).
+
+**Acceptance Scenarios**:
+
+1. **Given** uma onda que spawnou 1 subagente e o subagente concluiu
+   normalmente, **When** o operador abre o relatorio da onda, **Then** o
+   relatorio mostra tokens consumidos, tool-uses e duracao daquele spawn.
+2. **Given** uma onda que spawnou 3 subagentes em momentos diferentes,
+   **When** o operador abre o relatorio da onda, **Then** o relatorio mostra
+   as 3 metricas individualmente atribuidas a cada spawn, alem de um total
+   agregado da onda.
+3. **Given** um spawn cujo dado de uso nao pode ser obtido (ver Edge Cases),
+   **When** o operador abre o relatorio, **Then** a metrica daquele spawn
+   aparece marcada como indisponivel — nunca como zero ou um numero
+   estimado.
+
+---
+
+### User Story 2 - Auditar custo x modelo roteado (Priority: P2)
+
+Como operador que avalia se o roteamento automatico de modelos
+(model-routing) esta sendo economico, quero cruzar, por onda, o modelo que
+foi efetivamente roteado para cada subagente com o consumo de tokens
+observado naquele spawn — para decidir se o mapa de roteamento (ou um
+refino pontual) precisa mudar.
+
+**Why this priority**: depende da User Story 1 (a metrica de tokens precisa
+existir primeiro), mas e o que transforma a metrica bruta em decisao
+acionavel — sem o cruzamento com o modelo roteado, o numero de tokens sozinho
+nao diz se o roteamento esta caro ou barato.
+
+**Independent Test**: rodar duas ondas que roteiam modelos diferentes para o
+mesmo tipo de subagente e verificar que a auditoria de custo x roteamento
+existente no toolkit consegue exibir, lado a lado, o modelo roteado e o
+consumo de tokens de cada onda.
+
+**Acceptance Scenarios**:
+
+1. **Given** duas ondas historicas com modelos roteados diferentes para
+   subagentes equivalentes, **When** o operador consulta a auditoria de
+   custo x roteamento, **Then** consegue comparar tokens consumidos por
+   modelo sem fazer calculo manual fora do toolkit.
+
+---
+
+### User Story 3 - Consultar historico de consumo entre features/projetos (Priority: P3)
+
+Como operador que ja tem o habito de consultar decisoes e bloqueios
+passados via memoria de conhecimento cross-feature do toolkit, quero que o
+consumo de tokens por onda tambem fique disponivel nessa mesma memoria
+historica, para poder perguntar "quanto essa categoria de tarefa costuma
+consumir" antes de iniciar uma execucao nova.
+
+**Why this priority**: e uma extensao natural de uma capacidade que ja
+existe (a memoria cross-feature ja indexa decisoes, bloqueios e skills
+invocadas); sem ela, a metrica de tokens fica presa a execucao onde foi
+capturada e nao alimenta decisoes de planejamento futuras.
+
+**Independent Test**: apos uma onda com metrica de tokens capturada, uma
+consulta a memoria historica do toolkit por aquela feature/projeto retorna
+o consumo de tokens registrado, junto com a proveniencia (projeto, feature,
+onda, data) que a memoria ja oferece para outros tipos de registro.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma onda com metricas de tokens ja capturadas e persistidas,
+   **When** o operador consulta a memoria de conhecimento historica por
+   aquela feature, **Then** o consumo de tokens da onda aparece no
+   resultado, com a mesma proveniencia (projeto/feature/onda/data) dos
+   demais tipos de registro ja indexados.
+
+---
+
+### User Story 4 - Reconstruir metricas de execucoes passadas (Priority: P4)
+
+Como operador que so vai perceber o valor desta feature depois de ja ter
+rodado varias execucoes autonomas sem ela, quero poder recuperar o consumo
+de tokens dessas execucoes passadas a partir do que ja ficou registrado em
+disco durante aquelas sessoes — em vez de perder esse historico ou precisar
+re-executar tudo de novo so para gerar a metrica.
+
+**Why this priority**: e um bonus de menor prioridade sobre as stories
+anteriores — nao e necessario para o operador comecar a se beneficiar da
+metrica em execucoes NOVAS (US1-US3 ja entregam isso). E candidata natural
+a uma fase de implementacao separada, com seu proprio ritmo de validacao.
+
+**Independent Test**: escolher uma execucao autonoma concluida antes desta
+feature existir, cujos dados de sessao ainda estejam preservados em disco,
+rodar a reconstrucao retroativa e confirmar que o consumo de tokens daquela
+execucao passa a aparecer nos mesmos lugares onde apareceria se tivesse sido
+capturado ao vivo.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma execucao concluida antes desta feature existir, com os
+   dados de sessao originais ainda preservados em disco, **When** o operador
+   aciona a reconstrucao retroativa para essa execucao, **Then** o consumo
+   de tokens passa a estar disponivel nos relatorios e na consulta
+   historica, do mesmo jeito que uma execucao capturada ao vivo.
+2. **Given** uma execucao cujos dados de sessao originais ja nao existem
+   mais em disco (ex.: sessao expirada/removida), **When** o operador tenta
+   reconstruir retroativamente, **Then** o sistema informa explicitamente
+   que aquela execucao nao pode ser reconstruida — nunca preenche com um
+   valor estimado.
+
+---
+
+### Edge Cases
+
+- O que acontece quando um spawn de subagente falha/aborta antes de
+  retornar (nunca completa)? O consumo parcial ate o momento da falha deve
+  ser capturado, ou a metrica fica marcada como indisponivel para esse
+  spawn especifico?
+- O que acontece quando o dado de uso do subagente simplesmente nao esta
+  disponivel para captura (ambiente degradado, fonte de dados ausente)? A
+  onda continua normalmente, so sem aquela metrica (ver FR-008)?
+- Como o sistema atribui a metrica quando varios subagentes rodam em
+  paralelo dentro da mesma onda — cada spawn mantem sua metrica
+  individual, alem do agregado da onda?
+- O que acontece quando o operador tenta reconstruir retroativamente
+  (US4) uma execucao cujos dados de sessao originais ja foram removidos do
+  disco? (ver Acceptance Scenario 2 da US4)
+- O que acontece quando duas execucoes rodam concorrentemente sobre o
+  mesmo projeto — a atribuicao de consumo por onda continua correta sem
+  misturar spawns de execucoes diferentes?
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: O sistema MUST capturar, para cada spawn de subagente que
+  completa dentro de uma onda de orquestracao autonoma, uma metrica de
+  tokens consumidos associada aquele spawn.
+- **FR-002**: O sistema MUST capturar, para cada spawn de subagente que
+  completa dentro de uma onda, uma metrica de contagem de tool-uses e uma
+  metrica de duracao associadas aquele spawn.
+- **FR-003**: O sistema MUST associar cada metrica de spawn capturada a
+  onda, a feature/projeto e, quando aplicavel, ao modelo que foi roteado
+  para aquele spawn.
+- **FR-004**: As metricas de spawn capturadas MUST permanecer consultaveis
+  apos o encerramento da sessao de orquestracao (nao apenas visiveis
+  durante a conversa ao vivo).
+- **FR-005**: O sistema MUST exibir metricas agregadas de tokens/tool-uses/
+  duracao por onda nos relatorios de execucao ja existentes da
+  orquestracao autonoma.
+- **FR-006**: O sistema MUST tornar as metricas historicas de consumo por
+  spawn consultaveis entre features e projetos diferentes, de forma
+  consistente com o que ja acontece hoje para outros tipos de registro da
+  memoria de conhecimento cross-feature do toolkit.
+- **FR-007**: O sistema MUST permitir correlacionar o consumo de tokens
+  capturado com o modelo que foi roteado para aquele spawn (auditoria de
+  custo x roteamento ja existente no toolkit), para o operador avaliar se
+  o roteamento esta sendo economico.
+- **FR-008**: A captura de metricas de spawn MUST ser best-effort — a
+  ausencia ou malformacao da fonte de dados de uso subjacente MUST NOT
+  abortar nem bloquear a onda de orquestracao.
+- **FR-009**: O sistema MUST NOT inventar/estimar consumo de tokens quando
+  o valor real nao esta disponivel para um spawn — uma metrica indisponivel
+  MUST ser registrada explicitamente como ausente/desconhecida, nunca como
+  um numero fabricado (Constitution Principio VI).
+- **FR-010**: O sistema SHOULD suportar a reconstrucao de metricas de
+  consumo para execucoes de orquestracao passadas, a partir de dados ja
+  persistidos em disco durante aquelas sessoes, sem exigir que a sessao
+  seja re-executada (US4, prioridade menor — candidata a fase de
+  implementacao separada).
+- **FR-011**: Quando a reconstrucao retroativa (FR-010) e acionada para uma
+  execucao cujos dados de sessao originais ja nao existem mais em disco, o
+  sistema MUST informar explicitamente que aquela execucao nao pode ser
+  reconstruida, em vez de preencher a metrica com um valor estimado.
+
+> Decisoes de infraestrutura: N/A alem do already-coberto por FR-008/FR-009
+> (best-effort + nao-fabricacao) — a feature nao introduz scheduling,
+> criptografia, refresh de token externo ou lock multi-pod novos; ela
+> estende um mecanismo de captura best-effort que ja segue o mesmo padrao
+> usado hoje para a metrica de tool_calls (fail-open, sidecar por onda,
+> nunca bloqueia a orquestracao).
+
+### Key Entities
+
+- **Metrica de Uso de Spawn**: registro do consumo observado de um spawn de
+  subagente concluido — tokens consumidos, contagem de tool-uses, duracao,
+  e a associacao com a onda, a feature/projeto e o modelo roteado para
+  aquele spawn. Pode ter campos individuais marcados como indisponiveis
+  quando a fonte de dados subjacente nao permitiu captura-los (FR-009).
+- **Consumo Agregado da Onda**: soma das Metricas de Uso de Spawn de todos
+  os subagentes de uma mesma onda, exibida nos relatorios de execucao
+  (FR-005).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Para 100% dos spawns de subagente concluidos com sucesso
+  dentro de uma onda orquestrada (quando a fonte de dados de uso estava
+  disponivel), o relatorio da onda exibe tokens/tool-uses/duracao em vez de
+  apenas uma contagem de tool_calls como proxy.
+- **SC-002**: O operador consegue consultar retroativamente, para qualquer
+  onda concluida, o consumo de tokens associado, sem precisar reabrir a
+  sessao original de conversa.
+- **SC-003**: Em uma auditoria de custo x modelo roteado, o operador
+  consegue comparar, por onda, o modelo efetivamente roteado com o
+  consumo de tokens observado, sem precisar fazer calculo manual fora do
+  toolkit.
+- **SC-004**: Quando o dado de uso nao esta disponivel para um spawn, 100%
+  dos relatorios marcam a metrica daquele spawn explicitamente como
+  indisponivel — nunca exibem um numero inventado ou um zero apresentado
+  como valor real.
+- **SC-005**: Para execucoes historicas cujos dados de sessao originais
+  ainda existem em disco, o operador consegue reconstruir o consumo de
+  tokens daquela execucao sem re-executar a pipeline de orquestracao.
+
+## Assumptions & Dependencies
+
+- **Fonte de dados verificada (evidencia observada nesta sessao,
+  Constitution Principio VI)**: o transcript de sessao do Claude Code
+  persistido em disco (`~/.claude/projects/<projeto-codificado>/<sessao>.jsonl`)
+  contem, para cada retorno de spawn de subagente concluido, um registro
+  de resultado da tool call com o total de tokens consumidos, a contagem
+  total de tool-uses e a duracao total do spawn — confirmado pela
+  correspondencia entre os valores desse registro (tokens=106664,
+  tool-uses=38) e a contagem de tool-uses exibida ao operador ("38 tool
+  uses") para a mesma onda de uma execucao real
+  (`~/.claude/projects/-Users-jot-Projects--lab-Jot-financial-support/3695d350-2c3f-4356-aa3a-9e46918d9436.jsonl`).
+  Adicionalmente, observou-se nesta propria sessao que o resultado da tool
+  call de spawn devolvido ao orquestrador-pai ja carrega um resumo desses
+  mesmos totais (tokens=68853, tool-uses=0, duracao=4698ms observados).
+  Essas sao as duas fontes de dados sobre as quais esta feature assume
+  que a captura e possivel — a spec nao prescreve qual das duas (ou ambas)
+  sera usada; isso e decisao de `/plan`.
+- **Risco em aberto — mecanismo exato de captura**: nao foi verificado
+  ainda o payload exato que um hook de pos-execucao de tool call recebe no
+  momento em que um spawn de subagente completa (qual identificador de
+  tool chega, e se os totais de uso vem diretamente nesse payload ou
+  exigem acesso ao arquivo de transcript por um caminho fornecido
+  separadamente). Este e um risco tecnico a resolver na fase de pesquisa/
+  plano — nao um requisito desta spec — e pode reduzir o conjunto de
+  metricas capturaveis ao vivo (FR-001/FR-002) sem invalidar FR-010/FR-011
+  (a reconstrucao retroativa le o transcript persistido diretamente, via
+  caminho ja confirmado).
+- **Nao contradiz decisao historica anterior sobre custo em tokens**: uma
+  decisao registrada anteriormente no toolkit concluiu que "a harness nao
+  expoe contabilidade de tokens a scripts/env" (checagem `env | grep -i
+  token` vazia) e adotou `tool_calls` como proxy de custo. Essa conclusao
+  permanece valida para o canal que foi testado (variaveis de ambiente
+  disponiveis a scripts em execucao) — o canal que esta feature assume
+  (dado persistido no transcript em disco e no resultado da tool call de
+  spawn) e um canal diferente, nao testado por aquela decisao anterior.
+- Esta feature nao especifica o schema de armazenamento nem o formato
+  exato dos campos de captura — isso e decisao tecnica de `/plan`.

--- a/docs/specs/wave-token-metrics/spec.md
+++ b/docs/specs/wave-token-metrics/spec.md
@@ -307,3 +307,28 @@ capturado ao vivo.
   spawn) e um canal diferente, nao testado por aquela decisao anterior.
 - Esta feature nao especifica o schema de armazenamento nem o formato
   exato dos campos de captura — isso e decisao tecnica de `/plan`.
+
+## Fora de Escopo
+
+As fronteiras abaixo tornam formal o que ja estava implicito em
+"Assumptions & Dependencies" (CHK003):
+
+- **Schema/formato de persistencia**: o formato exato da linha do sidecar,
+  as colunas novas do `knowledge.db` e os campos de `state.json` sao
+  decisao tecnica de `/plan` (ja referenciado acima), nao desta spec.
+- **Custo em dinheiro / precificacao de tokens**: fora de escopo desta
+  feature. Decisao historica ja registrada no toolkit conclui que "a
+  harness nao expoe contabilidade de tokens/preco a scripts/env" e que
+  nenhum orquestrador MUST inventar custo em `$` (ver
+  `agente-00c-feature-orchestrator.md` §"Custo em tokens — NAO
+  inventar", dec-005). Esta feature captura contagem de tokens
+  (input/output/cache), nunca valor monetario.
+- **Dashboard visual**: qualquer apresentacao grafica/visual dos dados
+  capturados (series temporais, graficos por modelo, etc.) pertence ao
+  `cstk-panel` — fora desta feature, que entrega apenas captura +
+  agregacao + relatorio textual.
+- **Heuristica de estimativa para spawns `indisponivel`**: esta feature
+  NUNCA estima, infere ou preenche um valor aproximado quando o dado real
+  de uso nao esta disponivel (Constitution Principio VI, SC-004). Um
+  spawn sem dado observavel permanece marcado `indisponivel`,
+  nunca recebe um numero calculado/estimado em seu lugar.

--- a/docs/specs/wave-token-metrics/spec.md
+++ b/docs/specs/wave-token-metrics/spec.md
@@ -4,6 +4,12 @@
 **Created**: 2026-07-25
 **Status**: Draft
 
+## Clarifications
+
+### Session 2026-07-25
+
+- Q: Esta feature deve ESTENDER a infraestrutura de metricas por onda ja existente no toolkit (adicionando granularidade por spawn) ou introduzir um mecanismo de captura/armazenamento novo e independente? → A: Estender a infraestrutura ja existente, adicionando granularidade por spawn — mesmo padrao ja usado para tool_calls (fail-open, sidecar por onda, nunca bloqueia a orquestracao).
+
 ## User Scenarios & Testing
 
 ### User Story 1 - Ver tokens/tool-uses/duracao por onda no relatorio de execucao (Priority: P1)

--- a/docs/specs/wave-token-metrics/tasks.md
+++ b/docs/specs/wave-token-metrics/tasks.md
@@ -130,19 +130,19 @@ Ref: contracts/wave-usage-report.md §6
 
 Ref: data-model.md §"Extensao do knowledge.db: v9 -> v10"
 
-- [ ] 5.1.1 Bumpar `RECALL_SCHEMA_VERSION` de 9 para 10 em `cli/lib/recall.sh`
-- [ ] 5.1.2 Adicionar as 9 colunas novas `INTEGER` na tabela `waves` (`agent_spawns_total`, `agent_spawns_with_usage`, `agent_total_tokens`, `agent_input_tokens`, `agent_output_tokens`, `agent_cache_read_tokens`, `agent_cache_creation_tokens`, `agent_tool_use_count`, `agent_duration_ms`) via migracao aditiva idempotente (`PRAGMA table_info(waves)` + `case`, padrao literal ja usado em v7->v8/v8->v9)
-- [ ] 5.1.3 Confirmar que a migracao NAO faz `DROP` e preserva dados v9 existentes
-- [ ] 5.1.4 Aplicar `recall_int_or_null` (helper ja existente) em todas as 9 colunas novas na ingestao — onda antiga ou sem dado => `NULL`, nunca `0` (mesma regra de `wallclock_seconds`/`tool_calls`)
+- [x] 5.1.1 Bumpar `RECALL_SCHEMA_VERSION` de 9 para 10 em `cli/lib/recall.sh`
+- [x] 5.1.2 Adicionar as 9 colunas novas `INTEGER` na tabela `waves` (`agent_spawns_total`, `agent_spawns_with_usage`, `agent_total_tokens`, `agent_input_tokens`, `agent_output_tokens`, `agent_cache_read_tokens`, `agent_cache_creation_tokens`, `agent_tool_use_count`, `agent_duration_ms`) via migracao aditiva idempotente (`PRAGMA table_info(waves)` + `case`, padrao literal ja usado em v7->v8/v8->v9)
+- [x] 5.1.3 Confirmar que a migracao NAO faz `DROP` e preserva dados v9 existentes
+- [x] 5.1.4 Aplicar `recall_int_or_null` (helper ja existente) em todas as 9 colunas novas na ingestao — onda antiga ou sem dado => `NULL`, nunca `0` (mesma regra de `wallclock_seconds`/`tool_calls`)
 
 ### 5.2 Ingestao e retrofit `[A]`
 
 Ref: contracts/wave-usage-report.md §7
 
-- [ ] 5.2.1 Estender a rotina de ingestao (`--ingest`) para ler `.waves[].agent_usage` do `state.json` e popular as 9 colunas novas
-- [ ] 5.2.2 Estender `recall_mode_reindex()` (`--reindex`) para retrofit das colunas novas a partir de states existentes (aplicando os mesmos defaults `NULL`)
-- [ ] 5.2.3 Aplicar o guard best-effort de permissao `0600` no `knowledge.db` (subtarefa 1.2.4) no ponto de abertura/migracao de conexao
-- [ ] 5.2.4 Estender `tests/cstk/test_recall.sh` cobrindo: migracao v9->v10 idempotente, preservacao de dados v9, ingestao das 9 colunas novas, `--reindex` retrofit, `NULL` em vez de `0` para state antigo, permissao `0600` na criacao (subtarefa 1.2.6)
+- [x] 5.2.1 Estender a rotina de ingestao (`--ingest`) para ler `.waves[].agent_usage` do `state.json` e popular as 9 colunas novas
+- [x] 5.2.2 Estender `recall_mode_reindex()` (`--reindex`) para retrofit das colunas novas a partir de states existentes (aplicando os mesmos defaults `NULL`)
+- [x] 5.2.3 Aplicar o guard best-effort de permissao `0600` no `knowledge.db` (subtarefa 1.2.4) no ponto de abertura/migracao de conexao
+- [x] 5.2.4 Estender `tests/cstk/test_recall.sh` cobrindo: migracao v9->v10 idempotente, preservacao de dados v9, ingestao das 9 colunas novas, `--reindex` retrofit, `NULL` em vez de `0` para state antigo, permissao `0600` na criacao (subtarefa 1.2.6)
 
 ---
 

--- a/docs/specs/wave-token-metrics/tasks.md
+++ b/docs/specs/wave-token-metrics/tasks.md
@@ -27,36 +27,36 @@ registro (sem decidir) dos 2 items `{humano}` pendentes (CHK016, CHK024).
 
 Ref: checklists/requirements.md CHK003 `[Gap]`
 
-- [ ] 1.1.1 Adicionar secao explicita `## Fora de Escopo` em `spec.md`, tornando formal as fronteiras hoje implicitas em "Assumptions & Dependencies" (linhas 308-309: schema de armazenamento e formato exato dos campos de captura sao decisao de `/plan`, nao da spec)
-- [ ] 1.1.2 Listar nesta secao, no minimo: schema/formato de persistencia (decisao de plan), custo em dinheiro/token pricing (fora de escopo — ver `feature-00c-feature-orchestrator.md` §"Custo em tokens — NAO inventar", dec-005), dashboard visual (cstk-panel, fora desta feature), qualquer heuristica de estimativa de uso para spawns `indisponivel`
-- [ ] 1.1.3 Rodar `validate-documentation` sobre o `spec.md` atualizado para confirmar que a nova secao nao introduz inconsistencia com o restante do documento
+- [x] 1.1.1 Adicionar secao explicita `## Fora de Escopo` em `spec.md`, tornando formal as fronteiras hoje implicitas em "Assumptions & Dependencies" (linhas 308-309: schema de armazenamento e formato exato dos campos de captura sao decisao de `/plan`, nao da spec)
+- [x] 1.1.2 Listar nesta secao, no minimo: schema/formato de persistencia (decisao de plan), custo em dinheiro/token pricing (fora de escopo — ver `feature-00c-feature-orchestrator.md` §"Custo em tokens — NAO inventar", dec-005), dashboard visual (cstk-panel, fora desta feature), qualquer heuristica de estimativa de uso para spawns `indisponivel`
+- [x] 1.1.3 Rodar `validate-documentation` sobre o `spec.md` atualizado para confirmar que a nova secao nao introduz inconsistencia com o restante do documento
 
 ### 1.2 Definir permissoes de arquivo do sidecar e do knowledge.db `[A]`
 
 Ref: checklists/security.md CHK017 `[Gap]` (gap herdado do padrao pre-existente do toolkit — `posttooluse-tool-call-tick.sh` e `~/.claude/cstk/knowledge.db` ja em producao tambem carecem de requisito documentado; esta feature adiciona dado novo ao mesmo arquivo compartilhado, por isso o gap e resolvido aqui em vez de so herdado)
 
-- [ ] 1.2.1 Documentar em `data-model.md` §Sidecar a permissao de criacao do arquivo `wave-agent-usage.jsonl`: `0600` (leitura/escrita apenas do dono do processo), criado pelo hook via `umask 077` antes do primeiro append, mesma politica aplicavel retroativamente ao sidecar irmao `tool-call-ticks.log`
-- [ ] 1.2.2 Documentar a mesma politica (`0600`) para `~/.claude/cstk/knowledge.db`, aplicada na criacao (`sqlite3 ... "PRAGMA ..."` ja usada em `recall.sh`) — sem alterar permissao de um DB ja existente com permissao mais aberta (evitar quebrar setups locais existentes; apenas `chmod` best-effort se detectado mais aberto que `0600`, log via `log_out`, nunca falha)
-- [ ] 1.2.3 Implementar `umask 077` (ou `chmod 600` pos-criacao) em `posttooluse-agent-usage.sh` antes do primeiro append ao sidecar
-- [ ] 1.2.4 Implementar checagem best-effort de permissao do `knowledge.db` em `cli/lib/recall.sh` (na abertura de conexao/migracao), com `chmod 600` corretivo se o arquivo estiver mais aberto — nunca bloqueia, apenas normaliza e loga
-- [ ] 1.2.5 Escrever teste em `tests/test_posttooluse-agent-usage.sh` verificando que o sidecar criado tem permissao `0600` (via `stat` portavel POSIX/macOS+Linux)
-- [ ] 1.2.6 Escrever teste em `tests/cstk/test_recall.sh` verificando que o `knowledge.db` criado do zero tem permissao `0600`
+- [x] 1.2.1 Documentar em `data-model.md` §Sidecar a permissao de criacao do arquivo `wave-agent-usage.jsonl`: `0600` (leitura/escrita apenas do dono do processo), criado pelo hook via `umask 077` antes do primeiro append, mesma politica aplicavel retroativamente ao sidecar irmao `tool-call-ticks.log`
+- [x] 1.2.2 Documentar a mesma politica (`0600`) para `~/.claude/cstk/knowledge.db`, aplicada na criacao (`sqlite3 ... "PRAGMA ..."` ja usada em `recall.sh`) — sem alterar permissao de um DB ja existente com permissao mais aberta (evitar quebrar setups locais existentes; apenas `chmod` best-effort se detectado mais aberto que `0600`, log via `log_out`, nunca falha)
+- [ ] 1.2.3 Implementar `umask 077` (ou `chmod 600` pos-criacao) em `posttooluse-agent-usage.sh` antes do primeiro append ao sidecar <!-- depende de 2.1.1 (FASE 2, arquivo ainda nao existe); satisfeita em 2.1.6 -->
+- [x] 1.2.4 Implementar checagem best-effort de permissao do `knowledge.db` em `cli/lib/recall.sh` (na abertura de conexao/migracao), com `chmod 600` corretivo se o arquivo estiver mais aberto — nunca bloqueia, apenas normaliza e loga
+- [ ] 1.2.5 Escrever teste em `tests/test_posttooluse-agent-usage.sh` verificando que o sidecar criado tem permissao `0600` (via `stat` portavel POSIX/macOS+Linux) <!-- depende de 2.1.1 (FASE 2, arquivo ainda nao existe); satisfeita em 2.1.9 -->
+- [x] 1.2.6 Escrever teste em `tests/cstk/test_recall.sh` verificando que o `knowledge.db` criado do zero tem permissao `0600`
 
 ### 1.3 Definir teto de linhas/spawns do sidecar antes do reset `[A]`
 
 Ref: checklists/security.md CHK020 `[Gap]` (achado do gate `owasp-security`, dec-035, severidade INFO/LOW — nao bloqueia, mas fica registrado para create-tasks avaliar um contador leve)
 
-- [ ] 1.3.1 Definir e documentar em `research.md` §Decision 5 o teto: **500 linhas** por onda no sidecar `wave-agent-usage.jsonl` (ordem de grandeza generosa acima do "poucos spawns por onda" do plan §Scale/Scope; numero magico deliberado, revisitavel se a experiencia real mostrar insuficiencia)
-- [ ] 1.3.2 Implementar contador leve (`wc -l` best-effort) em `posttooluse-agent-usage.sh` ANTES de cada append: se a contagem atual já estiver `>= 500`, pular o append desta linha (fail-open, sem bloquear a tool call) e emitir `log_out` de aviso uma unica vez por onda (guard via arquivo-sentinela `<state-dir>/.wave-agent-usage-cap-warned` criado/removido no mesmo ciclo start/end do sidecar)
-- [ ] 1.3.3 Documentar em `data-model.md` §Sidecar o comportamento ao atingir o teto: spawns além do teto ficam fora do agregado da onda (undercounting silencioso conhecido, análogo à tolerância já documentada para a fronteira start/end); o `state-ondas.sh end` reporta `spawns_total` apenas dos observados, nunca fabrica o excedente
-- [ ] 1.3.4 Escrever teste em `tests/test_posttooluse-agent-usage.sh` cobrindo: sidecar com 500 linhas pre-existentes -> hook nao adiciona linha 501 e nao falha (exit 0)
+- [x] 1.3.1 Definir e documentar em `research.md` §Decision 5 o teto: **500 linhas** por onda no sidecar `wave-agent-usage.jsonl` (ordem de grandeza generosa acima do "poucos spawns por onda" do plan §Scale/Scope; numero magico deliberado, revisitavel se a experiencia real mostrar insuficiencia)
+- [ ] 1.3.2 Implementar contador leve (`wc -l` best-effort) em `posttooluse-agent-usage.sh` ANTES de cada append: se a contagem atual já estiver `>= 500`, pular o append desta linha (fail-open, sem bloquear a tool call) e emitir `log_out` de aviso uma unica vez por onda (guard via arquivo-sentinela `<state-dir>/.wave-agent-usage-cap-warned` criado/removido no mesmo ciclo start/end do sidecar) <!-- depende de 2.1.1 (FASE 2, arquivo ainda nao existe); satisfeita em 2.1.6 -->
+- [x] 1.3.3 Documentar em `data-model.md` §Sidecar o comportamento ao atingir o teto: spawns além do teto ficam fora do agregado da onda (undercounting silencioso conhecido, análogo à tolerância já documentada para a fronteira start/end); o `state-ondas.sh end` reporta `spawns_total` apenas dos observados, nunca fabrica o excedente
+- [ ] 1.3.4 Escrever teste em `tests/test_posttooluse-agent-usage.sh` cobrindo: sidecar com 500 linhas pre-existentes -> hook nao adiciona linha 501 e nao falha (exit 0) <!-- depende de 2.1.1 (FASE 2, arquivo ainda nao existe); satisfeita em 2.1.9 -->
 
 ### 1.4 Registrar decisoes pendentes do dono do produto (nao decidir) `[M]`
 
 Ref: checklists/requirements.md CHK016, CHK024 (`{humano}`)
 
-- [ ] 1.4.1 Adicionar em `spec.md` (ou em nota de rodape de `plan.md` §Riscos) um bloco "Decisoes aguardando dono do produto": (a) CHK016 — se a meta 100% de SC-001/SC-004 permanece formalmente correta mesmo com ~50% dos spawns reais sem `usage` (`async_launched`), e como comunicar essa condicional sem parecer metrica quebrada; (b) CHK024 — se a ausencia deliberada de alvo numerico de performance/latencia e aceitavel para este release ou se o operador quer um teto explicito
-- [ ] 1.4.2 NAO implementar nenhuma resposta hipotetica para CHK016/CHK024 nesta fase — registrar apenas o texto da pergunta e o estado atual (spec/plan ja documentam honestamente a ausencia/condicional); a resolucao fica para o operador decidir antes ou durante `review-task` final
+- [x] 1.4.1 Adicionar em `spec.md` (ou em nota de rodape de `plan.md` §Riscos) um bloco "Decisoes aguardando dono do produto": (a) CHK016 — se a meta 100% de SC-001/SC-004 permanece formalmente correta mesmo com ~50% dos spawns reais sem `usage` (`async_launched`), e como comunicar essa condicional sem parecer metrica quebrada; (b) CHK024 — se a ausencia deliberada de alvo numerico de performance/latencia e aceitavel para este release ou se o operador quer um teto explicito
+- [x] 1.4.2 NAO implementar nenhuma resposta hipotetica para CHK016/CHK024 nesta fase — registrar apenas o texto da pergunta e o estado atual (spec/plan ja documentam honestamente a ausencia/condicional); a resolucao fica para o operador decidir antes ou durante `review-task` final
 
 ---
 

--- a/docs/specs/wave-token-metrics/tasks.md
+++ b/docs/specs/wave-token-metrics/tasks.md
@@ -1,0 +1,231 @@
+# Tarefas wave-token-metrics - Metricas de Tokens por Spawn de Subagente
+
+Escopo: decompor `plan.md` (fases F1-F6) em backlog executavel. Cobre hook de
+captura `PostToolUse`/`Agent`, sidecar JSONL por onda, agregacao em
+`state-ondas.sh end`, relatorios (`wave-usage-report.sh` + `report.sh`),
+extensao do knowledge.db (v9->v10), consumo em `review-task` (custo x
+roteamento) e backfill via transcript. Inclui a resolucao dos 3 gaps abertos
+pelos checklists (`requirements.md` CHK003, `security.md` CHK017/CHK020) e o
+registro (sem decidir) dos 2 items `{humano}` pendentes (CHK016, CHK024).
+
+**Legenda de status:**
+- `[ ]` Pendente
+- `[~]` Em andamento
+- `[x]` Concluido
+- `[!]` Bloqueado
+
+**Legenda de criticidade:**
+- `[C]` Critico - Impacto financeiro direto ou bloqueante
+- `[A]` Alto - Funcionalidade essencial
+- `[M]` Medio - Necessario mas sem urgencia imediata
+
+---
+
+## FASE 1 - Fundacao: gaps de requisito/seguranca e decisoes pendentes
+
+### 1.1 Fechar gap de escopo da spec `[A]`
+
+Ref: checklists/requirements.md CHK003 `[Gap]`
+
+- [ ] 1.1.1 Adicionar secao explicita `## Fora de Escopo` em `spec.md`, tornando formal as fronteiras hoje implicitas em "Assumptions & Dependencies" (linhas 308-309: schema de armazenamento e formato exato dos campos de captura sao decisao de `/plan`, nao da spec)
+- [ ] 1.1.2 Listar nesta secao, no minimo: schema/formato de persistencia (decisao de plan), custo em dinheiro/token pricing (fora de escopo — ver `feature-00c-feature-orchestrator.md` §"Custo em tokens — NAO inventar", dec-005), dashboard visual (cstk-panel, fora desta feature), qualquer heuristica de estimativa de uso para spawns `indisponivel`
+- [ ] 1.1.3 Rodar `validate-documentation` sobre o `spec.md` atualizado para confirmar que a nova secao nao introduz inconsistencia com o restante do documento
+
+### 1.2 Definir permissoes de arquivo do sidecar e do knowledge.db `[A]`
+
+Ref: checklists/security.md CHK017 `[Gap]` (gap herdado do padrao pre-existente do toolkit — `posttooluse-tool-call-tick.sh` e `~/.claude/cstk/knowledge.db` ja em producao tambem carecem de requisito documentado; esta feature adiciona dado novo ao mesmo arquivo compartilhado, por isso o gap e resolvido aqui em vez de so herdado)
+
+- [ ] 1.2.1 Documentar em `data-model.md` §Sidecar a permissao de criacao do arquivo `wave-agent-usage.jsonl`: `0600` (leitura/escrita apenas do dono do processo), criado pelo hook via `umask 077` antes do primeiro append, mesma politica aplicavel retroativamente ao sidecar irmao `tool-call-ticks.log`
+- [ ] 1.2.2 Documentar a mesma politica (`0600`) para `~/.claude/cstk/knowledge.db`, aplicada na criacao (`sqlite3 ... "PRAGMA ..."` ja usada em `recall.sh`) — sem alterar permissao de um DB ja existente com permissao mais aberta (evitar quebrar setups locais existentes; apenas `chmod` best-effort se detectado mais aberto que `0600`, log via `log_out`, nunca falha)
+- [ ] 1.2.3 Implementar `umask 077` (ou `chmod 600` pos-criacao) em `posttooluse-agent-usage.sh` antes do primeiro append ao sidecar
+- [ ] 1.2.4 Implementar checagem best-effort de permissao do `knowledge.db` em `cli/lib/recall.sh` (na abertura de conexao/migracao), com `chmod 600` corretivo se o arquivo estiver mais aberto — nunca bloqueia, apenas normaliza e loga
+- [ ] 1.2.5 Escrever teste em `tests/test_posttooluse-agent-usage.sh` verificando que o sidecar criado tem permissao `0600` (via `stat` portavel POSIX/macOS+Linux)
+- [ ] 1.2.6 Escrever teste em `tests/cstk/test_recall.sh` verificando que o `knowledge.db` criado do zero tem permissao `0600`
+
+### 1.3 Definir teto de linhas/spawns do sidecar antes do reset `[A]`
+
+Ref: checklists/security.md CHK020 `[Gap]` (achado do gate `owasp-security`, dec-035, severidade INFO/LOW — nao bloqueia, mas fica registrado para create-tasks avaliar um contador leve)
+
+- [ ] 1.3.1 Definir e documentar em `research.md` §Decision 5 o teto: **500 linhas** por onda no sidecar `wave-agent-usage.jsonl` (ordem de grandeza generosa acima do "poucos spawns por onda" do plan §Scale/Scope; numero magico deliberado, revisitavel se a experiencia real mostrar insuficiencia)
+- [ ] 1.3.2 Implementar contador leve (`wc -l` best-effort) em `posttooluse-agent-usage.sh` ANTES de cada append: se a contagem atual já estiver `>= 500`, pular o append desta linha (fail-open, sem bloquear a tool call) e emitir `log_out` de aviso uma unica vez por onda (guard via arquivo-sentinela `<state-dir>/.wave-agent-usage-cap-warned` criado/removido no mesmo ciclo start/end do sidecar)
+- [ ] 1.3.3 Documentar em `data-model.md` §Sidecar o comportamento ao atingir o teto: spawns além do teto ficam fora do agregado da onda (undercounting silencioso conhecido, análogo à tolerância já documentada para a fronteira start/end); o `state-ondas.sh end` reporta `spawns_total` apenas dos observados, nunca fabrica o excedente
+- [ ] 1.3.4 Escrever teste em `tests/test_posttooluse-agent-usage.sh` cobrindo: sidecar com 500 linhas pre-existentes -> hook nao adiciona linha 501 e nao falha (exit 0)
+
+### 1.4 Registrar decisoes pendentes do dono do produto (nao decidir) `[M]`
+
+Ref: checklists/requirements.md CHK016, CHK024 (`{humano}`)
+
+- [ ] 1.4.1 Adicionar em `spec.md` (ou em nota de rodape de `plan.md` §Riscos) um bloco "Decisoes aguardando dono do produto": (a) CHK016 — se a meta 100% de SC-001/SC-004 permanece formalmente correta mesmo com ~50% dos spawns reais sem `usage` (`async_launched`), e como comunicar essa condicional sem parecer metrica quebrada; (b) CHK024 — se a ausencia deliberada de alvo numerico de performance/latencia e aceitavel para este release ou se o operador quer um teto explicito
+- [ ] 1.4.2 NAO implementar nenhuma resposta hipotetica para CHK016/CHK024 nesta fase — registrar apenas o texto da pergunta e o estado atual (spec/plan ja documentam honestamente a ausencia/condicional); a resolucao fica para o operador decidir antes ou durante `review-task` final
+
+---
+
+## FASE 2 - Hook de captura + sidecar (F1, base US1)
+
+### 2.1 Implementar hook `posttooluse-agent-usage.sh` `[A]`
+
+Ref: plan.md §Project Structure ("CRIAR"); contracts/hook-posttooluse-agent-usage.md
+
+- [ ] 2.1.1 Criar `global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh`, espelhando a estrutura de `posttooluse-tool-call-tick.sh`: le JSON do stdin, extrai `tool_name`, sai `exit 0` silencioso se `tool_name != "Agent"`
+- [ ] 2.1.2 Implementar deteccao de execucao 00c ativa (REUSO da logica ja existente em `pretooluse-bash-guard.sh` §4 — precedencia `agente-00c` > `feature-00c` por short-name lexicografico); `exit 0` sem interferencia se nenhuma execucao ativa
+- [ ] 2.1.3 Extrair campos do `tool_response` (`agentId`, `status`, `resolvedModel`, `modelsUsed`, `totalTokens`, `usage.*`, `totalToolUseCount`, `totalDurationMs`) e do `tool_input` (`subagent_type`) via `jq` com `// null` em todo acesso (Principio VI — nao inventar campo ausente)
+- [ ] 2.1.4 Derivar `status` (`completo`/`parcial`/`indisponivel`) conforme a state machine de `data-model.md` §State transitions; `indisponivel` **MUST** zerar (== `null`, nunca `0`) todos os campos numericos de uso
+- [ ] 2.1.5 Montar a linha JSON compacta (`jq -c`) do sidecar conforme `contracts/hook-posttooluse-agent-usage.md` §2, garantindo ausencia de `content`/`prompt`/`description` e tamanho < PIPE_BUF
+- [ ] 2.1.6 Aplicar `umask 077` antes do primeiro append (ref: subtarefa 1.2.3) e o cap de 500 linhas (ref: subtarefa 1.3.2) antes de gravar
+- [ ] 2.1.7 Fazer append atomico (`>>`) em `<state-dir>/wave-agent-usage.jsonl`; `source = "live"`, `observed_at` via `date -u +%Y-%m-%dT%H:%M:%SZ`
+- [ ] 2.1.8 Garantir politica fail-open absoluta: sem `set -e`; qualquer falha (jq ausente, stdin invalido, append negado) => `exit 0` silencioso, nunca stderr, nunca bloqueio da tool call
+- [ ] 2.1.9 Escrever `tests/test_posttooluse-agent-usage.sh` cobrindo: matcher `Agent` vs outros tools, execucao ativa vs inativa, `status` completo/parcial/indisponivel, ausencia de `content`/`prompt` na linha gravada, fail-open em jq ausente/stdin invalido, permissao `0600` (subtarefa 1.2.5), cap de 500 linhas (subtarefa 1.3.4)
+
+### 2.2 Provisionar o hook novo `[A]`
+
+Ref: plan.md §Project Structure ("MODIFICAR" settings.snippet.json)
+
+- [ ] 2.2.1 Adicionar entrada `PostToolUse` matcher `Agent` -> `posttooluse-agent-usage.sh` em `global/skills/agente-00c-runtime/hooks/settings.snippet.json`
+- [ ] 2.2.2 Confirmar em `cli/lib/hooks.sh::apply_guard_hooks()` que o hook novo e copiado no provisionamento de projeto (mesmo mecanismo do hook de ticks); ajustar se necessario
+- [ ] 2.2.3 Adicionar isencao existence-guarded do hook novo em `tests/run.sh::_is_internal_test` (precedente literal: linhas 298-303, hooks vivem fora de `scripts/` e por isso quebram a regra 1:1 do `--check-coverage`)
+- [ ] 2.2.4 Estender `tests/cstk/test_hooks.sh` cobrindo o provisionamento do hook novo (arquivo copiado + entrada no settings.snippet.json aplicada)
+
+---
+
+## FASE 3 - Agregacao em `state-ondas.sh` (F2, US1)
+
+### 3.1 Agregar `SpawnUsage` do sidecar em `.waves[]` `[A]`
+
+Ref: data-model.md §"Extensoes ao state.json"; contracts/wave-usage-report.md §4
+
+- [ ] 3.1.1 Em `state-ondas.sh start`, garantir reset do sidecar `wave-agent-usage.jsonl` (espelhando `_so_ticks_reset`) e remocao do sentinela de cap-warned (subtarefa 1.3.2)
+- [ ] 3.1.2 Em `state-ondas.sh end`, ler o sidecar da onda corrente e agregar em `WaveUsage`: `spawns_total`, `spawns_with_usage`, `spawns_unavailable`, somas de `total_tokens`/`input_tokens`/`output_tokens`/`cache_read_input_tokens`/`cache_creation_input_tokens`/`tool_use_count`/`duration_ms` (soma **apenas** sobre spawns com dado; `null` quando `spawns_with_usage == 0` — nunca `0` fabricado)
+- [ ] 3.1.3 Gravar o agregado em `.waves[N].agent_usage` e o array bruto de `SpawnUsage` em `.waves[N].agent_spawns[]`
+- [ ] 3.1.4 Incrementar `.accumulated_metrics.agent_spawns_total`, `.agent_spawns_with_usage_total`, `.agent_tokens_total`, `.agent_tool_use_count_total`, `.agent_duration_ms_total` no mesmo `jq` do `end` (padrao `(.campo // 0) + incremento` para retro-compatibilidade)
+- [ ] 3.1.5 Resetar o sidecar apos a agregacao (mesmo ciclo de vida do sidecar de ticks: reset em `start` e em `end`)
+- [ ] 3.1.6 Garantir retro-compatibilidade: onda sem sidecar (feature anterior a esta) produz `agent_usage: null`, `agent_spawns: []`, sem erro
+- [ ] 3.1.7 Estender `tests/test_state-ondas.sh` cobrindo: agregacao com spawns completos/parciais/indisponiveis misturados, onda sem sidecar (retro-compat), reset do sidecar em start/end, incremento correto de `.accumulated_metrics`
+
+---
+
+## FASE 4 - Relatorios (F3, US1/FR-005)
+
+### 4.1 Criar `wave-usage-report.sh` `[A]`
+
+Ref: contracts/wave-usage-report.md §2/§3
+
+- [ ] 4.1.1 Criar `global/skills/agente-00c-runtime/scripts/wave-usage-report.sh` com subcomando `aggregate --state-dir <DIR>` produzindo saida Markdown (default) conforme `contracts/wave-usage-report.md` §2.1, respeitando o invariante de honestidade SC-004 (exibir `spawns_total`/`spawns_with_usage`/`spawns_unavailable` juntos sempre que `spawns_unavailable > 0`)
+- [ ] 4.1.2 Implementar saida `--json` (contracts §2.2) com o mesmo agregado em formato maquina-legivel
+- [ ] 4.1.3 Implementar subcomando `backfill` (US4/FR-010/FR-011) conforme contracts §3 — ver detalhamento na FASE 7
+- [ ] 4.1.4 Escrever `tests/test_wave-usage-report.sh` cobrindo `aggregate` (Markdown + JSON), casos de zero spawns vs "metrica nao coletada" (research Decision 10), e o invariante SC-004
+
+### 4.2 Estender `report.sh` §1/§2 `[M]`
+
+Ref: contracts/wave-usage-report.md §6
+
+- [ ] 4.2.1 Adicionar secao de consumo de tokens/tool-uses/duracao ao relatorio gerado por `report.sh` (secoes 1 e 2), consumindo `wave-usage-report.sh aggregate --json` como fonte
+- [ ] 4.2.2 Garantir que o relatorio distingue "0 spawns" (nenhum subagente spawnado) de "metrica nao coletada" (hook nao provisionado) — nunca reportar 0 quando o dado real e ausencia de coleta
+- [ ] 4.2.3 Estender `tests/test_report.sh` (ou criar se inexistente) cobrindo as novas secoes do relatorio, incluindo o caso "metrica nao coletada"
+
+---
+
+## FASE 5 - knowledge.db v9 -> v10 (F4, US3/FR-006)
+
+### 5.1 Migracao de schema `[A]`
+
+Ref: data-model.md §"Extensao do knowledge.db: v9 -> v10"
+
+- [ ] 5.1.1 Bumpar `RECALL_SCHEMA_VERSION` de 9 para 10 em `cli/lib/recall.sh`
+- [ ] 5.1.2 Adicionar as 9 colunas novas `INTEGER` na tabela `waves` (`agent_spawns_total`, `agent_spawns_with_usage`, `agent_total_tokens`, `agent_input_tokens`, `agent_output_tokens`, `agent_cache_read_tokens`, `agent_cache_creation_tokens`, `agent_tool_use_count`, `agent_duration_ms`) via migracao aditiva idempotente (`PRAGMA table_info(waves)` + `case`, padrao literal ja usado em v7->v8/v8->v9)
+- [ ] 5.1.3 Confirmar que a migracao NAO faz `DROP` e preserva dados v9 existentes
+- [ ] 5.1.4 Aplicar `recall_int_or_null` (helper ja existente) em todas as 9 colunas novas na ingestao — onda antiga ou sem dado => `NULL`, nunca `0` (mesma regra de `wallclock_seconds`/`tool_calls`)
+
+### 5.2 Ingestao e retrofit `[A]`
+
+Ref: contracts/wave-usage-report.md §7
+
+- [ ] 5.2.1 Estender a rotina de ingestao (`--ingest`) para ler `.waves[].agent_usage` do `state.json` e popular as 9 colunas novas
+- [ ] 5.2.2 Estender `recall_mode_reindex()` (`--reindex`) para retrofit das colunas novas a partir de states existentes (aplicando os mesmos defaults `NULL`)
+- [ ] 5.2.3 Aplicar o guard best-effort de permissao `0600` no `knowledge.db` (subtarefa 1.2.4) no ponto de abertura/migracao de conexao
+- [ ] 5.2.4 Estender `tests/cstk/test_recall.sh` cobrindo: migracao v9->v10 idempotente, preservacao de dados v9, ingestao das 9 colunas novas, `--reindex` retrofit, `NULL` em vez de `0` para state antigo, permissao `0600` na criacao (subtarefa 1.2.6)
+
+---
+
+## FASE 6 - `review-task` custo x roteamento (F5, US2/FR-007)
+
+### 6.1 Consumir `wave-usage-report.sh` em `review-task` `[M]`
+
+Ref: contracts/wave-usage-report.md §5
+
+- [ ] 6.1.1 Adicionar em `global/skills/review-task/SKILL.md` §4.5 a invocacao de `wave-usage-report.sh aggregate --json` cruzada com `model-routing-report.sh aggregate` (mesma fonte de `.decisions[]`, sem tocar `.waves` — preserva o invariante que aquele script publica)
+- [ ] 6.1.2 Documentar no SKILL.md a leitura conjunta: para cada onda, exibir modelo aplicado (model-routing) lado a lado com consumo de tokens/tool-uses/duracao observado (wave-usage), destacando divergencias sugerido-vs-aplicado que tiveram alto consumo
+- [ ] 6.1.3 Escrever cenario de teste (fixture de state.json com `.waves[].agent_usage` + `.decisions[]` de model-routing) validando a secao cruzada, ou estender o test existente do `review-task` se houver harness automatizado para o SKILL.md
+
+---
+
+## FASE 7 - Backfill de transcripts (F6, US4/FR-010/FR-011)
+
+### 7.1 Implementar `wave-usage-report.sh backfill` `[M]`
+
+Ref: research.md §"Decision 9 — Backfill por janela temporal, com recusa explicita"; contracts/wave-usage-report.md §3
+
+- [ ] 7.1.1 Implementar subcomando `backfill --state-dir <DIR> --transcript <PATH>` que le o transcript JSONL informado e extrai `SpawnUsage` com `source = "backfill"` (nunca `"live"`)
+- [ ] 7.1.2 Implementar a heuristica de janela temporal (delimitando quais spawns do transcript pertencem a qual onda) conforme documentado em research.md Decision 9
+- [ ] 7.1.3 Implementar recusa explicita: quando o transcript nao cobre a janela da onda solicitada (ou esta ausente), o comando **MUST** recusar com mensagem clara em vez de estimar/inventar — nunca produzir `SpawnUsage` sintetico
+- [ ] 7.1.4 Documentar em `quickstart.md` o fluxo de uso do `backfill` (cenarios 9 e 10)
+- [ ] 7.1.5 Estender `tests/test_wave-usage-report.sh` cobrindo: backfill com transcript valido dentro da janela, recusa com transcript ausente/fora da janela, `source = "backfill"` sempre marcado corretamente
+
+---
+
+## Matriz de Dependencias
+
+```mermaid
+flowchart TD
+    F1[Fase 1 - Fundacao: gaps e decisoes pendentes]
+    F2[Fase 2 - Hook + sidecar]
+    F3[Fase 3 - Agregacao em state-ondas.sh]
+    F4[Fase 4 - Relatorios]
+    F5[Fase 5 - knowledge.db v9-v10]
+    F6[Fase 6 - review-task custo x roteamento]
+    F7[Fase 7 - Backfill de transcripts]
+
+    F1 --> F2
+    F2 --> F3
+    F3 --> F4
+    F3 --> F5
+    F4 --> F6
+    F5 --> F6
+    F4 --> F7
+```
+
+## Resumo Quantitativo
+
+| Fase | Tarefas | Subtarefas | Criticidade |
+|------|---------|------------|-------------|
+| 1 - Fundacao: gaps e decisoes pendentes | 4 | 15 | A/M |
+| 2 - Hook + sidecar | 2 | 13 | A |
+| 3 - Agregacao em state-ondas.sh | 1 | 7 | A |
+| 4 - Relatorios | 2 | 7 | A/M |
+| 5 - knowledge.db v9->v10 | 2 | 8 | A |
+| 6 - review-task custo x roteamento | 1 | 3 | M |
+| 7 - Backfill de transcripts | 1 | 5 | M |
+| **Total** | **13** | **58** | - |
+
+## Escopo Coberto
+
+| Item | Descricao | Fase |
+|------|-----------|------|
+| CHK003 | Secao "Fora de Escopo" formal na spec | 1 |
+| CHK017 | Permissoes de arquivo (0600) do sidecar e knowledge.db | 1 |
+| CHK020 | Teto de 500 linhas/spawns por onda no sidecar antes do reset | 1 |
+| F1 | Hook `posttooluse-agent-usage.sh` + provisionamento + testes | 2 |
+| F2 | Agregacao de `SpawnUsage` em `.waves[]`/`.accumulated_metrics` | 3 |
+| F3 | `wave-usage-report.sh aggregate` + extensao de `report.sh` §1/§2 | 4 |
+| F4 | knowledge.db v9->v10 (9 colunas novas) + ingestao + retrofit | 5 |
+| F5 | `review-task` §4.5 custo x roteamento | 6 |
+| F6 | `wave-usage-report.sh backfill` (US4) | 7 |
+
+## Escopo Excluido
+
+| Item | Descricao | Motivo |
+|------|-----------|--------|
+| Dashboard visual (cstk-panel) | Renderizacao grafica dos dados de consumo | Fora do escopo desta feature (dado disponivel no knowledge.db para consumo futuro; painel e projeto separado) |
+| Custo em $/pricing | Conversao de tokens em custo monetario | dec-005 do model-routing (harness nao expoe contabilidade de tokens/preco a scripts); `tool_calls` permanece o proxy documentado |
+| Estimativa/heuristica para spawns `indisponivel` | Preencher valor estimado quando o harness nao retorna `usage` | Violaria Principio VI (Zero Fabricacao) — `null` e a unica saida correta, nunca numero inferido |
+| CHK016 (meta 100% vs ~50% cobertura) | Decisao sobre comunicar a condicional da metrica 100% | `{humano}` — aguardando dono do produto (subtarefa 1.4.1), nao decidivel pelo backlog |
+| CHK024 (alvo de performance/latencia) | Definir teto numerico de latencia | `{humano}` — aguardando dono do produto (subtarefa 1.4.1), ausencia documentada como deliberada no plan |

--- a/docs/specs/wave-token-metrics/tasks.md
+++ b/docs/specs/wave-token-metrics/tasks.md
@@ -111,8 +111,8 @@ Ref: contracts/wave-usage-report.md §2/§3
 
 - [x] 4.1.1 Criar `global/skills/agente-00c-runtime/scripts/wave-usage-report.sh` com subcomando `aggregate --state-dir <DIR>` produzindo saida Markdown (default) conforme `contracts/wave-usage-report.md` §2.1, respeitando o invariante de honestidade SC-004 (exibir `spawns_total`/`spawns_with_usage`/`spawns_unavailable` juntos sempre que `spawns_unavailable > 0`)
 - [x] 4.1.2 Implementar saida `--json` (contracts §2.2) com o mesmo agregado em formato maquina-legivel
-- [ ] 4.1.3 Implementar subcomando `backfill` (US4/FR-010/FR-011) conforme contracts §3 — ver detalhamento na FASE 7. **DEFERIDO**: nao implementado nesta FASE 4 (onda-010) — a implementacao real (heuristica de janela temporal + recusa explicita + testes) e o proprio conteudo das tarefas 7.1.1-7.1.5; ate FASE 7 rodar, `backfill` cai no dispatch de "subcomando desconhecido" (exit 2), documentado no cabecalho do script
-- [x] 4.1.4 Escrever `tests/test_wave-usage-report.sh` cobrindo `aggregate` (Markdown + JSON), casos de zero spawns vs "metrica nao coletada" (research Decision 10), e o invariante SC-004 — 17/17 cenarios verdes, Markdown validado byte-a-byte contra o exemplo do contrato
+- [x] 4.1.3 Implementar subcomando `backfill` (US4/FR-010/FR-011) conforme contracts §3 — ver detalhamento na FASE 7. <!-- onda-013: implementado em FASE 7 (7.1.1-7.1.5), ver notas la -->
+- [x] 4.1.4 Escrever `tests/test_wave-usage-report.sh` cobrindo `aggregate` (Markdown + JSON), casos de zero spawns vs "metrica nao coletada" (research Decision 10), e o invariante SC-004 — 17/17 cenarios verdes, Markdown validado byte-a-byte contra o exemplo do contrato <!-- onda-013: arquivo estendido com cobertura de backfill (FASE 7), total 31/31 cenarios verdes -->
 
 ### 4.2 Estender `report.sh` §1/§2 `[M]`
 
@@ -164,11 +164,11 @@ Ref: contracts/wave-usage-report.md §5
 
 Ref: research.md §"Decision 9 — Backfill por janela temporal, com recusa explicita"; contracts/wave-usage-report.md §3
 
-- [ ] 7.1.1 Implementar subcomando `backfill --state-dir <DIR> --transcript <PATH>` que le o transcript JSONL informado e extrai `SpawnUsage` com `source = "backfill"` (nunca `"live"`)
-- [ ] 7.1.2 Implementar a heuristica de janela temporal (delimitando quais spawns do transcript pertencem a qual onda) conforme documentado em research.md Decision 9
-- [ ] 7.1.3 Implementar recusa explicita: quando o transcript nao cobre a janela da onda solicitada (ou esta ausente), o comando **MUST** recusar com mensagem clara em vez de estimar/inventar — nunca produzir `SpawnUsage` sintetico
-- [ ] 7.1.4 Documentar em `quickstart.md` o fluxo de uso do `backfill` (cenarios 9 e 10)
-- [ ] 7.1.5 Estender `tests/test_wave-usage-report.sh` cobrindo: backfill com transcript valido dentro da janela, recusa com transcript ausente/fora da janela, `source = "backfill"` sempre marcado corretamente
+- [x] 7.1.1 Implementar subcomando `backfill --state-dir <DIR> --transcript <PATH>` que le o transcript JSONL informado e extrai `SpawnUsage` com `source = "backfill"` (nunca `"live"`) <!-- onda-013: _wur_cmd_backfill + _wur_backfill_jq_program em wave-usage-report.sh; correlaciona tool_use(name="Agent") <-> tool_result via tool_use_id, mesma derivacao de status/null-vs-0 do hook posttooluse-agent-usage.sh; validado empiricamente contra o transcript real desta sessao (15 spawns extraidos, 1 coberto por onda-007 ja fechada) -->
+- [x] 7.1.2 Implementar a heuristica de janela temporal (delimitando quais spawns do transcript pertencem a qual onda) conforme documentado em research.md Decision 9 <!-- onda-013: started_at<=ts<finished_at via epoch(fromdateiso8601), primeiro match vence; spawns fora de toda janela sao descartados (nao pertencem a esta execucao) -->
+- [x] 7.1.3 Implementar recusa explicita: quando o transcript nao cobre a janela da onda solicitada (ou esta ausente), o comando **MUST** recusar com mensagem clara em vez de estimar/inventar — nunca produzir `SpawnUsage` sintetico <!-- onda-013: exit 3 em dois casos distintos — transcript ausente/ilegivel (checado antes do parse) e transcript lido mas covered_total==0 (nenhum spawn cai em nenhuma janela); mensagem nomeia .execution.id/basename do state-dir; nenhum write ocorre em ambos -->
+- [x] 7.1.4 Documentar em `quickstart.md` o fluxo de uso do `backfill` (cenarios 9 e 10) <!-- onda-013: Cenario 9/10 ja escritos no /plan batiam com o comportamento implementado (--dry-run lista onda+agent_id, dedup por (wave_id,agent_id), exit 3 com mensagem nomeando a execucao) — nenhuma correcao necessaria, conferido linha a linha -->
+- [x] 7.1.5 Estender `tests/test_wave-usage-report.sh` cobrindo: backfill com transcript valido dentro da janela, recusa com transcript ausente/fora da janela, `source = "backfill"` sempre marcado corretamente <!-- onda-013: 15 cenarios novos (uso invalido, ausente/sem-cobertura exit 3, happy-path por janela, indisponivel null-nao-zero, linha corrompida ignorada, idempotencia byte-identica, --dry-run sem side-effect, backup+sha256 apos apply, accumulated_metrics incrementado) — 31/31 verdes no arquivo total -->
 
 ---
 
@@ -229,3 +229,37 @@ flowchart TD
 | Estimativa/heuristica para spawns `indisponivel` | Preencher valor estimado quando o harness nao retorna `usage` | Violaria Principio VI (Zero Fabricacao) — `null` e a unica saida correta, nunca numero inferido |
 | CHK016 (meta 100% vs ~50% cobertura) | Decisao sobre comunicar a condicional da metrica 100% | `{humano}` — aguardando dono do produto (subtarefa 1.4.1), nao decidivel pelo backlog |
 | CHK024 (alvo de performance/latencia) | Definir teto numerico de latencia | `{humano}` — aguardando dono do produto (subtarefa 1.4.1), ausencia documentada como deliberada no plan |
+
+
+## FASE 8 - Convergência
+
+> Fase gerada automaticamente pela skill `converge` (reconciliação
+> spec-vs-código). Cada tarefa abaixo corresponde a um achado (`Gap`)
+> entre o que `spec.md`/`plan.md`/`tasks.md` descreveram e o estado
+> presente do código. Tarefas sem o prefixo `[Revisar]` são acionáveis
+> (`missing`/`partial`/`contradicts`); tarefas com `[Revisar]` são item de
+> revisão (`unrequested`, FR-013) — nunca "implementar", o código já
+> existe. Append-only: esta fase nunca reescreve fases/tarefas anteriores
+> do arquivo (FR-009).
+
+### 8.1 Exit code de `aggregate` diverge entre contrato e implementação `[C]`
+
+Ref: FR-005 / task 4.1.1 · tipo: `contradicts` · severidade: `HIGH`
+
+`contracts/wave-usage-report.md` §2 ("Exit codes") declara que `aggregate`
+retorna `2` quando `state.json` está ausente. A implementação em
+`global/skills/agente-00c-runtime/scripts/wave-usage-report.sh` (função
+`_wur_cmd_aggregate`, e o mesmo padrão replicado em `_wur_cmd_backfill`)
+retorna `1` para esse caso — consistente com o precedente que o próprio
+contrato cita ("espelham `model-routing-report.sh`"): `model-routing-report.sh`
+de fato usa exit `1` para `state.json` ausente (`_mrr_die "aggregate:
+state.json nao encontrado..." 1`), não `2`. `2` em ambos os scripts é
+reservado a uso inválido (flag ausente/desconhecida). O comportamento
+atual é o correto (bate com o precedente e com
+`tests/test_wave-usage-report.sh::scenario_aggregate_state_dir_inexistente_exit_1`)
+— o gap está no texto do contrato, desatualizado desde a FASE 4
+(onda-010), nunca corrigido.
+
+- [x] 8.1.1 Corrigir `docs/specs/wave-token-metrics/contracts/wave-usage-report.md` §2 ("Exit codes"): `state.json` inexistente retorna `1` (erro genérico), não `2`; `2` fica só para uso inválido (flag ausente/desconhecida) — sem tocar em código/testes, que já estão corretos <!-- onda-013: linha corrigida no contrato, alinhada ao codigo/testes ja corretos e ao precedente model-routing-report.sh -->
+
+<!-- converge-key: 5a156716f3bf -->

--- a/docs/specs/wave-token-metrics/tasks.md
+++ b/docs/specs/wave-token-metrics/tasks.md
@@ -37,9 +37,9 @@ Ref: checklists/security.md CHK017 `[Gap]` (gap herdado do padrao pre-existente 
 
 - [x] 1.2.1 Documentar em `data-model.md` §Sidecar a permissao de criacao do arquivo `wave-agent-usage.jsonl`: `0600` (leitura/escrita apenas do dono do processo), criado pelo hook via `umask 077` antes do primeiro append, mesma politica aplicavel retroativamente ao sidecar irmao `tool-call-ticks.log`
 - [x] 1.2.2 Documentar a mesma politica (`0600`) para `~/.claude/cstk/knowledge.db`, aplicada na criacao (`sqlite3 ... "PRAGMA ..."` ja usada em `recall.sh`) — sem alterar permissao de um DB ja existente com permissao mais aberta (evitar quebrar setups locais existentes; apenas `chmod` best-effort se detectado mais aberto que `0600`, log via `log_out`, nunca falha)
-- [ ] 1.2.3 Implementar `umask 077` (ou `chmod 600` pos-criacao) em `posttooluse-agent-usage.sh` antes do primeiro append ao sidecar <!-- depende de 2.1.1 (FASE 2, arquivo ainda nao existe); satisfeita em 2.1.6 -->
+- [x] 1.2.3 Implementar `umask 077` (ou `chmod 600` pos-criacao) em `posttooluse-agent-usage.sh` antes do primeiro append ao sidecar <!-- satisfeita em 2.1.6: umask 077 no subshell do append + chmod 600 best-effort apos, defesa em profundidade -->
 - [x] 1.2.4 Implementar checagem best-effort de permissao do `knowledge.db` em `cli/lib/recall.sh` (na abertura de conexao/migracao), com `chmod 600` corretivo se o arquivo estiver mais aberto — nunca bloqueia, apenas normaliza e loga
-- [ ] 1.2.5 Escrever teste em `tests/test_posttooluse-agent-usage.sh` verificando que o sidecar criado tem permissao `0600` (via `stat` portavel POSIX/macOS+Linux) <!-- depende de 2.1.1 (FASE 2, arquivo ainda nao existe); satisfeita em 2.1.9 -->
+- [x] 1.2.5 Escrever teste em `tests/test_posttooluse-agent-usage.sh` verificando que o sidecar criado tem permissao `0600` (via `stat` portavel POSIX/macOS+Linux) <!-- satisfeita em 2.1.9: scenario_sidecar_criado_com_permissao_0600 -->
 - [x] 1.2.6 Escrever teste em `tests/cstk/test_recall.sh` verificando que o `knowledge.db` criado do zero tem permissao `0600`
 
 ### 1.3 Definir teto de linhas/spawns do sidecar antes do reset `[A]`
@@ -47,9 +47,9 @@ Ref: checklists/security.md CHK017 `[Gap]` (gap herdado do padrao pre-existente 
 Ref: checklists/security.md CHK020 `[Gap]` (achado do gate `owasp-security`, dec-035, severidade INFO/LOW — nao bloqueia, mas fica registrado para create-tasks avaliar um contador leve)
 
 - [x] 1.3.1 Definir e documentar em `research.md` §Decision 5 o teto: **500 linhas** por onda no sidecar `wave-agent-usage.jsonl` (ordem de grandeza generosa acima do "poucos spawns por onda" do plan §Scale/Scope; numero magico deliberado, revisitavel se a experiencia real mostrar insuficiencia)
-- [ ] 1.3.2 Implementar contador leve (`wc -l` best-effort) em `posttooluse-agent-usage.sh` ANTES de cada append: se a contagem atual já estiver `>= 500`, pular o append desta linha (fail-open, sem bloquear a tool call) e emitir `log_out` de aviso uma unica vez por onda (guard via arquivo-sentinela `<state-dir>/.wave-agent-usage-cap-warned` criado/removido no mesmo ciclo start/end do sidecar) <!-- depende de 2.1.1 (FASE 2, arquivo ainda nao existe); satisfeita em 2.1.6 -->
+- [x] 1.3.2 Implementar contador leve (`wc -l` best-effort) em `posttooluse-agent-usage.sh` ANTES de cada append: se a contagem atual já estiver `>= 500`, pular o append desta linha (fail-open, sem bloquear a tool call) e emitir aviso uma unica vez por onda (guard via arquivo-sentinela `<state-dir>/.wave-agent-usage-cap-warned` criado aqui; remocao no ciclo start/end fica para a FASE 3) <!-- satisfeita em 2.1.6; DESVIO do texto original: aviso vai para stderr (printf direto), NAO `log_out` (stdout) — contracts/hook-posttooluse-agent-usage.md §3 e MUST literal "NAO escrever em stdout" para este hook (fail-open puro, stdout SEMPRE vazio, mesma politica de posttooluse-tool-call-tick.sh); log_out haveria contradito essa regra dura do proprio contrato -->
 - [x] 1.3.3 Documentar em `data-model.md` §Sidecar o comportamento ao atingir o teto: spawns além do teto ficam fora do agregado da onda (undercounting silencioso conhecido, análogo à tolerância já documentada para a fronteira start/end); o `state-ondas.sh end` reporta `spawns_total` apenas dos observados, nunca fabrica o excedente
-- [ ] 1.3.4 Escrever teste em `tests/test_posttooluse-agent-usage.sh` cobrindo: sidecar com 500 linhas pre-existentes -> hook nao adiciona linha 501 e nao falha (exit 0) <!-- depende de 2.1.1 (FASE 2, arquivo ainda nao existe); satisfeita em 2.1.9 -->
+- [x] 1.3.4 Escrever teste em `tests/test_posttooluse-agent-usage.sh` cobrindo: sidecar com 500 linhas pre-existentes -> hook nao adiciona linha 501 e nao falha (exit 0) <!-- satisfeita em 2.1.9: scenario_cap_500_linhas_nao_adiciona_501 + scenario_cap_sentinela_evita_aviso_duplicado -->
 
 ### 1.4 Registrar decisoes pendentes do dono do produto (nao decidir) `[M]`
 
@@ -66,24 +66,24 @@ Ref: checklists/requirements.md CHK016, CHK024 (`{humano}`)
 
 Ref: plan.md §Project Structure ("CRIAR"); contracts/hook-posttooluse-agent-usage.md
 
-- [ ] 2.1.1 Criar `global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh`, espelhando a estrutura de `posttooluse-tool-call-tick.sh`: le JSON do stdin, extrai `tool_name`, sai `exit 0` silencioso se `tool_name != "Agent"`
-- [ ] 2.1.2 Implementar deteccao de execucao 00c ativa (REUSO da logica ja existente em `pretooluse-bash-guard.sh` §4 — precedencia `agente-00c` > `feature-00c` por short-name lexicografico); `exit 0` sem interferencia se nenhuma execucao ativa
-- [ ] 2.1.3 Extrair campos do `tool_response` (`agentId`, `status`, `resolvedModel`, `modelsUsed`, `totalTokens`, `usage.*`, `totalToolUseCount`, `totalDurationMs`) e do `tool_input` (`subagent_type`) via `jq` com `// null` em todo acesso (Principio VI — nao inventar campo ausente)
-- [ ] 2.1.4 Derivar `status` (`completo`/`parcial`/`indisponivel`) conforme a state machine de `data-model.md` §State transitions; `indisponivel` **MUST** zerar (== `null`, nunca `0`) todos os campos numericos de uso
-- [ ] 2.1.5 Montar a linha JSON compacta (`jq -c`) do sidecar conforme `contracts/hook-posttooluse-agent-usage.md` §2, garantindo ausencia de `content`/`prompt`/`description` e tamanho < PIPE_BUF
-- [ ] 2.1.6 Aplicar `umask 077` antes do primeiro append (ref: subtarefa 1.2.3) e o cap de 500 linhas (ref: subtarefa 1.3.2) antes de gravar
-- [ ] 2.1.7 Fazer append atomico (`>>`) em `<state-dir>/wave-agent-usage.jsonl`; `source = "live"`, `observed_at` via `date -u +%Y-%m-%dT%H:%M:%SZ`
-- [ ] 2.1.8 Garantir politica fail-open absoluta: sem `set -e`; qualquer falha (jq ausente, stdin invalido, append negado) => `exit 0` silencioso, nunca stderr, nunca bloqueio da tool call
-- [ ] 2.1.9 Escrever `tests/test_posttooluse-agent-usage.sh` cobrindo: matcher `Agent` vs outros tools, execucao ativa vs inativa, `status` completo/parcial/indisponivel, ausencia de `content`/`prompt` na linha gravada, fail-open em jq ausente/stdin invalido, permissao `0600` (subtarefa 1.2.5), cap de 500 linhas (subtarefa 1.3.4)
+- [x] 2.1.1 Criar `global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh`, espelhando a estrutura de `posttooluse-tool-call-tick.sh`: le JSON do stdin, extrai `tool_name`, sai `exit 0` silencioso se `tool_name != "Agent"`
+- [x] 2.1.2 Implementar deteccao de execucao 00c ativa (REUSO da logica ja existente em `pretooluse-bash-guard.sh` §4 — precedencia `agente-00c` > `feature-00c` por short-name lexicografico); `exit 0` sem interferencia se nenhuma execucao ativa
+- [x] 2.1.3 Extrair campos do `tool_response` (`agentId`, `status`, `resolvedModel`, `modelsUsed`, `totalTokens`, `usage.*`, `totalToolUseCount`, `totalDurationMs`) e do `tool_input` (`subagent_type`) via `jq` com `// null` em todo acesso (Principio VI — nao inventar campo ausente)
+- [x] 2.1.4 Derivar `status` (`completo`/`parcial`/`indisponivel`) conforme a state machine de `data-model.md` §State transitions; `indisponivel` **MUST** zerar (== `null`, nunca `0`) todos os campos numericos de uso
+- [x] 2.1.5 Montar a linha JSON compacta (`jq -c`) do sidecar conforme `contracts/hook-posttooluse-agent-usage.md` §2, garantindo ausencia de `content`/`prompt`/`description` e tamanho < PIPE_BUF
+- [x] 2.1.6 Aplicar `umask 077` antes do primeiro append (ref: subtarefa 1.2.3) e o cap de 500 linhas (ref: subtarefa 1.3.2) antes de gravar
+- [x] 2.1.7 Fazer append atomico (`>>`) em `<state-dir>/wave-agent-usage.jsonl`; `source = "live"`, `observed_at` via `date -u +%Y-%m-%dT%H:%M:%SZ`
+- [x] 2.1.8 Garantir politica fail-open absoluta: sem `set -e`; qualquer falha (jq ausente, stdin invalido, append negado) => `exit 0` silencioso, nunca bloqueio da tool call <!-- "nunca stderr" vale para os caminhos de FALHA (verificado empiricamente: jq ausente e stdin invalido emitem stderr vazio); o UNICO stderr do hook e o aviso de cap deliberado (nota 1.3.2), rate-limited a 1x/onda via sentinela, exigido pelo proprio backlog -->
+- [x] 2.1.9 Escrever `tests/test_posttooluse-agent-usage.sh` cobrindo: matcher `Agent` vs outros tools, execucao ativa vs inativa, `status` completo/parcial/indisponivel, ausencia de `content`/`prompt` na linha gravada, fail-open em jq ausente/stdin invalido, permissao `0600` (subtarefa 1.2.5), cap de 500 linhas (subtarefa 1.3.4) <!-- 18 scenarios, todos verdes via ./tests/run.sh -->
 
 ### 2.2 Provisionar o hook novo `[A]`
 
 Ref: plan.md §Project Structure ("MODIFICAR" settings.snippet.json)
 
-- [ ] 2.2.1 Adicionar entrada `PostToolUse` matcher `Agent` -> `posttooluse-agent-usage.sh` em `global/skills/agente-00c-runtime/hooks/settings.snippet.json`
-- [ ] 2.2.2 Confirmar em `cli/lib/hooks.sh::apply_guard_hooks()` que o hook novo e copiado no provisionamento de projeto (mesmo mecanismo do hook de ticks); ajustar se necessario
-- [ ] 2.2.3 Adicionar isencao existence-guarded do hook novo em `tests/run.sh::_is_internal_test` (precedente literal: linhas 298-303, hooks vivem fora de `scripts/` e por isso quebram a regra 1:1 do `--check-coverage`)
-- [ ] 2.2.4 Estender `tests/cstk/test_hooks.sh` cobrindo o provisionamento do hook novo (arquivo copiado + entrada no settings.snippet.json aplicada)
+- [x] 2.2.1 Adicionar entrada `PostToolUse` matcher `Agent` -> `posttooluse-agent-usage.sh` em `global/skills/agente-00c-runtime/hooks/settings.snippet.json`
+- [x] 2.2.2 Confirmar em `cli/lib/hooks.sh::apply_guard_hooks()` que o hook novo e copiado no provisionamento de projeto (mesmo mecanismo do hook de ticks); ajustar se necessario
+- [x] 2.2.3 Adicionar isencao existence-guarded do hook novo em `tests/run.sh::_is_internal_test` (precedente literal: linhas 298-303, hooks vivem fora de `scripts/` e por isso quebram a regra 1:1 do `--check-coverage`)
+- [x] 2.2.4 Estender `tests/cstk/test_hooks.sh` cobrindo o provisionamento do hook novo (arquivo copiado + entrada no settings.snippet.json aplicada) <!-- scenario_apply_guard_hooks_copia_posttooluse_agent_usage + ghost-check em scenario_apply_guard_hooks_catalogo_antigo_sem_tick -->
 
 ---
 

--- a/docs/specs/wave-token-metrics/tasks.md
+++ b/docs/specs/wave-token-metrics/tasks.md
@@ -93,13 +93,13 @@ Ref: plan.md §Project Structure ("MODIFICAR" settings.snippet.json)
 
 Ref: data-model.md §"Extensoes ao state.json"; contracts/wave-usage-report.md §4
 
-- [ ] 3.1.1 Em `state-ondas.sh start`, garantir reset do sidecar `wave-agent-usage.jsonl` (espelhando `_so_ticks_reset`) e remocao do sentinela de cap-warned (subtarefa 1.3.2)
-- [ ] 3.1.2 Em `state-ondas.sh end`, ler o sidecar da onda corrente e agregar em `WaveUsage`: `spawns_total`, `spawns_with_usage`, `spawns_unavailable`, somas de `total_tokens`/`input_tokens`/`output_tokens`/`cache_read_input_tokens`/`cache_creation_input_tokens`/`tool_use_count`/`duration_ms` (soma **apenas** sobre spawns com dado; `null` quando `spawns_with_usage == 0` — nunca `0` fabricado)
-- [ ] 3.1.3 Gravar o agregado em `.waves[N].agent_usage` e o array bruto de `SpawnUsage` em `.waves[N].agent_spawns[]`
-- [ ] 3.1.4 Incrementar `.accumulated_metrics.agent_spawns_total`, `.agent_spawns_with_usage_total`, `.agent_tokens_total`, `.agent_tool_use_count_total`, `.agent_duration_ms_total` no mesmo `jq` do `end` (padrao `(.campo // 0) + incremento` para retro-compatibilidade)
-- [ ] 3.1.5 Resetar o sidecar apos a agregacao (mesmo ciclo de vida do sidecar de ticks: reset em `start` e em `end`)
-- [ ] 3.1.6 Garantir retro-compatibilidade: onda sem sidecar (feature anterior a esta) produz `agent_usage: null`, `agent_spawns: []`, sem erro
-- [ ] 3.1.7 Estender `tests/test_state-ondas.sh` cobrindo: agregacao com spawns completos/parciais/indisponiveis misturados, onda sem sidecar (retro-compat), reset do sidecar em start/end, incremento correto de `.accumulated_metrics`
+- [x] 3.1.1 Em `state-ondas.sh start`, garantir reset do sidecar `wave-agent-usage.jsonl` (espelhando `_so_ticks_reset`) e remocao do sentinela de cap-warned (subtarefa 1.3.2)
+- [x] 3.1.2 Em `state-ondas.sh end`, ler o sidecar da onda corrente e agregar em `WaveUsage`: `spawns_total`, `spawns_with_usage`, `spawns_unavailable`, somas de `total_tokens`/`input_tokens`/`output_tokens`/`cache_read_input_tokens`/`cache_creation_input_tokens`/`tool_use_count`/`duration_ms` (soma **apenas** sobre spawns com dado; `null` quando `spawns_with_usage == 0` — nunca `0` fabricado)
+- [x] 3.1.3 Gravar o agregado em `.waves[N].agent_usage` e o array bruto de `SpawnUsage` em `.waves[N].agent_spawns[]`
+- [x] 3.1.4 Incrementar `.accumulated_metrics.agent_spawns_total`, `.agent_spawns_with_usage_total`, `.agent_tokens_total`, `.agent_tool_use_count_total`, `.agent_duration_ms_total` no mesmo `jq` do `end` (padrao `(.campo // 0) + incremento` para retro-compatibilidade) <!-- campos nullable (agent_tokens_total/agent_tool_use_count_total/agent_duration_ms_total) usam helper add_null (delta null preserva o acumulado existente) em vez do padrao `// 0` simples, para nao fabricar 0 quando a onda nao contribui dado -->
+- [x] 3.1.5 Resetar o sidecar apos a agregacao (mesmo ciclo de vida do sidecar de ticks: reset em `start` e em `end`)
+- [x] 3.1.6 Garantir retro-compatibilidade: onda sem sidecar (feature anterior a esta) produz `agent_usage: null`, `agent_spawns: []`, sem erro
+- [x] 3.1.7 Estender `tests/test_state-ondas.sh` cobrindo: agregacao com spawns completos/parciais/indisponiveis misturados, onda sem sidecar (retro-compat), reset do sidecar em start/end, incremento correto de `.accumulated_metrics` <!-- 9 scenarios novos (70 total no arquivo, todos verdes); inclui cenario extra de linhas corrompidas no sidecar (resiliencia via `jq -R -n '[inputs | fromjson?]'`) e cenario de nao-fabricacao de 0 quando todos os spawns sao indisponivel -->
 
 ---
 

--- a/docs/specs/wave-token-metrics/tasks.md
+++ b/docs/specs/wave-token-metrics/tasks.md
@@ -109,10 +109,10 @@ Ref: data-model.md §"Extensoes ao state.json"; contracts/wave-usage-report.md �
 
 Ref: contracts/wave-usage-report.md §2/§3
 
-- [ ] 4.1.1 Criar `global/skills/agente-00c-runtime/scripts/wave-usage-report.sh` com subcomando `aggregate --state-dir <DIR>` produzindo saida Markdown (default) conforme `contracts/wave-usage-report.md` §2.1, respeitando o invariante de honestidade SC-004 (exibir `spawns_total`/`spawns_with_usage`/`spawns_unavailable` juntos sempre que `spawns_unavailable > 0`)
-- [ ] 4.1.2 Implementar saida `--json` (contracts §2.2) com o mesmo agregado em formato maquina-legivel
-- [ ] 4.1.3 Implementar subcomando `backfill` (US4/FR-010/FR-011) conforme contracts §3 — ver detalhamento na FASE 7
-- [ ] 4.1.4 Escrever `tests/test_wave-usage-report.sh` cobrindo `aggregate` (Markdown + JSON), casos de zero spawns vs "metrica nao coletada" (research Decision 10), e o invariante SC-004
+- [x] 4.1.1 Criar `global/skills/agente-00c-runtime/scripts/wave-usage-report.sh` com subcomando `aggregate --state-dir <DIR>` produzindo saida Markdown (default) conforme `contracts/wave-usage-report.md` §2.1, respeitando o invariante de honestidade SC-004 (exibir `spawns_total`/`spawns_with_usage`/`spawns_unavailable` juntos sempre que `spawns_unavailable > 0`)
+- [x] 4.1.2 Implementar saida `--json` (contracts §2.2) com o mesmo agregado em formato maquina-legivel
+- [ ] 4.1.3 Implementar subcomando `backfill` (US4/FR-010/FR-011) conforme contracts §3 — ver detalhamento na FASE 7. **DEFERIDO**: nao implementado nesta FASE 4 (onda-010) — a implementacao real (heuristica de janela temporal + recusa explicita + testes) e o proprio conteudo das tarefas 7.1.1-7.1.5; ate FASE 7 rodar, `backfill` cai no dispatch de "subcomando desconhecido" (exit 2), documentado no cabecalho do script
+- [x] 4.1.4 Escrever `tests/test_wave-usage-report.sh` cobrindo `aggregate` (Markdown + JSON), casos de zero spawns vs "metrica nao coletada" (research Decision 10), e o invariante SC-004 — 17/17 cenarios verdes, Markdown validado byte-a-byte contra o exemplo do contrato
 
 ### 4.2 Estender `report.sh` §1/§2 `[M]`
 

--- a/docs/specs/wave-token-metrics/tasks.md
+++ b/docs/specs/wave-token-metrics/tasks.md
@@ -118,9 +118,9 @@ Ref: contracts/wave-usage-report.md §2/§3
 
 Ref: contracts/wave-usage-report.md §6
 
-- [ ] 4.2.1 Adicionar secao de consumo de tokens/tool-uses/duracao ao relatorio gerado por `report.sh` (secoes 1 e 2), consumindo `wave-usage-report.sh aggregate --json` como fonte
-- [ ] 4.2.2 Garantir que o relatorio distingue "0 spawns" (nenhum subagente spawnado) de "metrica nao coletada" (hook nao provisionado) — nunca reportar 0 quando o dado real e ausencia de coleta
-- [ ] 4.2.3 Estender `tests/test_report.sh` (ou criar se inexistente) cobrindo as novas secoes do relatorio, incluindo o caso "metrica nao coletada"
+- [x] 4.2.1 Adicionar secao de consumo de tokens/tool-uses/duracao ao relatorio gerado por `report.sh` (secoes 1 e 2), consumindo `wave-usage-report.sh aggregate --json` como fonte
+- [x] 4.2.2 Garantir que o relatorio distingue "0 spawns" (nenhum subagente spawnado) de "metrica nao coletada" (hook nao provisionado) — nunca reportar 0 quando o dado real e ausencia de coleta
+- [x] 4.2.3 Estender `tests/test_report.sh` (ou criar se inexistente) cobrindo as novas secoes do relatorio, incluindo o caso "metrica nao coletada" <!-- onda-012: report.sh delega a wave-usage-report.sh aggregate --json (script irmao, best-effort); secoes 1/2 ganham Spawns/Tokens/Cobertura + colunas Spawns/Tokens por onda; fallback JSON com null (nunca 0) quando o helper esta ausente; 25/25 cenarios verdes em test_report.sh (3 novos: coletado, nao-coletado, helper ausente) -->
 
 ---
 
@@ -152,9 +152,9 @@ Ref: contracts/wave-usage-report.md §7
 
 Ref: contracts/wave-usage-report.md §5
 
-- [ ] 6.1.1 Adicionar em `global/skills/review-task/SKILL.md` §4.5 a invocacao de `wave-usage-report.sh aggregate --json` cruzada com `model-routing-report.sh aggregate` (mesma fonte de `.decisions[]`, sem tocar `.waves` — preserva o invariante que aquele script publica)
-- [ ] 6.1.2 Documentar no SKILL.md a leitura conjunta: para cada onda, exibir modelo aplicado (model-routing) lado a lado com consumo de tokens/tool-uses/duracao observado (wave-usage), destacando divergencias sugerido-vs-aplicado que tiveram alto consumo
-- [ ] 6.1.3 Escrever cenario de teste (fixture de state.json com `.waves[].agent_usage` + `.decisions[]` de model-routing) validando a secao cruzada, ou estender o test existente do `review-task` se houver harness automatizado para o SKILL.md
+- [x] 6.1.1 Adicionar em `global/skills/review-task/SKILL.md` §4.5 a invocacao de `wave-usage-report.sh aggregate --json` cruzada com `model-routing-report.sh aggregate` (mesma fonte de `.decisions[]`, sem tocar `.waves` — preserva o invariante que aquele script publica)
+- [x] 6.1.2 Documentar no SKILL.md a leitura conjunta: para cada onda, exibir modelo aplicado (model-routing) lado a lado com consumo de tokens/tool-uses/duracao observado (wave-usage), destacando divergencias sugerido-vs-aplicado que tiveram alto consumo
+- [x] 6.1.3 Escrever cenario de teste (fixture de state.json com `.waves[].agent_usage` + `.decisions[]` de model-routing) validando a secao cruzada, ou estender o test existente do `review-task` se houver harness automatizado para o SKILL.md <!-- onda-012: review-task/SKILL.md nao tem harness automatizado proprio (skill prose-driven); seguiu o padrao "sanity" ja usado por test_model-routing-report.sh — 2 cenarios novos em test_wave-usage-report.sh (referencia da subsecao no SKILL.md + composicao real dos dois scripts sobre o mesmo state.json, provando read-only preservado e join correto); 19/19 verdes. Subsecao "Cruzamento com consumo de tokens observado" adicionada em SKILL.md §4.5 (join via jq entre linhas_onda[] de model-routing-report.sh --json e por_onda[] de wave-usage-report.sh --json, chave onda; nenhum dos dois scripts alterado, preservando ambos os invariantes publicados); template de relatorio + Gotcha "Agregado model-routing nao deve ser reformatado" atualizados com a excecao explicita (subsecao derivada, nao verbatim) -->
 
 ---
 

--- a/global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh
+++ b/global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh
@@ -1,0 +1,189 @@
+#!/bin/sh
+# posttooluse-agent-usage.sh — hook PostToolUse (matcher "Agent"): captura
+# metrica de uso de tokens/tool-uses/duracao de cada spawn de subagente
+# durante execucoes ativas agente-00c/feature-00c.
+#
+# Gap que fecha: hoje nenhum mecanismo automatico registra quanto cada
+# spawn (Skill(execute-task)/Agent) custou em tokens — a unica proxy de
+# custo existente e `tool_calls` (posttooluse-tool-call-tick.sh), que nao
+# distingue spawns caros de baratos. Este hook fecha esse gap com dado real
+# do proprio harness (tool_response de PostToolUse/Agent), nunca estimado.
+#
+# POLITICA: mesma familia de posttooluse-tool-call-tick.sh — isto e
+# METRICA, nao guarda. Fail-OPEN absoluto: qualquer falha (jq ausente,
+# stdin invalido/vazio, state ilegivel, append negado) = exit 0 silencioso,
+# stdout SEMPRE vazio. Este hook NUNCA bloqueia, atrasa ou interfere numa
+# tool call. Por isso NAO usa `set -e` — cada passo trata a propria falha
+# com no-op (contracts/hook-posttooluse-agent-usage.md §3).
+#
+# REGRA DURA — NAO tocar o state.json: mesma justificativa de
+# posttooluse-tool-call-tick.sh:28-37 (PostToolUse dispara CONCORRENTE as
+# tool calls do orquestrador; um read-modify-write aqui poderia clobberar
+# um write transacional gravado entre o read e o `mv`). O dado vai num
+# SIDECAR append-only:
+#
+#   <state-dir>/wave-agent-usage.jsonl  — 1 linha JSON (SpawnUsage) por spawn
+#
+# Append com O_APPEND e atomico para linhas curtas (< PIPE_BUF) — por isso
+# a linha NUNCA inclui `content`/`prompt`/`description` (texto livre,
+# tambem proibido por vazamento de segredo). Agregacao acontece em
+# `state-ondas.sh end` (FASE 3); `start`/`end` resetam o sidecar (janela de
+# contagem = start->end, mesmo ciclo do sidecar de ticks).
+#
+# Deteccao de execucao ativa: mesmo algoritmo e precedencia de
+# pretooluse-bash-guard.sh / posttooluse-tool-call-tick.sh (agente-00c
+# vence; entre feature-00c, menor short-name lexicografico byte-wise;
+# status em_andamento|aguardando_humano). Fora de execucao ativa: exit 0,
+# zero interferencia na sessao manual.
+#
+# Permissao do sidecar (CHK017, data-model.md §Sidecar): `umask 077` MUST
+# ser aplicado antes do primeiro append de cada arquivo (a criacao so
+# acontece no primeiro append; umask nao afeta arquivo ja existente). Um
+# `chmod 600` best-effort apos cada append reforca a politica mesmo se o
+# arquivo ja existia com permissao mais aberta (defesa em profundidade,
+# nao falha nunca).
+#
+# Teto de linhas (CHK020, data-model.md §Teto de linhas): 500 linhas por
+# onda (research.md Decision 5, numero magico deliberado). Ao atingir o
+# teto, o append desta linha e pulado (fail-open, spawn nunca bloqueado) e
+# um aviso e emitido em stderr **uma unica vez por onda**, guardado pelo
+# arquivo-sentinela `<state-dir>/.wave-agent-usage-cap-warned` (criado
+# aqui; removido no ciclo start/end de `state-ondas.sh`, FASE 3). Contrato
+# §3 diz "MUST NOT escrever em stdout" — o aviso vai para stderr, nunca
+# stdout (stdout permanece SEMPRE vazio, igual ao hook irmao).
+#
+# jq: mesma dependencia OPCIONAL confinada dos demais hooks (Constitution
+# 1.1.0 Principio II carve-out). Sem jq nao ha parsing seguro do stdin ->
+# no-op (fail-open).
+
+set -u
+
+_PAU_CAP_LINES=500
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+_PAU_INPUT=$(cat 2>/dev/null) || exit 0
+[ -n "$_PAU_INPUT" ] || exit 0
+
+_PAU_CWD=$(printf '%s' "$_PAU_INPUT" | jq -r '.cwd // ""' 2>/dev/null) || exit 0
+_PAU_TOOL_NAME=$(printf '%s' "$_PAU_INPUT" | jq -r '.tool_name // ""' 2>/dev/null) || exit 0
+
+[ -n "$_PAU_CWD" ] || exit 0
+# Guarda defensiva mesmo com matcher "Agent" no settings.snippet.json
+# (contracts/hook-posttooluse-agent-usage.md §1.2).
+[ "$_PAU_TOOL_NAME" = "Agent" ] || exit 0
+
+_pau_is_active_status() {
+  case "$1" in
+    em_andamento | aguardando_humano) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Deteccao de execucao ativa (precedencia identica ao pretooluse-bash-guard.sh
+# e ao posttooluse-tool-call-tick.sh — contrato §4, REUSO nao reimplementacao).
+_PAU_STATE_DIR=""
+
+_pau_agente_state="$_PAU_CWD/.claude/agente-00c-state/state.json"
+if [ -f "$_pau_agente_state" ]; then
+  _pau_status=$(jq -r '.execution.status // ""' "$_pau_agente_state" 2>/dev/null) || _pau_status=""
+  if _pau_is_active_status "$_pau_status"; then
+    _PAU_STATE_DIR="$_PAU_CWD/.claude/agente-00c-state"
+  fi
+fi
+
+if [ -z "$_PAU_STATE_DIR" ]; then
+  _pau_feat_root="$_PAU_CWD/.claude/feature-00c-state"
+  if [ -d "$_pau_feat_root" ]; then
+    _pau_active_shorts=""
+    for _pau_d in "$_pau_feat_root"/*/; do
+      [ -d "$_pau_d" ] || continue
+      [ -f "${_pau_d}state.json" ] || continue
+      _pau_status=$(jq -r '.execution.status // ""' "${_pau_d}state.json" 2>/dev/null) || continue
+      _pau_is_active_status "$_pau_status" || continue
+      _pau_active_shorts="${_pau_active_shorts}$(basename "$_pau_d")
+"
+    done
+    if [ -n "$_pau_active_shorts" ]; then
+      # Ordem lexicografica byte-wise (C locale), deterministica — mesma
+      # regra do guard e do hook de ticks.
+      _pau_first=$(printf '%s' "$_pau_active_shorts" | LC_ALL=C sort | sed -n '1p')
+      _PAU_STATE_DIR="$_pau_feat_root/$_pau_first"
+    fi
+  fi
+fi
+
+# Fora de escopo: nenhuma execucao ativa -> zero interferencia.
+[ -n "$_PAU_STATE_DIR" ] || exit 0
+
+_PAU_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || _PAU_TS="unknown"
+
+# Monta a linha SpawnUsage inteira num unico jq (contracts/
+# hook-posttooluse-agent-usage.md §2). `empty` quando nao ha `agentId`
+# (tool_response ausente/malformado sem chave minima) -> sem linha
+# (contrato §3: "exit 0 se nem agentId houver"). `status=indisponivel`
+# MUST zerar (== null) todos os campos numericos, nunca 0 (FR-009).
+_PAU_LINE=$(
+  printf '%s' "$_PAU_INPUT" | jq -c --arg ts "$_PAU_TS" '
+    (.tool_response // null) as $tr |
+    (.tool_input // null) as $ti |
+    (if $tr == null then null else ($tr.agentId // null) end) as $agent_id |
+    if $agent_id == null then empty else
+      (($tr.status // "")) as $status_raw |
+      (if $status_raw == "completed" and ($tr.totalTokens != null) then "completo"
+       elif $status_raw == "completed" then "parcial"
+       else "indisponivel" end) as $derived |
+      {
+        agent_id: $agent_id,
+        agent_type: (if $ti == null then null else ($ti.subagent_type // null) end),
+        status: $derived,
+        model: ($tr.resolvedModel // "nao-aplicavel"),
+        models_used: ($tr.modelsUsed // null),
+        total_tokens: (if $derived == "indisponivel" then null else ($tr.totalTokens // null) end),
+        input_tokens: (if $derived == "indisponivel" then null else ($tr.usage.input_tokens // null) end),
+        output_tokens: (if $derived == "indisponivel" then null else ($tr.usage.output_tokens // null) end),
+        cache_read_input_tokens: (if $derived == "indisponivel" then null else ($tr.usage.cache_read_input_tokens // null) end),
+        cache_creation_input_tokens: (if $derived == "indisponivel" then null else ($tr.usage.cache_creation_input_tokens // null) end),
+        tool_use_count: (if $derived == "indisponivel" then null else ($tr.totalToolUseCount // null) end),
+        duration_ms: (if $derived == "indisponivel" then null else ($tr.totalDurationMs // null) end),
+        source: "live",
+        observed_at: $ts
+      }
+    end
+  ' 2>/dev/null
+) || _PAU_LINE=""
+
+[ -n "$_PAU_LINE" ] || exit 0
+
+_PAU_SIDECAR="$_PAU_STATE_DIR/wave-agent-usage.jsonl"
+_PAU_CAP_SENTINEL="$_PAU_STATE_DIR/.wave-agent-usage-cap-warned"
+
+_pau_line_count() {
+  [ -f "$1" ] || { printf '0'; return 0; }
+  wc -l < "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
+_pau_current_count=$(_pau_line_count "$_PAU_SIDECAR")
+case "$_pau_current_count" in
+  '' | *[!0-9]*) _pau_current_count=0 ;;
+esac
+
+if [ "$_pau_current_count" -ge "$_PAU_CAP_LINES" ]; then
+  if [ ! -f "$_PAU_CAP_SENTINEL" ]; then
+    : > "$_PAU_CAP_SENTINEL" 2>/dev/null || :
+    printf 'posttooluse-agent-usage: cap de %s linhas atingido em %s; spawns adicionais desta onda ficam fora do agregado (undercounting silencioso documentado)\n' \
+      "$_PAU_CAP_LINES" "$_PAU_SIDECAR" >&2
+  fi
+  exit 0
+fi
+
+# umask 077 antes do primeiro append -> arquivo criado com 0600 (CHK017).
+# So afeta CRIACAO; se o sidecar ja existia mais aberto, o chmod abaixo
+# corrige best-effort apos o append.
+(
+  umask 077
+  printf '%s\n' "$_PAU_LINE" >> "$_PAU_SIDECAR" 2>/dev/null
+) || :
+chmod 600 -- "$_PAU_SIDECAR" 2>/dev/null || :
+
+exit 0

--- a/global/skills/agente-00c-runtime/hooks/settings.snippet.json
+++ b/global/skills/agente-00c-runtime/hooks/settings.snippet.json
@@ -22,6 +22,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/posttooluse-agent-usage.sh",
+            "timeout": 5
+          }
+        ]
       }
     ]
   }

--- a/global/skills/agente-00c-runtime/scripts/report.sh
+++ b/global/skills/agente-00c-runtime/scripts/report.sh
@@ -4,6 +4,14 @@
 # Ref: docs/specs/agente-00c/contracts/report-format.md
 #      docs/specs/agente-00c/spec.md FR-011, SC-001
 #      docs/specs/agente-00c/tasks.md FASE 8.1 + 8.2
+#      docs/specs/wave-token-metrics/contracts/wave-usage-report.md §6
+#        (secoes 1/2 estendidas com consumo de subagente — FASE 4.2)
+#
+# Secoes 1 e 2 consomem `wave-usage-report.sh aggregate --json` (script
+# irmao no mesmo diretorio) para exibir spawns/tokens observados por
+# execucao e por onda. Best-effort: helper ausente/falhando NUNCA aborta
+# o relatorio — degrada para "nao coletado nesta execucao"/"indisponivel"
+# (ver _rp_wave_usage_json), nunca fabricando `0` (Principio VI).
 #
 # Subcomandos:
 #   report.sh generate --state-dir DIR [--final] [--paragrafo-resumo TEXT]
@@ -54,6 +62,28 @@ _rp_require_jq() {
 _rp_iso_now() { date -u +%FT%TZ; }
 _rp_state_file() { printf '%s/state.json\n' "$1"; }
 
+# _rp_wave_usage_json STATE_DIR — agregado read-only de consumo de
+# tokens/tool-uses/duracao de subagente (FASE 4.2 de wave-token-metrics,
+# contracts/wave-usage-report.md §6). Delega ao helper irmao
+# wave-usage-report.sh (le .waves[].agent_usage; nunca reimplementa a
+# agregacao aqui). Best-effort: helper ausente/nao-executavel ou
+# `aggregate` falhando NUNCA aborta o relatorio — produz um JSON neutro
+# com metric_collected=false e campos numericos `null` (nunca `0`
+# fabricado — Principio VI/FR-009). Este fallback e distinto do "0 spawns
+# reais" que o proprio wave-usage-report.sh ja retorna corretamente
+# (spawns_total=0 e uma contagem literal) quando roda com sucesso mas nao
+# encontra nenhum agent_usage no state.json.
+_rp_wave_usage_json() {
+  _wu_script="$(dirname -- "$0")/wave-usage-report.sh"
+  if [ -x "$_wu_script" ]; then
+    if _wu_out=$("$_wu_script" aggregate --state-dir "$1" --json 2>/dev/null); then
+      printf '%s' "$_wu_out"
+      return 0
+    fi
+  fi
+  printf '%s' '{"metric_collected":false,"spawns_total":null,"spawns_with_usage":null,"spawns_unavailable":null,"total_tokens":null,"coverage_pct":null,"por_onda":[]}'
+}
+
 # _rp_render_header STATE_FILE GERADO_EM
 # READER de state.json: paths EN + fallback (.en // .pt) (schema-en-migration).
 _rp_render_header() {
@@ -70,11 +100,22 @@ _rp_render_header() {
   ' "$1"
 }
 
-# _rp_render_secao_1 STATE_FILE PARAGRAFO
+# _rp_render_secao_1 STATE_FILE PARAGRAFO WAVE_USAGE_JSON
 _rp_render_secao_1() {
   _para=$2
   [ -n "$_para" ] || _para="(Paragrafo de resumo nao fornecido — orquestrador deve gerar via --paragrafo-resumo na invocacao final.)"
-  jq -r --arg para "$_para" '
+  jq -r --arg para "$_para" --argjson wu "$3" '
+    def fmt_tokens_num(v):
+      if v == null then null
+      elif v >= 10000 then
+        (v / 100 | floor) as $tenths
+        | ($tenths / 10 | floor) as $whole
+        | ($tenths - ($whole * 10)) as $dec
+        | (($whole | tostring) + "." + ($dec | tostring) + "k")
+      else
+        (v | tostring)
+      end;
+    def fmt_tokens(v): (fmt_tokens_num(v)) // "indisponivel";
     (.execution // .execucao) as $exec
     | (.accumulated_metrics // .metricas_acumuladas) as $met
     | "## 1. Resumo Executivo",
@@ -96,26 +137,43 @@ _rp_render_secao_1() {
     "| Sugestoes para skills globais | \(($met.global_skill_suggestions_total // $met.sugestoes_skills_globais_total) // (((.suggestions // .sugestoes) // []) | length)) |",
     "| Issues abertas no toolkit | \(($met.toolkit_issues_opened // $met.issues_toolkit_abertas) // 0) |",
     "| Profundidade max de subagentes | \(($met.max_depth_reached // $met.profundidade_max_atingida) // 1) |",
+    "| Spawns de subagente | \(if ($wu.metric_collected // false) then "\($wu.spawns_total) (\($wu.spawns_with_usage) com uso; \($wu.spawns_unavailable) indisponiveis)" else "nao coletado nesta execucao" end) |",
+    "| Tokens totais (observados) | \(if ($wu.metric_collected // false) then fmt_tokens($wu.total_tokens) else "nao coletado nesta execucao" end) |",
+    "| Cobertura da metrica | \(if ($wu.metric_collected // false) then (($wu.coverage_pct) // "n/a (sem spawns indisponiveis)") else "nao coletado nesta execucao" end) |",
     "",
     $para,
     ""
   ' "$1"
 }
 
-# _rp_render_secao_2 STATE_FILE
+# _rp_render_secao_2 STATE_FILE WAVE_USAGE_JSON
 _rp_render_secao_2() {
-  jq -r '
-    ((.waves // .ondas) // []) as $waves
+  jq -r --argjson wu "$2" '
+    def fmt_tokens_num(v):
+      if v == null then null
+      elif v >= 10000 then
+        (v / 100 | floor) as $tenths
+        | ($tenths / 10 | floor) as $whole
+        | ($tenths - ($whole * 10)) as $dec
+        | (($whole | tostring) + "." + ($dec | tostring) + "k")
+      else
+        (v | tostring)
+      end;
+    def fmt_tokens(v): (fmt_tokens_num(v)) // "indisponivel";
+    (($wu.por_onda // []) | map({(.onda): .}) | add // {}) as $wu_by_onda
+    | ((.waves // .ondas) // []) as $waves
     | "## 2. Linha do Tempo",
     "",
-    "| Onda | Inicio | Fim | Etapas | Tool calls | Wallclock | Termino |",
-    "|------|--------|-----|--------|------------|-----------|---------|",
+    "| Onda | Inicio | Fim | Etapas | Tool calls | Wallclock | Spawns | Tokens | Termino |",
+    "|------|--------|-----|--------|------------|-----------|--------|--------|---------|",
     (
       if $waves | length == 0 then
-        "| - | - | - | (nenhuma onda completa ainda) | - | - | - |"
+        "| - | - | - | (nenhuma onda completa ainda) | - | - | - | - | - |"
       else
         ($waves[] |
-          "| \(.id) | \(.started_at // .inicio) | \((.finished_at // .fim) // "-") | \(((.executed_stages // .etapas_executadas) // []) | join(", ")) | \(.tool_calls // 0) | \(.wallclock_seconds // 0)s | \((.termination_reason // .motivo_termino) // "(em andamento)") |"
+          . as $w
+          | ($wu_by_onda[$w.id] // null) as $u
+          | "| \($w.id) | \($w.started_at // $w.inicio) | \(($w.finished_at // $w.fim) // "-") | \((($w.executed_stages // $w.etapas_executadas) // []) | join(", ")) | \($w.tool_calls // 0) | \($w.wallclock_seconds // 0)s | \(if $u == null then "indisponivel" else "\($u.spawns_total) (\($u.spawns_with_usage) c/uso)" end) | \(if $u == null then "indisponivel" else fmt_tokens($u.total_tokens) end) | \((($w.termination_reason // $w.motivo_termino)) // "(em andamento)") |"
         )
       end
     ),
@@ -362,9 +420,10 @@ _rp_cmd_generate() {
   [ -f "$_sf" ] || _rp_die "generate: state.json ausente em $_sd" 1
 
   _now=$(_rp_iso_now)
+  _wu_json=$(_rp_wave_usage_json "$_sd")
   _rp_render_header "$_sf" "$_now"
-  _rp_render_secao_1 "$_sf" "$_para"
-  _rp_render_secao_2 "$_sf"
+  _rp_render_secao_1 "$_sf" "$_para" "$_wu_json"
+  _rp_render_secao_2 "$_sf" "$_wu_json"
   _rp_render_secao_3 "$_sf"
   _rp_render_secao_4 "$_sf"
   _rp_render_secao_5 "$_sf"
@@ -470,10 +529,11 @@ _rp_cmd_emit() {
   _scrubbed=$(mktemp) || { rm -f -- "$_raw"; _rp_die "emit: mktemp falhou" 1; }
 
   _now=$(_rp_iso_now)
+  _wu_json=$(_rp_wave_usage_json "$_sd")
   {
     _rp_render_header "$_sf" "$_now"
-    _rp_render_secao_1 "$_sf" "$_para"
-    _rp_render_secao_2 "$_sf"
+    _rp_render_secao_1 "$_sf" "$_para" "$_wu_json"
+    _rp_render_secao_2 "$_sf" "$_wu_json"
     _rp_render_secao_3 "$_sf"
     _rp_render_secao_4 "$_sf"
     _rp_render_secao_5 "$_sf"

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -14,7 +14,10 @@
 #           executed_stages = []
 #           tool_calls = 0
 #         Reseta .budgets.tool_calls_current_wave = 0 e
-#         .budgets.current_wave_start = started_at.
+#         .budgets.current_wave_start = started_at. Tambem reseta os
+#         sidecares de tick (tool-call-ticks.log) e de uso de agente
+#         (wave-agent-usage.jsonl + sentinela de cap) — janela da onda nova
+#         comeca zerada (wave-token-metrics FASE 3, task 3.1.1).
 #         Stdout: id da nova onda.
 #
 #   state-ondas.sh end --state-dir DIR --motivo-termino MOTIVO
@@ -28,6 +31,19 @@
 #         manuais) + linhas do sidecar tool-call-ticks.log (ticks do hook
 #         PostToolUse) — sidecar resetado apos o fechamento.
 #         --add-etapa pode ser passada N vezes para append em executed_stages.
+#         Tambem agrega o sidecar wave-agent-usage.jsonl (hook
+#         posttooluse-agent-usage.sh, wave-token-metrics FASE 3) em
+#         .waves[-1].agent_usage (WaveUsage: spawns_total/with_usage/
+#         unavailable + somas de tokens/tool-uses/duracao, `null` quando
+#         nao observado — NUNCA `0` fabricado) e .waves[-1].agent_spawns
+#         (array bruto de SpawnUsage). Sem sidecar/spawns nesta onda =>
+#         agent_usage null, agent_spawns []. Incrementa
+#         .accumulated_metrics.agent_spawns_total/
+#         agent_spawns_with_usage_total (sempre int) e agent_tokens_total/
+#         agent_tool_use_count_total/agent_duration_ms_total (int|null,
+#         ficam intactos quando a onda nao contribui dado). Sidecar
+#         resetado apos a agregacao (mesmo ciclo de vida do sidecar de
+#         ticks).
 #
 #   state-ondas.sh tool-call-tick --state-dir DIR
 #       — Incrementa .budgets.tool_calls_current_wave (1 unidade).
@@ -236,6 +252,44 @@ _so_ticks_reset() {
   rm -f -- "$(_so_ticks_file "$1")" 2>/dev/null || :
 }
 
+# ---------- Sidecar de uso de agente (hook PostToolUse/Agent) ----------
+#
+# Espelha o sidecar de ticks acima (wave-token-metrics FASE 3,
+# data-model.md §Sidecar). O hook posttooluse-agent-usage.sh NAO toca o
+# state.json (mesma razao: concorrencia com writes transacionais); appenda
+# 1 linha JSON (SpawnUsage) por spawn em <state-dir>/wave-agent-usage.jsonl.
+# Aqui esse sidecar e AGREGADO (end soma em .waves[-1].agent_usage /
+# .accumulated_metrics.agent_*) e RESETADO (start/end delimitam a janela,
+# junto com o sentinela de cap .wave-agent-usage-cap-warned).
+
+_so_agent_usage_file() { printf '%s/wave-agent-usage.jsonl\n' "$1"; }
+_so_agent_usage_cap_sentinel() { printf '%s/.wave-agent-usage-cap-warned\n' "$1"; }
+
+# _so_agent_usage_reset DIR -> remove o sidecar + sentinela de cap
+# (best-effort; hook recria no proximo spawn). Mesma tolerancia de fronteira
+# do sidecar de ticks.
+_so_agent_usage_reset() {
+  rm -f -- "$(_so_agent_usage_file "$1")" 2>/dev/null || :
+  rm -f -- "$(_so_agent_usage_cap_sentinel "$1")" 2>/dev/null || :
+}
+
+# _so_agent_usage_read DIR -> stdout: array JSON de SpawnUsage validos.
+# Resiliente a sidecar ausente (=> "[]") e a linhas corrompidas dentro do
+# arquivo: usa o idioma `inputs | fromjson?` (jq -R -n) para descartar
+# SILENCIOSAMENTE linhas que nao parseiam como JSON, em vez de abortar o
+# arquivo inteiro (jq -c 'inputs' pararia no primeiro erro de parse).
+# Degradacao graciosa (Principio VI: nunca fabrica dado, apenas ignora o
+# que nao pode ler) — jamais falha `end`.
+_so_agent_usage_read() {
+  _auf=$(_so_agent_usage_file "$1")
+  [ -f "$_auf" ] || { printf '[]\n'; return 0; }
+  _out=$(jq -R -n '[inputs | fromjson?]' "$_auf" 2>/dev/null) || _out=""
+  case "$_out" in
+    '') printf '[]\n' ;;
+    *)  printf '%s\n' "$_out" ;;
+  esac
+}
+
 # ---------- Subcomandos ----------
 
 _so_cmd_start() {
@@ -280,6 +334,10 @@ _so_cmd_start() {
   # entre o end anterior e este start pertencem a fechamento/overhead do
   # orquestrador, nao a onda nova).
   _so_ticks_reset "$_sdir"
+  # Idem para o sidecar de uso de agente (wave-token-metrics FASE 3,
+  # task 3.1.1): spawns entre o end anterior e este start ficam fora da
+  # onda nova; mesma tolerancia de fronteira do sidecar de ticks.
+  _so_agent_usage_reset "$_sdir"
 
   # Baseline de untracked (living-specs FASE 5, FR-014/data-model.md
   # UntrackedBaseline: "escrito por commit-mode.sh snapshot no inicio da
@@ -387,6 +445,12 @@ $2"; shift 2 ;;
     _proxima_json="\"$_proxima\""
   fi
 
+  # Agregacao do sidecar de uso de agente (wave-token-metrics FASE 3,
+  # data-model.md §"Entity: Consumo Agregado da Onda"). Resiliente a
+  # sidecar ausente/corrompido — nunca falha `end` (Principio VI: so
+  # agrega o que foi de fato observado, nunca fabrica o resto).
+  _au_spawns_json=$(_so_agent_usage_read "$_sdir")
+
   _new=$(mktemp) || _so_die "mktemp falhou" 1
   jq \
     --arg now "$_now" \
@@ -394,27 +458,60 @@ $2"; shift 2 ;;
     --argjson wc "$_wc" \
     --argjson tc "$_tc" \
     --argjson etapas "$_etapas_json" \
-    --argjson prox "$_proxima_json" '
-    (.waves[-1] |= (
-      .finished_at = $now
-      | .wallclock_seconds = $wc
-      | .tool_calls = $tc
-      | .termination_reason = $motivo
-      | .next_wave_scheduled_for = $prox
-      | .executed_stages += $etapas
-    ))
-    | .accumulated_metrics.waves_total = ((.accumulated_metrics.waves_total // 0) + 1)
-    | .accumulated_metrics.tool_calls_total = ((.accumulated_metrics.tool_calls_total // 0) + $tc)
-    | .accumulated_metrics.wallclock_total_seconds =
-        ((.accumulated_metrics.wallclock_total_seconds // 0) + $wc)
+    --argjson prox "$_proxima_json" \
+    --argjson spawns "$_au_spawns_json" '
+    ($spawns) as $sp
+    | ($sp | length) as $au_total
+    | ([$sp[] | select(.status != "indisponivel")] | length) as $au_with_usage
+    | ($au_total - $au_with_usage) as $au_unavailable
+    | def sum_field(f): ([$sp[] | select(f != null) | f]) as $vals
+        | if ($vals | length) > 0 then ($vals | add) else null end;
+      (if $au_total > 0 then {
+          spawns_total: $au_total,
+          spawns_with_usage: $au_with_usage,
+          spawns_unavailable: $au_unavailable,
+          total_tokens: sum_field(.total_tokens),
+          input_tokens: sum_field(.input_tokens),
+          output_tokens: sum_field(.output_tokens),
+          cache_read_input_tokens: sum_field(.cache_read_input_tokens),
+          cache_creation_input_tokens: sum_field(.cache_creation_input_tokens),
+          tool_use_count: sum_field(.tool_use_count),
+          duration_ms: sum_field(.duration_ms)
+        } else null end) as $au
+    | def add_null(existing; delta): if delta == null then existing else ((existing // 0) + delta) end;
+      (.waves[-1] |= (
+        .finished_at = $now
+        | .wallclock_seconds = $wc
+        | .tool_calls = $tc
+        | .termination_reason = $motivo
+        | .next_wave_scheduled_for = $prox
+        | .executed_stages += $etapas
+        | .agent_usage = $au
+        | .agent_spawns = $sp
+      ))
+      | .accumulated_metrics.waves_total = ((.accumulated_metrics.waves_total // 0) + 1)
+      | .accumulated_metrics.tool_calls_total = ((.accumulated_metrics.tool_calls_total // 0) + $tc)
+      | .accumulated_metrics.wallclock_total_seconds =
+          ((.accumulated_metrics.wallclock_total_seconds // 0) + $wc)
+      | .accumulated_metrics.agent_spawns_total =
+          ((.accumulated_metrics.agent_spawns_total // 0) + $au_total)
+      | .accumulated_metrics.agent_spawns_with_usage_total =
+          ((.accumulated_metrics.agent_spawns_with_usage_total // 0) + $au_with_usage)
+      | .accumulated_metrics.agent_tokens_total =
+          add_null(.accumulated_metrics.agent_tokens_total; $au.total_tokens)
+      | .accumulated_metrics.agent_tool_use_count_total =
+          add_null(.accumulated_metrics.agent_tool_use_count_total; $au.tool_use_count)
+      | .accumulated_metrics.agent_duration_ms_total =
+          add_null(.accumulated_metrics.agent_duration_ms_total; $au.duration_ms)
   ' "$_sf" > "$_new" || { rm -f -- "$_new"; _so_die "jq update falhou" 1; }
 
   _so_backup_current "$_sdir"
   _so_atomic_write "$_sf" "$_new"
   rm -f -- "$_new" 2>/dev/null || :
   _so_update_sha "$_sdir"
-  # Sidecar consumido por esta onda; zera para nao vazar para a proxima.
+  # Sidecares consumidos por esta onda; zeram para nao vazar para a proxima.
   _so_ticks_reset "$_sdir"
+  _so_agent_usage_reset "$_sdir"
   _so_log "end: onda finalizada (motivo=$_motivo, wallclock=${_wc}s, tool_calls=$_tc)"
 }
 

--- a/global/skills/agente-00c-runtime/scripts/wave-usage-report.sh
+++ b/global/skills/agente-00c-runtime/scripts/wave-usage-report.sh
@@ -6,7 +6,10 @@
 # Ref: docs/specs/wave-token-metrics/contracts/wave-usage-report.md §2/§3
 #      docs/specs/wave-token-metrics/data-model.md
 #        (Entity: SpawnUsage / WaveUsage; secao "Extensoes ao state.json")
+#      docs/specs/wave-token-metrics/research.md
+#        Decision 9 — Backfill por janela temporal, com recusa explicita
 #      docs/specs/wave-token-metrics/tasks.md FASE 4 (4.1.1, 4.1.2, 4.1.4)
+#        e FASE 7 (7.1.1-7.1.5 — subcomando backfill)
 #
 # Por que um helper novo (e nao estender model-routing-report.sh): ver
 # contracts/wave-usage-report.md §1 — model-routing-report.sh le SOMENTE
@@ -22,17 +25,47 @@
 #         Default: Markdown canonico (colavel verbatim em review-task/
 #         report.sh). Com --json: agregado maquina-legivel.
 #
+#   wave-usage-report.sh backfill --state-dir DIR --transcript PATH [--dry-run]
+#       — US4/FR-010/FR-011 (contracts §3, research Decision 9). Reconstroi
+#         SpawnUsage retroativamente a partir de um transcript JSONL de
+#         sessao ja encerrada, para execucoes anteriores a esta feature (ou
+#         com hook nao provisionado no momento). Algoritmo:
+#           1. Extrai do transcript os pares tool_use(name="Agent") + o
+#              tool_result correspondente (mesmo tool_use_id) cujo
+#              toolUseResult carrega agentId — mesmos campos do hook
+#              posttooluse-agent-usage.sh (agentId, status, resolvedModel,
+#              modelsUsed, totalTokens, usage.*, totalToolUseCount,
+#              totalDurationMs), com a MESMA derivacao de `status`
+#              (completo/parcial/indisponivel) e a MESMA regra de
+#              null-nao-fabricado (Principio VI/FR-009).
+#           2. Atribui cada SpawnUsage a onda cuja janela
+#              `started_at <= ts < finished_at` o contem (ts = timestamp do
+#              registro de tool_result no transcript). HEURISTICA, nao
+#              chave — o transcript nao carrega id de onda (Decision 9).
+#              Spawns fora de toda janela sao descartados (nao pertencem a
+#              esta execucao ou ao intervalo coberto pelo transcript).
+#           3. Todo SpawnUsage gravado leva `source: "backfill"` (nunca
+#              "live") — proveniencia obrigatoria.
+#           4. Dedup por chave natural `(wave_id, agent_id)`: spawns ja
+#              presentes em `.waves[].agent_spawns` (de qualquer source) sao
+#              ignorados — reexecutar sobre o mesmo transcript e idempotente
+#              (byte-idêntico, sem novo write).
+#           5. `--dry-run`: imprime o que seria aplicado (onda destino +
+#              agent_id por spawn) e sai 0, sem escrever nada.
+#         Recusa explicita (FR-011, exit 3) quando: (a) --transcript esta
+#         ausente/ilegivel, ou (b) o transcript foi lido mas NENHUM spawn
+#         correlacionado cai dentro de nenhuma janela de onda desta
+#         execucao (transcript nao cobre a execucao). Em ambos os casos,
+#         NENHUM campo de metrica e escrito — nunca estimado/sintetico.
+#         Escrita (quando ha >=1 spawn novo): delega a
+#         `state-rw.sh write --state-dir DIR` (stdin = state.json completo
+#         apos o merge) — reusa o caminho canonico de escrita do runtime
+#         (backup em state-history/ + escrita atomica + recomputo de
+#         state.json.sha256), a mesma garantia que `state-ondas.sh end` ja
+#         oferece para a captura ao vivo.
+#
 #   wave-usage-report.sh -h | --help
 #       — Imprime USO em stderr e exit 2 (padrao do dispatch do runtime).
-#
-# NAO IMPLEMENTADO NESTE ARQUIVO (deliberado): o subcomando `backfill`
-# (contracts/wave-usage-report.md §3, US4/FR-010/FR-011) e trabalho da
-# FASE 7 do backlog (tasks.md 7.1.1-7.1.5 — heuristica de janela temporal +
-# recusa explicita quando o transcript nao cobre a onda). A tarefa 4.1.3
-# desta FASE 4 e um forward-reference explicito para aquela fase ("ver
-# detalhamento na FASE 7") — implementar aqui uma leitura de transcript sem
-# a heuristica/testes da FASE 7 fabricaria funcionalidade nao validada.
-# Ate la, `backfill` cai no dispatch de "subcomando desconhecido" (exit 2).
 #
 # ---------------------------------------------------------------------
 # Semantica de agregacao (decisoes de design desta implementacao — o
@@ -83,16 +116,29 @@
 # imprime uma tabela de zeros — imprime a frase explicita exigida pelo
 # contrato §2.1 ponto 4.
 #
-# Exit codes (espelham model-routing-report.sh):
+# Exit codes de `aggregate` (espelham model-routing-report.sh):
 #   0 sucesso
 #   1 erro generico (state.json ausente/ilegivel, jq ausente, parsing invalido)
 #   2 uso incorreto (flag ausente, subcomando desconhecido)
 #
+# Exit codes de `backfill` (contracts §3):
+#   0 backfill aplicado, ou 0 novos spawns (idempotente), ou --dry-run OK
+#   1 erro generico (state.json ausente/ilegivel, jq ausente)
+#   2 uso incorreto (flag ausente)
+#   3 recusa explicita FR-011 (transcript ausente/ilegivel, ou transcript
+#     nao cobre nenhuma onda desta execucao) — NUNCA escreve valor estimado
+#
 # Invariantes:
-#   IR-1: read-only sobre state.json — jq sem -i, sem redirecionamento ao
-#         arquivo (auditavel via grep no codigo).
-#   IR-2: idempotente — sem timestamps no payload; mesmo input -> mesmo
-#         output byte-a-byte.
+#   IR-1: `aggregate` e read-only sobre state.json — jq sem -i, sem
+#         redirecionamento ao arquivo (auditavel via grep no codigo).
+#         `backfill` e a UNICA excecao documentada: quando ha >=1 spawn
+#         novo, escreve via `state-rw.sh write` (backup + atomic write +
+#         sha256 update no caminho canonico do runtime — nunca io direto
+#         no arquivo por este script).
+#   IR-2: `aggregate` e idempotente — sem timestamps no payload; mesmo
+#         input -> mesmo output byte-a-byte. `backfill` e idempotente por
+#         dedup de chave natural (wave_id, agent_id): reexecutar sobre o
+#         mesmo transcript produz 0 novos spawns e nenhum write.
 #   IR-3: Principio II — #!/bin/sh, set -eu, deps apenas em jq.
 #
 # POSIX sh + jq.
@@ -118,6 +164,7 @@ _wur_print_usage() {
   cat <<'EOF'
 USO:
   wave-usage-report.sh aggregate --state-dir DIR [--json]
+  wave-usage-report.sh backfill --state-dir DIR --transcript PATH [--dry-run]
   wave-usage-report.sh -h | --help
 EOF
 }
@@ -125,6 +172,12 @@ EOF
 _wur_require_jq() {
   command -v jq >/dev/null 2>&1 \
     || _wur_die "jq nao encontrado no PATH" 1
+}
+
+# Diretorio do proprio script (mesma receita de _so_self_dir em
+# state-ondas.sh) — usado por backfill para localizar state-rw.sh irmao.
+_wur_self_dir() {
+  CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P
 }
 
 # ---------- Subcomando: aggregate ----------
@@ -339,6 +392,277 @@ _wur_cmd_aggregate() {
   fi
 }
 
+# ---------- Subcomando: backfill ----------
+
+# _wur_backfill_jq_program — programa jq compartilhado do subcomando
+# backfill. Le o transcript ja parseado (array de registros JSONL, injetado
+# via --slurpfile tr, $tr[0]) e o state.json (input principal `.`) e produz
+# UM objeto: { refuse, extracted_total, covered_total, new_total,
+# duplicate_total, by_wave, state }. `state` e o state.json COMPLETO apos o
+# merge (identico ao original quando new_total == 0 — o chamador so escreve
+# quando new_total > 0, preservando IR-2/idempotencia).
+#
+# Extracao: mesma correlacao tool_use(name="Agent") <-> tool_result via
+# tool_use_id, e a MESMA derivacao de status/campos-null que
+# posttooluse-agent-usage.sh usa para a captura ao vivo (contracts §3:
+# "verificado 6/6 nesta sessao" — Decision 1/2 do research). Atribuicao de
+# onda por janela temporal (Decision 9): heuristica, primeiro match vence.
+_wur_backfill_jq_program() {
+  cat <<'JQ'
+. as $ORIG_STATE |
+def strip_ms(ts): if ts == null then null else (ts | sub("\\.[0-9]+Z$"; "Z")) end;
+def epoch(ts): (strip_ms(ts)) as $s | if $s == null then null else (try ($s | fromdateiso8601) catch null) end;
+
+def sum_field(arr; f): ([arr[] | select(f != null) | f]) as $vals
+  | if ($vals|length) > 0 then ($vals|add) else null end;
+
+# Mesma formula de agregacao de _so_cmd_end (state-ondas.sh) — WaveUsage a
+# partir de um array de SpawnUsage. spawns=[] -> null (nunca onda fantasma).
+def wave_usage_of(spawns):
+  (spawns | length) as $total
+  | ([spawns[] | select(.status != "indisponivel")] | length) as $with_usage
+  | ($total - $with_usage) as $unavail
+  | if $total > 0 then {
+      spawns_total: $total, spawns_with_usage: $with_usage, spawns_unavailable: $unavail,
+      total_tokens: sum_field(spawns; .total_tokens),
+      input_tokens: sum_field(spawns; .input_tokens),
+      output_tokens: sum_field(spawns; .output_tokens),
+      cache_read_input_tokens: sum_field(spawns; .cache_read_input_tokens),
+      cache_creation_input_tokens: sum_field(spawns; .cache_creation_input_tokens),
+      tool_use_count: sum_field(spawns; .tool_use_count),
+      duration_ms: sum_field(spawns; .duration_ms)
+    } else null end;
+
+def add_null(existing; delta): if delta == null then existing else ((existing // 0) + delta) end;
+
+($tr[0] // []) as $records
+
+# tool_use(name="Agent") -> agent_type, indexado por tool_use_id.
+| ([$records[] | select(.type=="assistant") | (.message.content // [])[]
+     | select(.type=="tool_use" and .name=="Agent")
+     | {id: .id, agent_type: (.input.subagent_type // null)}]) as $agent_calls
+| ($agent_calls | map({(.id): .agent_type}) | add // {}) as $agent_type_by_id
+
+# tool_result cujo tool_use_id casa com uma chamada Agent E cujo
+# toolUseResult carrega agentId (mesma condicao de "empty" do hook: sem
+# agentId -> sem SpawnUsage).
+| ([$records[]
+     | select(.type=="user" and .toolUseResult != null)
+     | . as $rec
+     | (((.message.content // [])[] | select(.type=="tool_result") | .tool_use_id) // null) as $tuid
+     | select($tuid != null and ($agent_type_by_id | has($tuid)))
+     | ($rec.toolUseResult) as $trr
+     | ($trr.agentId // null) as $aid
+     | select($aid != null)
+     | ($trr.status // "") as $status_raw
+     | (if $status_raw == "completed" and ($trr.totalTokens != null) then "completo"
+        elif $status_raw == "completed" then "parcial"
+        else "indisponivel" end) as $derived
+     | {
+         agent_id: $aid,
+         agent_type: ($agent_type_by_id[$tuid] // null),
+         status: $derived,
+         model: ($trr.resolvedModel // "nao-aplicavel"),
+         models_used: ($trr.modelsUsed // null),
+         total_tokens: (if $derived=="indisponivel" then null else ($trr.totalTokens // null) end),
+         input_tokens: (if $derived=="indisponivel" then null else ($trr.usage.input_tokens // null) end),
+         output_tokens: (if $derived=="indisponivel" then null else ($trr.usage.output_tokens // null) end),
+         cache_read_input_tokens: (if $derived=="indisponivel" then null else ($trr.usage.cache_read_input_tokens // null) end),
+         cache_creation_input_tokens: (if $derived=="indisponivel" then null else ($trr.usage.cache_creation_input_tokens // null) end),
+         tool_use_count: (if $derived=="indisponivel" then null else ($trr.totalToolUseCount // null) end),
+         duration_ms: (if $derived=="indisponivel" then null else ($trr.totalDurationMs // null) end),
+         source: "backfill",
+         observed_at: ($rec.timestamp // null),
+         _ts_epoch: epoch($rec.timestamp)
+       }
+   ]) as $extracted
+
+| (.waves // []) as $waves_orig
+| ($waves_orig | map({id: .id, s: epoch(.started_at), f: epoch(.finished_at)})) as $windows
+
+# Atribuicao por janela temporal: started_at <= ts < finished_at (onda
+# aberta, finished_at=null -> sem limite superior). Primeiro match vence
+# (ondas nao se sobrepoem em condicoes normais).
+| ($extracted | map(
+     . as $sp
+     | (reduce $windows[] as $w (null;
+         if . == null and $w.s != null and $sp._ts_epoch != null
+            and $sp._ts_epoch >= $w.s and ($w.f == null or $sp._ts_epoch < $w.f)
+         then $w.id else . end)) as $wid
+     | $sp + {wave_id: $wid}
+   )) as $assigned_all
+
+| ($assigned_all | map(select(.wave_id != null))) as $covered
+| ($waves_orig | map({(.id): ([(.agent_spawns // [])[] | .agent_id])}) | add // {}) as $existing_ids_by_wave
+# Dedup por (wave_id, agent_id) — chave natural (data-model.md §"Chave
+# natural"); spawn ja presente (de qualquer source) nao entra de novo.
+| ($covered | map(. as $c | select( ((($existing_ids_by_wave[$c.wave_id]) // []) | index($c.agent_id)) == null ))) as $new_spawns
+
+| ($extracted | length) as $extracted_total
+| ($covered | length) as $covered_total
+| ($new_spawns | length) as $new_total
+| ($covered_total - $new_total) as $duplicate_total
+| ($new_spawns | group_by(.wave_id) | map({wave_id: .[0].wave_id, count: length, agent_ids: map(.agent_id)})) as $by_wave
+
+# FR-011: transcript nao cobre NENHUMA onda desta execucao -> recusa.
+# Distinto de "0 novos" (idempotencia): covered_total==0 e sobre o transcript
+# em si, nao sobre o que ja foi persistido.
+| (if $covered_total == 0 then true else false end) as $refuse
+
+| (
+    if $new_total == 0 then $ORIG_STATE
+    else
+      ($ORIG_STATE
+        | .waves = (.waves | map(
+            . as $w
+            | (($new_spawns | map(select(.wave_id == $w.id)) | map(del(.wave_id, ._ts_epoch)))) as $add
+            | if ($add | length) > 0 then
+                (.agent_spawns = ((.agent_spawns // []) + $add))
+                | (.agent_usage = wave_usage_of(.agent_spawns))
+              else . end
+          ))
+        | (wave_usage_of($new_spawns | map(del(.wave_id, ._ts_epoch)))) as $delta
+        | .accumulated_metrics.agent_spawns_total = ((.accumulated_metrics.agent_spawns_total // 0) + $new_total)
+        | .accumulated_metrics.agent_spawns_with_usage_total =
+            ((.accumulated_metrics.agent_spawns_with_usage_total // 0) + ([$new_spawns[] | select(.status != "indisponivel")] | length))
+        | .accumulated_metrics.agent_tokens_total = add_null(.accumulated_metrics.agent_tokens_total; $delta.total_tokens)
+        | .accumulated_metrics.agent_tool_use_count_total = add_null(.accumulated_metrics.agent_tool_use_count_total; $delta.tool_use_count)
+        | .accumulated_metrics.agent_duration_ms_total = add_null(.accumulated_metrics.agent_duration_ms_total; $delta.duration_ms)
+      )
+    end
+  ) as $new_state
+
+| {
+    refuse: $refuse,
+    extracted_total: $extracted_total,
+    covered_total: $covered_total,
+    new_total: $new_total,
+    duplicate_total: $duplicate_total,
+    by_wave: $by_wave,
+    state: $new_state
+  }
+JQ
+}
+
+_wur_cmd_backfill() {
+  _wur_require_jq
+
+  _wur_bt_state_dir=""
+  _wur_bt_transcript=""
+  _wur_bt_dry_run=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --state-dir)
+        [ $# -ge 2 ] || _wur_die_usage "backfill: --state-dir requer valor"
+        _wur_bt_state_dir=$2
+        shift 2
+        ;;
+      --state-dir=*)
+        _wur_bt_state_dir=${1#--state-dir=}
+        shift
+        ;;
+      --transcript)
+        [ $# -ge 2 ] || _wur_die_usage "backfill: --transcript requer valor"
+        _wur_bt_transcript=$2
+        shift 2
+        ;;
+      --transcript=*)
+        _wur_bt_transcript=${1#--transcript=}
+        shift
+        ;;
+      --dry-run)
+        _wur_bt_dry_run=1
+        shift
+        ;;
+      *)
+        _wur_die_usage "backfill: argumento desconhecido: $1"
+        ;;
+    esac
+  done
+
+  [ -n "$_wur_bt_state_dir" ] \
+    || _wur_die_usage "backfill: --state-dir obrigatorio"
+  [ -n "$_wur_bt_transcript" ] \
+    || _wur_die_usage "backfill: --transcript obrigatorio"
+
+  _wur_bt_state_file="$_wur_bt_state_dir/state.json"
+  [ -f "$_wur_bt_state_file" ] \
+    || _wur_die "backfill: state.json nao encontrado em $_wur_bt_state_file" 1
+
+  # Rotulo da execucao para a mensagem de recusa (FR-011: "nomeando a
+  # execucao que nao pode ser reconstruida"). Fallback ao basename do
+  # state-dir quando .execution.id ausente (state antigo).
+  _wur_bt_label=$(jq -r '.execution.id // empty' "$_wur_bt_state_file" 2>/dev/null) || _wur_bt_label=""
+  [ -n "$_wur_bt_label" ] || _wur_bt_label=$(basename -- "$_wur_bt_state_dir")
+
+  # FR-011, exit 3: transcript ausente/ilegivel — recusa explicita, NUNCA
+  # estimar. Checado ANTES de qualquer tentativa de parse.
+  if [ ! -f "$_wur_bt_transcript" ] || [ ! -r "$_wur_bt_transcript" ]; then
+    _wur_die "backfill: recusado — transcript ausente/ilegivel: $_wur_bt_transcript; execucao $_wur_bt_label (state-dir: $_wur_bt_state_dir) nao pode ser reconstruida a partir deste arquivo" 3
+  fi
+
+  # Parse tolerante do transcript JSONL (mesmo idioma de _so_agent_usage_read
+  # em state-ondas.sh): linhas corrompidas sao descartadas silenciosamente,
+  # nunca abortam o arquivo inteiro (Principio VI — degradacao graciosa).
+  _wur_bt_parsed=$(mktemp) || _wur_die "backfill: mktemp falhou" 1
+  if ! jq -R -n '[inputs | fromjson?]' "$_wur_bt_transcript" > "$_wur_bt_parsed" 2>/dev/null; then
+    rm -f -- "$_wur_bt_parsed"
+    _wur_die "backfill: falha ao ler transcript (jq falhou sobre $_wur_bt_transcript)" 1
+  fi
+
+  _wur_bt_out=$(jq -c --slurpfile tr "$_wur_bt_parsed" "$(_wur_backfill_jq_program)" "$_wur_bt_state_file") \
+    || { rm -f -- "$_wur_bt_parsed"; _wur_die "backfill: jq falhou ao processar transcript/state.json" 1; }
+  rm -f -- "$_wur_bt_parsed"
+
+  _wur_bt_refuse=$(printf '%s' "$_wur_bt_out" | jq -r '.refuse')
+  if [ "$_wur_bt_refuse" = "true" ]; then
+    _wur_die "backfill: recusado — transcript $_wur_bt_transcript nao cobre nenhuma onda da execucao $_wur_bt_label (state-dir: $_wur_bt_state_dir); nenhum SpawnUsage sintetico foi gravado" 3
+  fi
+
+  _wur_bt_extracted=$(printf '%s' "$_wur_bt_out" | jq -r '.extracted_total')
+  _wur_bt_covered=$(printf '%s' "$_wur_bt_out" | jq -r '.covered_total')
+  _wur_bt_new=$(printf '%s' "$_wur_bt_out" | jq -r '.new_total')
+  _wur_bt_dup=$(printf '%s' "$_wur_bt_out" | jq -r '.duplicate_total')
+
+  if [ "$_wur_bt_dry_run" = 1 ]; then
+    printf 'backfill --dry-run (%s):\n' "$_wur_bt_label"
+    printf '  spawns extraidos do transcript: %s\n' "$_wur_bt_extracted"
+    printf '  cobertos por alguma janela de onda: %s\n' "$_wur_bt_covered"
+    printf '  ja registrados (duplicados, seriam ignorados): %s\n' "$_wur_bt_dup"
+    printf '  NOVOS a aplicar: %s\n' "$_wur_bt_new"
+    printf '%s' "$_wur_bt_out" | jq -r '
+      .by_wave[] | "    \(.wave_id): +\(.count) spawn(s) (source=backfill) — agent_id: \(.agent_ids | join(", "))"
+    '
+    printf 'Nenhuma escrita realizada (--dry-run).\n'
+    return 0
+  fi
+
+  if [ "$_wur_bt_new" = 0 ]; then
+    printf 'backfill (%s): 0 spawns novos — %s cobertos, todos ja registrados (idempotente); nenhuma escrita realizada\n' \
+      "$_wur_bt_label" "$_wur_bt_covered"
+    return 0
+  fi
+
+  # Escrita via caminho canonico do runtime (IR-1: unica excecao
+  # documentada) — backup em state-history/ + atomic write + sha256 update,
+  # tudo dentro de state-rw.sh write.
+  _wur_selfdir=$(_wur_self_dir) || _wur_die "backfill: nao foi possivel resolver o diretorio do script" 1
+  _wur_state_rw="$_wur_selfdir/state-rw.sh"
+  [ -f "$_wur_state_rw" ] \
+    || _wur_die "backfill: state-rw.sh nao encontrado em $_wur_selfdir (runtime incompleto)" 1
+
+  printf '%s' "$_wur_bt_out" | jq -c '.state' \
+    | sh "$_wur_state_rw" write --state-dir "$_wur_bt_state_dir" \
+    || _wur_die "backfill: state-rw.sh write falhou — nenhuma garantia sobre o estado do arquivo, verifique state-history/" 1
+
+  printf 'backfill (%s): %s spawn(s) novo(s) aplicado(s) (source=backfill), %s duplicado(s) ignorado(s)\n' \
+    "$_wur_bt_label" "$_wur_bt_new" "$_wur_bt_dup"
+  printf '%s' "$_wur_bt_out" | jq -r '
+    .by_wave[] | "  \(.wave_id): +\(.count) spawn(s) — agent_id: \(.agent_ids | join(", "))"
+  '
+}
+
 # ---------- Dispatch ----------
 
 if [ $# -eq 0 ]; then
@@ -354,6 +678,10 @@ case "$1" in
   aggregate)
     shift
     _wur_cmd_aggregate "$@"
+    ;;
+  backfill)
+    shift
+    _wur_cmd_backfill "$@"
     ;;
   *)
     printf '%s: subcomando desconhecido: %s\n' "$_WUR_NAME" "$1" >&2

--- a/global/skills/agente-00c-runtime/scripts/wave-usage-report.sh
+++ b/global/skills/agente-00c-runtime/scripts/wave-usage-report.sh
@@ -1,0 +1,363 @@
+#!/bin/sh
+# wave-usage-report.sh — agregador read-only para consumo de tokens/tool-uses/
+# duracao observado nos spawns de subagente de uma execucao agente-00c/
+# feature-00c. Cumpre FR-005 (US1) da feature wave-token-metrics.
+#
+# Ref: docs/specs/wave-token-metrics/contracts/wave-usage-report.md §2/§3
+#      docs/specs/wave-token-metrics/data-model.md
+#        (Entity: SpawnUsage / WaveUsage; secao "Extensoes ao state.json")
+#      docs/specs/wave-token-metrics/tasks.md FASE 4 (4.1.1, 4.1.2, 4.1.4)
+#
+# Por que um helper novo (e nao estender model-routing-report.sh): ver
+# contracts/wave-usage-report.md §1 — model-routing-report.sh le SOMENTE
+# .decisions[] e documenta explicitamente que nao le .waves; agregar
+# .waves[].agent_usage la quebraria esse invariante publicado.
+#
+# Subcomandos:
+#   wave-usage-report.sh aggregate --state-dir DIR [--json]
+#       — Le state.json em <DIR>/state.json e agrega .waves[].agent_usage +
+#         .waves[].agent_spawns[] (escritos por state-ondas.sh end, que por
+#         sua vez consome o sidecar wave-agent-usage.jsonl do hook
+#         posttooluse-agent-usage.sh). Read-only sobre state.json.
+#         Default: Markdown canonico (colavel verbatim em review-task/
+#         report.sh). Com --json: agregado maquina-legivel.
+#
+#   wave-usage-report.sh -h | --help
+#       — Imprime USO em stderr e exit 2 (padrao do dispatch do runtime).
+#
+# NAO IMPLEMENTADO NESTE ARQUIVO (deliberado): o subcomando `backfill`
+# (contracts/wave-usage-report.md §3, US4/FR-010/FR-011) e trabalho da
+# FASE 7 do backlog (tasks.md 7.1.1-7.1.5 — heuristica de janela temporal +
+# recusa explicita quando o transcript nao cobre a onda). A tarefa 4.1.3
+# desta FASE 4 e um forward-reference explicito para aquela fase ("ver
+# detalhamento na FASE 7") — implementar aqui uma leitura de transcript sem
+# a heuristica/testes da FASE 7 fabricaria funcionalidade nao validada.
+# Ate la, `backfill` cai no dispatch de "subcomando desconhecido" (exit 2).
+#
+# ---------------------------------------------------------------------
+# Semantica de agregacao (decisoes de design desta implementacao — o
+# contrato fornece exemplo ilustrativo mas nao formaliza a formula; ver
+# Decisao auditavel dec-* registrada na onda de implementacao):
+#
+#   - Uma "onda" so entra em `por_onda`/na tabela Markdown quando
+#     `.waves[N].agent_usage != null`, isto e: pelo menos 1 SpawnUsage foi
+#     observado naquela onda (spawns_total > 0), MESMO que todos tenham
+#     ficado `indisponivel`. Ondas com zero spawns (agent_usage null por
+#     ausencia total de registro) sao OMITIDAS da tabela — nao ha o que
+#     reportar sobre uma onda que nunca tentou spawnar subagente.
+#   - `waves_total`/`waves_with_usage` (JSON) e "Ondas com metrica: X de Y"
+#     (Markdown) usam Y = numero de ondas presentes na tabela (que TIVERAM
+#     spawns observados) e X = quantas dessas tiveram spawns_with_usage>0
+#     (dado de fato utilizavel, nao so tentativa). Bate exatamente com o
+#     exemplo do contrato (2 ondas na tabela, 1 com uso real => "1 de 2").
+#   - Formatacao "k" (milhares): valores >= 10000 sao renderizados como
+#     "N.Nk" (1 casa decimal, truncada — nao arredondada); abaixo disso,
+#     inteiro cru. Essa e a UNICA formula consistente com todos os valores
+#     do exemplo do contrato (250900 -> "250.9k", 254000 -> "254.0k", mas
+#     1049/1975/4/72 permanecem crus). Duracao usa segundos inteiros
+#     truncados + sufixo "s" (923000ms -> "923s").
+#   - `por_modelo` (JSON) agrupa TODOS os SpawnUsage (de todas as ondas com
+#     `agent_usage != null`) pelo campo `.model`, que e SEMPRE presente no
+#     schema (data-model.md: "nao-aplicavel" quando resolvedModel ausente
+#     na fonte) — logo spawns `indisponivel` aparecem no balde
+#     "nao-aplicavel" com todos os campos de uso em null, nunca omitidos.
+#
+# Campos numericos de uso (`total_tokens`, `input_tokens`, `output_tokens`,
+# `cache_read_input_tokens`, `cache_creation_input_tokens`,
+# `tool_use_count`, `duration_ms`) sao SOMAS apenas dos valores nao-null;
+# ausencia total de dado produz `null` (JSON) / "indisponivel" (Markdown) —
+# NUNCA `0` fabricado (FR-009/SC-004, Principio VI). Contadores literais de
+# ocorrencia (`spawns_total`, `spawns_with_usage`, `spawns_unavailable`,
+# `waves_total`, `waves_with_usage`) sao sempre inteiros — `0` ali e uma
+# contagem real, nao uma fabricacao.
+#
+# Campo `metric_collected` (JSON, ADITIVO ao contrato — nao quebra
+# consumidores que ignoram campos desconhecidos): `false` quando NENHUMA
+# onda da execucao produziu `agent_usage != null` — isto e, o hook nunca
+# gerou dado observavel em toda a execucao (research Decision 10: hook
+# ausente/nao provisionado E "zero spawns em toda a execucao" sao
+# indistinguiveis a partir do state.json; o campo apenas nomeia esse
+# estado agregado para consumidores como report.sh/review-task, FASE 4.2 /
+# FASE 6, que precisam decidir se mostram "0" ou uma mensagem de
+# degradacao). Quando `metric_collected=false`, a saida Markdown NUNCA
+# imprime uma tabela de zeros — imprime a frase explicita exigida pelo
+# contrato §2.1 ponto 4.
+#
+# Exit codes (espelham model-routing-report.sh):
+#   0 sucesso
+#   1 erro generico (state.json ausente/ilegivel, jq ausente, parsing invalido)
+#   2 uso incorreto (flag ausente, subcomando desconhecido)
+#
+# Invariantes:
+#   IR-1: read-only sobre state.json — jq sem -i, sem redirecionamento ao
+#         arquivo (auditavel via grep no codigo).
+#   IR-2: idempotente — sem timestamps no payload; mesmo input -> mesmo
+#         output byte-a-byte.
+#   IR-3: Principio II — #!/bin/sh, set -eu, deps apenas em jq.
+#
+# POSIX sh + jq.
+
+set -eu
+
+_WUR_NAME="wave-usage-report"
+
+# ---------- Helpers privados ----------
+
+_wur_die_usage() {
+  printf '%s: %s\n' "$_WUR_NAME" "$1" >&2
+  _wur_print_usage >&2
+  exit 2
+}
+
+_wur_die() {
+  printf '%s: %s\n' "$_WUR_NAME" "$1" >&2
+  exit "${2:-1}"
+}
+
+_wur_print_usage() {
+  cat <<'EOF'
+USO:
+  wave-usage-report.sh aggregate --state-dir DIR [--json]
+  wave-usage-report.sh -h | --help
+EOF
+}
+
+_wur_require_jq() {
+  command -v jq >/dev/null 2>&1 \
+    || _wur_die "jq nao encontrado no PATH" 1
+}
+
+# ---------- Subcomando: aggregate ----------
+
+# _wur_jq_program — programa jq compartilhado. Le .waves[] do state.json e
+# produz o agregado descrito no cabecalho deste arquivo. Read-only (IR-1).
+_wur_jq_program() {
+  cat <<'JQ'
+# soma so os valores nao-null de xs; [] ou so-nulls -> null (nunca 0
+# fabricado — Principio VI / FR-009).
+def sum_or_null(xs):
+  ([xs[] | select(. != null)]) as $vals
+  | if ($vals | length) > 0 then ($vals | add) else null end;
+
+# "N.Nk" (>=10000, 1 casa truncada) ou inteiro cru (<10000); null -> null.
+# Formula documentada no cabecalho do arquivo.
+def fmt_tokens_num(v):
+  if v == null then null
+  elif v >= 10000 then
+    (v / 100 | floor) as $tenths
+    | ($tenths / 10 | floor) as $whole
+    | ($tenths - ($whole * 10)) as $dec
+    | (($whole | tostring) + "." + ($dec | tostring) + "k")
+  else
+    (v | tostring)
+  end;
+
+def fmt_tokens(v): (fmt_tokens_num(v)) // "indisponivel";
+
+def fmt_duration(ms):
+  if ms == null then "indisponivel"
+  else (((ms / 1000) | floor | tostring) + "s")
+  end;
+
+# pct com 1 casa truncada; tot=0 -> null (0/0 indefinido, nao "0.0%").
+def pct1_or_null(n; tot):
+  if tot == 0 then null
+  else
+    ((n * 1000 / tot) | floor) as $t
+    | ($t / 10 | floor) as $whole
+    | ($t - ($whole * 10)) as $dec
+    | (($whole | tostring) + "." + ($dec | tostring) + "%")
+  end;
+
+(.waves // []) as $waves
+
+# Ondas com pelo menos 1 SpawnUsage observado (agent_usage != null).
+| ($waves | map(select((.agent_usage // null) != null))) as $rows_src
+
+| ($rows_src | map({
+    onda:                         .id,
+    spawns_total:                 .agent_usage.spawns_total,
+    spawns_with_usage:            .agent_usage.spawns_with_usage,
+    spawns_unavailable:           .agent_usage.spawns_unavailable,
+    total_tokens:                 .agent_usage.total_tokens,
+    input_tokens:                 .agent_usage.input_tokens,
+    output_tokens:                .agent_usage.output_tokens,
+    cache_read_input_tokens:      .agent_usage.cache_read_input_tokens,
+    cache_creation_input_tokens:  .agent_usage.cache_creation_input_tokens,
+    tool_use_count:               .agent_usage.tool_use_count,
+    duration_ms:                  .agent_usage.duration_ms
+  })) as $por_onda
+
+| ($por_onda | length) as $waves_total
+| ($por_onda | map(select(.spawns_with_usage > 0)) | length) as $waves_with_usage
+| (($por_onda | map(.spawns_total) | add) // 0) as $spawns_total
+| (($por_onda | map(.spawns_with_usage) | add) // 0) as $spawns_with_usage
+| ($spawns_total - $spawns_with_usage) as $spawns_unavailable
+
+| sum_or_null($por_onda | map(.total_tokens))                as $total_tokens
+| sum_or_null($por_onda | map(.input_tokens))                as $input_tokens
+| sum_or_null($por_onda | map(.output_tokens))               as $output_tokens
+| sum_or_null($por_onda | map(.cache_read_input_tokens))     as $cache_read_input_tokens
+| sum_or_null($por_onda | map(.cache_creation_input_tokens)) as $cache_creation_input_tokens
+| sum_or_null($por_onda | map(.tool_use_count))               as $tool_use_count
+| sum_or_null($por_onda | map(.duration_ms))                  as $duration_ms
+
+# por_modelo: agrupa TODOS os SpawnUsage brutos (de ondas com agent_usage
+# != null) pelo campo .model (sempre presente no schema — "nao-aplicavel"
+# quando o harness nao expos resolvedModel).
+| ($rows_src | map(.agent_spawns // []) | add // []) as $all_spawns
+| ( $all_spawns
+    | group_by(.model // "nao-aplicavel")
+    | map({
+        key: ((.[0].model // "nao-aplicavel")),
+        value: {
+          spawns:                        (. | length),
+          spawns_with_usage:             ([.[] | select(.status != "indisponivel")] | length),
+          total_tokens:                  sum_or_null(map(.total_tokens)),
+          input_tokens:                  sum_or_null(map(.input_tokens)),
+          output_tokens:                 sum_or_null(map(.output_tokens)),
+          cache_read_input_tokens:       sum_or_null(map(.cache_read_input_tokens)),
+          cache_creation_input_tokens:   sum_or_null(map(.cache_creation_input_tokens)),
+          tool_use_count:                sum_or_null(map(.tool_use_count)),
+          duration_ms:                   sum_or_null(map(.duration_ms))
+        }
+      })
+    | from_entries
+  ) as $por_modelo
+
+| {
+    waves_total:                  $waves_total,
+    waves_with_usage:             $waves_with_usage,
+    spawns_total:                 $spawns_total,
+    spawns_with_usage:            $spawns_with_usage,
+    spawns_unavailable:           $spawns_unavailable,
+    coverage_pct:                 pct1_or_null($spawns_with_usage; $spawns_total),
+    total_tokens:                 $total_tokens,
+    input_tokens:                 $input_tokens,
+    output_tokens:                $output_tokens,
+    cache_read_input_tokens:      $cache_read_input_tokens,
+    cache_creation_input_tokens:  $cache_creation_input_tokens,
+    tool_use_count:               $tool_use_count,
+    duration_ms:                  $duration_ms,
+    por_onda:                     $por_onda,
+    por_modelo:                   $por_modelo,
+    metric_collected:             ($waves_total > 0)
+  }
+JQ
+}
+
+# _wur_render_md AGG_JSON
+# Recebe o JSON agregado e renderiza a saida Markdown canonica (contract §2.1).
+_wur_render_md() {
+  printf '%s' "$1" | jq -r '
+    def fmt_tokens_num(v):
+      if v == null then null
+      elif v >= 10000 then
+        (v / 100 | floor) as $tenths
+        | ($tenths / 10 | floor) as $whole
+        | ($tenths - ($whole * 10)) as $dec
+        | (($whole | tostring) + "." + ($dec | tostring) + "k")
+      else
+        (v | tostring)
+      end;
+    def fmt_tokens(v): (fmt_tokens_num(v)) // "indisponivel";
+    def fmt_duration(ms):
+      if ms == null then "indisponivel"
+      else (((ms / 1000) | floor | tostring) + "s")
+      end;
+
+    "## Consumo por onda (tokens / tool-uses / duracao)",
+    "",
+    ( if .metric_collected then
+        (
+          "| onda | spawns | com uso | tokens | input | output | cache-read | cache-creation | tool-uses | duracao |",
+          "|------|--------|---------|--------|-------|--------|------------|----------------|-----------|---------|",
+          ( .por_onda[]
+            | "| \(.onda) | \(.spawns_total) | \(.spawns_with_usage) | \(fmt_tokens(.total_tokens)) | \(fmt_tokens(.input_tokens)) | \(fmt_tokens(.output_tokens)) | \(fmt_tokens(.cache_read_input_tokens)) | \(fmt_tokens(.cache_creation_input_tokens)) | \(fmt_tokens(.tool_use_count)) | \(fmt_duration(.duration_ms)) |"
+          ),
+          "",
+          "**Sumario**:",
+          "- Ondas com metrica: \(.waves_with_usage) de \(.waves_total)",
+          "- Spawns observados: \(.spawns_total) (com uso: \(.spawns_with_usage); indisponiveis: \(.spawns_unavailable))",
+          "- Tokens totais: \(fmt_tokens(.total_tokens)) (input \(fmt_tokens(.input_tokens)) / output \(fmt_tokens(.output_tokens)) / cache-read \(fmt_tokens(.cache_read_input_tokens)) / cache-creation \(fmt_tokens(.cache_creation_input_tokens)))",
+          ( if .spawns_unavailable > 0 then
+              "- Cobertura da metrica: \(.coverage_pct // "indisponivel") dos spawns"
+            else empty end
+          )
+        )
+      else
+        (
+          "Metrica de uso de subagente nao foi coletada nesta execucao (hook `posttooluse-agent-usage.sh` ausente/nao provisionado, ou nenhum subagente foi spawnado ate agora). Nao reportar como \"0 tokens\" — o dado simplesmente nao foi observado."
+        )
+      end
+    )
+  '
+}
+
+_wur_cmd_aggregate() {
+  _wur_require_jq
+
+  _wur_state_dir=""
+  _wur_emit_json=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --state-dir)
+        [ $# -ge 2 ] || _wur_die_usage "aggregate: --state-dir requer valor"
+        _wur_state_dir=$2
+        shift 2
+        ;;
+      --state-dir=*)
+        _wur_state_dir=${1#--state-dir=}
+        shift
+        ;;
+      --json)
+        _wur_emit_json=1
+        shift
+        ;;
+      *)
+        _wur_die_usage "aggregate: argumento desconhecido: $1"
+        ;;
+    esac
+  done
+
+  [ -n "$_wur_state_dir" ] \
+    || _wur_die_usage "aggregate: --state-dir obrigatorio"
+
+  _wur_state_file="$_wur_state_dir/state.json"
+  [ -f "$_wur_state_file" ] \
+    || _wur_die "aggregate: state.json nao encontrado em $_wur_state_file" 1
+
+  # Read-only sobre state.json (IR-1) — jq sem -i, sem redir.
+  _wur_agg=$(jq -c "$(_wur_jq_program)" "$_wur_state_file") \
+    || _wur_die "aggregate: jq falhou ao processar state.json" 1
+
+  if [ "$_wur_emit_json" = 1 ]; then
+    printf '%s\n' "$_wur_agg" | jq '.'
+  else
+    _wur_render_md "$_wur_agg"
+  fi
+}
+
+# ---------- Dispatch ----------
+
+if [ $# -eq 0 ]; then
+  _wur_print_usage >&2
+  exit 2
+fi
+
+case "$1" in
+  -h|--help|help)
+    _wur_print_usage >&2
+    exit 2
+    ;;
+  aggregate)
+    shift
+    _wur_cmd_aggregate "$@"
+    ;;
+  *)
+    printf '%s: subcomando desconhecido: %s\n' "$_WUR_NAME" "$1" >&2
+    _wur_print_usage >&2
+    exit 2
+    ;;
+esac

--- a/global/skills/review-task/SKILL.md
+++ b/global/skills/review-task/SKILL.md
@@ -238,6 +238,92 @@ ratificado em
 `agente-00c-runtime` nao instalada), pule a agregacao silenciosamente
 — nao bloqueie o restante do review-task.
 
+#### Cruzamento com consumo de tokens observado (wave-usage-report)
+
+Ref: feature `wave-token-metrics`, FASE 6 (F5, US2/FR-007).
+
+Quando a mesma `state.json` tambem tem `.waves[].agent_usage` (populado
+pelo hook `posttooluse-agent-usage.sh` + `state-ondas.sh end` — ver
+`docs/specs/wave-token-metrics/`), cruze a secao **por-onda** do
+model-routing (`linhas_onda[]`, saida `--json` de
+`model-routing-report.sh`) com o agregado do `wave-usage-report.sh`
+(`por_onda[]`, saida `--json`) pela chave comum `onda`. Objetivo: por
+onda, mostrar o **modelo aplicado** (model-routing) lado a lado com o
+**consumo observado** (tokens/tool-uses/duracao — wave-usage),
+destacando divergencias sugerido≠aplicado que tiveram alto consumo.
+
+**Nao existe um unico script que ja produza esse cruzamento verbatim** —
+e deliberado: `model-routing-report.sh` publica o invariante "le SOMENTE
+`.decisions[]`, nunca `.waves`" (ver cabecalho do script); adicionar um
+campo agregado de `.waves` ali quebraria esse contrato. O review-task
+computa o join a partir dos DOIS `--json`, sem alterar nenhum dos dois
+helpers:
+
+```bash
+STATE_DIR="<projeto>/.claude/feature-00c-state/<feature>"   # ou agente-00c-state
+MR_JSON=$(~/.claude/skills/agente-00c-runtime/scripts/model-routing-report.sh \
+  aggregate --state-dir "$STATE_DIR" --json 2>/dev/null) \
+  || MR_JSON='{"ondas":{"total":0},"linhas_onda":[]}'
+WU_JSON=$(~/.claude/skills/agente-00c-runtime/scripts/wave-usage-report.sh \
+  aggregate --state-dir "$STATE_DIR" --json 2>/dev/null) \
+  || WU_JSON='{"metric_collected":false,"por_onda":[]}'
+
+jq -n --argjson mr "$MR_JSON" --argjson wu "$WU_JSON" '
+  ($wu.por_onda // [] | map({(.onda): .}) | add // {}) as $wu_by_onda
+  | ($mr.linhas_onda // []) as $rows
+  # media de tokens (so valores nao-null) entre as ondas roteadas nesta
+  # execucao — "alto consumo" e RELATIVO a esta execucao, nunca um
+  # limiar fixo inventado (Principio VI: so agrega dado real observado).
+  | ($rows | map($wu_by_onda[.onda].total_tokens) | map(select(. != null))) as $vals
+  | (if ($vals | length) > 0 then ($vals | add / length) else null end) as $media
+  | $rows
+  | map(. as $r
+      | ($wu_by_onda[$r.onda]) as $u
+      | $r + {
+          tokens:      (($u.total_tokens)     // null),
+          tool_uses:   (($u.tool_use_count)    // null),
+          duration_ms: (($u.duration_ms)       // null),
+          alto_consumo: ($r.divergente
+            and (($u.total_tokens) != null)
+            and $media != null
+            and (($u.total_tokens) > $media))
+        })
+'
+```
+
+**Renderizacao** (tabela `#### Consumo x roteamento por onda`, colunas
+GFM): `onda | etapa | sugerido | aplicado | origem | tokens | tool-uses
+| duracao | divergente+alto-consumo`. Marque a ultima coluna com `⚠`
+quando `alto_consumo=true` — sinaliza exatamente o caso mais caro para o
+operador auditar: a escalada/override divergiu do roteamento primario
+**e** custou mais tokens que a media das ondas roteadas nesta execucao.
+
+**Diferenca de §4.5 acima**: as duas tabelas de §4.5 (legado + por-onda)
+sao copiadas **verbatim** do stdout de `model-routing-report.sh` — nunca
+reformatadas (ver Gotcha "Agregado model-routing nao deve ser
+reformatado"). Esta subsecao e **derivada** (join calculado pelo
+review-task sobre dois `--json` independentes); nao ha saida canonica
+unica para colar verbatim, entao a tabela acima e a UNICA
+representacao — mantenha as colunas e o rotulo `⚠` estaveis para nao
+quebrar comparacoes entre relatorios sucessivos.
+
+**Quando incluir** (regra binaria, mesmo espirito de §4.5):
+
+- **Incluir** quando AMBOS os `--json` tem dado (`mr.ondas.total > 0` E
+  `wu.metric_collected == true`) E o join produz >=1 linha com
+  `tokens != null`.
+- **Omitir** silenciosamente quando qualquer uma dessas condicoes falha
+  por AUSENCIA de dado (nao houve roteamento por-onda nesta execucao,
+  ou a metrica de consumo nunca foi coletada) — nao emita cabecalho
+  sozinho.
+- **Skip auditavel** quando QUALQUER um dos dois helpers falha com
+  `exit != 0` (script ausente, `state.json` ilegivel etc.): nao inclua a
+  subsecao, mas adicione nota em "Recomendacoes" (mesmo formato de §4.5
+  §4 do contrato `review-task-aggregate.md`).
+
+**Defesa em profundidade**: identica a §4.5 — qualquer um dos dois
+helpers ausente/falhando nunca bloqueia o restante do review-task.
+
 ### 4.6 Reconciliacao + completude de tasks (.tasks[] ↔ tasks.md)
 
 Quando a feature tem `state.json` da execucao em
@@ -390,6 +476,13 @@ Ordene tarefas pendentes por:
 - manter-atual: n
 - fallback-default: n (pct%)
 
+<!-- INSERIR AQUI quando aplicavel — vide §4.5 (Cruzamento com consumo de tokens observado) -->
+## Consumo x roteamento por onda (wave-usage x model-routing)
+
+| onda | etapa | sugerido | aplicado | origem | tokens | tool-uses | duracao | divergente+alto-consumo |
+|------|-------|----------|----------|--------|--------|-----------|---------|--------------------------|
+| ...  | ...   | ...      | ...      | ...    | ...    | ...       | ...     | ...                      |
+
 ---
 
 ## Recomendacoes
@@ -456,3 +549,5 @@ Esta skill LE e RELATA; nao executa trabalho pendente. Se o usuario pergunta "st
 ### Agregado model-routing nao deve ser reformatado
 
 O `model-routing-report.sh aggregate` retorna Markdown ja canonicalizado (cabecalho, colunas, sumario com chaves fixas). Reformatar (mudar header, reordenar colunas, esconder rotulos com zero) quebra o INV-RT-1 do contrato `docs/specs/agente-00c-model-routing/contracts/review-task-aggregate.md` e invalida testes de integracao. Copie verbatim ou nao inclua.
+
+Excecao deliberada: a subsecao "Cruzamento com consumo de tokens observado" de §4.5 NAO copia verbatim — e um join calculado pelo review-task sobre dois `--json` independentes (`model-routing-report.sh` + `wave-usage-report.sh`), porque nenhum dos dois scripts pode emitir esse cruzamento sem violar seu proprio invariante publicado (`model-routing-report.sh` nunca le `.waves`). Nesse caso especifico, siga o formato de tabela documentado em §4.5 em vez de "copiar verbatim".

--- a/tests/cstk/test_hooks.sh
+++ b/tests/cstk/test_hooks.sh
@@ -194,8 +194,9 @@ scenario_merge_source_ausente() {
 # ==== apply_guard_hooks (enforced-guards US1, task 2.4.4) ====
 
 # _guard_src_fixture: monta um src_dir minimo com pretooluse-bash-guard.sh +
-# posttooluse-tool-call-tick.sh (conteudo trivial, so precisa existir p/ cp)
-# + settings.snippet.json (PreToolUse + PostToolUse, como o catalogo real).
+# posttooluse-tool-call-tick.sh + posttooluse-agent-usage.sh (conteudo
+# trivial, so precisa existir p/ cp) + settings.snippet.json (PreToolUse +
+# PostToolUse, como o catalogo real).
 _guard_src_fixture() {
   _gsf_dir="$TMPDIR_TEST/guard-src"
   mkdir -p "$_gsf_dir"
@@ -203,7 +204,9 @@ _guard_src_fixture() {
   chmod +x "$_gsf_dir/pretooluse-bash-guard.sh"
   printf '#!/bin/sh\nexit 0\n' > "$_gsf_dir/posttooluse-tool-call-tick.sh"
   chmod +x "$_gsf_dir/posttooluse-tool-call-tick.sh"
-  printf '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"x","timeout":5}]}],"PostToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"y","timeout":5}]}]}}\n' \
+  printf '#!/bin/sh\nexit 0\n' > "$_gsf_dir/posttooluse-agent-usage.sh"
+  chmod +x "$_gsf_dir/posttooluse-agent-usage.sh"
+  printf '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"x","timeout":5}]}],"PostToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"y","timeout":5}]},{"matcher":"Agent","hooks":[{"type":"command","command":"z","timeout":5}]}]}}\n' \
     > "$_gsf_dir/settings.snippet.json"
   printf '%s' "$_gsf_dir"
 }
@@ -306,6 +309,21 @@ scenario_apply_guard_hooks_copia_posttooluse_tick() {
     || { _fail "settings.json sem bloco PostToolUse" "$(cat "$_dest/settings.json" 2>/dev/null)"; return 1; }
 }
 
+# Provisionamento do hook de metrica de uso de tokens por spawn
+# (wave-token-metrics FASE 2, tarefa 2.2.4) — mesmo padrao do tick acima.
+scenario_apply_guard_hooks_copia_posttooluse_agent_usage() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _src=$(_guard_src_fixture)
+  _dest="$TMPDIR_TEST/claude-root"
+  capture sh -c ". $CSTK_LIB/hooks.sh && apply_guard_hooks '$_src' '$_dest' 0"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "apply exit" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "merged" || return 1
+  [ -x "$_dest/hooks/posttooluse-agent-usage.sh" ] \
+    || { _fail "agent-usage hook nao copiado/executavel" ""; return 1; }
+  jq -e '[.hooks.PostToolUse[] | select(.matcher == "Agent")] | length == 1' "$_dest/settings.json" >/dev/null \
+    || { _fail "settings.json sem entrada PostToolUse/Agent" "$(cat "$_dest/settings.json" 2>/dev/null)"; return 1; }
+}
+
 # Catalogo ANTIGO (skill sem o hook de metrica): provisionamento do guard
 # segue integral — o tick e best-effort e sua ausencia nao e erro.
 scenario_apply_guard_hooks_catalogo_antigo_sem_tick() {
@@ -323,6 +341,8 @@ scenario_apply_guard_hooks_catalogo_antigo_sem_tick() {
   [ -x "$_dest/hooks/pretooluse-bash-guard.sh" ] || { _fail "guard nao copiado" ""; return 1; }
   [ -f "$_dest/hooks/posttooluse-tool-call-tick.sh" ] \
     && { _fail "tick fantasma" "catalogo antigo nao traz o tick; nada a copiar"; return 1; }
+  [ -f "$_dest/hooks/posttooluse-agent-usage.sh" ] \
+    && { _fail "agent-usage fantasma" "catalogo antigo nao traz o hook de uso; nada a copiar"; return 1; }
   return 0
 }
 

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -603,9 +603,9 @@ SQL
   # Aplica schema v7 via funcao real (caminho de recall_apply_schema).
   sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_mdb" || {
     _fail "apply schema v7" "recall_apply_schema falhou"; return 1; }
-  # (a) schema_version virou a corrente (9 — v9 executions-target-path).
+  # (a) schema_version virou a corrente (10 — v10 wave-token-metrics).
   _sv=$(sqlite3 "$_mdb" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "9" ] || { _fail "schema_version" "esperado 9, obtido $_sv"; return 1; }
+  [ "$_sv" = "10" ] || { _fail "schema_version" "esperado 10, obtido $_sv"; return 1; }
   # (b) tabela bloqueios DROPADA; blocks (EN) criada no lugar.
   _hasbloq=$(sqlite3 "$_mdb" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='bloqueios'")
   [ "$_hasbloq" = "0" ] || { _fail "bloqueios dropada" "tabela pt-BR bloqueios sobreviveu"; return 1; }
@@ -650,7 +650,7 @@ scenario_m11b_v7_reindex_repopula() {
   _v7db="$TMPDIR_TEST/v7.db"
   _rc --reindex --states-root "$TMPDIR_TEST/rxv7" --db "$_v7db" >/dev/null 2>&1
   _sv=$(sqlite3 "$_v7db" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "9" ] || { _fail "reindex schema corrente" "esperado schema_version 9, obtido $_sv"; return 1; }
+  [ "$_sv" = "10" ] || { _fail "reindex schema corrente" "esperado schema_version 10, obtido $_sv"; return 1; }
   # decisions repopuladas em EN (2 decisoes do _write_state).
   _n=$(sqlite3 "$_v7db" "SELECT count(*) FROM decisions WHERE feature='featV7'")
   [ "$_n" = "2" ] || { _fail "reindex repopula" "esperado 2 decisoes, obtido $_n"; return 1; }
@@ -672,7 +672,7 @@ scenario_m12_ddl_idempotente() {
   sqlite3 "$_mdb" "INSERT INTO decisions(project,feature,wave,execution_id,source_ts,source_id,choice,ingested_at) VALUES('p','f','w','e','t','dec-keep','keep','now')"
   assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_mdb" || return 1
   _sv=$(sqlite3 "$_mdb" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "9" ] || { _fail "schema estavel" "esperado 9 apos 2x, obtido $_sv"; return 1; }
+  [ "$_sv" = "10" ] || { _fail "schema estavel" "esperado 10 apos 2x, obtido $_sv"; return 1; }
   _keep=$(sqlite3 "$_mdb" "SELECT count(*) FROM decisions WHERE source_id='dec-keep'")
   [ "$_keep" = "1" ] || { _fail "idempotente sem re-drop" "linha sumiu: 2o apply re-dropou ($_keep)"; return 1; }
 }
@@ -1869,10 +1869,11 @@ scenario_b11_ddl_tasks_events() {
   assert_exit 0 _rc --ingest --state-dir "$TMPDIR_TEST/featB" --db "$TMPDIR_TEST/k.db" || return 1
   _has=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ('tasks','events')")
   [ "$_has" = "2" ] || { _fail "DDL tasks/events" "esperado 2 tabelas, obtido $_has"; return 1; }
-  # schema_version = 9 (executions-target-path: coluna target_project_path em
-  # executions; v8 recall-worktree-identity: coluna session em executions/waves).
+  # schema_version = 10 (wave-token-metrics: 9 colunas agent_* em waves;
+  # v9 executions-target-path: coluna target_project_path em executions; v8
+  # recall-worktree-identity: coluna session em executions/waves).
   _sv=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "9" ] || { _fail "schema_version" "esperado 9, obtido $_sv"; return 1; }
+  [ "$_sv" = "10" ] || { _fail "schema_version" "esperado 10, obtido $_sv"; return 1; }
   # tasks tem a coluna title (EN, DDL fresco).
   _hascol=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT count(*) FROM pragma_table_info('tasks') WHERE name='title'")
   [ "$_hascol" = "1" ] || { _fail "coluna title" "esperado 1, obtido $_hascol"; return 1; }
@@ -2185,10 +2186,10 @@ scenario_m1_schema_memories_table_exists() {
     *memories*) : ;;
     *) _fail "memories table ausente" "$_tables"; return 1 ;;
   esac
-  # schema_version deve ser 9 (executions-target-path: coluna target_project_path)
+  # schema_version deve ser 10 (wave-token-metrics: colunas agent_* em waves)
   _ver=$(sqlite3 "$TMPDIR_TEST/m1.db" \
     "SELECT value FROM schema_meta WHERE key='schema_version';" 2>/dev/null)
-  [ "$_ver" = "9" ] || { _fail "schema_version errado" "esperado 9, obtido '$_ver'"; return 1; }
+  [ "$_ver" = "10" ] || { _fail "schema_version errado" "esperado 10, obtido '$_ver'"; return 1; }
 }
 
 # M1-enum — RECALL_TYPE_ENUM inclui 'memory' apos bump.
@@ -2230,10 +2231,10 @@ scenario_m4_neg_context_type_invalido() {
 }
 
 # M1-migration — DB v3 pre-existente (pt-BR) e migrado pela cadeia completa
-# v3 -> ... -> v9: tabelas renomeadas dropadas+recriadas EN (drop v7),
+# v3 -> ... -> v10: tabelas renomeadas dropadas+recriadas EN (drop v7),
 # memories/suggestions criadas, e o ingest subsequente repopula decisions em
 # EN (o derivado legacy do v3 e descartado pelo drop v7, mas o ingest do
-# state.json o reconstroi). schema_version final = 9.
+# state.json o reconstroi). schema_version final = 10.
 scenario_m1_migration_v3_to_current() {
   _have_deps || return 0
   # Criar um DB v3 com schema pt-BR antigo (sem memories) simulando pre-existente
@@ -2274,10 +2275,11 @@ scenario_m1_migration_v3_to_current() {
   _dcols=$(sqlite3 "$_v3db" "SELECT group_concat(name,',') FROM pragma_table_info('decisions')")
   case ",$_dcols," in *,choice,*) : ;; *) _fail "migration: decisions nao-EN" "$_dcols"; return 1 ;; esac
   case ",$_dcols," in *,escolha,*|*,execucao_id,*) _fail "migration: decisions pt-BR leak" "$_dcols"; return 1 ;; esac
-  # schema_version deve ser 9 (cadeia completa v3 -> ... -> v9; as colunas
-  # session/target_project_path de executions vem do DDL fresco pos-drop v7)
+  # schema_version deve ser 10 (cadeia completa v3 -> ... -> v10; as colunas
+  # session/target_project_path de executions e agent_* de waves vem do DDL
+  # fresco pos-drop v7)
   _ver=$(sqlite3 "$_v3db" "SELECT value FROM schema_meta WHERE key='schema_version';" 2>/dev/null)
-  [ "$_ver" = "9" ] || { _fail "migration: schema_version errado" "esperado 9, obtido '$_ver'"; return 1; }
+  [ "$_ver" = "10" ] || { _fail "migration: schema_version errado" "esperado 10, obtido '$_ver'"; return 1; }
   # decisions repopuladas pelo ingest (>=1; o derivado v3 foi descartado, o
   # state.json o reconstroi em EN).
   _n=$(sqlite3 "$_v3db" "SELECT count(*) FROM decisions;" 2>/dev/null)
@@ -3027,7 +3029,7 @@ INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,i
     *) _fail "W5 waves.session" "coluna session ausente em waves pos-migracao"; return 1 ;;
   esac
   _w5_ver=$(sqlite3 "$_w5_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_w5_ver" = "9" ] || { _fail "W5 schema_version" "esperado '9' (corrente pos-v9), obtido '$_w5_ver'"; return 1; }
+  [ "$_w5_ver" = "10" ] || { _fail "W5 schema_version" "esperado '10' (corrente pos-v10), obtido '$_w5_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/w5/sd" --db "$_w5_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "W5 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3144,14 +3146,16 @@ JSON
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "TP1c ingest exit" "$_CAPTURED_EXIT"; return 1; }
   _tp1c=$(sqlite3 "$_tp1_db" "SELECT COALESCE(target_project_path,'NULL') FROM executions WHERE feature='feat-abs';")
   [ "$_tp1c" = "NULL" ] || { _fail "TP1c ausente" "esperado NULL, obtido '$_tp1c'"; return 1; }
-  # (d) shape v9 em DB fresca: coluna presente + schema_version=9
+  # (d) shape v9 (target_project_path) presente em DB fresca, mesmo com
+  # schema_version ja corrente (10 — v10 wave-token-metrics: colunas agent_*
+  # em waves nao afetam a coluna v9 em executions, ambas coexistem no DDL).
   _tp1_shape=$(sqlite3 "$_tp1_db" "PRAGMA table_info(executions);")
   case "$_tp1_shape" in
     *'|target_project_path|'*) : ;;
     *) _fail "TP1d shape v9" "coluna target_project_path ausente em executions"; return 1 ;;
   esac
   _tp1_ver=$(sqlite3 "$_tp1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_tp1_ver" = "9" ] || { _fail "TP1d schema_version" "esperado 9, obtido '$_tp1_ver'"; return 1; }
+  [ "$_tp1_ver" = "10" ] || { _fail "TP1d schema_version" "esperado 10, obtido '$_tp1_ver'"; return 1; }
 }
 
 # Cenario TP2 — re-ingestao idempotente + backfill: DB v8 preexistente com
@@ -3184,7 +3188,8 @@ INSERT INTO executions(project,feature,wave,execution_id,source_ts,source_id,ing
 # fixture DB v8 (executions/waves COM session, SEM target_project_path +
 # schema_version=8 + linha de OUTRA chave) -> ingest adiciona a coluna via
 # ALTER guardado por PRAGMA; linha v8 INTACTA (session preservada, path NULL
-# nela); schema_version=9; 2a rodada sem erro de coluna duplicada.
+# nela); schema_version = corrente (10, cadeia v8->v9->v10 aplicada em
+# batch pelo mesmo ingest); 2a rodada sem erro de coluna duplicada.
 scenario_tp3_migracao_v8_v9_idempotente() {
   _have_deps || return 0
   _tp3_db="$TMPDIR_TEST/tp3/k.db"
@@ -3205,12 +3210,180 @@ INSERT INTO executions(project,feature,wave,execution_id,source_ts,source_id,ses
   _tp3_new=$(sqlite3 "$_tp3_db" "SELECT target_project_path FROM executions WHERE feature='feat-tp3';")
   [ "$_tp3_new" = "/nonexistent/tp3proj" ] || { _fail "TP3 linha nova" "esperado '/nonexistent/tp3proj', obtido '$_tp3_new'"; return 1; }
   _tp3_ver=$(sqlite3 "$_tp3_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_tp3_ver" = "9" ] || { _fail "TP3 schema_version" "esperado '9', obtido '$_tp3_ver'"; return 1; }
+  [ "$_tp3_ver" = "10" ] || { _fail "TP3 schema_version" "esperado '10', obtido '$_tp3_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada, sem duplicata)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/tp3/sd" --db "$_tp3_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "TP3 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
   _tp3_cnt=$(sqlite3 "$_tp3_db" "SELECT COUNT(*) FROM executions;")
   [ "$_tp3_cnt" = "2" ] || { _fail "TP3 count pos-2a-rodada" "esperado '2', obtido '$_tp3_cnt'"; return 1; }
+}
+
+# =========================================================================
+# Cenarios WT1-WT4 — knowledge.db v9 -> v10 (wave-token-metrics, FASE 5):
+# 9 colunas aditivas INTEGER em waves para o agregado .waves[].agent_usage
+# (agent_spawns_total .. agent_duration_ms). Migracao idempotente (ALTER
+# guardado por PRAGMA, mesmo padrao v8/v9), NULL != 0 (FR-009/Principio VI),
+# retrofit via --reindex, permissao 0600 ja coberta pela suite geral (nao
+# reexercitada aqui — ver cenario 15 / TP1d).
+# =========================================================================
+
+# Cenario WT1 — ingest com .agent_usage completo: as 9 colunas recebem os
+# valores exatos, incluindo um campo legitimamente 0 (cache_read_input_tokens)
+# — prova que `//` do jq nao confunde 0 com ausencia (so false/null/vazio).
+# DB fresca nasce v10 com as 9 colunas no shape.
+scenario_wt1_agent_usage_completo() {
+  _have_deps || return 0
+  _wt1_db="$TMPDIR_TEST/wt1/k.db"
+  mkdir -p "$TMPDIR_TEST/wt1/sd"
+  cat > "$TMPDIR_TEST/wt1/sd/state.json" <<'JSON'
+{
+  "short_name": "feat-wt1",
+  "execution": { "id": "exec-feat-wt1", "target_project_path": "/home/u/proj-wt1" },
+  "waves": [
+    { "id": "onda-001", "started_at": "2026-01-01T00:00:00Z", "finished_at": "2026-01-01T01:00:00Z",
+      "executed_stages": ["specify"], "tool_calls": 3, "wallclock_seconds": 60,
+      "termination_reason": "ok",
+      "agent_usage": { "spawns_total": 2, "spawns_with_usage": 1, "total_tokens": 500,
+        "input_tokens": 300, "output_tokens": 200, "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 10, "tool_use_count": 5, "duration_ms": 12345 } }
+  ]
+}
+JSON
+  capture _rc --ingest --state-dir "$TMPDIR_TEST/wt1/sd" --db "$_wt1_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT1 ingest exit" "$_CAPTURED_EXIT"; return 1; }
+  _wt1_row=$(sqlite3 "$_wt1_db" "SELECT agent_spawns_total||'|'||agent_spawns_with_usage||'|'||agent_total_tokens||'|'||agent_input_tokens||'|'||agent_output_tokens||'|'||agent_cache_read_tokens||'|'||agent_cache_creation_tokens||'|'||agent_tool_use_count||'|'||agent_duration_ms FROM waves WHERE wave='onda-001';")
+  [ "$_wt1_row" = "2|1|500|300|200|0|10|5|12345" ] || { _fail "WT1 valores" "esperado '2|1|500|300|200|0|10|5|12345', obtido '$_wt1_row'"; return 1; }
+  _wt1_shape=$(sqlite3 "$_wt1_db" "PRAGMA table_info(waves);")
+  case "$_wt1_shape" in
+    *'|agent_spawns_total|'*) : ;;
+    *) _fail "WT1 shape v10" "coluna agent_spawns_total ausente em waves"; return 1 ;;
+  esac
+  _wt1_ver=$(sqlite3 "$_wt1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
+  [ "$_wt1_ver" = "10" ] || { _fail "WT1 schema_version" "esperado 10, obtido '$_wt1_ver'"; return 1; }
+}
+
+# Cenario WT2 — onda SEM .agent_usage: as 9 colunas ficam NULL, nunca 0
+# (Principio VI: nao fabricar dado nao observado). Mesmo state tambem tem uma
+# onda COM agent_usage, para provar que a ausencia e por-onda, nao global.
+scenario_wt2_null_sem_agent_usage() {
+  _have_deps || return 0
+  _wt2_db="$TMPDIR_TEST/wt2/k.db"
+  mkdir -p "$TMPDIR_TEST/wt2/sd"
+  cat > "$TMPDIR_TEST/wt2/sd/state.json" <<'JSON'
+{
+  "short_name": "feat-wt2",
+  "execution": { "id": "exec-feat-wt2", "target_project_path": "/home/u/proj-wt2" },
+  "waves": [
+    { "id": "onda-001", "started_at": "t", "finished_at": "t", "executed_stages": [],
+      "tool_calls": 0, "wallclock_seconds": 0, "termination_reason": "ok" },
+    { "id": "onda-002", "started_at": "t", "finished_at": "t", "executed_stages": [],
+      "tool_calls": 1, "wallclock_seconds": 5, "termination_reason": "ok",
+      "agent_usage": { "spawns_total": 1, "spawns_with_usage": 1, "total_tokens": 100,
+        "input_tokens": 60, "output_tokens": 40, "cache_read_input_tokens": 1,
+        "cache_creation_input_tokens": 2, "tool_use_count": 3, "duration_ms": 999 } }
+  ]
+}
+JSON
+  capture _rc --ingest --state-dir "$TMPDIR_TEST/wt2/sd" --db "$_wt2_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT2 ingest exit" "$_CAPTURED_EXIT"; return 1; }
+  _wt2_absent=$(sqlite3 "$_wt2_db" "SELECT COALESCE(agent_spawns_total,-999)||'|'||COALESCE(agent_duration_ms,-999) FROM waves WHERE wave='onda-001';")
+  [ "$_wt2_absent" = "-999|-999" ] || { _fail "WT2 sem agent_usage" "esperado NULL(-999)/NULL(-999), obtido '$_wt2_absent'"; return 1; }
+  _wt2_present=$(sqlite3 "$_wt2_db" "SELECT agent_spawns_total||'|'||agent_duration_ms FROM waves WHERE wave='onda-002';")
+  [ "$_wt2_present" = "1|999" ] || { _fail "WT2 com agent_usage" "esperado '1|999', obtido '$_wt2_present'"; return 1; }
+}
+
+# Cenario WT3 — migracao v9->v10 idempotente (espelho de TP3 para o passo
+# v10): fixture DB v9 (executions+waves shape v9, SEM as 9 colunas novas +
+# schema_version=9 + linha de outra chave) -> ingest adiciona as colunas via
+# ALTER guardado por PRAGMA; linha v9 INTACTA (session preservada, colunas
+# novas NULL nela); schema_version=10; 2a rodada idempotente (sem erro de
+# coluna duplicada, sem duplicata).
+scenario_wt3_migracao_v9_v10_idempotente() {
+  _have_deps || return 0
+  _wt3_db="$TMPDIR_TEST/wt3/k.db"
+  mkdir -p "$TMPDIR_TEST/wt3"
+  sqlite3 "$_wt3_db" "
+CREATE TABLE executions (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, status TEXT, termination_reason TEXT, current_stage TEXT, started_at TEXT, finished_at TEXT, duration_seconds INTEGER, suggested_stack TEXT, waves_total INTEGER, tool_calls_total INTEGER, wallclock_total_seconds INTEGER, subagents_spawned INTEGER, max_depth INTEGER, decisions_total INTEGER, human_blocks_total INTEGER, skill_suggestions_total INTEGER, toolkit_issues_opened INTEGER, session TEXT, target_project_path TEXT, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE waves (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, stages TEXT, started_at TEXT, finished_at TEXT, wallclock_seconds INTEGER, tool_calls INTEGER, termination_reason TEXT, n_stages INTEGER, n_skills INTEGER, session TEXT, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE schema_meta (key TEXT PRIMARY KEY, value TEXT);
+INSERT INTO schema_meta VALUES('schema_version','9');
+INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,session,ingested_at) VALUES('legacyp9','legacyf9','onda-legacy','e-v9','t','onda-legacy','sess-v9','t');
+" || { _fail "WT3 fixture" "criacao do DB v9 falhou"; return 1; }
+  mkdir -p "$TMPDIR_TEST/wt3/sd"
+  cat > "$TMPDIR_TEST/wt3/sd/state.json" <<'JSON'
+{
+  "short_name": "feat-wt3",
+  "execution": { "id": "exec-feat-wt3", "target_project_path": "/home/u/proj-wt3" },
+  "waves": [
+    { "id": "onda-001", "started_at": "t", "finished_at": "t", "executed_stages": [],
+      "tool_calls": 0, "wallclock_seconds": 0, "termination_reason": "ok",
+      "agent_usage": { "spawns_total": 3, "spawns_with_usage": 2, "total_tokens": 700,
+        "input_tokens": 400, "output_tokens": 300, "cache_read_input_tokens": 5,
+        "cache_creation_input_tokens": 6, "tool_use_count": 7, "duration_ms": 4321 } }
+  ]
+}
+JSON
+  # 1a rodada: migra v9->v10
+  capture _rc --ingest --state-dir "$TMPDIR_TEST/wt3/sd" --db "$_wt3_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT3 ingest#1 exit" "$_CAPTURED_EXIT"; return 1; }
+  _wt3_leg=$(sqlite3 "$_wt3_db" "SELECT session||'|'||COALESCE(agent_spawns_total,-999) FROM waves WHERE project='legacyp9';")
+  [ "$_wt3_leg" = "sess-v9|-999" ] || { _fail "WT3 linha v9 intacta" "esperado 'sess-v9|-999', obtido '$_wt3_leg'"; return 1; }
+  _wt3_new=$(sqlite3 "$_wt3_db" "SELECT agent_spawns_total||'|'||agent_duration_ms FROM waves WHERE feature='feat-wt3';")
+  [ "$_wt3_new" = "3|4321" ] || { _fail "WT3 linha nova" "esperado '3|4321', obtido '$_wt3_new'"; return 1; }
+  _wt3_ver=$(sqlite3 "$_wt3_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
+  [ "$_wt3_ver" = "10" ] || { _fail "WT3 schema_version" "esperado '10', obtido '$_wt3_ver'"; return 1; }
+  # 2a rodada: idempotente (sem erro de coluna duplicada, sem duplicata)
+  capture _rc --ingest --state-dir "$TMPDIR_TEST/wt3/sd" --db "$_wt3_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT3 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
+  _wt3_cnt=$(sqlite3 "$_wt3_db" "SELECT COUNT(*) FROM waves;")
+  [ "$_wt3_cnt" = "2" ] || { _fail "WT3 count pos-2a-rodada" "esperado '2', obtido '$_wt3_cnt'"; return 1; }
+}
+
+# Cenario WT4 — retrofit via --reindex: varre 2 states no layout de
+# descoberta padrao (com e sem .agent_usage) e confirma que o reindex povoa
+# as colunas novas identicamente ao --ingest direto (NULL para a onda sem
+# dado, valores para a onda com dado). Reindex 2x = mesma contagem (idempotente).
+scenario_wt4_reindex_retrofit() {
+  _have_deps || return 0
+  _wt4_db="$TMPDIR_TEST/wt4/k.db"
+  _wt4_dirA="$TMPDIR_TEST/wt4root/pA/.claude/feature-00c-state/featA"
+  _wt4_dirB="$TMPDIR_TEST/wt4root/pB/.claude/feature-00c-state/featB"
+  mkdir -p "$_wt4_dirA" "$_wt4_dirB"
+  cat > "$_wt4_dirA/state.json" <<'JSON'
+{
+  "short_name": "featA",
+  "execution": { "id": "exec-featA", "target_project_path": "/home/u/projA" },
+  "waves": [
+    { "id": "onda-001", "started_at": "t", "finished_at": "t", "executed_stages": [],
+      "tool_calls": 0, "wallclock_seconds": 0, "termination_reason": "ok" }
+  ]
+}
+JSON
+  cat > "$_wt4_dirB/state.json" <<'JSON'
+{
+  "short_name": "featB",
+  "execution": { "id": "exec-featB", "target_project_path": "/home/u/projB" },
+  "waves": [
+    { "id": "onda-001", "started_at": "t", "finished_at": "t", "executed_stages": [],
+      "tool_calls": 0, "wallclock_seconds": 0, "termination_reason": "ok",
+      "agent_usage": { "spawns_total": 4, "spawns_with_usage": 4, "total_tokens": 800,
+        "input_tokens": 500, "output_tokens": 300, "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0, "tool_use_count": 9, "duration_ms": 5555 } }
+  ]
+}
+JSON
+  capture _rc --reindex --states-root "$TMPDIR_TEST/wt4root" --db "$_wt4_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT4 reindex#1 exit" "$_CAPTURED_EXIT"; return 1; }
+  _wt4_a=$(sqlite3 "$_wt4_db" "SELECT COALESCE(agent_spawns_total,-999) FROM waves WHERE feature='featA';")
+  [ "$_wt4_a" = "-999" ] || { _fail "WT4 retrofit NULL" "esperado -999 (NULL), obtido '$_wt4_a'"; return 1; }
+  _wt4_b=$(sqlite3 "$_wt4_db" "SELECT agent_spawns_total||'|'||agent_duration_ms FROM waves WHERE feature='featB';")
+  [ "$_wt4_b" = "4|5555" ] || { _fail "WT4 retrofit valores" "esperado '4|5555', obtido '$_wt4_b'"; return 1; }
+  _wt4_cnt0=$(sqlite3 "$_wt4_db" "SELECT COUNT(*) FROM waves;")
+  # 2a rodada: reindex apaga e reconstroi do zero — mesma contagem (idempotente).
+  capture _rc --reindex --states-root "$TMPDIR_TEST/wt4root" --db "$_wt4_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT4 reindex#2 exit" "$_CAPTURED_EXIT"; return 1; }
+  _wt4_cnt1=$(sqlite3 "$_wt4_db" "SELECT COUNT(*) FROM waves;")
+  [ "$_wt4_cnt0" = "$_wt4_cnt1" ] || { _fail "WT4 reindex idempotente" "N0=$_wt4_cnt0 != N1=$_wt4_cnt1"; return 1; }
 }
 
 run_all_scenarios

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -18,6 +18,7 @@
 #   13b payload adversarial de injecao na busca (A05/CWE-89)
 #   13c payload adversarial de injecao na ingestao
 #   14 concorrencia WAL best-effort (FR-016)
+#   15 permissao 0600 no knowledge.db criado do zero (CHK017, wave-token-metrics)
 #
 # DB de teste sempre em $TMPDIR_TEST (--db), nunca o indice global.
 # Fixtures de bytes crus (NUL) usam escape OCTAL \000, nunca hex \xHH.
@@ -393,6 +394,50 @@ scenario_14_concorrencia_wal() {
   # graciosa). Aceitamos >=1 feature (best-effort) e exigimos integridade.
   _feats=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT count(DISTINCT feature) FROM decisions" 2>/dev/null)
   [ "${_feats:-0}" -ge 1 ] || { _fail "concorrencia conteudo" "nenhuma feature ingerida"; return 1; }
+}
+
+# _file_mode PATH -> imprime o modo octal do arquivo, portavel BSD/GNU.
+_file_mode() {
+  stat -f '%Lp' -- "$1" 2>/dev/null || stat -c '%a' -- "$1" 2>/dev/null
+}
+
+# =========================================================================
+# Cenario 15 — Permissao 0600 no knowledge.db criado do zero (CHK017,
+# feature wave-token-metrics, subtarefas 1.2.4/1.2.6). Cobre tanto --ingest
+# (recall_apply_schema cria o arquivo pela primeira vez) quanto --reindex
+# (apaga e recria do zero) e a normalizacao best-effort de um DB PRE-EXISTENTE
+# com permissao mais aberta (recall_normalize_db_perms nao falha o caller).
+# =========================================================================
+scenario_15_permissao_0600_knowledge_db() {
+  _have_deps || return 0
+  # HOME isolado em $TMPDIR_TEST (via _rc_home, nao _rc): --ingest/--reindex
+  # tambem varrem ~/.claude/projects/*/memory/ para memorias (recall_mode_ingest/
+  # recall_mode_reindex); sem isolar HOME, a varredura cai na arvore REAL do
+  # operador (potencialmente grande) em vez do tmpdir do teste — mesmo padrao
+  # ja usado alhures neste arquivo (scenarios TP1-TP3, _rc_home_fake).
+  # (a) --ingest cria o DB do zero -> 0600.
+  _write_state "$TMPDIR_TEST/perm1" "/home/u/permproj" "permfeat"
+  _p1_db="$TMPDIR_TEST/perm1.db"
+  capture _rc_home "$TMPDIR_TEST" --ingest --state-dir "$TMPDIR_TEST/perm1" --db "$_p1_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "perm ingest exit" "$_CAPTURED_EXIT"; return 1; }
+  _p1_mode=$(_file_mode "$_p1_db")
+  [ "$_p1_mode" = "600" ] || { _fail "perm ingest modo" "esperado 600, obtido '$_p1_mode'"; return 1; }
+
+  # (b) --reindex apaga e recria do zero -> 0600.
+  capture _rc_home "$TMPDIR_TEST" --reindex --states-root "$TMPDIR_TEST/perm1" --db "$_p1_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "perm reindex exit" "$_CAPTURED_EXIT"; return 1; }
+  _p1_mode2=$(_file_mode "$_p1_db")
+  [ "$_p1_mode2" = "600" ] || { _fail "perm reindex modo" "esperado 600, obtido '$_p1_mode2'"; return 1; }
+
+  # (c) DB pre-existente com permissao mais aberta -> normalizado, sem falhar.
+  _p2_db="$TMPDIR_TEST/perm2.db"
+  : > "$_p2_db"
+  chmod 644 "$_p2_db" 2>/dev/null || { _fail "perm setup chmod 644" "falhou"; return 1; }
+  _write_state "$TMPDIR_TEST/perm2" "/home/u/permproj2" "permfeat2"
+  capture _rc_home "$TMPDIR_TEST" --ingest --state-dir "$TMPDIR_TEST/perm2" --db "$_p2_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "perm normalizacao exit" "$_CAPTURED_EXIT"; return 1; }
+  _p2_mode=$(_file_mode "$_p2_db")
+  [ "$_p2_mode" = "600" ] || { _fail "perm normalizacao modo" "esperado 600, obtido '$_p2_mode'"; return 1; }
 }
 
 # =========================================================================

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -302,6 +302,14 @@ _is_internal_test() {
       # por convencao. Existence-guarded.
       [ -f "$REPO_ROOT/global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh" ] && return 0
       return 1 ;;
+    test_posttooluse-agent-usage.sh)
+      # cobre global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh
+      # (hook PostToolUse/matcher "Agent" de metrica de uso de tokens por
+      # spawn de subagente — wave-token-metrics FASE 2) — mesma razao dos
+      # dois casos acima: hooks/ esta fora do escaneio por convencao.
+      # Existence-guarded.
+      [ -f "$REPO_ROOT/global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh" ] && return 0
+      return 1 ;;
     *) return 1 ;;
   esac
 }

--- a/tests/test_posttooluse-agent-usage.sh
+++ b/tests/test_posttooluse-agent-usage.sh
@@ -1,0 +1,352 @@
+#!/bin/sh
+# test_posttooluse-agent-usage.sh — cobre
+# global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh
+# (hook PostToolUse/matcher "Agent" de metrica de uso de tokens por spawn;
+# sidecar append-only wave-agent-usage.jsonl).
+#
+# Feature: wave-token-metrics, FASE 2, tarefa 2.1.9 (incorpora as
+# subtarefas adiadas 1.2.5 e 1.3.4). Contrato:
+# docs/specs/wave-token-metrics/contracts/hook-posttooluse-agent-usage.md §6.
+#
+# Politica sob teste (mesma familia de test_posttooluse-tool-call-tick.sh):
+# fail-OPEN absoluto — o hook NUNCA emite decisao em stdout, NUNCA sai com
+# exit != 0 e NUNCA escreve no state.json; unico efeito permitido e o
+# append em <state-dir>/wave-agent-usage.jsonl quando ha execucao ativa e
+# tool_name == "Agent".
+#
+# Mesmo idioma de invocacao do test_pretooluse-bash-guard.sh /
+# test_posttooluse-tool-call-tick.sh: o script nao aceita argv — le JSON
+# do stdin via `sh -c 'printf "%s" "$1" | "$2"' _ "$json" "$SCRIPT"`.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh"
+
+# _run_hook JSON -> invoca o script com JSON via stdin; popula _CAPTURED_*.
+_run_hook() {
+  capture sh -c 'printf "%s" "$1" | "$2"' _ "$1" "$SCRIPT"
+}
+
+# _active_feature CWD SHORT STATUS -> fixture de execucao feature-00c.
+_active_feature() {
+  mkdir -p "$1/.claude/feature-00c-state/$2"
+  printf '{"execution":{"status":"%s"}}' "$3" \
+    > "$1/.claude/feature-00c-state/$2/state.json"
+}
+
+# _active_agente CWD STATUS -> fixture de execucao agente-00c.
+_active_agente() {
+  mkdir -p "$1/.claude/agente-00c-state"
+  printf '{"execution":{"status":"%s"}}' "$2" > "$1/.claude/agente-00c-state/state.json"
+}
+
+# _sidecar_for CWD SHORT -> path do sidecar de uso para uma feature.
+_sidecar_for() {
+  printf '%s/.claude/feature-00c-state/%s/wave-agent-usage.jsonl' "$1" "$2"
+}
+
+# _lines_count FILE -> nº de linhas do sidecar (0 se ausente).
+_lines_count() {
+  [ -f "$1" ] || { printf '0'; return 0; }
+  wc -l < "$1" | tr -d '[:space:]'
+}
+
+# _perm FILE -> permissao octal do arquivo (portavel BSD/GNU — mesmo
+# padrao de tests/cstk/test_recall.sh:401).
+_perm() {
+  stat -f '%Lp' -- "$1" 2>/dev/null || stat -c '%a' -- "$1" 2>/dev/null
+}
+
+# _payload CWD TOOL_NAME TOOL_RESPONSE_JSON [TOOL_INPUT_JSON] -> payload
+# PostToolUse completo via jq -n (evita quoting manual de JSON aninhado).
+_payload() {
+  _pl_ti=$4
+  if [ -z "$_pl_ti" ]; then
+    _pl_ti='{}'
+  fi
+  jq -n --arg cwd "$1" --arg tn "$2" --argjson tr "$3" --argjson ti "$_pl_ti" \
+    '{cwd:$cwd,hook_event_name:"PostToolUse",tool_name:$tn,tool_input:$ti,tool_response:$tr}'
+}
+
+# _make_shim_path: PATH controlado com POSIX essenciais, SEM jq. Espelha
+# tests/test_pretooluse-bash-guard.sh::_make_shim_path (manter em sync).
+_make_shim_path() {
+  _shim="$TMPDIR_TEST/shimbin"
+  mkdir -p "$_shim"
+  for _cmd in sh mktemp awk sed grep find head printf cp mv rm mkdir \
+              chmod ls dirname basename tr cut wc env command sort \
+              uniq date cat stat; do
+    _src=$(command -v "$_cmd" 2>/dev/null) || continue
+    [ -n "$_src" ] || continue
+    ln -sf "$_src" "$_shim/$_cmd" 2>/dev/null || :
+  done
+  printf '%s' "$_shim"
+}
+
+# ==== Cenario: spawn completed com usage completo -> status=completo ====
+
+scenario_completed_com_usage_completo() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _tr='{"status":"completed","agentId":"a1b598e5d8f9a0318","content":[{"type":"text","text":"NAO PODE VAZAR"}],"resolvedModel":"claude-sonnet-5","totalTokens":131692,"totalDurationMs":681768,"totalToolUseCount":45,"usage":{"input_tokens":2,"output_tokens":1097,"cache_read_input_tokens":130176,"cache_creation_input_tokens":417}}'
+  _ti='{"subagent_type":"general-purpose","prompt":"segredo de tarefa"}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr" "$_ti")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio (metrica silenciosa): $_CAPTURED_STDOUT"; return 1; }
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  [ "$(_lines_count "$_side")" = 1 ] || { _fail "sidecar" "esperado 1 linha, obtido $(_lines_count "$_side")"; return 1; }
+  _line=$(cat "$_side")
+  echo "$_line" | jq -e '.status == "completo"' >/dev/null || { _fail "status" "$_line"; return 1; }
+  echo "$_line" | jq -e '.agent_id == "a1b598e5d8f9a0318"' >/dev/null || { _fail "agent_id" "$_line"; return 1; }
+  echo "$_line" | jq -e '.model == "claude-sonnet-5"' >/dev/null || { _fail "model" "$_line"; return 1; }
+  echo "$_line" | jq -e '.total_tokens == 131692 and .input_tokens == 2 and .output_tokens == 1097' >/dev/null \
+    || { _fail "breakdown" "$_line"; return 1; }
+  echo "$_line" | jq -e '.tool_use_count == 45 and .duration_ms == 681768' >/dev/null \
+    || { _fail "tool_use/duration" "$_line"; return 1; }
+  echo "$_line" | jq -e '.source == "live"' >/dev/null || { _fail "source" "$_line"; return 1; }
+}
+
+# ==== Cenario: status=async_launched -> indisponivel, todos numericos null ====
+
+scenario_async_launched_indisponivel() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _tr='{"status":"async_launched","agentId":"a35a086e9e6589c0b","description":"x","prompt":"y","outputFile":"z","resolvedModel":"claude-opus-4-8[1m]","isAsync":true,"canReadOutputFile":true}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  _line=$(cat "$_side")
+  echo "$_line" | jq -e '.status == "indisponivel"' >/dev/null || { _fail "status" "$_line"; return 1; }
+  echo "$_line" | jq -e '.total_tokens == null and .input_tokens == null and .output_tokens == null' >/dev/null \
+    || { _fail "numericos deveriam ser null, nao 0" "$_line"; return 1; }
+  echo "$_line" | jq -e '.cache_read_input_tokens == null and .cache_creation_input_tokens == null' >/dev/null \
+    || { _fail "cache deveria ser null" "$_line"; return 1; }
+  echo "$_line" | jq -e '.tool_use_count == null and .duration_ms == null' >/dev/null \
+    || { _fail "tool_use/duration deveriam ser null" "$_line"; return 1; }
+}
+
+# ==== Cenario: completed sem usage -> parcial, observados preenchidos ====
+
+scenario_completed_sem_usage_parcial() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _tr='{"status":"completed","agentId":"xyz","resolvedModel":"claude-haiku-5"}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  _line=$(cat "$_side")
+  echo "$_line" | jq -e '.status == "parcial"' >/dev/null || { _fail "status" "$_line"; return 1; }
+  echo "$_line" | jq -e '.model == "claude-haiku-5"' >/dev/null || { _fail "model observado" "$_line"; return 1; }
+  echo "$_line" | jq -e '.total_tokens == null and .input_tokens == null' >/dev/null \
+    || { _fail "campos nao observados deveriam ser null" "$_line"; return 1; }
+}
+
+# ==== Cenario: resolvedModel ausente -> model == "nao-aplicavel" ====
+
+scenario_resolved_model_ausente_nao_aplicavel() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _tr='{"status":"completed","agentId":"sem-modelo","totalTokens":10}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  _line=$(cat "$_side")
+  echo "$_line" | jq -e '.model == "nao-aplicavel"' >/dev/null \
+    || { _fail "model" "esperado literal nao-aplicavel (FR-003), obtido: $_line"; return 1; }
+}
+
+# ==== Cenario: jq ausente -> fail-OPEN (no-op, sidecar nao criado) ====
+
+scenario_jq_ausente_fail_open() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _shim=$(_make_shim_path)
+  _tr='{"status":"completed","agentId":"x","totalTokens":1}'
+  _json=$(jq -n --arg cwd "$TMPDIR_TEST" --argjson tr "$_tr" \
+    '{cwd:$cwd,hook_event_name:"PostToolUse",tool_name:"Agent",tool_input:{},tool_response:$tr}')
+  capture env -i PATH="$_shim" HOME="$TMPDIR_TEST" \
+    sh -c 'printf "%s" "$1" | "$2"' _ "$_json" "$SCRIPT"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "fail-open exige exit 0 sem jq, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "fail-open NUNCA emite decisao: $_CAPTURED_STDOUT"; return 1; }
+  [ -f "$(_sidecar_for "$TMPDIR_TEST" "minha-feat")" ] \
+    && { _fail "sidecar" "sem jq nao ha parsing seguro -> sem linha"; return 1; }
+  return 0
+}
+
+# ==== Cenario: fora de execucao ativa -> zero interferencia, sem sidecar ====
+
+scenario_fora_de_execucao_zero_interferencia() {
+  _tr='{"status":"completed","agentId":"x","totalTokens":1}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio: $_CAPTURED_STDOUT"; return 1; }
+  find "$TMPDIR_TEST" -name 'wave-agent-usage.jsonl' 2>/dev/null | grep -q . \
+    && { _fail "sidecar" "NAO deveria existir sidecar fora de execucao ativa"; return 1; }
+  return 0
+}
+
+# ==== Cenario: status terminal (concluida) nao gera linha ====
+
+scenario_status_terminal_nao_gera_linha() {
+  _active_feature "$TMPDIR_TEST" "feat-velha" "concluida"
+  _tr='{"status":"completed","agentId":"x","totalTokens":1}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$(_sidecar_for "$TMPDIR_TEST" "feat-velha")" ] \
+    && { _fail "sidecar" "state concluido NAO deveria receber linha"; return 1; }
+  return 0
+}
+
+# ==== Cenario: tool_name != Agent -> exit 0, sidecar nao criado ====
+
+scenario_tool_name_diferente_de_agent_nao_gera_linha() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _run_hook "$(_payload "$TMPDIR_TEST" "Bash" '{}')"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$(_sidecar_for "$TMPDIR_TEST" "minha-feat")" ] \
+    && { _fail "sidecar" "matcher deve ser Agent, nao qualquer tool"; return 1; }
+  return 0
+}
+
+# ==== Cenario: 2 features ativas -> menor short lexicografico vence ====
+
+scenario_feature_menor_short_vence() {
+  _active_feature "$TMPDIR_TEST" "zebra-feat" "em_andamento"
+  _active_feature "$TMPDIR_TEST" "alpha-feat" "em_andamento"
+  _tr='{"status":"completed","agentId":"x","totalTokens":1}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  [ "$(_lines_count "$(_sidecar_for "$TMPDIR_TEST" "alpha-feat")")" = 1 ] \
+    || { _fail "precedencia" "menor short (alpha-feat) deveria receber a linha"; return 1; }
+  [ -f "$(_sidecar_for "$TMPDIR_TEST" "zebra-feat")" ] \
+    && { _fail "precedencia" "zebra-feat NAO deveria receber linha"; return 1; }
+  return 0
+}
+
+# ==== Cenario: agente-00c precede feature-00c (mesma regra do guard/tick) ====
+
+scenario_agente_precede_feature() {
+  _active_agente "$TMPDIR_TEST" "em_andamento"
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _tr='{"status":"completed","agentId":"x","totalTokens":1}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  [ "$(_lines_count "$TMPDIR_TEST/.claude/agente-00c-state/wave-agent-usage.jsonl")" = 1 ] \
+    || { _fail "precedencia" "linha deveria ir para agente-00c-state"; return 1; }
+  [ -f "$(_sidecar_for "$TMPDIR_TEST" "minha-feat")" ] \
+    && { _fail "precedencia" "feature-00c NAO deveria receber linha quando agente-00c esta ativo"; return 1; }
+  return 0
+}
+
+# ==== Cenario: stdin vazio / JSON invalido -> no-op exit 0, sem crash ====
+
+scenario_stdin_vazio_fail_open() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _run_hook ""
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio: $_CAPTURED_STDOUT"; return 1; }
+  return 0
+}
+
+scenario_stdin_malformado_fail_open() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _run_hook "isto nao e json {"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$(_sidecar_for "$TMPDIR_TEST" "minha-feat")" ] \
+    && { _fail "sidecar" "JSON invalido nao pode gerar linha"; return 1; }
+  return 0
+}
+
+# ==== Cenario: agentId ausente -> exit 0 sem linha (contrato §3) ====
+
+scenario_agent_id_ausente_sem_linha() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _tr='{"status":"completed","totalTokens":1}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$(_sidecar_for "$TMPDIR_TEST" "minha-feat")" ] \
+    && { _fail "sidecar" "sem agentId nao ha chave natural -> sem linha"; return 1; }
+  return 0
+}
+
+# ==== Cenario: append repetido -> 2 spawns geram 2 linhas, ordem preservada ====
+
+scenario_append_repetido_preserva_ordem() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _tr1='{"status":"completed","agentId":"primeiro","totalTokens":10}'
+  _tr2='{"status":"completed","agentId":"segundo","totalTokens":20}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr1")"
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr2")"
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  [ "$(_lines_count "$_side")" = 2 ] || { _fail "sidecar" "esperado 2 linhas, obtido $(_lines_count "$_side")"; return 1; }
+  sed -n '1p' "$_side" | jq -e '.agent_id == "primeiro"' >/dev/null \
+    || { _fail "ordem" "1a linha deveria ser 'primeiro'"; return 1; }
+  sed -n '2p' "$_side" | jq -e '.agent_id == "segundo"' >/dev/null \
+    || { _fail "ordem" "2a linha deveria ser 'segundo'"; return 1; }
+}
+
+# ==== Cenario: anti-vazamento — content/prompt nunca aparecem na linha ====
+
+scenario_anti_vazamento_content_prompt() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _tr='{"status":"completed","agentId":"x","totalTokens":1,"content":[{"type":"text","text":"SEGREDO-DE-SAIDA-NAO-PODE-VAZAR"}]}'
+  _ti='{"subagent_type":"general-purpose","prompt":"SEGREDO-DE-ENTRADA-NAO-PODE-VAZAR","description":"tambem nao pode vazar"}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr" "$_ti")"
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  _line=$(cat "$_side")
+  case "$_line" in
+    *SEGREDO*) _fail "vazamento" "linha do sidecar contem texto livre: $_line"; return 1 ;;
+  esac
+  echo "$_line" | jq -e 'has("content") | not' >/dev/null || { _fail "vazamento" "chave content presente"; return 1; }
+  echo "$_line" | jq -e 'has("prompt") | not' >/dev/null || { _fail "vazamento" "chave prompt presente"; return 1; }
+  echo "$_line" | jq -e 'has("description") | not' >/dev/null || { _fail "vazamento" "chave description presente"; return 1; }
+}
+
+# ==== Cenario: sidecar criado tem permissao 0600 (subtarefa 1.2.5) ====
+
+scenario_sidecar_criado_com_permissao_0600() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _tr='{"status":"completed","agentId":"x","totalTokens":1}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  [ -f "$_side" ] || { _fail "sidecar" "nao foi criado"; return 1; }
+  _perm=$(_perm "$_side")
+  [ "$_perm" = "600" ] || { _fail "permissao" "esperado 600, obtido $_perm"; return 1; }
+}
+
+# ==== Cenario: cap de 500 linhas (subtarefa 1.3.4) ====
+
+scenario_cap_500_linhas_nao_adiciona_501() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  _i=1
+  while [ "$_i" -le 500 ]; do
+    printf '{"filler":%s}\n' "$_i" >> "$_side"
+    _i=$((_i + 1))
+  done
+  _tr='{"status":"completed","agentId":"linha-501","totalTokens":1}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "cap deve ser fail-open, obtido $_CAPTURED_EXIT"; return 1; }
+  [ "$(_lines_count "$_side")" = 500 ] \
+    || { _fail "cap" "esperado 500 linhas (append pulado), obtido $(_lines_count "$_side")"; return 1; }
+  [ -f "$TMPDIR_TEST/.claude/feature-00c-state/minha-feat/.wave-agent-usage-cap-warned" ] \
+    || { _fail "sentinela" "sentinela de aviso deveria ter sido criado"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"cap de 500"*) : ;;
+    *) _fail "aviso" "esperado aviso de cap em stderr, obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "aviso deve ir para stderr, nao stdout: $_CAPTURED_STDOUT"; return 1; }
+}
+
+# ==== Cenario: cap ja avisado nesta onda -> nao duplica aviso ====
+
+scenario_cap_sentinela_evita_aviso_duplicado() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  _i=1
+  while [ "$_i" -le 500 ]; do
+    printf '{"filler":%s}\n' "$_i" >> "$_side"
+    _i=$((_i + 1))
+  done
+  : > "$TMPDIR_TEST/.claude/feature-00c-state/minha-feat/.wave-agent-usage-cap-warned"
+  _tr='{"status":"completed","agentId":"linha-501-de-novo","totalTokens":1}'
+  _run_hook "$(_payload "$TMPDIR_TEST" "Agent" "$_tr")"
+  [ -z "$_CAPTURED_STDERR" ] || { _fail "aviso duplicado" "sentinela ja existia, nao deveria reavisar: $_CAPTURED_STDERR"; return 1; }
+  [ "$(_lines_count "$_side")" = 500 ] || { _fail "cap" "ainda deveria estar em 500"; return 1; }
+}
+
+run_all_scenarios
+exit $?

--- a/tests/test_report.sh
+++ b/tests/test_report.sh
@@ -357,6 +357,67 @@ scenario_emit_aborta_sem_secrets_filter() {
   assert_stderr_contains "secrets-filter" || return 1
 }
 
+# ---------- Secoes 1/2 estendidas com consumo de subagente (FASE 4.2 de
+# wave-token-metrics, contracts/wave-usage-report.md §6) ----------
+
+scenario_generate_secao1_spawns_tokens_quando_coletado() {
+  _sd="$TMPDIR_TEST/state"
+  _init "$_sd"
+  _run_wave_with_decision "$_sd"
+  # injeta agent_usage na onda-001 (equivalente ao que state-ondas.sh end
+  # gravaria a partir do sidecar do hook posttooluse-agent-usage.sh)
+  capture jq '.waves[0].agent_usage = {"spawns_total":3,"spawns_with_usage":2,"spawns_unavailable":1,"total_tokens":254000,"input_tokens":4,"output_tokens":1975,"cache_read_input_tokens":250900,"cache_creation_input_tokens":1049,"tool_use_count":72,"duration_ms":923000}' "$_sd/state.json"
+  printf '%s' "$_CAPTURED_STDOUT" > "$_sd/state.json.tmp" && mv "$_sd/state.json.tmp" "$_sd/state.json"
+  capture "$SCRIPT" generate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "generate" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "| Spawns de subagente | 3 (2 com uso; 1 indisponiveis) |" || return 1
+  assert_stdout_contains "| Tokens totais (observados) | 254.0k |" || return 1
+  assert_stdout_contains "| Cobertura da metrica | 66.6% |" || return 1
+  # secao 2: colunas novas + linha da onda-001 com dado real
+  assert_stdout_contains "| Onda | Inicio | Fim | Etapas | Tool calls | Wallclock | Spawns | Tokens | Termino |" || return 1
+  assert_stdout_contains "| onda-001 |" || return 1
+  case "$_CAPTURED_STDOUT" in
+    *"3 (2 c/uso) | 254.0k"*) : ;;
+    *) _fail "generate secao2" "linha da onda sem spawns/tokens esperados"; return 1 ;;
+  esac
+}
+
+scenario_generate_distingue_zero_spawns_de_nao_coletado() {
+  # SC-004/FR-009 (Principio VI): "0 spawns" (dado real observado) e
+  # "metrica nao coletada" (hook nunca provisionado/nenhum spawn tentado)
+  # sao estados DIFERENTES e nao podem ser confundidos.
+  #
+  # Aqui simulamos o segundo caso: wave-usage-report.sh roda com sucesso,
+  # mas nenhuma onda tem agent_usage != null (metric_collected=false) ->
+  # secao 1 MUST dizer "nao coletado", NUNCA fabricar "0".
+  _sd="$TMPDIR_TEST/state"
+  _init "$_sd"
+  _run_wave_with_decision "$_sd"
+  capture "$SCRIPT" generate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "generate" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "| Spawns de subagente | nao coletado nesta execucao |" || return 1
+  assert_stdout_contains "| Tokens totais (observados) | nao coletado nesta execucao |" || return 1
+  assert_stdout_contains "| Cobertura da metrica | nao coletado nesta execucao |" || return 1
+  # secao 2: onda sem agent_usage -> "indisponivel", nunca "0"
+  assert_stdout_contains "indisponivel | indisponivel | etapa_concluida_avancando |" || return 1
+}
+
+scenario_generate_wave_usage_report_ausente_degrada_graciosamente() {
+  # Defesa em profundidade: se wave-usage-report.sh nao esta ao lado de
+  # report.sh (skill parcialmente instalada), generate NUNCA aborta —
+  # degrada para "nao coletado nesta execucao" (nunca 0 fabricado).
+  _iso="$TMPDIR_TEST/iso-wu"
+  mkdir -p "$_iso"
+  cp "$SCRIPT" "$_iso/report.sh"
+  _sd="$TMPDIR_TEST/state"
+  _init "$_sd"
+  _run_wave_with_decision "$_sd"
+  capture "$_iso/report.sh" generate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "generate sem wave-usage-report" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "| Spawns de subagente | nao coletado nesta execucao |" || return 1
+  assert_stdout_contains "## 2. Linha do Tempo" || return 1
+}
+
 scenario_stack_final_condicional_ao_status() {
   # Regressao: 'Stack final' nao pode afirmar 'abortada' numa execucao
   # concluida sem suggested_stack (caso feature-00c, herda stack do projeto).

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -990,4 +990,152 @@ scenario_end_sem_sidecar_usa_so_o_campo() {
   [ "$_tc" = 1 ] || { _fail "tool_calls" "sem sidecar, esperado 1 (so campo), obtido $_tc"; return 1; }
 }
 
+# ==== Sidecar de uso de agente (wave-agent-usage.jsonl, wave-token-metrics FASE 3) ====
+
+_wau_write_sidecar() {
+  # $1 = state-dir; escreve 3 SpawnUsage: completo + parcial + indisponivel.
+  cat > "$1/wave-agent-usage.jsonl" <<'JSONL'
+{"agent_id":"a1","agent_type":"x","status":"completo","model":"sonnet","models_used":null,"total_tokens":100,"input_tokens":60,"output_tokens":40,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_count":5,"duration_ms":1000,"source":"live","observed_at":"t"}
+{"agent_id":"a2","agent_type":"y","status":"parcial","model":"sonnet","models_used":null,"total_tokens":50,"input_tokens":null,"output_tokens":null,"cache_read_input_tokens":null,"cache_creation_input_tokens":null,"tool_use_count":null,"duration_ms":null,"source":"live","observed_at":"t"}
+{"agent_id":"a3","agent_type":"z","status":"indisponivel","model":"nao-aplicavel","models_used":null,"total_tokens":null,"input_tokens":null,"output_tokens":null,"cache_read_input_tokens":null,"cache_creation_input_tokens":null,"tool_use_count":null,"duration_ms":null,"source":"live","observed_at":"t"}
+JSONL
+}
+
+scenario_end_agrega_sidecar_agent_usage_misto() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  _wau_write_sidecar "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+
+  _total=$(jq -r '.waves[-1].agent_usage.spawns_total' "$_sd/state.json")
+  [ "$_total" = 3 ] || { _fail "spawns_total" "esperado 3, obtido $_total"; return 1; }
+  _with_usage=$(jq -r '.waves[-1].agent_usage.spawns_with_usage' "$_sd/state.json")
+  [ "$_with_usage" = 2 ] || { _fail "spawns_with_usage" "esperado 2 (completo+parcial), obtido $_with_usage"; return 1; }
+  _unavail=$(jq -r '.waves[-1].agent_usage.spawns_unavailable' "$_sd/state.json")
+  [ "$_unavail" = 1 ] || { _fail "spawns_unavailable" "esperado 1, obtido $_unavail"; return 1; }
+  _tot_tok=$(jq -r '.waves[-1].agent_usage.total_tokens' "$_sd/state.json")
+  [ "$_tot_tok" = 150 ] || { _fail "total_tokens" "esperado 150 (100+50), obtido $_tot_tok"; return 1; }
+  _spawns_n=$(jq -r '.waves[-1].agent_spawns | length' "$_sd/state.json")
+  [ "$_spawns_n" = 3 ] || { _fail "agent_spawns" "esperado 3 entradas brutas, obtido $_spawns_n"; return 1; }
+  return 0
+}
+
+scenario_end_agent_usage_sem_sidecar_produz_null() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  _au=$(jq -r '.waves[-1].agent_usage' "$_sd/state.json")
+  [ "$_au" = "null" ] || { _fail "agent_usage" "esperado null (sem sidecar), obtido $_au"; return 1; }
+  _sp=$(jq -c '.waves[-1].agent_spawns' "$_sd/state.json")
+  [ "$_sp" = "[]" ] || { _fail "agent_spawns" "esperado [], obtido $_sp"; return 1; }
+  return 0
+}
+
+scenario_end_agent_usage_ignora_linhas_corrompidas() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  # 2 linhas validas + 1 corrompida no meio: agregacao MUST descartar a
+  # corrompida sem abortar o `end` inteiro (Principio VI — nunca fabrica,
+  # mas tambem nunca falha por causa de dado ilegivel de terceiros).
+  cat > "$_sd/wave-agent-usage.jsonl" <<'JSONL'
+{"agent_id":"a1","agent_type":"x","status":"completo","model":"sonnet","models_used":null,"total_tokens":100,"input_tokens":60,"output_tokens":40,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_count":5,"duration_ms":1000,"source":"live","observed_at":"t"}
+{ isto nao e json valido
+{"agent_id":"a2","agent_type":"y","status":"completo","model":"sonnet","models_used":null,"total_tokens":25,"input_tokens":10,"output_tokens":15,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_count":2,"duration_ms":300,"source":"live","observed_at":"t"}
+JSONL
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "linha corrompida nao deveria abortar end: $_CAPTURED_STDERR"; return 1; }
+  _total=$(jq -r '.waves[-1].agent_usage.spawns_total' "$_sd/state.json")
+  [ "$_total" = 2 ] || { _fail "spawns_total" "esperado 2 (linha corrompida descartada), obtido $_total"; return 1; }
+  _tot_tok=$(jq -r '.waves[-1].agent_usage.total_tokens' "$_sd/state.json")
+  [ "$_tot_tok" = 125 ] || { _fail "total_tokens" "esperado 125 (100+25), obtido $_tot_tok"; return 1; }
+  return 0
+}
+
+scenario_end_agent_usage_null_nunca_fabrica_zero() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  # Todos indisponivel: spawns_with_usage=0, mas spawns_total>0 -> agent_usage
+  # NAO deve ser null (houve spawn); campos numericos MUST ser null, nunca 0.
+  cat > "$_sd/wave-agent-usage.jsonl" <<'JSONL'
+{"agent_id":"a1","agent_type":"x","status":"indisponivel","model":"nao-aplicavel","models_used":null,"total_tokens":null,"input_tokens":null,"output_tokens":null,"cache_read_input_tokens":null,"cache_creation_input_tokens":null,"tool_use_count":null,"duration_ms":null,"source":"live","observed_at":"t"}
+JSONL
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  _au=$(jq -r '.waves[-1].agent_usage' "$_sd/state.json")
+  [ "$_au" != "null" ] || { _fail "agent_usage" "spawns_total=1 (mesmo indisponivel) nao deveria produzir agent_usage null"; return 1; }
+  _tot_tok=$(jq -r '.waves[-1].agent_usage.total_tokens' "$_sd/state.json")
+  [ "$_tot_tok" = "null" ] || { _fail "total_tokens" "esperado null (nao observado), NUNCA 0 fabricado, obtido $_tot_tok"; return 1; }
+  _with_usage=$(jq -r '.waves[-1].agent_usage.spawns_with_usage' "$_sd/state.json")
+  [ "$_with_usage" = 0 ] || { _fail "spawns_with_usage" "esperado 0, obtido $_with_usage"; return 1; }
+  return 0
+}
+
+scenario_start_reseta_sidecar_agent_usage_residual() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  # Residuo de spawns + sentinela de cap do ciclo anterior.
+  printf '{"agent_id":"residuo"}\n' > "$_sd/wave-agent-usage.jsonl"
+  : > "$_sd/.wave-agent-usage-cap-warned"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start" "$_CAPTURED_STDERR"; return 1; }
+  [ -f "$_sd/wave-agent-usage.jsonl" ] \
+    && { _fail "sidecar" "start deveria zerar wave-agent-usage.jsonl (janela = start->end)"; return 1; }
+  [ -f "$_sd/.wave-agent-usage-cap-warned" ] \
+    && { _fail "sentinela" "start deveria remover o sentinela de cap-warned residual"; return 1; }
+  return 0
+}
+
+scenario_end_reseta_sidecar_agent_usage_consumido() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  _wau_write_sidecar "$_sd"
+  : > "$_sd/.wave-agent-usage-cap-warned"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  [ -f "$_sd/wave-agent-usage.jsonl" ] \
+    && { _fail "sidecar" "end deveria remover o sidecar consumido"; return 1; }
+  [ -f "$_sd/.wave-agent-usage-cap-warned" ] \
+    && { _fail "sentinela" "end deveria remover o sentinela de cap-warned consumido"; return 1; }
+  return 0
+}
+
+scenario_end_acumula_accumulated_metrics_agent_entre_ondas() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  # Onda 1: com sidecar (contribui dado real).
+  capture "$SCRIPT" start --state-dir "$_sd"
+  _wau_write_sidecar "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end onda1" "$_CAPTURED_STDERR"; return 1; }
+
+  # Onda 2: SEM sidecar (nenhum spawn) — acumulado nao deve ser corrompido
+  # com 0 fabricado; total de tokens permanece o da onda 1.
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end onda2" "$_CAPTURED_STDERR"; return 1; }
+
+  _spawns_total=$(jq -r '.accumulated_metrics.agent_spawns_total' "$_sd/state.json")
+  [ "$_spawns_total" = 3 ] || { _fail "agent_spawns_total" "esperado 3 (so onda1 contribuiu), obtido $_spawns_total"; return 1; }
+  _tokens_total=$(jq -r '.accumulated_metrics.agent_tokens_total' "$_sd/state.json")
+  [ "$_tokens_total" = 150 ] || { _fail "agent_tokens_total" "esperado 150 (onda2 nao fabrica 0), obtido $_tokens_total"; return 1; }
+
+  # Onda 3: novo sidecar -> acumulado soma sobre o total anterior.
+  capture "$SCRIPT" start --state-dir "$_sd"
+  _wau_write_sidecar "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end onda3" "$_CAPTURED_STDERR"; return 1; }
+  _tokens_total3=$(jq -r '.accumulated_metrics.agent_tokens_total' "$_sd/state.json")
+  [ "$_tokens_total3" = 300 ] || { _fail "agent_tokens_total onda3" "esperado 300 (150+150), obtido $_tokens_total3"; return 1; }
+  _spawns_with_usage_total=$(jq -r '.accumulated_metrics.agent_spawns_with_usage_total' "$_sd/state.json")
+  [ "$_spawns_with_usage_total" = 4 ] || { _fail "agent_spawns_with_usage_total" "esperado 4 (2+0+2), obtido $_spawns_with_usage_total"; return 1; }
+  return 0
+}
+
 run_all_scenarios

--- a/tests/test_wave-usage-report.sh
+++ b/tests/test_wave-usage-report.sh
@@ -3,14 +3,13 @@
 # global/skills/agente-00c-runtime/scripts/wave-usage-report.sh.
 #
 # Feature: wave-token-metrics
-# Ref: docs/specs/wave-token-metrics/contracts/wave-usage-report.md §2
-#      docs/specs/wave-token-metrics/tasks.md FASE 4 (4.1.4)
+# Ref: docs/specs/wave-token-metrics/contracts/wave-usage-report.md §2/§3
+#      docs/specs/wave-token-metrics/tasks.md FASE 4 (4.1.4) e FASE 7 (7.1.5)
 #
 # Cobertura:
 #   Dispatch:
 #     - sem args -> exit 2 + USO em stderr
-#     - subcomando desconhecido (inclusive "backfill", ainda nao
-#       implementado — FASE 7) -> exit 2
+#     - subcomando desconhecido -> exit 2
 #     - -h/--help/help -> exit 2 + USO
 #   aggregate — uso invalido:
 #     - sem --state-dir -> exit 2
@@ -34,6 +33,23 @@
 #   Estabilidade da saida (IR-2):
 #     - 3 invocacoes consecutivas -> stdout identico byte-a-byte (JSON e MD)
 #     - read-only: sha256 do state.json inalterado apos aggregate
+#   backfill (US4/FR-010/FR-011, FASE 7):
+#     - uso invalido: sem --state-dir / sem --transcript -> exit 2
+#     - transcript ausente/ilegivel -> exit 3, mensagem nomeia a execucao
+#     - transcript sem nenhum spawn dentro de janela de onda -> exit 3
+#       (nao confundir com "0 novos" por dedup — ver idempotencia)
+#     - happy path: spawns extraidos + atribuidos a onda por janela
+#       temporal, source="backfill" sempre, status/null-vs-0 identicos as
+#       regras do hook ao vivo (indisponivel -> todos os campos null)
+#     - linha corrompida no meio do transcript e ignorada (nao aborta)
+#     - idempotencia: reexecutar sobre o mesmo transcript -> 0 novos
+#       spawns, state.json byte-identico (sha256 inalterado), sem backup
+#       novo em state-history/
+#     - --dry-run: reporta onda+agent_id sem escrever nada (sha256
+#       inalterado, sem state-history/ novo)
+#     - apos apply: state-history/ ganha snapshot, state.json.sha256
+#       recomputado (sha256-verify passa), accumulated_metrics.agent_*
+#       incrementados pelo delta correto
 #   IR-3 (Principio II POSIX):
 #     - shebang #!/bin/sh + set -eu
 #
@@ -124,14 +140,6 @@ scenario_subcomando_desconhecido_exit_2() {
   [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2" "obtido $_CAPTURED_EXIT"; return 1; }
   assert_stderr_contains "subcomando desconhecido" || return 1
   assert_stderr_contains "bogus-subcmd-xyz" || return 1
-}
-
-# backfill (contract §3) e trabalho da FASE 7 (tasks.md 7.1.*) — nesta FASE
-# 4 o dispatch ainda NAO conhece o subcomando; cai no branch generico.
-scenario_backfill_ainda_nao_implementado_exit_2() {
-  capture sh "$SCRIPT" backfill --state-dir /nao/importa --transcript /nao/importa
-  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (backfill nao implementado)" "obtido $_CAPTURED_EXIT"; return 1; }
-  assert_stderr_contains "subcomando desconhecido" || return 1
 }
 
 scenario_help_flag_short_long_e_help_subcmd() {
@@ -439,6 +447,236 @@ JSON
   ')
   printf '%s' "$_joined" | jq -e '.[0].onda == "onda-004" and .[0].tokens == 50000 and .[0].divergente == true' >/dev/null \
     || { _fail "join model-routing x wave-usage" "resultado inesperado: $_joined"; return 1; }
+}
+
+# ==== backfill (US4/FR-010/FR-011, FASE 7) ====
+#
+# Fixture compartilhada: 2 ondas (onda-001 20:27:44Z-20:32:23Z, onda-002
+# 20:39:08Z-20:49:16Z) + execution.id, espelhando o formato real de
+# .waves[]/.execution do runtime (state-ondas.sh start/end).
+
+_wur_write_backfill_state() {
+  cat > "$TMPDIR_TEST/state.json" <<'JSON'
+{
+  "execution": {"id": "feat-wtm-test-exec"},
+  "waves": [
+    {"id":"onda-001","started_at":"2026-07-25T20:27:44Z","finished_at":"2026-07-25T20:32:23Z","agent_usage":null,"agent_spawns":[]},
+    {"id":"onda-002","started_at":"2026-07-25T20:39:08Z","finished_at":"2026-07-25T20:49:16Z","agent_usage":null,"agent_spawns":[]}
+  ],
+  "accumulated_metrics": {"waves_total":2,"tool_calls_total":10,"wallclock_total_seconds":600,"agent_spawns_total":0,"agent_spawns_with_usage_total":0}
+}
+JSON
+}
+
+# Transcript valido: agent-001 (completo, onda-001), agent-002
+# (indisponivel/async_launched, onda-002), agent-out (fora de toda janela).
+_wur_write_transcript_valida() {
+  cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_A1","name":"Agent","input":{"description":"d","prompt":"p","subagent_type":"feature-00c-clarify-asker"}}]},"timestamp":"2026-07-25T20:28:00.100Z"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A1","content":"ok"}]},"toolUseResult":{"agentId":"agent-001","agentType":"feature-00c-clarify-asker","status":"completed","resolvedModel":"claude-sonnet-5","totalTokens":29678,"totalDurationMs":45000,"totalToolUseCount":3,"usage":{"input_tokens":100,"output_tokens":200,"cache_read_input_tokens":29000,"cache_creation_input_tokens":378}},"timestamp":"2026-07-25T20:29:00.500Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_A2","name":"Agent","input":{"description":"d","prompt":"p","subagent_type":"agente-00c-feature-orchestrator"}}]},"timestamp":"2026-07-25T20:40:00.000Z"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_A2"}]},"toolUseResult":{"agentId":"agent-002","agentType":"agente-00c-feature-orchestrator","status":"async_launched"},"timestamp":"2026-07-25T20:41:00.000Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_OUT","name":"Agent","input":{"description":"fora","subagent_type":"x"}}]},"timestamp":"2026-07-25T19:00:00.000Z"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_OUT"}]},"toolUseResult":{"agentId":"agent-out","status":"completed","totalTokens":1000},"timestamp":"2026-07-25T19:01:00.000Z"}
+EOF
+}
+
+# Mesmo conteudo, com 1 linha corrompida inserida no meio.
+_wur_write_transcript_corrompida() {
+  _wur_write_transcript_valida
+  _tmp_ins=$(mktemp)
+  _line=0
+  while IFS= read -r _l; do
+    _line=$((_line + 1))
+    printf '%s\n' "$_l" >> "$_tmp_ins"
+    [ "$_line" -eq 2 ] && printf '%s\n' 'isto nao e json valido {{{' >> "$_tmp_ins"
+  done < "$TMPDIR_TEST/transcript.jsonl"
+  mv -- "$_tmp_ins" "$TMPDIR_TEST/transcript.jsonl"
+}
+
+# Transcript so com o spawn fora de qualquer janela (nao cobre a execucao).
+_wur_write_transcript_sem_cobertura() {
+  cat > "$TMPDIR_TEST/transcript.jsonl" <<'EOF'
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_OUT","name":"Agent","input":{"description":"fora","subagent_type":"x"}}]},"timestamp":"2026-07-25T19:00:00.000Z"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_OUT"}]},"toolUseResult":{"agentId":"agent-out","status":"completed","totalTokens":1000},"timestamp":"2026-07-25T19:01:00.000Z"}
+EOF
+}
+
+scenario_backfill_sem_state_dir_exit_2() {
+  capture sh "$SCRIPT" backfill --transcript /nao/importa
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (sem --state-dir)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "--state-dir obrigatorio" || return 1
+}
+
+scenario_backfill_sem_transcript_exit_2() {
+  mktemp_test || return 2
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST"
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (sem --transcript)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "--transcript obrigatorio" || return 1
+}
+
+scenario_backfill_state_json_ausente_exit_1() {
+  mktemp_test || return 2
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST/nope" --transcript /nao/importa
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit=1 (sem state.json)" "obtido $_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_backfill_transcript_ausente_exit_3_nao_estima() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/nao-existe.jsonl"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "exit=3 (FR-011, transcript ausente)" "obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "ausente/ilegivel" || return 1
+  assert_stderr_contains "feat-wtm-test-exec" || return 1
+
+  # FR-011: nenhum campo de metrica escrito — state.json intacto.
+  _tt=$(jq -r '.waves[0].agent_usage' "$TMPDIR_TEST/state.json")
+  [ "$_tt" = "null" ] || { _fail "state.json inalterado" "waves[0].agent_usage nao e mais null: $_tt"; return 1; }
+}
+
+scenario_backfill_transcript_sem_cobertura_exit_3() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+  _wur_write_transcript_sem_cobertura
+
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "exit=3 (transcript nao cobre nenhuma onda)" "obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "nao cobre nenhuma onda" || return 1
+}
+
+scenario_backfill_happy_path_atribui_por_janela_e_marca_source() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+  _wur_write_transcript_valida
+
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit=0" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "2 spawn(s) novo(s)" || return 1
+
+  # agent-001 -> onda-001, completo, source=backfill; agent-out (fora de
+  # toda janela) NUNCA aparece em nenhuma onda.
+  _src1=$(jq -r '.waves[0].agent_spawns[0].source' "$TMPDIR_TEST/state.json")
+  [ "$_src1" = "backfill" ] || { _fail "onda-001 spawn source=backfill" "obtido $_src1"; return 1; }
+  _aid1=$(jq -r '.waves[0].agent_spawns[0].agent_id' "$TMPDIR_TEST/state.json")
+  [ "$_aid1" = "agent-001" ] || { _fail "onda-001 agent_id=agent-001" "obtido $_aid1"; return 1; }
+  _tt1=$(jq -r '.waves[0].agent_usage.total_tokens' "$TMPDIR_TEST/state.json")
+  [ "$_tt1" = "29678" ] || { _fail "onda-001 total_tokens=29678" "obtido $_tt1"; return 1; }
+
+  _n_out=$(jq -r '[.waves[].agent_spawns[] | select(.agent_id == "agent-out")] | length' "$TMPDIR_TEST/state.json")
+  [ "$_n_out" = "0" ] || { _fail "agent-out nunca atribuido a nenhuma onda" "obtido $_n_out ocorrencias"; return 1; }
+}
+
+scenario_backfill_status_indisponivel_campos_null_nao_zero() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+  _wur_write_transcript_valida
+
+  sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl" >/dev/null
+
+  # agent-002 (async_launched) -> onda-002, status=indisponivel, TODOS os
+  # campos numericos null (nunca 0) — Principio VI/FR-009.
+  _status2=$(jq -r '.waves[1].agent_spawns[0].status' "$TMPDIR_TEST/state.json")
+  [ "$_status2" = "indisponivel" ] || { _fail "onda-002 status=indisponivel" "obtido $_status2"; return 1; }
+  _tt2=$(jq -r '.waves[1].agent_spawns[0].total_tokens' "$TMPDIR_TEST/state.json")
+  [ "$_tt2" = "null" ] || { _fail "onda-002 total_tokens=null (nao 0)" "obtido $_tt2"; return 1; }
+  _wu2=$(jq -r '.waves[1].agent_usage.total_tokens' "$TMPDIR_TEST/state.json")
+  [ "$_wu2" = "null" ] || { _fail "onda-002 agent_usage.total_tokens=null" "obtido $_wu2"; return 1; }
+}
+
+scenario_backfill_linha_corrompida_e_ignorada_sem_abortar() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+  _wur_write_transcript_corrompida
+
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit=0 (linha corrompida nao aborta)" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "2 spawn(s) novo(s)" || return 1
+}
+
+scenario_backfill_idempotente_segunda_execucao_zero_novos() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+  _wur_write_transcript_valida
+
+  sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl" >/dev/null
+  _sha_apos_1a=$(_sha256_of "$TMPDIR_TEST/state.json")
+
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit=0 (rerun idempotente)" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "0 spawns novos" || return 1
+  assert_stdout_contains "idempotente" || return 1
+
+  _sha_apos_2a=$(_sha256_of "$TMPDIR_TEST/state.json")
+  [ "$_sha_apos_1a" = "$_sha_apos_2a" ] || { _fail "state.json byte-identico apos rerun" "sha256 mudou"; return 1; }
+}
+
+scenario_backfill_dry_run_nao_escreve_nada() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+  _wur_write_transcript_valida
+
+  _sha_antes=$(_sha256_of "$TMPDIR_TEST/state.json")
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl" --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit=0 (--dry-run)" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "onda-001" || return 1
+  assert_stdout_contains "agent-001" || return 1
+  assert_stdout_contains "Nenhuma escrita realizada" || return 1
+
+  _sha_depois=$(_sha256_of "$TMPDIR_TEST/state.json")
+  [ "$_sha_antes" = "$_sha_depois" ] || { _fail "state.json inalterado (--dry-run)" "sha256 mudou"; return 1; }
+  [ -d "$TMPDIR_TEST/state-history" ] && { _fail "sem state-history/ apos --dry-run" "diretorio foi criado"; return 1; }
+  return 0
+}
+
+scenario_backfill_apply_grava_backup_e_recomputa_sha256() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+  _wur_write_transcript_valida
+
+  sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl" >/dev/null
+
+  [ -d "$TMPDIR_TEST/state-history" ] || { _fail "state-history/ criado" "ausente"; return 1; }
+  _n_backups=$(find "$TMPDIR_TEST/state-history" -type f -name '*.json' | wc -l | tr -d '[:space:]')
+  [ "$_n_backups" -ge 1 ] || { _fail ">=1 backup em state-history/" "obtido $_n_backups"; return 1; }
+
+  [ -f "$TMPDIR_TEST/state.json.sha256" ] || { _fail "state.json.sha256 criado" "ausente"; return 1; }
+  _stored=$(head -n1 "$TMPDIR_TEST/state.json.sha256" | tr -d '[:space:]')
+  _actual=$(_sha256_of "$TMPDIR_TEST/state.json")
+  [ "$_stored" = "$_actual" ] || { _fail "sha256 recomputado bate com o conteudo" "stored=$_stored actual=$_actual"; return 1; }
+}
+
+scenario_backfill_accumulated_metrics_incrementado_pelo_delta() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+  _wur_write_transcript_valida
+
+  sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl" >/dev/null
+
+  _st=$(jq -r '.accumulated_metrics.agent_spawns_total' "$TMPDIR_TEST/state.json")
+  [ "$_st" = "2" ] || { _fail "agent_spawns_total=2" "obtido $_st"; return 1; }
+  _swu=$(jq -r '.accumulated_metrics.agent_spawns_with_usage_total' "$TMPDIR_TEST/state.json")
+  [ "$_swu" = "1" ] || { _fail "agent_spawns_with_usage_total=1" "obtido $_swu"; return 1; }
+  _tt=$(jq -r '.accumulated_metrics.agent_tokens_total' "$TMPDIR_TEST/state.json")
+  [ "$_tt" = "29678" ] || { _fail "agent_tokens_total=29678" "obtido $_tt"; return 1; }
+  # tool_calls_total/wallclock_total_seconds (campos EXISTENTES) intactos.
+  _tct=$(jq -r '.accumulated_metrics.tool_calls_total' "$TMPDIR_TEST/state.json")
+  [ "$_tct" = "10" ] || { _fail "tool_calls_total preservado=10" "obtido $_tct"; return 1; }
+}
+
+scenario_backfill_argumento_desconhecido_exit_2() {
+  mktemp_test || return 2
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript /x --bogus-flag
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (flag desconhecida)" "obtido $_CAPTURED_EXIT"; return 1; }
 }
 
 # ==== IR-3: Principio II POSIX ====

--- a/tests/test_wave-usage-report.sh
+++ b/tests/test_wave-usage-report.sh
@@ -1,0 +1,357 @@
+#!/bin/sh
+# test_wave-usage-report.sh — cobre
+# global/skills/agente-00c-runtime/scripts/wave-usage-report.sh.
+#
+# Feature: wave-token-metrics
+# Ref: docs/specs/wave-token-metrics/contracts/wave-usage-report.md §2
+#      docs/specs/wave-token-metrics/tasks.md FASE 4 (4.1.4)
+#
+# Cobertura:
+#   Dispatch:
+#     - sem args -> exit 2 + USO em stderr
+#     - subcomando desconhecido (inclusive "backfill", ainda nao
+#       implementado — FASE 7) -> exit 2
+#     - -h/--help/help -> exit 2 + USO
+#   aggregate — uso invalido:
+#     - sem --state-dir -> exit 2
+#     - --state-dir inexistente (sem state.json) -> exit 1
+#   aggregate — agregacao correta (fixture espelhando o exemplo do
+#     contrato §2.1, validada byte-a-byte contra a Markdown do contrato):
+#     - tabela com 2 ondas, contagens de spawns/tokens/tool-uses/duracao
+#     - formatacao "k" (>=10000 -> N.Nk truncado; abaixo disso, cru)
+#     - Sumario com "Ondas com metrica: 1 de 2", cobertura 40.0%
+#     - JSON com todos os campos do contrato §2.2 + por_modelo
+#   null vs 0 (Principio VI / FR-009):
+#     - onda com spawns todos indisponivel -> total_tokens null, NUNCA 0
+#     - onda sem nenhum spawn (agent_usage null) -> omitida da tabela
+#   "metrica nao coletada" (research Decision 10):
+#     - todas as ondas com agent_usage null -> Markdown com frase
+#       explicita, sem tabela; JSON com metric_collected=false
+#     - state.json sem campo .waves -> mesmo comportamento (retro-compat)
+#   Distribuicao por modelo (US2):
+#     - por_modelo agrega por .model, incluindo balde "nao-aplicavel"
+#       para spawns indisponivel
+#   Estabilidade da saida (IR-2):
+#     - 3 invocacoes consecutivas -> stdout identico byte-a-byte (JSON e MD)
+#     - read-only: sha256 do state.json inalterado apos aggregate
+#   IR-3 (Principio II POSIX):
+#     - shebang #!/bin/sh + set -eu
+#
+# Convencao de exit code de scenario (interpretada pelo runner):
+#   0 PASS, 1 FAIL, 2 ERROR (pre-req faltando — jq ausente, mktemp falhou)
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/wave-usage-report.sh"
+
+# ---------- helpers locais ----------
+
+_wur_have_jq() {
+  command -v jq >/dev/null 2>&1
+}
+
+# Fixture canonica: espelha ao pe da letra o exemplo do contrato §2.1/2.2
+# (onda-004 com 3 spawns/2 com uso, onda-005 com 2 spawns/0 com uso, onda-006
+# sem nenhum spawn -> agent_usage null, omitida da tabela).
+_wur_write_fixture_contrato() {
+  cat > "$TMPDIR_TEST/state.json" <<'JSON'
+{
+  "schema_version": 1,
+  "waves": [
+    {
+      "id": "onda-004",
+      "agent_usage": {
+        "spawns_total": 3,
+        "spawns_with_usage": 2,
+        "spawns_unavailable": 1,
+        "total_tokens": 254000,
+        "input_tokens": 4,
+        "output_tokens": 1975,
+        "cache_read_input_tokens": 250900,
+        "cache_creation_input_tokens": 1049,
+        "tool_use_count": 72,
+        "duration_ms": 923000
+      },
+      "agent_spawns": [
+        {"agent_id":"a1","agent_type":"t1","status":"completo","model":"sonnet","models_used":null,"total_tokens":200000,"input_tokens":2,"output_tokens":1000,"cache_read_input_tokens":198000,"cache_creation_input_tokens":998,"tool_use_count":50,"duration_ms":600000,"source":"live","observed_at":"t"},
+        {"agent_id":"a2","agent_type":"t2","status":"completo","model":"opus","models_used":null,"total_tokens":54000,"input_tokens":2,"output_tokens":975,"cache_read_input_tokens":52900,"cache_creation_input_tokens":51,"tool_use_count":22,"duration_ms":323000,"source":"live","observed_at":"t"},
+        {"agent_id":"a3","agent_type":"t3","status":"indisponivel","model":"nao-aplicavel","models_used":null,"total_tokens":null,"input_tokens":null,"output_tokens":null,"cache_read_input_tokens":null,"cache_creation_input_tokens":null,"tool_use_count":null,"duration_ms":null,"source":"live","observed_at":"t"}
+      ]
+    },
+    {
+      "id": "onda-005",
+      "agent_usage": {
+        "spawns_total": 2,
+        "spawns_with_usage": 0,
+        "spawns_unavailable": 2,
+        "total_tokens": null,
+        "input_tokens": null,
+        "output_tokens": null,
+        "cache_read_input_tokens": null,
+        "cache_creation_input_tokens": null,
+        "tool_use_count": null,
+        "duration_ms": null
+      },
+      "agent_spawns": [
+        {"agent_id":"b1","agent_type":"t1","status":"indisponivel","model":"nao-aplicavel","models_used":null,"total_tokens":null,"input_tokens":null,"output_tokens":null,"cache_read_input_tokens":null,"cache_creation_input_tokens":null,"tool_use_count":null,"duration_ms":null,"source":"live","observed_at":"t"},
+        {"agent_id":"b2","agent_type":"t2","status":"indisponivel","model":"nao-aplicavel","models_used":null,"total_tokens":null,"input_tokens":null,"output_tokens":null,"cache_read_input_tokens":null,"cache_creation_input_tokens":null,"tool_use_count":null,"duration_ms":null,"source":"live","observed_at":"t"}
+      ]
+    },
+    {
+      "id": "onda-006",
+      "agent_usage": null,
+      "agent_spawns": []
+    }
+  ]
+}
+JSON
+}
+
+# ==== Dispatch ====
+
+scenario_sem_args_exit_2_e_usage_em_stderr() {
+  capture sh "$SCRIPT"
+  assert_exit 2 sh "$SCRIPT" || return 1
+  assert_stderr_contains "USO:" || return 1
+  assert_stderr_contains "aggregate" || return 1
+}
+
+scenario_subcomando_desconhecido_exit_2() {
+  capture sh "$SCRIPT" bogus-subcmd-xyz
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "subcomando desconhecido" || return 1
+  assert_stderr_contains "bogus-subcmd-xyz" || return 1
+}
+
+# backfill (contract §3) e trabalho da FASE 7 (tasks.md 7.1.*) — nesta FASE
+# 4 o dispatch ainda NAO conhece o subcomando; cai no branch generico.
+scenario_backfill_ainda_nao_implementado_exit_2() {
+  capture sh "$SCRIPT" backfill --state-dir /nao/importa --transcript /nao/importa
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (backfill nao implementado)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "subcomando desconhecido" || return 1
+}
+
+scenario_help_flag_short_long_e_help_subcmd() {
+  capture sh "$SCRIPT" -h
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (-h)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "USO:" || return 1
+
+  capture sh "$SCRIPT" --help
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (--help)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "USO:" || return 1
+
+  capture sh "$SCRIPT" help
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (help)" "obtido $_CAPTURED_EXIT"; return 1; }
+}
+
+# ==== aggregate: uso invalido ====
+
+scenario_aggregate_sem_state_dir_exit_2() {
+  capture sh "$SCRIPT" aggregate
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (sem --state-dir)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "--state-dir obrigatorio" || return 1
+}
+
+scenario_aggregate_state_dir_inexistente_exit_1() {
+  mktemp_test || return 2
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST/nope"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit=1 (sem state.json)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "state.json nao encontrado" || return 1
+}
+
+scenario_aggregate_argumento_desconhecido_exit_2() {
+  mktemp_test || return 2
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --bogus-flag
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit=2 (flag desconhecida)" "obtido $_CAPTURED_EXIT"; return 1; }
+}
+
+# ==== aggregate: fixture do contrato — Markdown byte-a-byte ====
+
+scenario_aggregate_markdown_bate_com_exemplo_do_contrato() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_fixture_contrato
+
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit=0" "$_CAPTURED_STDERR"; return 1; }
+
+  _expected='## Consumo por onda (tokens / tool-uses / duracao)
+
+| onda | spawns | com uso | tokens | input | output | cache-read | cache-creation | tool-uses | duracao |
+|------|--------|---------|--------|-------|--------|------------|----------------|-----------|---------|
+| onda-004 | 3 | 2 | 254.0k | 4 | 1975 | 250.9k | 1049 | 72 | 923s |
+| onda-005 | 2 | 0 | indisponivel | indisponivel | indisponivel | indisponivel | indisponivel | indisponivel | indisponivel |
+
+**Sumario**:
+- Ondas com metrica: 1 de 2
+- Spawns observados: 5 (com uso: 2; indisponiveis: 3)
+- Tokens totais: 254.0k (input 4 / output 1975 / cache-read 250.9k / cache-creation 1049)
+- Cobertura da metrica: 40.0% dos spawns'
+
+  [ "$_CAPTURED_STDOUT" = "$_expected" ] || {
+    _fail "Markdown identico ao exemplo do contrato" \
+      "diff:
+$(diff <(printf '%s' "$_expected") <(printf '%s' "$_CAPTURED_STDOUT"))"
+    return 1
+  }
+
+  # onda-006 (sem nenhum spawn) NAO aparece na tabela.
+  assert_stdout_not_contains "onda-006" || return 1
+}
+
+scenario_aggregate_json_bate_com_contrato() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_fixture_contrato
+
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit=0" "$_CAPTURED_STDERR"; return 1; }
+
+  _get() { printf '%s' "$_CAPTURED_STDOUT" | jq -r "$1"; }
+
+  [ "$(_get '.waves_total')" = "2" ]         || { _fail "waves_total=2" "obtido $(_get '.waves_total')"; return 1; }
+  [ "$(_get '.waves_with_usage')" = "1" ]    || { _fail "waves_with_usage=1" "obtido $(_get '.waves_with_usage')"; return 1; }
+  [ "$(_get '.spawns_total')" = "5" ]        || { _fail "spawns_total=5" "obtido $(_get '.spawns_total')"; return 1; }
+  [ "$(_get '.spawns_with_usage')" = "2" ]   || { _fail "spawns_with_usage=2" "obtido $(_get '.spawns_with_usage')"; return 1; }
+  [ "$(_get '.spawns_unavailable')" = "3" ]  || { _fail "spawns_unavailable=3" "obtido $(_get '.spawns_unavailable')"; return 1; }
+  [ "$(_get '.coverage_pct')" = "40.0%" ]    || { _fail "coverage_pct=40.0%" "obtido $(_get '.coverage_pct')"; return 1; }
+  [ "$(_get '.total_tokens')" = "254000" ]   || { _fail "total_tokens=254000" "obtido $(_get '.total_tokens')"; return 1; }
+  [ "$(_get '.input_tokens')" = "4" ]        || { _fail "input_tokens=4" "obtido $(_get '.input_tokens')"; return 1; }
+  [ "$(_get '.output_tokens')" = "1975" ]    || { _fail "output_tokens=1975" "obtido $(_get '.output_tokens')"; return 1; }
+  [ "$(_get '.cache_read_input_tokens')" = "250900" ]     || { _fail "cache_read=250900" "obtido $(_get '.cache_read_input_tokens')"; return 1; }
+  [ "$(_get '.cache_creation_input_tokens')" = "1049" ]   || { _fail "cache_creation=1049" "obtido $(_get '.cache_creation_input_tokens')"; return 1; }
+  [ "$(_get '.tool_use_count')" = "72" ]     || { _fail "tool_use_count=72" "obtido $(_get '.tool_use_count')"; return 1; }
+  [ "$(_get '.duration_ms')" = "923000" ]    || { _fail "duration_ms=923000" "obtido $(_get '.duration_ms')"; return 1; }
+  [ "$(_get '.metric_collected')" = "true" ] || { _fail "metric_collected=true" "obtido $(_get '.metric_collected')"; return 1; }
+  [ "$(_get '.por_onda | length')" = "2" ]   || { _fail "por_onda tem 2 entradas" "obtido $(_get '.por_onda | length')"; return 1; }
+}
+
+# ==== null vs 0 (Principio VI / FR-009) ====
+
+scenario_onda_todos_indisponivel_total_tokens_null_nao_zero() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_fixture_contrato
+
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json
+  _tt=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.por_onda[] | select(.onda == "onda-005") | .total_tokens')
+  [ "$_tt" = "null" ] || { _fail "onda-005.total_tokens=null" "obtido $_tt (fabricacao de 0 proibida)"; return 1; }
+}
+
+scenario_onda_sem_spawns_omitida_da_tabela_json() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_fixture_contrato
+
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json
+  _n=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '[.por_onda[] | select(.onda == "onda-006")] | length')
+  [ "$_n" = "0" ] || { _fail "onda-006 ausente de por_onda" "obtido $_n entradas"; return 1; }
+}
+
+# ==== "metrica nao coletada" (research Decision 10) ====
+
+scenario_todas_ondas_sem_usage_metrica_nao_coletada() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  cat > "$TMPDIR_TEST/state.json" <<'JSON'
+{ "schema_version": 1, "waves": [
+  { "id": "onda-001", "agent_usage": null, "agent_spawns": [] },
+  { "id": "onda-002", "agent_usage": null, "agent_spawns": [] }
+] }
+JSON
+
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit=0" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "nao foi coletada" || return 1
+  assert_stdout_not_contains "| onda" || return 1
+  assert_stdout_not_contains "0 tokens totais" || return 1
+
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json
+  _mc=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.metric_collected')
+  [ "$_mc" = "false" ] || { _fail "metric_collected=false" "obtido $_mc"; return 1; }
+  _tt=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.total_tokens')
+  [ "$_tt" = "null" ] || { _fail "total_tokens=null (nao 0)" "obtido $_tt"; return 1; }
+}
+
+scenario_state_sem_campo_waves_retro_compat() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  printf '{"schema_version":1}' > "$TMPDIR_TEST/state.json"
+
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit=0 (state pre-feature sem .waves)" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "nao foi coletada" || return 1
+
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit=0 --json" "$_CAPTURED_STDERR"; return 1; }
+  _wt=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.waves_total')
+  [ "$_wt" = "0" ] || { _fail "waves_total=0" "obtido $_wt"; return 1; }
+}
+
+# ==== Distribuicao por modelo (US2) ====
+
+scenario_por_modelo_agrupa_incluindo_nao_aplicavel() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_fixture_contrato
+
+  capture sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json
+  _get() { printf '%s' "$_CAPTURED_STDOUT" | jq -r "$1"; }
+
+  [ "$(_get '.por_modelo.sonnet.total_tokens')" = "200000" ] || { _fail "sonnet.total_tokens=200000" "obtido $(_get '.por_modelo.sonnet.total_tokens')"; return 1; }
+  [ "$(_get '.por_modelo.opus.total_tokens')" = "54000" ]    || { _fail "opus.total_tokens=54000" "obtido $(_get '.por_modelo.opus.total_tokens')"; return 1; }
+  # nao-aplicavel: 3 spawns indisponivel (a3 de onda-004 + b1/b2 de onda-005),
+  # todos com uso zero -> total_tokens null (nunca 0).
+  [ "$(_get '.por_modelo["nao-aplicavel"].spawns')" = "3" ]  || { _fail "nao-aplicavel.spawns=3" "obtido $(_get '.por_modelo["nao-aplicavel"].spawns')"; return 1; }
+  [ "$(_get '.por_modelo["nao-aplicavel"].total_tokens')" = "null" ] || { _fail "nao-aplicavel.total_tokens=null" "obtido $(_get '.por_modelo["nao-aplicavel"].total_tokens')"; return 1; }
+}
+
+# ==== Estabilidade / read-only (IR-1, IR-2) ====
+
+scenario_idempotente_json_e_markdown() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_fixture_contrato
+
+  _j1=$(sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json)
+  _j2=$(sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json)
+  _j3=$(sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json)
+  [ "$_j1" = "$_j2" ] && [ "$_j2" = "$_j3" ] || { _fail "JSON identico em 3 invocacoes" "diferem"; return 1; }
+
+  _m1=$(sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST")
+  _m2=$(sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST")
+  [ "$_m1" = "$_m2" ] || { _fail "Markdown identico em 2 invocacoes" "diferem"; return 1; }
+}
+
+scenario_read_only_state_json_inalterado() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_fixture_contrato
+
+  _before=$(_sha256_of "$TMPDIR_TEST/state.json")
+  sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" >/dev/null
+  sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json >/dev/null
+  _after=$(_sha256_of "$TMPDIR_TEST/state.json")
+  [ "$_before" = "$_after" ] || { _fail "state.json inalterado (read-only)" "sha256 mudou"; return 1; }
+}
+
+_sha256_of() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+
+# ==== IR-3: Principio II POSIX ====
+
+scenario_shebang_posix_e_set_eu() {
+  _head1=$(head -n1 "$SCRIPT")
+  [ "$_head1" = "#!/bin/sh" ] || { _fail "shebang #!/bin/sh" "obtido: $_head1"; return 1; }
+  grep -q '^set -eu$' "$SCRIPT" || { _fail "set -eu presente" "nao encontrado"; return 1; }
+}
+
+run_all_scenarios "$0"

--- a/tests/test_wave-usage-report.sh
+++ b/tests/test_wave-usage-report.sh
@@ -346,6 +346,101 @@ _sha256_of() {
   fi
 }
 
+# ==== FASE 6 (feature wave-token-metrics): cruzamento com model-routing
+# em review-task/SKILL.md §4.5 (F5, US2/FR-007) ====
+#
+# review-task/SKILL.md nao tem harness automatizado proprio (skill
+# prose-driven, sem script dedicado) — cobertura aqui segue o mesmo
+# padrao "sanity" ja usado em test_model-routing-report.sh
+# (scenario_integracao_review_task_skill_md_referencia_helper): grep-based,
+# falha cedo se a SKILL.md for reformatada/perder a secao.
+
+scenario_skill_md_referencia_cruzamento_wave_usage() {
+  _skill="$REPO_ROOT/global/skills/review-task/SKILL.md"
+  [ -f "$_skill" ] || { _fail "SKILL.md ausente" "$_skill"; return 1; }
+  grep -qF 'wave-usage-report.sh' "$_skill" \
+    || { _fail "SKILL.md nao referencia wave-usage-report.sh" ""; return 1; }
+  grep -qF 'Cruzamento com consumo de tokens observado' "$_skill" \
+    || { _fail "subsecao de cruzamento ausente em SKILL.md §4.5" ""; return 1; }
+  grep -qF 'model-routing-report.sh' "$_skill" \
+    || { _fail "SKILL.md nao referencia model-routing-report.sh no cruzamento" ""; return 1; }
+}
+
+# Prova que os dois helpers compoem sem interferencia sobre a MESMA
+# state.json: model-routing-report.sh continua lendo SOMENTE .decisions[]
+# (nunca .waves) e wave-usage-report.sh continua lendo SOMENTE .waves[]
+# (nunca .decisions) — o invariante que a subsecao de cruzamento do
+# SKILL.md promete preservar (nenhum dos dois scripts foi alterado).
+scenario_composicao_com_model_routing_report_preserva_invariantes() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _mrr_script="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/model-routing-report.sh"
+  [ -x "$_mrr_script" ] || { _error "model-routing-report.sh ausente/nao-executavel"; return 2; }
+
+  cat > "$TMPDIR_TEST/state.json" <<'JSON'
+{
+  "schema_version": 1,
+  "waves": [
+    {
+      "id": "onda-004",
+      "agent_usage": {
+        "spawns_total": 1, "spawns_with_usage": 1, "spawns_unavailable": 0,
+        "total_tokens": 50000, "input_tokens": 100, "output_tokens": 900,
+        "cache_read_input_tokens": 48900, "cache_creation_input_tokens": 100,
+        "tool_use_count": 10, "duration_ms": 60000
+      },
+      "agent_spawns": [
+        {"agent_id":"a1","agent_type":"t1","status":"completo","model":"opus","models_used":null,"total_tokens":50000,"input_tokens":100,"output_tokens":900,"cache_read_input_tokens":48900,"cache_creation_input_tokens":100,"tool_use_count":10,"duration_ms":60000,"source":"live","observed_at":"t"}
+      ]
+    }
+  ],
+  "decisions": [
+    {
+      "id": "dec-001",
+      "wave_id": "onda-004",
+      "timestamp": "2026-01-01T00:00:00Z",
+      "stage": "plan",
+      "agent": "agente-00c-feature-orchestrator",
+      "context": "Selecao de modelo para onda onda-004 (fase plan)",
+      "options_considered": ["sonnet", "opus"],
+      "choice": "model:opus",
+      "rationale": "sugerido=sonnet aplicado=opus origem=override-operador | operador pediu opus",
+      "justification_score": 3
+    }
+  ]
+}
+JSON
+
+  _before=$(_sha256_of "$TMPDIR_TEST/state.json")
+
+  _wu_json=$(sh "$SCRIPT" aggregate --state-dir "$TMPDIR_TEST" --json)
+  _mr_json=$("$_mrr_script" aggregate --state-dir "$TMPDIR_TEST" --json)
+
+  _after=$(_sha256_of "$TMPDIR_TEST/state.json")
+  [ "$_before" = "$_after" ] || { _fail "read-only preservado" "sha256 do state.json mudou apos os dois aggregates"; return 1; }
+
+  # wave-usage-report.sh: onda-004 presente com tokens reais.
+  printf '%s' "$_wu_json" | jq -e '.por_onda[] | select(.onda == "onda-004") | .total_tokens == 50000' >/dev/null \
+    || { _fail "wave-usage por_onda" "onda-004/total_tokens=50000 nao encontrado: $_wu_json"; return 1; }
+
+  # model-routing-report.sh: onda-004 presente na secao por-onda, com
+  # divergencia sugerido!=aplicado rotulada como override-operador.
+  printf '%s' "$_mr_json" | jq -e '.linhas_onda[] | select(.onda == "onda-004") | .sugerido == "sonnet" and .aplicado == "opus" and .origem == "override-operador" and .divergente == true' >/dev/null \
+    || { _fail "model-routing linhas_onda" "onda-004 nao bate com esperado: $_mr_json"; return 1; }
+
+  # Join (mesma receita documentada em review-task/SKILL.md §4.5): a
+  # onda diverge E tem token acima da media (unica onda com dado -> nao
+  # ha "acima da media" com 1 ponto so; aqui validamos so que o join
+  # produz a linha com os campos combinados, sem quebrar).
+  _joined=$(jq -n --argjson mr "$_mr_json" --argjson wu "$_wu_json" '
+    ($wu.por_onda // [] | map({(.onda): .}) | add // {}) as $wu_by_onda
+    | ($mr.linhas_onda // []) as $rows
+    | $rows | map(. as $r | ($wu_by_onda[$r.onda]) as $u | $r + {tokens: (($u.total_tokens) // null)})
+  ')
+  printf '%s' "$_joined" | jq -e '.[0].onda == "onda-004" and .[0].tokens == 50000 and .[0].divergente == true' >/dev/null \
+    || { _fail "join model-routing x wave-usage" "resultado inesperado: $_joined"; return 1; }
+}
+
 # ==== IR-3: Principio II POSIX ====
 
 scenario_shebang_posix_e_set_eu() {


### PR DESCRIPTION
## Resumo

Captura métricas de uso dos spawns de subagente (tokens com breakdown por categoria, tool uses, duração, modelo) e as alimenta nos relatórios do toolkit. Pipeline SDD completa via feature-00c (14 ondas, 76 decisões auditadas, backlog 59/59).

- **Hook PostToolUse** `posttooluse-agent-usage.sh`: matcher `Agent`, fail-open absoluto, sidecar append-only `wave-agent-usage.jsonl` (0600, cap 500 linhas), nunca toca state.json; spawns async sem usage = `indisponivel` (null ≠ 0, nunca estimado).
- **Agregação por onda**: `state-ondas.sh start/end` consome o sidecar → `.waves[N].agent_usage` + `.agent_spawns[]` + `.accumulated_metrics.agent_*`.
- **Relatórios**: novo `wave-usage-report.sh` (aggregate Markdown/JSON + backfill offline de transcripts); `report.sh` §1/§2 estendidos; `review-task` §4.5 ganha cruzamento custo×roteamento (join com model-routing-report).
- **knowledge.db v9→v10**: 9 colunas `agent_*` na tabela `waves`; migração idempotente; `--reindex` retrofit (NULL para dados antigos).
- **Backfill**: `wave-usage-report.sh backfill` correlaciona `tool_use(Agent)` ↔ `toolUseResult` via `tool_use_id` em transcripts JSONL (validado empiricamente).

## Fatos verificados (Princípio VI)

Payload do hook confirmado na doc oficial do Claude Code (tool_response de Agent carrega usage; tool_name = `Agent`); ~50% dos spawns reais são `async_launched` sem usage — por isso `spawns_total` ≠ `spawns_with_usage` em todo o desenho.

## Testes

- 4 arquivos de teste novos/estendidos: test_posttooluse-agent-usage (18), test_state-ondas (+9 → 70), test_wave-usage-report (31), test_report (+3 → 25), test_recall (+4 → 117, arquivo completo verde em 706s).
- `./tests/run.sh --check-coverage`: zero órfãos. Suite completa fica para o gate de release.

## Pendências pós-merge (operador)

- Itens {humano} CHK016/CHK024 registrados em tasks.md §1.4 (metas de cobertura/performance).
- Sync do runtime instalado: `cli/lib/recall.sh` e scripts vão por `cstk self-update` após release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwLBx798z2ku6cZUSBKjpQ