### PR TITLE
feat: triagem de sugestoes da knowledge.db (7 correcoes) — 5.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,89 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.26.0] - 2026-07-26
+
+Triagem das sugestões acumuladas na `knowledge.db` — 7 correções validadas
+contra o código antes de aceitas. A mais importante não é uma correção de
+bug: os três hooks do runtime 00c **nunca chegaram a nenhum projeto-alvo**
+desta máquina, o que deixou a guarda fail-closed de Bash inerte em toda
+execução real e zerou as métricas de onda.
+
+### Added
+
+- **`guard-hooks-status.sh`** (agente-00c-runtime, novo helper READ-ONLY):
+  responde se os três hooks 00c (`pretooluse-bash-guard.sh`,
+  `posttooluse-tool-call-tick.sh`, `posttooluse-agent-usage.sh`) estão de
+  fato ativos no projeto-alvo — presentes **e** registrados no
+  `settings.json` (cada metade sozinha não basta: arquivo no lugar sem
+  registro = hook que nunca roda). Dois subcomandos: `check` (TSV por hook +
+  remediação em stderr; exit 1 se algum faltar) e `tick-mode` (`hook` |
+  `manual`). Nunca copia hook nem edita `settings.json` — provisionar segue
+  sendo trabalho exclusivo do `cstk install --scope project`, única fonte da
+  regra. POSIX puro, sem jq.
+  - **Motivação**: `apply_guard_hooks()` só roda com `--scope project` **e**
+    `agente-00c-runtime` na seleção, mas o default de `cstk install`/`update`
+    é `--scope global`, que pula o provisionamento por FR-009c. Como o
+    `cstk install` roda no repo do cstk e não no alvo, não havia momento no
+    fluxo em que o operador fosse avisado. Constatado em campo: projeto com
+    35 ondas 00c executadas e zero hooks em `.claude/hooks/`.
+- **`state-ondas.sh end --next-instruction TEXT`**: grava `.next_instruction`
+  no **mesmo write atômico** do fechamento da onda. Antes exigia um
+  `state-rw.sh set` separado e, como `end` também escreve no `state.json`,
+  seguir a ordem literal `backup → hash → end` do prompt deixava backup e
+  sha256 defasados.
+- Testes: `tests/test_guard-hooks-status.sh` (20 cenários) + extensões em
+  `test_commit-mode.sh` (+6), `test_state-ondas.sh` (+6) e
+  `test_validate-sdd.sh` (+2). Suíte completa: 1857 cenários, 0 falhas.
+
+### Changed
+
+- **`/agente-00c` (passo 2.bis) e `/feature-00c` (pré-flight 8)** passam a
+  chamar `guard-hooks-status.sh check` no init — advisory, exit 1 **não**
+  aborta a execução. A guarda de Bash inativa é destacada como item grave; o
+  resto é métrica.
+- **Orquestradores** deixam de assumir que o hook de tick está ativo:
+  consultam `guard-hooks-status.sh tick-mode` e só pulam o
+  `state-ondas.sh tool-call-tick` manual quando a resposta é `hook`. O
+  default `manual` impede a métrica de zerar em silêncio — a instrução
+  anterior ("não ticke manualmente quando o hook está ativo") não tinha como
+  verificar a condição e virava, na prática, "nunca ticke".
+- **`sc-not-measurable` deixa de sinalizar `API`** (`validate-sdd.sh`): é
+  termo genérico de domínio, e o `SKILL.md` de `validate-documentation` já
+  prometia explicitamente que `API`/`CLI`/`JSON` não disparariam — a tabela
+  de findings do próprio SKILL.md contradizia esse parágrafo e foi alinhada.
+  Sobram apenas termos de performance de implementação (`TPS`, `paint time`,
+  `render time`). Caso real: `SC-002` com "serviços Go que expõem API HTTP"
+  era rejeitado e só passava reescrito para "endpoints HTTP".
+- **`commit-mode.sh task-message`** comprime IDs por *runs* contíguos dentro
+  da mesma fase. A heurística anterior tratava a transição de fase
+  (`major+1`, `minor=1`) como continuidade sem verificar se os minors
+  intermediários estavam na lista: `--task-ids "1.1,2.1,2.2,2.3"` (com
+  1.2/1.3 bloqueadas na onda) emitia `feat: tasks 1.1-2.3`, implicando
+  falsamente que tasks puladas foram concluídas. Agora emite
+  `feat: tasks 1.1, 2.1-2.3`. IDs não-numéricos deixam de entrar em
+  aritmética (sob `set -eu`, abortavam o script).
+- **`state-ondas.sh record-task`** avisa em stderr quando `--task-id` tem 3+
+  níveis (`N.M.K` = subtarefa/checkbox em vez do heading `### N.M` do
+  `tasks.md`). Aviso, não erro — gravar no nível errado já aconteceu em
+  campo, só descoberto depois pelo `reconcile-tasks`.
+
+### Fixed
+
+- **`commit-mode.sh finalize` violava o próprio contrato "sempre exit 0 +
+  `push_pr_result` sempre gravado"**: o script roda sob `set -eu` e o
+  `eval "cstk session pr …"` estava numa linha própria, então uma falha do
+  comando abortava a função inteira antes de qualquer `_cm_record_result`.
+  Observado em campo: exit 9 com `.push_pr_result` null. Agora usa
+  `|| _cstk_rc=$?`, preservando o fallback `git push` + `gh pr create`.
+- **`commit-mode.sh stage-derived` retornava rc=3 "allowlist vazia" enganoso
+  com `--scope-dir` absoluto**: o filtro casa por prefixo contra paths de
+  `git status --porcelain`, que são sempre relativos, mas os prompts dos
+  orquestradores passam `<FD>`, que resolve para absoluto em vários pontos —
+  o casamento nunca ocorria mesmo havendo arquivos staged-áveis. Valores
+  absolutos sob `--projeto-alvo-path` agora são normalizados; fora do repo,
+  emitem diagnóstico em vez de silêncio.
+
 ## [5.25.0] - 2026-07-26
 
 Métricas de consumo por spawn de subagente (feature `wave-token-metrics`,
@@ -3948,6 +4031,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.26.0]: https://github.com/JotJunior/cstk/releases/tag/v5.26.0
 [5.25.0]: https://github.com/JotJunior/cstk/releases/tag/v5.25.0
 [5.24.0]: https://github.com/JotJunior/cstk/releases/tag/v5.24.0
 [5.23.0]: https://github.com/JotJunior/cstk/releases/tag/v5.23.0

--- a/global/agents/agente-00c-feature-orchestrator.md
+++ b/global/agents/agente-00c-feature-orchestrator.md
@@ -272,13 +272,18 @@ Sequencia da onda corrente. Cada iteracao:
     inicio real da onda corrente.
 4. budget.sh check
    - se threshold atingido → encerrar onda + Schedule intent
-   - a dimensao tool_calls e alimentada AUTOMATICAMENTE pelo hook
-     PostToolUse posttooluse-tool-call-tick.sh (sidecar tool-call-ticks.log
-     no state dir, somado ao campo do state por budget.sh check e por
-     state-ondas.sh end). NAO chamar state-ondas.sh tool-call-tick
-     manualmente com o hook ativo (contagem dobrada). Sem o hook
-     provisionado a metrica degrada para 0 — best-effort, nunca gateia;
-     wallclock/state_size seguem cobrindo o orcamento.
+   - a dimensao tool_calls e alimentada pelo hook PostToolUse
+     posttooluse-tool-call-tick.sh (sidecar tool-call-ticks.log no state
+     dir, somado ao campo do state por budget.sh check e por
+     state-ondas.sh end) — mas SO se o hook estiver provisionado no
+     projeto-alvo, o que exige `cstk install --scope project
+     agente-00c-runtime` rodado LA (o default e `--scope global`, que
+     pula os hooks). NAO assuma que esta ativo; consulte
+     `guard-hooks-status.sh tick-mode --projeto-alvo-path <PAP>`:
+       - "hook"   → NAO chamar state-ondas.sh tool-call-tick (dobraria)
+       - "manual" → chamar tool-call-tick a cada tool call relevante,
+         senao tool_calls fica 0 na onda inteira (observado em campo)
+     wallclock/state_size seguem cobrindo o orcamento nos dois modos.
 4.ter (best-effort, ADITIVO — dica de onda, US4 — FR-006):
     Exibir dica da skill correspondente a fase corrente. Fail-silent absoluto:
     nao bloqueia nem falha se cstk/show-tip.sh ausentes ou catalogo indisponivel.

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -110,6 +110,7 @@ infraestrutura interna deste agente.
 | `commit-mode.sh` | is-enabled/set-enabled/guard-branch/stage-message/task-message/finalize | Modo atomic-commit opt-in: commit por etapa, commit por task, push+PR terminal (FR-003/004/008 — atomic-commit-pr) |
 | `bloqueios.sh` | register/respond/list/count/next-id/get | Ciclo de vida de BloqueioHumano (FR-015/FR-016) |
 | `budget.sh` | check/status | Proxies de orcamento de sessao (FR-009: tool calls, wallclock, state size) |
+| `guard-hooks-status.sh` | check/tick-mode | Hooks 00c provisionados no projeto-alvo? READ-ONLY. `tick-mode` decide se `tool-call-tick` deve ser chamado na mao (default `manual`, nunca zera a metrica em silencio) |
 | `cycles.sh` | tick/check/count/reset | Limite de ciclos por etapa (FR-014.a — `loop_em_etapa`) |
 | `circular.sh` | push/detect/list/clear | Deteccao de movimento circular (FR-014.b — buffer 6) |
 | `drift.sh` | init/check/aspectos | Drift detection (FR-027 — aspectos-chave congelados; warn>=3, abort>=5) |
@@ -282,13 +283,26 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
 
 2. **Onda nova**: `state-ondas.sh start --state-dir <SD>`. A metrica de
    tool calls da onda e registrada AUTOMATICAMENTE pelo hook PostToolUse
-   `posttooluse-tool-call-tick.sh` (provisionado por `cstk install`/`update`
-   no projeto-alvo), que appenda no sidecar `tool-call-ticks.log` do state
-   dir; `budget.sh check` e `state-ondas.sh end` agregam o sidecar. NAO
-   chame `state-ondas.sh tool-call-tick` manualmente quando o hook esta
-   ativo — cada call contaria em dobro. Sem o hook provisionado a metrica
-   degrada para 0 (best-effort; os proxies wallclock/state_size continuam
-   gateando a onda normalmente).
+   `posttooluse-tool-call-tick.sh` — mas SO se ele estiver de fato
+   provisionado no projeto-alvo, o que exige
+   `cstk install --scope project agente-00c-runtime` rodado LA (o default
+   do `cstk install`/`update` e `--scope global`, que pula os hooks).
+   NAO assuma que esta ativo: consulte
+
+   ```sh
+   MODO_TICK=$(guard-hooks-status.sh tick-mode \
+     --projeto-alvo-path "<PROJETO_ALVO_PATH>")
+   ```
+
+   - `MODO_TICK=hook` → o sidecar `tool-call-ticks.log` e alimentado
+     sozinho; NAO chame `state-ondas.sh tool-call-tick` (contaria em dobro).
+   - `MODO_TICK=manual` → o hook NAO esta ativo; chame
+     `state-ondas.sh tool-call-tick --state-dir <SD>` a cada tool call
+     relevante, senao `tool_calls` fica 0 na onda inteira e o proxy de
+     orcamento vira letra morta (observado em campo: 35 ondas, todas 0).
+
+   Em qualquer dos modos os proxies wallclock/state_size seguem gateando a
+   onda normalmente.
 
 2.bis **Dica de onda** (fail-silent, US4 — FR-006): exibir dica da skill
    correspondente a fase corrente, se disponivel. Nao bloqueia nem falha:

--- a/global/commands/agente-00c.md
+++ b/global/commands/agente-00c.md
@@ -148,6 +148,32 @@ ja preparado fora do script), apenas defensivo.
   `/agente-00c-resume` ou `/agente-00c-abort`. Use
   `state-lock.sh check-execution-busy --state-dir <SD>`.
 
+### 2.bis Hooks 00c provisionados no projeto-alvo? (ADVISORY, nunca bloqueia)
+
+Os tres hooks do runtime (guarda de Bash + duas metricas) so chegam ao
+projeto-alvo via `cstk install --scope project agente-00c-runtime` rodado
+DENTRO dele. O default de `cstk install`/`update` e `--scope global`, que
+pula o provisionamento — entao o caso comum e o projeto-alvo NAO ter hook
+nenhum. Como o `cstk install` roda no repo do cstk e nao aqui, este e o
+unico momento do fluxo que esta dentro do projeto-alvo: e aqui que o
+operador precisa ser avisado.
+
+```sh
+guard-hooks-status.sh check --projeto-alvo-path "<PROJETO_ALVO_PATH>" || :
+```
+
+READ-ONLY: nunca copia hook nem edita `settings.json` (provisionar e
+trabalho do `cstk install`, unica fonte da regra). Exit 1 NAO aborta a
+execucao — mostre a saida ao operador e siga:
+
+- `pretooluse-bash-guard.sh` inativo → **avise com destaque**: a guarda
+  fail-closed de Bash NAO esta enforced nesta execucao. E o item grave;
+  o resto e metrica.
+- `posttooluse-tool-call-tick.sh` inativo → o orquestrador vai tickar
+  manualmente (ver passo 2 do orchestrator); `tool_calls` nao zera.
+- `posttooluse-agent-usage.sh` inativo → `agent_usage`/tokens ficam null
+  nas ondas; nao ha fallback manual, so o provisionamento resolve.
+
 ### 3. Aquisicao do lock + inicializacao de estado
 
 Adquirir o lock ANTES de inicializar o estado (o orquestrador NAO adquire

--- a/global/commands/feature-00c.md
+++ b/global/commands/feature-00c.md
@@ -144,6 +144,19 @@ Exporte: `AGENTE_00C_STATE_DIR=<projeto>/.claude/feature-00c-state/<short_name>`
    _lock="$AGENTE_00C_STATE_DIR/.lock"
    state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR"
    - se ocupado, stderr "outra sessao ativa para $SHORT"; exit 3
+
+8. hooks 00c provisionados? (ADVISORY — exit 1 NAO aborta):
+   guard-hooks-status.sh check --projeto-alvo-path "$_proj" || :
+   - READ-ONLY (nunca copia hook nem edita settings.json; provisionar e
+     trabalho do `cstk install --scope project agente-00c-runtime`, unica
+     fonte da regra). O default do install e `--scope global`, que pula os
+     hooks — logo o caso comum e o projeto-alvo nao ter nenhum, e este e o
+     unico ponto do fluxo que roda DENTRO dele.
+   - guarda inativa (pretooluse-bash-guard.sh) => avisar com DESTAQUE: a
+     guarda fail-closed de Bash nao esta enforced nesta execucao (item
+     grave; o resto e metrica)
+   - tick-hook inativo => o orquestrador ticka manualmente (passo 4 dele)
+   - agent-usage inativo => agent_usage/tokens ficam null, sem fallback
 ```
 
 ### 3. Init do state.json

--- a/global/skills/agente-00c-runtime/scripts/commit-mode.sh
+++ b/global/skills/agente-00c-runtime/scripts/commit-mode.sh
@@ -17,6 +17,9 @@
 #                [--title T] [--body B]
 #   snapshot      --state-dir DIR --projeto-alvo-path PATH
 #   stage-derived --state-dir DIR --projeto-alvo-path PATH [--scope-dir REL_DIR]...
+#                 REL_DIR e RELATIVO a raiz do projeto-alvo. Um valor
+#                 ABSOLUTO sob --projeto-alvo-path e normalizado para
+#                 relativo automaticamente (tolerancia, nao contrato).
 #
 # Exit codes globais:
 #   0  sucesso / caso tratado (inclui skips nao-fatais; stage-derived: >=1 path staged)
@@ -290,65 +293,77 @@ _cm_cmd_task_message() {
     return 0
   fi
 
-  # Multiplos IDs: checar contiguidade
-  # Separa em lista de IDs e verifica se formam range continuo
-  # IDs format: N.M (ex: 1.1, 1.2, 2.1)
-  _first=""
-  _last=""
+  # Multiplos IDs (format N.M): agrupar em RUNS contiguos DENTRO da mesma
+  # fase (major), emitindo "A-B" por run com >=2 IDs e "A" para run unitario,
+  # unidos por ", ".
+  #
+  # A transicao de fase NUNCA conta como continuidade. A heuristica antiga
+  # aceitava "major = prev_major+1 e minor = 1" como contiguo, sem verificar
+  # se os minors intermediarios da fase anterior estavam de fato na lista:
+  # com --task-ids "1.1,2.1,2.2,2.3" (1.2/1.3 bloqueadas nesta onda) ela
+  # emitia "feat: tasks 1.1-2.3", implicando FALSAMENTE que 1.2/1.3 foram
+  # concluidas. Nao ha como saber daqui qual e o ultimo minor esperado de
+  # uma fase (isso mora no tasks.md), entao a compressao cross-fase e
+  # abandonada: "1.1,2.1,2.2,2.3" -> "feat: tasks 1.1, 2.1-2.3".
+  _id_list=$(printf '%s' "$_ids" | tr ',' '\n' | sed 's/^ *//;s/ *$//;/^$/d')
+
+  _out=""
+  _run_first=""
+  _run_last=""
+  _run_n=0
   _prev_major=""
   _prev_minor=""
-  _is_range=1
+  _prev_numeric=0
 
-  # Processar cada ID na lista
-  _n=0
-  _id_list=$(printf '%s' "$_ids" | tr ',' '\n' | sed 's/^ *//;s/ *$//')
   while IFS= read -r _id; do
     [ -z "$_id" ] && continue
-    _n=$((_n + 1))
-    [ "$_n" -eq 1 ] && _first="$_id"
-    _last="$_id"
 
-    # Extrair major.minor
     _major=$(printf '%s' "$_id" | cut -d'.' -f1)
     _minor=$(printf '%s' "$_id" | cut -d'.' -f2)
 
-    if [ "$_n" -gt 1 ]; then
-      # Verificar contiguidade: mesmo major e minor = prev+1,
-      # OU major = prev_major+1 e minor = 1 (transicao de fase)
-      if [ "$_major" = "$_prev_major" ]; then
-        _expected=$((_prev_minor + 1))
-        if [ "$_minor" != "$_expected" ]; then
-          _is_range=0
-        fi
-      else
-        _expected_major=$((_prev_major + 1))
-        if [ "$_major" != "$_expected_major" ] || [ "$_minor" != "1" ]; then
-          _is_range=0
-        fi
+    # ID nao-numerico (ex: "A.1", "1", "1.x") jamais entra em aritmetica —
+    # sob `set -eu` um $(( )) sobre nao-numero aborta o script inteiro.
+    _numeric=1
+    case "$_major" in ''|*[!0-9]*) _numeric=0 ;; esac
+    case "$_minor" in ''|*[!0-9]*) _numeric=0 ;; esac
+
+    _continues=0
+    if [ "$_run_n" -gt 0 ] && [ "$_numeric" = 1 ] && [ "$_prev_numeric" = 1 ] \
+       && [ "$_major" = "$_prev_major" ] \
+       && [ "$_minor" -eq $((_prev_minor + 1)) ]; then
+      _continues=1
+    fi
+
+    if [ "$_continues" = 1 ]; then
+      _run_last="$_id"
+      _run_n=$((_run_n + 1))
+    else
+      if [ "$_run_n" -gt 0 ]; then
+        if [ "$_run_n" -eq 1 ]; then _seg="$_run_first"; else _seg="$_run_first-$_run_last"; fi
+        if [ -z "$_out" ]; then _out="$_seg"; else _out="$_out, $_seg"; fi
       fi
+      _run_first="$_id"
+      _run_last="$_id"
+      _run_n=1
     fi
 
     _prev_major="$_major"
     _prev_minor="$_minor"
+    _prev_numeric="$_numeric"
   done << EOF
 $_id_list
 EOF
 
-  if [ "$_is_range" = 1 ]; then
-    # Range contiguos
-    if [ -n "$_brief" ]; then
-      printf 'feat: tasks %s-%s %s\n' "$_first" "$_last" "$_brief"
-    else
-      printf 'feat: tasks %s-%s\n' "$_first" "$_last"
-    fi
+  # Flush do ultimo run.
+  if [ "$_run_n" -gt 0 ]; then
+    if [ "$_run_n" -eq 1 ]; then _seg="$_run_first"; else _seg="$_run_first-$_run_last"; fi
+    if [ -z "$_out" ]; then _out="$_seg"; else _out="$_out, $_seg"; fi
+  fi
+
+  if [ -n "$_brief" ]; then
+    printf 'feat: tasks %s %s\n' "$_out" "$_brief"
   else
-    # Lista nao-contigua: substituir virgulas por ", "
-    _ids_formatted=$(printf '%s' "$_ids" | sed 's/,/, /g')
-    if [ -n "$_brief" ]; then
-      printf 'feat: tasks %s %s\n' "$_ids_formatted" "$_brief"
-    else
-      printf 'feat: tasks %s\n' "$_ids_formatted"
-    fi
+    printf 'feat: tasks %s\n' "$_out"
   fi
   return 0
 }
@@ -449,6 +464,37 @@ _cm_cmd_stage_derived() {
     _cm_err "stage-derived: git nao encontrado no PATH"
     _cm_diag "error" "git-missing" "git nao encontrado no PATH" "instale git ou ajuste o PATH antes de habilitar atomic-commit"
     return 1
+  fi
+
+  # --scope-dir e RELATIVO a raiz do projeto-alvo (casa por prefixo contra
+  # os paths de `git status --porcelain`, que sao SEMPRE relativos). Passar
+  # um path ABSOLUTO fazia o filtro nunca casar e devolver rc=3 "allowlist
+  # vazia" — diagnostico enganoso, ja que havia arquivos staged-aveis.
+  # Normalizamos aqui (depois do parse: --projeto-alvo-path pode vir DEPOIS
+  # de --scope-dir em argv) em vez de exigir que todo chamador acerte o
+  # formato: os prompts dos orquestradores passam <FD>, que resolve para
+  # absoluto em varios pontos.
+  if [ "$_has_scope" = 1 ]; then
+    _pap_prefix="${_pap%/}/"
+    _scope_norm="$_scope_file.norm"
+    : > "$_scope_norm"
+    while IFS= read -r _sc_line; do
+      [ -z "$_sc_line" ] && continue
+      case "$_sc_line" in
+        "$_pap_prefix"*)
+          _sc_line="${_sc_line#"$_pap_prefix"}"
+          ;;
+        /*)
+          # Absoluto FORA do projeto-alvo: nao ha relativo equivalente.
+          # Mantido como veio (nunca vai casar, mesmo comportamento de
+          # antes), mas agora com diagnostico em vez de rc=3 silencioso.
+          _cm_err "stage-derived: --scope-dir absoluto fora de --projeto-alvo-path: $_sc_line (esperado path RELATIVO a $_pap)"
+          _cm_diag "warning" "scope-dir-outside-repo" "--scope-dir $_sc_line nao esta sob $_pap" "passe --scope-dir relativo a raiz do projeto-alvo (ex: docs/specs/<feature>)"
+          ;;
+      esac
+      printf '%s\n' "$_sc_line" >> "$_scope_norm"
+    done < "$_scope_file"
+    mv "$_scope_norm" "$_scope_file"
   fi
 
   _raw="${TMPDIR:-/tmp}/cm-raw.$$"
@@ -681,9 +727,14 @@ _cm_cmd_finalize() {
       esac
     fi
 
-    # Executar cstk session pr (delega push + PR)
-    eval "cstk session pr $_cstk_args" >/dev/null 2>&1
-    _cstk_rc=$?
+    # Executar cstk session pr (delega push + PR).
+    # `|| _cstk_rc=$?` e OBRIGATORIO: o script roda sob `set -eu` e um
+    # `eval` cru numa linha propria aborta a funcao INTEIRA quando o
+    # comando falha — antes de qualquer _cm_record_result, quebrando a
+    # garantia documentada "finalize e sempre exit 0 + push_pr_result
+    # sempre gravado" (observado em campo: exit 9 com .push_pr_result null).
+    _cstk_rc=0
+    eval "cstk session pr $_cstk_args" >/dev/null 2>&1 || _cstk_rc=$?
     if [ "$_cstk_rc" = 0 ]; then
       # Obter URL do PR criado
       _pr_url=$(gh pr view "$_curr_branch" --json url -q '.url' 2>/dev/null) || _pr_url=""

--- a/global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
+++ b/global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+# guard-hooks-status.sh — verifica se os hooks 00c estao provisionados no
+# projeto-alvo (READ-ONLY, nunca escreve nada).
+#
+# PROBLEMA QUE ISTO RESOLVE
+# -------------------------
+# Os tres hooks do runtime 00c so chegam a um projeto-alvo via
+# `apply_guard_hooks()` (cli/lib/hooks.sh), que roda EXCLUSIVAMENTE quando
+# `cstk install`/`cstk update` e invocado com `--scope project` E com
+# `agente-00c-runtime` na selecao. O default de ambos os comandos e
+# `--scope global`, que pula o provisionamento por FR-009c.
+#
+# Consequencia observada em campo: projeto com 35 ondas 00c executadas e
+# ZERO hooks em .claude/hooks/ —
+#   - pretooluse-bash-guard.sh ausente  => a guarda fail-closed de Bash
+#     (enforced-guards US1) nunca foi enforced; a execucao inteira rodou
+#     sem a protecao que a doc afirma estar ativa. E o item GRAVE.
+#   - posttooluse-tool-call-tick.sh ausente => tool_calls fica 0 em todas
+#     as ondas (proxy de orcamento inutilizado).
+#   - posttooluse-agent-usage.sh ausente => agent_usage/tokens ficam null.
+#
+# Como o `cstk install` roda no repo do cstk e nao no projeto-alvo, nao ha
+# momento natural para avisar o operador la. O ponto de checagem correto e
+# o inicio da execucao 00c, que ja esta DENTRO do projeto-alvo — dai este
+# script, consumido pelos commands /agente-00c e /feature-00c.
+#
+# Subcomandos:
+#   guard-hooks-status.sh check --projeto-alvo-path PATH [--quiet]
+#       — stdout: uma linha TSV por hook:
+#             <arquivo>\t<present|missing>\t<registered|unregistered>
+#         "registered" = o basename aparece em <PAP>/.claude/settings.json
+#         (o hook so roda de fato se estiver copiado E registrado).
+#       — stderr: diagnostico + comando de remediacao (suprimido por --quiet).
+#       — exit 0 se os 3 estao present+registered; 1 caso contrario.
+#
+#   guard-hooks-status.sh tick-mode --projeto-alvo-path PATH
+#       — stdout: "hook" se posttooluse-tool-call-tick.sh esta ativo
+#         (present+registered), senao "manual".
+#         Consumido pelo orquestrador para decidir se chama
+#         `state-ondas.sh tool-call-tick` na mao. A regra "NAO tickar
+#         manualmente" so vale quando o hook existe — sem esta checagem o
+#         default virava "nao ticka" e a metrica zerava em silencio.
+#       — exit 0 sempre (0 = consulta respondida, nao veredito).
+#
+# Exit codes:
+#   0  check: tudo provisionado | tick-mode: consulta respondida
+#   1  check: pelo menos um hook ausente ou nao-registrado
+#   2  uso incorreto
+#
+# READ-ONLY por construcao: nao copia hook, nao edita settings.json, nao
+# toca state.json. Provisionar e trabalho do `cstk install --scope project`
+# (unica fonte da regra); reimplementar a copia aqui duplicaria a regra em
+# dois lugares — mesmo motivo pelo qual o hook PreToolUse delega a decisao
+# a bash-guard.sh em vez de reimplementa-la.
+#
+# POSIX sh puro. Sem jq, sem sqlite3, sem rede.
+
+set -eu
+
+_GH_NAME="guard-hooks-status"
+
+_gh_die_usage() { printf '%s: %s\n' "$_GH_NAME" "$1" >&2; exit 2; }
+_gh_err()       { printf '%s: %s\n' "$_GH_NAME" "$1" >&2; }
+
+# Os 3 hooks provisionados por apply_guard_hooks(). Ordem = a do
+# settings.snippet.json (guard primeiro, metricas depois).
+_GH_HOOKS='pretooluse-bash-guard.sh
+posttooluse-tool-call-tick.sh
+posttooluse-agent-usage.sh'
+
+# _gh_present PAP HOOK -> 0 se o arquivo existe e e executavel
+_gh_present() {
+  [ -f "$1/.claude/hooks/$2" ] && [ -x "$1/.claude/hooks/$2" ]
+}
+
+# _gh_registered PAP HOOK -> 0 se o basename aparece no settings.json.
+# Busca textual (grep -F) em vez de parse: o hook e registrado como
+# fragmento de linha de comando ("$CLAUDE_PROJECT_DIR"/.claude/hooks/X.sh),
+# entao a presenca do basename e condicao necessaria e suficiente na
+# pratica — e mantem o script sem dependencia de jq (que pode faltar
+# justamente no projeto-alvo mal provisionado que estamos diagnosticando).
+_gh_registered() {
+  _gh_settings="$1/.claude/settings.json"
+  [ -f "$_gh_settings" ] || return 1
+  grep -Fq -- "$2" "$_gh_settings" 2>/dev/null
+}
+
+_gh_cmd_check() {
+  _pap=""
+  _quiet=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --projeto-alvo-path) _pap=$2; shift 2 ;;
+      --quiet)             _quiet=1; shift ;;
+      *) _gh_die_usage "check: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_pap" ] || _gh_die_usage "check: --projeto-alvo-path obrigatorio"
+  [ -d "$_pap" ] || _gh_die_usage "check: --projeto-alvo-path nao e diretorio: $_pap"
+
+  _missing=0
+  _guard_missing=0
+  for _h in $_GH_HOOKS; do
+    if _gh_present "$_pap" "$_h"; then
+      _st_file="present"
+    else
+      _st_file="missing"
+    fi
+    if _gh_registered "$_pap" "$_h"; then
+      _st_reg="registered"
+    else
+      _st_reg="unregistered"
+    fi
+    printf '%s\t%s\t%s\n' "$_h" "$_st_file" "$_st_reg"
+    if [ "$_st_file" != "present" ] || [ "$_st_reg" != "registered" ]; then
+      _missing=$((_missing + 1))
+      [ "$_h" = "pretooluse-bash-guard.sh" ] && _guard_missing=1
+    fi
+  done
+
+  [ "$_missing" -eq 0 ] && return 0
+
+  if [ "$_quiet" = 0 ]; then
+    _gh_err "$_missing de 3 hooks 00c NAO estao ativos em $_pap/.claude/"
+    if [ "$_guard_missing" = 1 ]; then
+      _gh_err "ATENCAO: pretooluse-bash-guard.sh inativo — a guarda fail-closed de Bash NAO esta enforced nesta execucao."
+    fi
+    _gh_err "Remediacao (rode NO PROJETO-ALVO, uma vez):"
+    _gh_err "  cd $_pap && cstk install --scope project agente-00c-runtime"
+    _gh_err "Sem isso: tool_calls fica 0 e agent_usage fica null em todas as ondas."
+  fi
+  return 1
+}
+
+_gh_cmd_tick_mode() {
+  _pap=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --projeto-alvo-path) _pap=$2; shift 2 ;;
+      *) _gh_die_usage "tick-mode: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_pap" ] || _gh_die_usage "tick-mode: --projeto-alvo-path obrigatorio"
+
+  if _gh_present "$_pap" "posttooluse-tool-call-tick.sh" \
+     && _gh_registered "$_pap" "posttooluse-tool-call-tick.sh"; then
+    printf 'hook\n'
+  else
+    printf 'manual\n'
+  fi
+  return 0
+}
+
+# ---------- dispatch ----------
+
+[ "$#" -gt 0 ] || _gh_die_usage "subcomando obrigatorio: check|tick-mode"
+
+_gh_sub=$1
+shift
+case "$_gh_sub" in
+  check)     _gh_cmd_check "$@" ;;
+  tick-mode) _gh_cmd_tick_mode "$@" ;;
+  -h|--help)
+    cat >&2 <<'HELP'
+guard-hooks-status.sh — hooks 00c provisionados no projeto-alvo? (READ-ONLY)
+
+USO:
+  guard-hooks-status.sh check     --projeto-alvo-path PATH [--quiet]
+  guard-hooks-status.sh tick-mode --projeto-alvo-path PATH
+
+check     TSV <hook>\t<present|missing>\t<registered|unregistered>;
+          exit 0 se os 3 ativos, 1 caso contrario.
+tick-mode "hook" ou "manual" — o orquestrador so ticka na mao em "manual".
+
+Remediacao quando faltam: rodar NO PROJETO-ALVO
+  cstk install --scope project agente-00c-runtime
+HELP
+    exit 2
+    ;;
+  *) _gh_die_usage "subcomando desconhecido: $_gh_sub" ;;
+esac

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -23,6 +23,7 @@
 #   state-ondas.sh end --state-dir DIR --motivo-termino MOTIVO
 #                      [--proxima-agendada-para ISO]
 #                      [--add-etapa STAGE]
+#                      [--next-instruction TEXT]
 #       — Atualiza ultima Onda (.waves[-1]) com finished_at/wallclock_seconds/
 #         tool_calls/termination_reason/next_wave_scheduled_for. Atualiza
 #         accumulated_metrics (waves_total += 1, tool_calls_total +=
@@ -31,6 +32,9 @@
 #         manuais) + linhas do sidecar tool-call-ticks.log (ticks do hook
 #         PostToolUse) — sidecar resetado apos o fechamento.
 #         --add-etapa pode ser passada N vezes para append em executed_stages.
+#         --next-instruction grava .next_instruction NO MESMO write atomico
+#         (dispensa o `state-rw.sh set` separado ANTES de end — que deixava
+#         backup/sha defasados, ja que `end` tambem escreve no state.json).
 #         Tambem agrega o sidecar wave-agent-usage.jsonl (hook
 #         posttooluse-agent-usage.sh, wave-token-metrics FASE 3) em
 #         .waves[-1].agent_usage (WaveUsage: spawns_total/with_usage/
@@ -397,11 +401,14 @@ _so_cmd_end() {
   _motivo=""
   _proxima="null"
   _etapas=""
+  _next_instr=""
+  _next_instr_set=0
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --state-dir)             _sdir=$2; shift 2 ;;
       --motivo-termino)        _motivo=$2; shift 2 ;;
       --proxima-agendada-para) _proxima=$2; shift 2 ;;
+      --next-instruction)      _next_instr=$2; _next_instr_set=1; shift 2 ;;
       --add-etapa)             _etapas="$_etapas
 $2"; shift 2 ;;
       *) _so_die_usage "end: flag desconhecida: $1" ;;
@@ -409,6 +416,9 @@ $2"; shift 2 ;;
   done
   [ -n "$_sdir" ]   || _so_die_usage "end: --state-dir obrigatorio"
   [ -n "$_motivo" ] || _so_die_usage "end: --motivo-termino obrigatorio"
+  if [ "$_next_instr_set" = 1 ] && [ -z "$_next_instr" ]; then
+    _so_die_usage "end: --next-instruction nao aceita valor vazio"
+  fi
   case "$_motivo" in
     etapa_concluida_avancando|threshold_proxy_atingido|bloqueio_humano|aborto|concluido) ;;
     *) _so_die "end: motivo invalido: $_motivo" 2 ;;
@@ -451,8 +461,20 @@ $2"; shift 2 ;;
   # agrega o que foi de fato observado, nunca fabrica o resto).
   _au_spawns_json=$(_so_agent_usage_read "$_sdir")
 
+  # .next_instruction gravado DENTRO do mesmo write atomico do fechamento
+  # da onda. Antes exigia um `state-rw.sh set` separado, e como `end`
+  # tambem escreve no state.json, seguir a ordem literal backup -> hash ->
+  # end do prompt do orquestrador deixava backup/hash defasados. Aqui
+  # backup/atomic-write/sha rodam UMA vez, depois de tudo.
+  _next_instr_json="null"
+  if [ "$_next_instr_set" = 1 ]; then
+    _next_instr_json=$(printf '%s' "$_next_instr" | jq -Rs .) \
+      || _so_die "end: falha ao serializar --next-instruction" 1
+  fi
+
   _new=$(mktemp) || _so_die "mktemp falhou" 1
   jq \
+    --argjson next_instr "$_next_instr_json" \
     --arg now "$_now" \
     --arg motivo "$_motivo" \
     --argjson wc "$_wc" \
@@ -503,6 +525,7 @@ $2"; shift 2 ;;
           add_null(.accumulated_metrics.agent_tool_use_count_total; $au.tool_use_count)
       | .accumulated_metrics.agent_duration_ms_total =
           add_null(.accumulated_metrics.agent_duration_ms_total; $au.duration_ms)
+      | (if $next_instr != null then .next_instruction = $next_instr else . end)
   ' "$_sf" > "$_new" || { rm -f -- "$_new"; _so_die "jq update falhou" 1; }
 
   _so_backup_current "$_sdir"
@@ -647,6 +670,17 @@ _so_cmd_record_task() {
   done
   [ -n "$_sdir" ] || _so_die_usage "record-task: --state-dir obrigatorio"
   [ -n "$_tid" ]  || _so_die_usage "record-task: --task-id obrigatorio"
+  # task_id = nivel do heading de TAREFA no tasks.md ("### N.M"), NUNCA o
+  # nivel de subtarefa/checkbox (N.M.K). Aviso e nao erro: gravar no nivel
+  # errado ja aconteceu em campo (7 record-task em N.M.K numa execucao, so
+  # descoberto depois pelo reconcile-tasks do review-task) e daqui nao ha
+  # como saber o nivel correto sem o tasks.md — logo, sinalizamos sem
+  # bloquear.
+  case "$_tid" in
+    *.*.*)
+      _so_log "record-task: AVISO — --task-id '$_tid' tem 3+ niveis; esperado N.M (heading '### N.M' do tasks.md), nao N.M.K (subtarefa/checkbox)"
+      ;;
+  esac
   [ -n "$_oc" ]   || _so_die_usage "record-task: --outcome obrigatorio"
   case "$_oc" in pass|fail) : ;; *) _so_die_usage "record-task: --outcome deve ser pass|fail" ;; esac
   case "$_tr" in ''|*[!0-9]*) _so_die_usage "record-task: --testes-rodados deve ser inteiro >= 0" ;; esac
@@ -975,6 +1009,7 @@ USO:
   state-ondas.sh end            --state-dir DIR --motivo-termino MOTIVO
                                 [--proxima-agendada-para ISO]
                                 [--add-etapa STAGE]...
+                                [--next-instruction TEXT]
   state-ondas.sh tool-call-tick --state-dir DIR
   state-ondas.sh record-skill   --state-dir DIR --skill NAME
                                 [--decisao-id DEC-NNN]

--- a/global/skills/validate-documentation/SKILL.md
+++ b/global/skills/validate-documentation/SKILL.md
@@ -289,7 +289,7 @@ path) OU deteccao automatica quando `FILE` casa a convencao
 |------|------------|----------|
 | `missing-section` | Erro | Falta uma das 3 secoes obrigatorias (`User Scenarios & Testing`, `Requirements`, `Success Criteria`). |
 | `impl-detail-in-spec` | Erro | Termo de stack/linguagem/framework/lib especifica no corpo da spec (ex.: `bcrypt`, `PostgreSQL`, `React`). |
-| `sc-not-measurable` | Erro | Success Criterion sem metrica quantificavel OU com jargao tecnico (ex.: `API`, `TPS`, `paint time`). |
+| `sc-not-measurable` | Erro | Success Criterion sem metrica quantificavel OU com jargao tecnico de performance de implementacao (ex.: `TPS`, `paint time`, `render time`). Termos genericos de dominio (`API`, `CLI`, `JSON`) NAO disparam. |
 | `too-many-clarifications` | Erro | Mais de 3 marcadores `[NEEDS CLARIFICATION]` no total. |
 | `duplicate-id` | Erro | ID `FR-`/`SC-` repetido no mesmo documento (reusa a convencao do Gotcha abaixo). |
 | `na-placeholder-section` | Aviso | Secao deixada com placeholder `N/A` em vez de removida. |

--- a/global/skills/validate-documentation/scripts/validate-sdd.sh
+++ b/global/skills/validate-documentation/scripts/validate-sdd.sh
@@ -233,7 +233,12 @@ validate_spec_profile() {
   if [ -n "$_sc_lines" ]; then
     printf '%s\n' "$_sc_lines" | while IFS=: read -r _ln _rest; do
       _sc_id=$(printf '%s' "$_rest" | grep -oE 'SC-[0-9]+' | head -n 1)
-      if printf '%s' "$_rest" | grep -qiE '\<(API|TPS|paint time|render time)\>'; then
+      # "API" (idem "CLI"/"JSON") NAO entra aqui: e termo generico de
+      # dominio, legitimo em specs de ferramentas de dev — o SKILL.md
+      # promete explicitamente que nao dispara falso-positivo. Reproduzido
+      # em campo: SC-002 com "servicos Go que expoem API HTTP" era
+      # rejeitado. Ficam so termos de performance de implementacao.
+      if printf '%s' "$_rest" | grep -qiE '\<(TPS|paint time|render time)\>'; then
         emit error sc-not-measurable "${_sc_id} usa jargao tecnico de implementacao (linha ${_ln})"
       elif ! printf '%s' "$_rest" | grep -qE '[0-9]'; then
         emit error sc-not-measurable "${_sc_id} sem metrica quantificavel (linha ${_ln})"

--- a/tests/test_commit-mode.sh
+++ b/tests/test_commit-mode.sh
@@ -228,6 +228,70 @@ scenario_inv4_finalize_gh_missing() {
     || { _fail "status esperado skipped-gh-missing ou skipped-no-commits" "stdout: $_fin_out"; return 1; }
 }
 
+# ==== Regressao de campo: falha de `cstk session pr` NAO pode abortar ====
+# O contrato documentado e "finalize e sempre exit 0 + push_pr_result
+# sempre gravado". Como o script roda sob `set -eu`, um `eval "cstk session
+# pr ..."` cru numa linha propria abortava a funcao INTEIRA quando o comando
+# falhava — observado em campo: exit 9 com .push_pr_result null, sem passar
+# por nenhum _cm_record_result.
+
+scenario_finalize_cstk_session_pr_falha_mantem_exit0() {
+  _gdir="$TMPDIR_TEST/repo-cstkfail"
+  _sd="$TMPDIR_TEST/fin-cstkfail"
+  _init_state "$_sd" true
+  _init_git_repo "$_gdir" "feat/cstk-fail"
+
+  # Branch default local + origin/HEAD, para o finalize passar do passo 3
+  # (senao para em skipped-no-commits e nunca chega no passo 6).
+  git -C "$_gdir" branch main 2>/dev/null || :
+  git -C "$_gdir" update-ref refs/remotes/origin/main "$(git -C "$_gdir" rev-parse main)" 2>/dev/null || :
+  git -C "$_gdir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || :
+
+  printf 'change\n' >> "$_gdir/README.md"
+  git -C "$_gdir" add README.md 2>/dev/null
+  git -C "$_gdir" commit -q -m "feat: change" 2>/dev/null
+
+  # Shims: gh autenticado mas sem PR; cstk que falha com exit 9.
+  _stub="$TMPDIR_TEST/stub-cstkfail"
+  mkdir -p "$_stub"
+  cat > "$_stub/gh" <<'GHEOF'
+#!/bin/sh
+case "$1" in
+  auth) exit 0 ;;
+  *)    exit 1 ;;
+esac
+GHEOF
+  cat > "$_stub/cstk" <<'CSTKEOF'
+#!/bin/sh
+exit 9
+CSTKEOF
+  chmod +x "$_stub/gh" "$_stub/cstk"
+
+  _orig_path="$PATH"
+  PATH="$_stub:$_orig_path"
+  export PATH
+
+  capture "$SCRIPT" finalize --state-dir "$_sd" --projeto-alvo-path "$_gdir" \
+    --session "minha-sessao"
+  _fin_exit=$_CAPTURED_EXIT
+  _fin_out=$_CAPTURED_STDOUT
+  _fin_err=$_CAPTURED_STDERR
+
+  PATH="$_orig_path"
+  export PATH
+
+  [ "$_fin_exit" = 0 ] \
+    || { _fail "exit esperado 0 mesmo com cstk falhando" "obtido $_fin_exit (regressao: set -eu abortando no eval)"; return 1; }
+  printf '%s' "$_fin_err" | grep -q 'cstk session pr falhou (exit 9)' \
+    || { _fail "esperado diagnostico da falha do cstk" "stderr: $_fin_err"; return 1; }
+  # push_pr_result SEMPRE gravado — a garantia que o bug quebrava.
+  printf '%s' "$_fin_out" | grep -q '"status":"' \
+    || { _fail "push_pr_result deveria ter sido emitido" "stdout: $_fin_out"; return 1; }
+  _persisted=$(jq -r '.push_pr_result.status // "null"' "$_sd/state.json" 2>/dev/null) || _persisted="null"
+  [ "$_persisted" != "null" ] \
+    || { _fail "push_pr_result nao persistido no state.json" "obtido null"; return 1; }
+}
+
 # ==== INV-6: stage-message emite Conventional-Commit subjects ====
 
 scenario_inv6_stage_message_conventional_commit() {
@@ -272,6 +336,40 @@ scenario_inv7_task_message_id_unico() {
     _fail "ID unico: nao deve ser plural" "obtido '$_CAPTURED_STDOUT'"
     return 1
   fi
+}
+
+# INV-7 (regressao de campo): transicao de fase NAO e continuidade.
+# "1.1,2.1,2.2,2.3" com 1.2/1.3 deliberadamente puladas/bloqueadas nesta
+# onda emitia "feat: tasks 1.1-2.3" — mensagem que implica FALSAMENTE que
+# 1.2/1.3 foram concluidas. Esperado agora: "feat: tasks 1.1, 2.1-2.3".
+scenario_inv7_task_message_transicao_de_fase_nao_vira_range() {
+  capture "$SCRIPT" task-message --feature "test-feat" --task-ids "1.1,2.1,2.2,2.3" --brief "fase 2"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *"1.1-2.3"*)
+      _fail "range cross-fase implica tasks puladas como concluidas" "obtido '$_CAPTURED_STDOUT'"
+      return 1
+      ;;
+  esac
+  printf '%s' "$_CAPTURED_STDOUT" | grep -qF 'feat: tasks 1.1, 2.1-2.3 fase 2' \
+    || { _fail "esperado 'feat: tasks 1.1, 2.1-2.3 fase 2'" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+# INV-7: runs contiguos DENTRO da mesma fase seguem comprimindo.
+scenario_inv7_task_message_runs_multiplos_por_fase() {
+  capture "$SCRIPT" task-message --feature "f" --task-ids "1.1,1.2,1.4,1.5,1.6"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | grep -qF 'feat: tasks 1.1-1.2, 1.4-1.6' \
+    || { _fail "esperado 'feat: tasks 1.1-1.2, 1.4-1.6'" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+# INV-7: IDs nao-numericos nunca entram em aritmetica (o script roda sob
+# `set -eu`; um $(( )) sobre nao-numero abortaria tudo).
+scenario_inv7_task_message_ids_nao_numericos_nao_abortam() {
+  capture "$SCRIPT" task-message --feature "f" --task-ids "A.1,A.2"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT stderr='$_CAPTURED_STDERR'"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | grep -qF 'feat: tasks A.1, A.2' \
+    || { _fail "esperado lista literal" "obtido '$_CAPTURED_STDOUT'"; return 1; }
 }
 
 # INV-7: task-message sem --brief tambem funciona
@@ -466,6 +564,64 @@ scenario_5_3_1_stagederived_scope_dir_exclui_alien() {
     *alien.pptx*) : ;;
     *) _fail "alien.pptx deveria permanecer untracked" "obtido: $_untracked"; return 1 ;;
   esac
+}
+
+# ==== Regressao de campo: --scope-dir ABSOLUTO sob o projeto-alvo ====
+# Os prompts dos orquestradores passam <FD>, que resolve para path absoluto
+# em varios pontos. Antes, o casamento por prefixo contra os paths de
+# `git status --porcelain` (sempre relativos) nunca casava e o comando
+# devolvia rc=3 "allowlist vazia" — diagnostico enganoso, havia arquivo
+# staged-avel. Agora o absoluto e normalizado para relativo.
+
+scenario_stagederived_scope_dir_absoluto_normaliza() {
+  _gdir="$TMPDIR_TEST/repo-abs-scope"
+  _sd="$TMPDIR_TEST/sd-abs-scope"
+  _init_git_repo "$_gdir" "feat/abs-scope"
+
+  printf 'alien\n' > "$_gdir/alien.pptx"
+  capture "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  mkdir -p "$_gdir/docs/specs/feat-abs"
+  printf 's\n' > "$_gdir/docs/specs/feat-abs/spec.md"
+
+  # --scope-dir ABSOLUTO (o modo de falha reportado)
+  capture "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir" \
+    --scope-dir "$_gdir/docs/specs/feat-abs"
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "stage-derived com scope absoluto" "esperado exit 0, obtido $_CAPTURED_EXIT stderr='$_CAPTURED_STDERR'"; return 1; }
+
+  _staged=$(git -C "$_gdir" diff --cached --name-only)
+  case "$_staged" in
+    *"docs/specs/feat-abs/spec.md"*) : ;;
+    *) _fail "spec.md deveria estar staged" "obtido: $_staged"; return 1 ;;
+  esac
+  # Confinamento preservado: o alheio continua fora.
+  case "$_staged" in
+    *alien.pptx*) _fail "alien.pptx nao deveria estar staged" "obtido: $_staged"; return 1 ;;
+  esac
+}
+
+# Absoluto FORA do projeto-alvo: nao ha relativo equivalente. Mantem o
+# comportamento anterior (nao casa => allowlist vazia => rc=3), mas agora
+# com diagnostico explicito em vez de silencio.
+scenario_stagederived_scope_dir_absoluto_fora_do_repo_diagnostica() {
+  _gdir="$TMPDIR_TEST/repo-abs-fora"
+  _sd="$TMPDIR_TEST/sd-abs-fora"
+  _init_git_repo "$_gdir" "feat/abs-fora"
+
+  capture "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+
+  mkdir -p "$_gdir/docs"
+  printf 's\n' > "$_gdir/docs/spec.md"
+
+  capture "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir" \
+    --scope-dir "/caminho/totalmente/alheio"
+  [ "$_CAPTURED_EXIT" = 3 ] \
+    || { _fail "esperado rc=3 (allowlist vazia)" "obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s' "$_CAPTURED_STDERR" | grep -q 'fora de --projeto-alvo-path' \
+    || { _fail "faltou diagnostico de scope-dir fora do repo" "stderr='$_CAPTURED_STDERR'"; return 1; }
 }
 
 # ==== 5.3.2: commit de task (baseline + arquivo novo pos-snapshot) inclui o novo ====

--- a/tests/test_guard-hooks-status.sh
+++ b/tests/test_guard-hooks-status.sh
@@ -1,0 +1,269 @@
+#!/bin/sh
+# test_guard-hooks-status.sh — cobre
+# global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
+#
+# Invariantes sob teste:
+#   INV-1: READ-ONLY — nenhuma invocacao cria/edita arquivo no projeto-alvo.
+#   INV-2: um hook so conta como ativo se estiver PRESENTE (arquivo +x) E
+#          REGISTRADO (basename citado em .claude/settings.json). Cada
+#          metade sozinha e insuficiente — foi exatamente o modo de falha
+#          de campo (arquivo la, settings.json ausente => hook nunca roda).
+#   INV-3: check -> exit 0 so com os 3 ativos; 1 caso contrario.
+#   INV-4: tick-mode -> "manual" sempre que o tick-hook nao estiver ativo
+#          (default seguro: na duvida, ticka na mao em vez de zerar a
+#          metrica em silencio).
+#   INV-5: remediacao citada em stderr aponta `--scope project` (a causa
+#          raiz e o default `--scope global` do cstk install/update).
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh"
+
+_HOOKS='pretooluse-bash-guard.sh
+posttooluse-tool-call-tick.sh
+posttooluse-agent-usage.sh'
+
+# _mkproj NAME -> cria projeto-alvo vazio (com .claude/) e ecoa o path.
+_mkproj() {
+  _p="$TMPDIR_TEST/$1"
+  mkdir -p "$_p/.claude"
+  printf '%s' "$_p"
+}
+
+# _put_hook PAP HOOK -> materializa o arquivo do hook, executavel.
+_put_hook() {
+  mkdir -p "$1/.claude/hooks"
+  printf '#!/bin/sh\nexit 0\n' > "$1/.claude/hooks/$2"
+  chmod +x "$1/.claude/hooks/$2"
+}
+
+# _register PAP HOOK... -> settings.json citando os hooks passados.
+_register() {
+  _rp=$1
+  shift
+  {
+    printf '{"hooks":{"PostToolUse":['
+    _first=1
+    for _h in "$@"; do
+      [ "$_first" = 1 ] || printf ','
+      _first=0
+      printf '{"hooks":[{"type":"command","command":"$CLAUDE_PROJECT_DIR/.claude/hooks/%s"}]}' "$_h"
+    done
+    printf ']}}'
+  } > "$_rp/.claude/settings.json"
+}
+
+# _fully_provisioned PAP -> os 3 hooks presentes E registrados.
+_fully_provisioned() {
+  for _h in $_HOOKS; do _put_hook "$1" "$_h"; done
+  # shellcheck disable=SC2086
+  _register "$1" $_HOOKS
+}
+
+# ==== INV-3 + INV-2: projeto totalmente provisionado ====
+
+scenario_check_completo_exit0() {
+  _p=$(_mkproj proj-ok)
+  _fully_provisioned "$_p"
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  for _h in $_HOOKS; do
+    printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered$" \
+      || { _fail "TSV" "esperado '$_h present registered'"; return 1; }
+  done
+  return 0
+}
+
+# ==== INV-3: projeto virgem (o caso real: 35 ondas, zero hooks) ====
+
+scenario_check_nenhum_hook_exit1() {
+  _p=$(_mkproj proj-virgem)
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c 'missing	unregistered')
+  [ "$_n" = 3 ] || { _fail "TSV" "esperado 3 linhas missing/unregistered, obtido $_n"; return 1; }
+  return 0
+}
+
+# ==== INV-2: arquivo presente mas NAO registrado => nao conta ====
+
+scenario_check_presente_sem_registro_exit1() {
+  _p=$(_mkproj proj-sem-settings)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  # settings.json deliberadamente ausente
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q 'present	unregistered' \
+    || { _fail "TSV" "esperado present+unregistered"; return 1; }
+  return 0
+}
+
+# ==== INV-2: registrado mas arquivo ausente => nao conta ====
+
+scenario_check_registrado_sem_arquivo_exit1() {
+  _p=$(_mkproj proj-so-settings)
+  # shellcheck disable=SC2086
+  _register "$_p" $_HOOKS
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q 'missing	registered' \
+    || { _fail "TSV" "esperado missing+registered"; return 1; }
+  return 0
+}
+
+# ==== INV-2: arquivo sem bit de execucao => nao conta ====
+
+scenario_check_hook_sem_exec_bit_nao_conta() {
+  _p=$(_mkproj proj-noexec)
+  _fully_provisioned "$_p"
+  chmod -x "$_p/.claude/hooks/pretooluse-bash-guard.sh"
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^pretooluse-bash-guard.sh	missing' \
+    || { _fail "TSV" "hook sem +x deve contar como missing"; return 1; }
+  return 0
+}
+
+# ==== INV-3: provisionamento parcial (so as metricas, sem a guarda) ====
+
+scenario_check_parcial_exit1_com_alerta_da_guarda() {
+  _p=$(_mkproj proj-parcial)
+  _put_hook "$_p" "posttooluse-tool-call-tick.sh"
+  _register "$_p" "posttooluse-tool-call-tick.sh"
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-tool-call-tick.sh	present	registered$' \
+    || { _fail "TSV" "tick-hook ativo deveria aparecer como present/registered"; return 1; }
+  # A ausencia da guarda e o item grave: precisa vir destacada em stderr.
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'pretooluse-bash-guard.sh inativo' \
+    || { _fail "stderr" "faltou alerta destacado da guarda inativa"; return 1; }
+  return 0
+}
+
+# ==== INV-5: remediacao aponta --scope project ====
+
+scenario_check_stderr_cita_scope_project() {
+  _p=$(_mkproj proj-remediacao)
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q -- '--scope project' \
+    || { _fail "stderr" "remediacao deve citar 'cstk install --scope project'"; return 1; }
+  return 0
+}
+
+# ==== --quiet suprime stderr mas mantem TSV + exit ====
+
+scenario_check_quiet_sem_stderr() {
+  _p=$(_mkproj proj-quiet)
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --quiet
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDERR" ] || { _fail "stderr" "--quiet nao pode emitir stderr"; return 1; }
+  [ -n "$_CAPTURED_STDOUT" ] || { _fail "stdout" "--quiet nao pode suprimir o TSV"; return 1; }
+  return 0
+}
+
+# ==== INV-1: READ-ONLY ====
+
+scenario_read_only_nao_cria_nada() {
+  _p=$(_mkproj proj-readonly)
+  _before=$(find "$_p" | sort)
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  _after=$(find "$_p" | sort)
+  [ "$_before" = "$_after" ] \
+    || { _fail "read-only" "arvore do projeto-alvo mudou apos as consultas"; return 1; }
+  return 0
+}
+
+# ==== INV-4: tick-mode ====
+
+scenario_tick_mode_hook_quando_ativo() {
+  _p=$(_mkproj proj-tick-hook)
+  _fully_provisioned "$_p"
+  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ "$_CAPTURED_STDOUT" = "hook" ] \
+    || { _fail "stdout" "esperado 'hook', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+scenario_tick_mode_manual_quando_ausente() {
+  _p=$(_mkproj proj-tick-manual)
+  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ "$_CAPTURED_STDOUT" = "manual" ] \
+    || { _fail "stdout" "esperado 'manual', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+# tick-mode e consulta, nao veredito: exit 0 mesmo com tudo ausente.
+scenario_tick_mode_exit0_mesmo_sem_hooks() {
+  _p=$(_mkproj proj-tick-exit)
+  assert_exit 0 sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p" || return 1
+  return 0
+}
+
+# Hook presente mas NAO registrado => "manual" (INV-2 aplicado ao tick-mode).
+scenario_tick_mode_manual_sem_registro() {
+  _p=$(_mkproj proj-tick-noreg)
+  _put_hook "$_p" "posttooluse-tool-call-tick.sh"
+  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_STDOUT" = "manual" ] \
+    || { _fail "stdout" "hook nao-registrado deve dar 'manual'"; return 1; }
+  return 0
+}
+
+# ==== Uso incorreto -> exit 2 ====
+
+scenario_sem_subcomando_exit2() {
+  assert_exit 2 sh "$SCRIPT" || return 1
+  return 0
+}
+
+scenario_subcomando_desconhecido_exit2() {
+  assert_exit 2 sh "$SCRIPT" nao-existe --projeto-alvo-path /tmp || return 1
+  return 0
+}
+
+scenario_check_sem_pap_exit2() {
+  assert_exit 2 sh "$SCRIPT" check || return 1
+  return 0
+}
+
+scenario_check_flag_desconhecida_exit2() {
+  _p=$(_mkproj proj-flag)
+  assert_exit 2 sh "$SCRIPT" check --projeto-alvo-path "$_p" --nao-existe || return 1
+  return 0
+}
+
+scenario_check_pap_inexistente_exit2() {
+  assert_exit 2 sh "$SCRIPT" check --projeto-alvo-path "$TMPDIR_TEST/nao-existe-mesmo" || return 1
+  return 0
+}
+
+scenario_tick_mode_sem_pap_exit2() {
+  assert_exit 2 sh "$SCRIPT" tick-mode || return 1
+  return 0
+}
+
+# ==== Sem jq no PATH: o script nao pode depender dele ====
+# O projeto-alvo mal provisionado e justamente onde jq pode faltar.
+
+scenario_funciona_sem_jq() {
+  _p=$(_mkproj proj-sem-jq)
+  _fully_provisioned "$_p"
+  _shim="$TMPDIR_TEST/shimbin-nojq"
+  mkdir -p "$_shim"
+  for _cmd in sh grep printf find sort chmod mkdir cat rm ls; do
+    _src=$(command -v "$_cmd" 2>/dev/null) || continue
+    ln -sf "$_src" "$_shim/$_cmd" 2>/dev/null || :
+  done
+  capture env PATH="$_shim" sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "exit" "sem jq deveria continuar exit 0, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+run_all_scenarios
+exit $?

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -104,6 +104,107 @@ scenario_end_atualiza_onda_e_acumulados() {
   assert_stdout_contains "briefing" || return 1
 }
 
+# --next-instruction: grava .next_instruction NO MESMO write atomico do
+# fechamento da onda. Antes exigia um `state-rw.sh set` separado; como
+# `end` tambem escreve no state.json, seguir a ordem literal
+# backup -> hash -> end do prompt deixava backup/sha defasados.
+scenario_end_next_instruction_grava_no_mesmo_write() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando \
+    --next-instruction "Retomar em plan: rodar skill plan sobre docs/specs/x"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.next_instruction'
+  assert_stdout_contains "Retomar em plan" || return 1
+
+  # O sha256 gravado por `end` precisa bater com o state.json final —
+  # e exatamente isso que o caminho antigo (set separado APOS end)
+  # quebrava.
+  if [ -f "$_sd/state.json.sha256" ]; then
+    _expected=$(awk '{print $1}' "$_sd/state.json.sha256")
+    if command -v shasum >/dev/null 2>&1; then
+      _actual=$(shasum -a 256 "$_sd/state.json" | awk '{print $1}')
+    elif command -v sha256sum >/dev/null 2>&1; then
+      _actual=$(sha256sum "$_sd/state.json" | awk '{print $1}')
+    else
+      _actual="$_expected"
+    fi
+    [ "$_expected" = "$_actual" ] \
+      || { _fail "sha256 defasado apos end --next-instruction" "esperado $_expected, obtido $_actual"; return 1; }
+  fi
+  return 0
+}
+
+# Sem a flag, .next_instruction NAO e tocado por `end`.
+scenario_end_sem_next_instruction_preserva_campo() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$RW" set --state-dir "$_sd" --field '.next_instruction' --value '"valor previo"'
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.next_instruction'
+  assert_stdout_contains "valor previo" || return 1
+  return 0
+}
+
+# Texto com aspas/newline nao pode quebrar o JSON (serializado via jq -Rs).
+scenario_end_next_instruction_texto_com_aspas() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando \
+    --next-instruction 'usar "aspas" e $cifrao no texto'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  jq -e . "$_sd/state.json" >/dev/null 2>&1 \
+    || { _fail "state.json invalido apos --next-instruction com aspas" "jq falhou"; return 1; }
+  _got=$(jq -r '.next_instruction' "$_sd/state.json")
+  [ "$_got" = 'usar "aspas" e $cifrao no texto' ] \
+    || { _fail "next_instruction corrompido" "obtido '$_got'"; return 1; }
+  return 0
+}
+
+scenario_end_next_instruction_vazia_exit2() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando \
+    --next-instruction ""
+  [ "$_CAPTURED_EXIT" = 2 ] \
+    || { _fail "valor vazio" "esperado exit 2, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+# record-task: task_id = heading "### N.M" do tasks.md, nunca N.M.K
+# (subtarefa/checkbox). Gravar no nivel errado ja aconteceu em campo (7
+# entradas, so descobertas depois pelo reconcile-tasks). Aviso, nao erro.
+scenario_record_task_id_com_3_niveis_avisa_sem_falhar() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id "4.1.1" --outcome pass
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "record-task deve continuar gravando" "obtido exit $_CAPTURED_EXIT"; return 1; }
+  printf '%s' "$_CAPTURED_STDERR" | grep -q 'AVISO' \
+    || { _fail "esperado aviso de nivel em stderr" "stderr: $_CAPTURED_STDERR"; return 1; }
+  # Aviso nao pode impedir a gravacao.
+  _got=$(jq -r '.tasks[-1].task_id' "$_sd/state.json")
+  [ "$_got" = "4.1.1" ] || { _fail "entrada nao gravada" "obtido '$_got'"; return 1; }
+  return 0
+}
+
+scenario_record_task_id_dois_niveis_sem_aviso() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id "4.1" --outcome pass
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "record-task" "$_CAPTURED_STDERR"; return 1; }
+  printf '%s' "$_CAPTURED_STDERR" | grep -q 'AVISO' \
+    && { _fail "N.M nao pode disparar aviso de nivel" "stderr: $_CAPTURED_STDERR"; return 1; }
+  return 0
+}
+
 scenario_end_motivo_invalido_falha() {
   _sd="$TMPDIR_TEST/state"
   _init_state "$_sd"

--- a/tests/test_validate-sdd.sh
+++ b/tests/test_validate-sdd.sh
@@ -36,9 +36,14 @@ scenario_c02_spec_secao_ausente() {
 
 # ==== Cenario 3 — spec.md com termo de stack em Success Criteria ====
 
+# NOTA: o payload antigo era "API response time under 200ms". "API" saiu da
+# regex de sc-not-measurable — e termo generico de dominio, e o SKILL.md
+# sempre prometeu que nao dispararia (ver
+# scenario_sc_com_api_nao_dispara_falso_positivo). O cenario continua
+# valendo com um termo de stack de verdade.
 scenario_c03_spec_termo_stack_em_sc() {
   cp "$EG/spec.md" "$TMPDIR_TEST/broken.md"
-  printf -- '- **SC-099**: API response time under 200ms\n' >> "$TMPDIR_TEST/broken.md"
+  printf -- '- **SC-099**: React components render with <50ms paint time\n' >> "$TMPDIR_TEST/broken.md"
   assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/broken.md" --sdd-spec || return 1
   case "${_CAPTURED_STDOUT:-}" in
     *'FINDING|error|sc-not-measurable|'*|*'FINDING|error|impl-detail-in-spec|'*) : ;;
@@ -276,6 +281,62 @@ EOF
   assert_stdout_contains 'FINDING|warning|vague-adjective|' || return 1
   # Anti-padrao 6: N/A residual
   assert_stdout_contains 'FINDING|warning|na-placeholder-section|' || return 1
+}
+
+# ==== Regressao de campo: "API" NAO e jargao de implementacao ====
+# O SKILL.md de validate-documentation promete que termos genericos de
+# dominio (API/CLI/JSON) nao geram falso-positivo em specs de ferramentas
+# de dev — mas a regex de sc-not-measurable incluia "API" e rejeitava
+# SC-002 de uma spec real ("servicos Go que expoem API HTTP"); so passou
+# depois de reescrever para "endpoints HTTP". Script e promessa agora
+# concordam: sobram apenas termos de performance de implementacao.
+
+scenario_sc_com_api_nao_dispara_falso_positivo() {
+  cat > "$TMPDIR_TEST/sc-api.md" <<'EOF'
+# Feature Specification: sc-api
+
+## User Scenarios & Testing
+
+### User Story P1 - Operador instrumenta servico (Priority: P1)
+
+Texto.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST registrar cada requisicao recebida.
+
+## Key Entities
+
+- **Servico**: unidade instrumentada.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 100% dos 12 servicos Go que expoem API HTTP ficam instrumentados
+- **SC-002**: 3 dos 3 clientes CLI reportam status em ate 5 segundos
+- **SC-003**: 100% das respostas JSON validam contra o schema publicado
+EOF
+  capture sh "$SCRIPT" "$TMPDIR_TEST/sc-api.md" --sdd-spec
+  assert_stdout_not_contains 'sc-not-measurable' || return 1
+}
+
+# Termos de performance de implementacao seguem sendo Erro.
+scenario_sc_com_tps_e_paint_time_ainda_dispara() {
+  cat > "$TMPDIR_TEST/sc-perf.md" <<'EOF'
+# Feature Specification: sc-perf
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Database handles 1000 TPS
+- **SC-002**: Components render with <50ms paint time
+EOF
+  capture sh "$SCRIPT" "$TMPDIR_TEST/sc-perf.md" --sdd-spec
+  assert_stdout_contains 'FINDING|error|sc-not-measurable|' || return 1
 }
 
 run_all_scenarios


### PR DESCRIPTION
## Contexto

Validação das 12 sugestões mais recentes da `knowledge.db` (tabela `suggestions`, 40 no total), cada uma checada **contra o código** antes de aceita: 7 implementadas, 2 já resolvidas antes, 2 descartadas com motivo registrado, 1 com diagnóstico certo mas proposta inviável.

## Achado principal (não é bugfix)

Os três hooks do runtime 00c **nunca chegaram a nenhum projeto-alvo desta máquina** — `find ~/Projects -path '*/.claude/hooks/posttooluse-tool-call-tick.sh'` retorna zero, e `~/.claude/settings.json` tem `.hooks == null`.

Causa: `apply_guard_hooks()` (`cli/lib/hooks.sh:197`) só roda com `--scope project` **e** `agente-00c-runtime` na seleção, mas o default de `cstk install`/`update` é `--scope global`, que pula o provisionamento por FR-009c. Como o `cstk install` roda no repo do cstk e não no alvo, não havia momento no fluxo em que o operador fosse avisado.

Efeito: a guarda fail-closed de Bash (enforced-guards US1) ficou **inerte em toda execução real** — segue advisory de fato — e `tool_calls`/`agent_usage` zeraram. Constatado em projeto com 35 ondas 00c executadas e zero hooks em `.claude/hooks/`.

## Mudanças

### Added
- **`guard-hooks-status.sh`** (READ-ONLY): `check` (TSV por hook + remediação) e `tick-mode` (`hook`|`manual`). Um hook só conta como ativo se **presente e registrado** — arquivo no lugar sem registro é hook que nunca roda. Nunca provisiona: isso segue exclusivo do `cstk install --scope project`, única fonte da regra.
- **`state-ondas.sh end --next-instruction`**: grava no mesmo write atômico do fechamento da onda; backup/sha deixam de ficar defasados.

### Changed
- `/agente-00c` (2.bis) e `/feature-00c` (pré-flight 8) chamam `check` no init — advisory, exit 1 não aborta.
- Orquestradores consultam `tick-mode` em vez de assumir o hook ativo. A instrução anterior ("não ticke manualmente quando o hook está ativo") não tinha como verificar a condição e virava "nunca ticke".
- `sc-not-measurable` deixa de sinalizar `API` — o `SKILL.md` já prometia isso num parágrafo e negava na tabela de findings; ambos alinhados.
- `task-message` comprime IDs por *runs* dentro da mesma fase: `1.1,2.1,2.2,2.3` → `1.1, 2.1-2.3` (antes `1.1-2.3`, implicando falsamente que 1.2/1.3 bloqueadas foram concluídas).
- `record-task` avisa quando `--task-id` tem 3+ níveis.

### Fixed
- **`finalize` violava o próprio contrato** "sempre exit 0 + `push_pr_result` sempre gravado": sob `set -eu`, o `eval "cstk session pr …"` cru abortava a função antes de qualquer `_cm_record_result` (observado: exit 9 com campo null).
- **`stage-derived` retornava rc=3 "allowlist vazia" enganoso** com `--scope-dir` absoluto — o filtro casa contra paths relativos do `git status`, mas os prompts passam `<FD>`, que resolve para absoluto.

## Descartadas (registrado o porquê)
- **`reconcile-untracked`** — a própria sugestão admite "causa raiz não investigada" e propõe varredura ampla justamente onde o FR-014 acabou de introduzir allowlist derivada para conter o incidente `.pptx`.
- **3º modo do `clarify`** — já resolvido via `args` + ETAPA 5 direta; contrato novo para caminho raro não se paga.

## Testes
Suíte completa: **1857 cenários, 0 falhas** (`--check-coverage` limpo, shellcheck sem warnings novos).
`test_guard-hooks-status.sh` novo (20 cenários) + 14 cenários em arquivos existentes. O teste do `finalize` foi validado contra a regressão: revertendo o fix ele falha com exit 9, exatamente o sintoma reportado em campo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h3LpRcNK55CHRA3sdVboe