### PR TITLE
feat(cli): cstk hooks install — provisiona só os hooks 00c (5.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.27.0] - 2026-07-26
+
+Fecha a lacuna que a 5.26.0 deixou aberta: a detecção avisava que os hooks
+00c não estavam ativos, mas o único caminho para provisioná-los duplicava o
+catálogo inteiro dentro do repo-alvo. Agora há um caminho enxuto.
+
+### Added
+
+- **`cstk hooks install`** (novo subcomando): provisiona os três hooks do
+  runtime 00c (`pretooluse-bash-guard.sh`,
+  `posttooluse-tool-call-tick.sh`, `posttooluse-agent-usage.sh`) num
+  projeto-alvo, tocando **apenas** `.claude/hooks/` e `.claude/settings.json`.
+  Flags: `--project-path PATH` (default: diretório corrente),
+  `--catalog DIR` (default: `$HOME/.claude`) e `--dry-run`.
+  - **Motivação**: até 5.26.0 o único caminho documentado era
+    `cstk install --scope project agente-00c-runtime`, que além dos hooks
+    copia 1 skill + 6 commands + 7 agents para dentro do repo — 14 artefatos
+    duplicados do catálogo global por projeto, com ruído no versionamento e
+    superfície de drift. Como sem os hooks a guarda fail-closed de Bash fica
+    inerte e `tool_calls`/`agent_usage` ficam zerados, o custo de ativação
+    precisava cair.
+  - **Nenhuma regra nova**: `hooks_main` delega integralmente a
+    `apply_guard_hooks()` (`cli/lib/hooks.sh`), a mesma função usada por
+    `install.sh` e `update.sh` — que segue sendo a fonte única da regra de
+    provisionamento. Escopo de projeto por construção (FR-009c): apontar
+    `--project-path` para `$HOME` é recusado com exit 1.
+  - Testes: +9 cenários em `tests/cstk/test_hooks.sh` (incluindo idempotência
+    e a asserção de que **não** cria `skills/`, `commands/` ou `agents/` no
+    alvo) e +4 em `tests/cstk/test_cstk-main.sh` (wiring do dispatch).
+
+### Changed
+
+- **README** (`en` + `pt-BR`): nova seção "00c runtime hooks (`cstk hooks`)"
+  explicando que os hooks só rodam quando copiados **e** registrados, e que
+  sem eles a guarda de Bash é inerte.
+
 ## [5.26.0] - 2026-07-26
 
 Triagem das sugestões acumuladas na `knowledge.db` — 7 correções validadas
@@ -4031,6 +4067,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.27.0]: https://github.com/JotJunior/cstk/releases/tag/v5.27.0
 [5.26.0]: https://github.com/JotJunior/cstk/releases/tag/v5.26.0
 [5.25.0]: https://github.com/JotJunior/cstk/releases/tag/v5.25.0
 [5.24.0]: https://github.com/JotJunior/cstk/releases/tag/v5.24.0

--- a/README.md
+++ b/README.md
@@ -230,6 +230,32 @@ cstk install --scope project advisor owasp-security
 # (in --scope global, hooks are omitted with a warning in the summary — FR-009c)
 ```
 
+### 00c runtime hooks (`cstk hooks`)
+
+The three 00c runtime hooks — `pretooluse-bash-guard.sh` (fail-closed Bash
+guard), `posttooluse-tool-call-tick.sh` and `posttooluse-agent-usage.sh`
+(per-wave metrics) — only run in a target project once they are copied into
+`.claude/hooks/` **and** registered in `.claude/settings.json`.
+
+`cstk install --scope project agente-00c-runtime` does that, but it also
+copies the skill, 6 commands and 7 agents into the repo. When you only want
+the hooks, use:
+
+```bash
+cd ~/projects/my-target-project
+cstk hooks install                    # touches .claude/hooks/ + settings.json only
+cstk hooks install --dry-run          # show the plan without writing
+cstk hooks install --project-path ../other-project
+```
+
+Without this step the Bash guard is inert and `tool_calls`/`agent_usage`
+stay at zero for every wave. To check the current state without writing
+anything:
+
+```bash
+guard-hooks-status.sh check --projeto-alvo-path .
+```
+
 **Interactive mode** (numbered selector in a TTY) and **dry-run**:
 
 ```bash

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -229,6 +229,33 @@ cstk install --scope project advisor owasp-security
 # (em --scope global, hooks são omitidos com aviso no summary — FR-009c)
 ```
 
+### Hooks do runtime 00c (`cstk hooks`)
+
+Os três hooks do runtime 00c — `pretooluse-bash-guard.sh` (guarda
+fail-closed de Bash), `posttooluse-tool-call-tick.sh` e
+`posttooluse-agent-usage.sh` (métricas por onda) — só rodam num projeto-alvo
+depois de copiados para `.claude/hooks/` **e** registrados em
+`.claude/settings.json`.
+
+O `cstk install --scope project agente-00c-runtime` faz isso, mas também
+copia a skill, 6 commands e 7 agents para dentro do repo. Quando você quer
+apenas os hooks:
+
+```bash
+cd ~/projects/meu-projeto-alvo
+cstk hooks install                    # toca só .claude/hooks/ + settings.json
+cstk hooks install --dry-run          # mostra o plano sem escrever
+cstk hooks install --project-path ../outro-projeto
+```
+
+Sem esse passo a guarda de Bash fica inerte e `tool_calls`/`agent_usage`
+ficam zerados em todas as ondas. Para conferir o estado atual sem escrever
+nada:
+
+```bash
+guard-hooks-status.sh check --projeto-alvo-path .
+```
+
 **Modo interativo** (seletor numerado em TTY) e **dry-run**:
 
 ```bash

--- a/cli/cstk
+++ b/cli/cstk
@@ -143,6 +143,8 @@ COMANDOS:
                 tambem --ingest (pos-onda) e --reindex (reconstrucao)
   show-tip      Exibe uma dica sobre uma skill do toolkit (aleatoria ou por SKILL/--phase)
   serve         Inicia o painel web cstk; baixa e instala na primeira execucao
+  hooks         Provisiona os hooks do runtime 00c num projeto-alvo
+                (so hooks + settings.json; nao duplica skill/commands/agents)
   00c <path>    Bootstrap interativo de projeto-alvo do agente-00C
                 (cria diretorio, coleta parametros e invoca claude)
 
@@ -161,6 +163,13 @@ HELP
     exit "$CSTK_EXIT_OK"
   fi
   case "$_sub" in
+    hooks)
+      printf 'cstk help hooks: provisiona os hooks do runtime 00c num projeto-alvo.\n'
+      printf 'Toca apenas .claude/hooks/ + .claude/settings.json — nao duplica\n'
+      printf 'skill/commands/agents como "cstk install --scope project".\n'
+      printf 'Para help inline, rode: cstk hooks --help\n'
+      exit "$CSTK_EXIT_OK"
+      ;;
     install|update|self-update|list|doctor|session|serve)
       printf 'cstk help %s: consulte docs/specs/cstk-cli/contracts/cli-commands.md §%s\n' \
         "$_sub" "$_sub"
@@ -186,7 +195,7 @@ HELP
       ;;
     *)
       printf 'cstk: comando desconhecido para help: %s\n' "$_sub" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, 00c\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, 00c\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac
@@ -219,7 +228,7 @@ _dispatch() {
       . "$_lib_file"
       serve_main "$@"
       ;;
-    install|update|self-update|list|doctor|session|recall|show-tip)
+    install|update|self-update|list|doctor|session|recall|show-tip|hooks)
       # Boot-check para todos exceto self-update (que e o caminho de recovery
       # da janela transiente — bloquea-lo aqui causaria deadlock).
       case "$_cmd" in
@@ -268,7 +277,7 @@ _dispatch() {
       ;;
     *)
       printf 'cstk: comando desconhecido: %s\n' "$_cmd" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, 00c, help, --version\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, 00c, help, --version\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac

--- a/cli/lib/hooks.sh
+++ b/cli/lib/hooks.sh
@@ -299,3 +299,162 @@ apply_guard_hooks() {
   fi
   return 0
 }
+
+# ============================================================================
+# hooks_main — comando `cstk hooks install`
+# ============================================================================
+#
+# Ref: README.md §"Hooks do runtime 00c" (o contrato do CLI foi arquivado em
+#      docs/specs/_archived/cstk-cli/ e nao cobre este subcomando)
+#
+# PROBLEMA QUE ISTO RESOLVE
+# -------------------------
+# Ate 5.26.0 o UNICO caminho para provisionar os hooks 00c num projeto-alvo
+# era `cstk install --scope project agente-00c-runtime`, que — alem dos 3
+# hooks — copia 1 skill + 6 commands + 7 agents para dentro do repo. Ou
+# seja: para ativar a guarda fail-closed de Bash o operador precisava
+# duplicar 14 artefatos do catalogo global dentro de cada projeto, com o
+# custo de ruido no repo (arquivos que acabam versionados) e de drift (duas
+# copias do mesmo artefato para manter em sincronia).
+#
+# `cstk hooks install` faz SO a parte dos hooks. Nao ha regra nova aqui:
+# delega integralmente a apply_guard_hooks() (mesma funcao usada por
+# install.sh e update.sh), que segue sendo a fonte unica da regra de
+# provisionamento.
+#
+# Sintaxe:
+#   cstk hooks install [--project-path PATH] [--catalog DIR] [--dry-run]
+#
+#   --project-path PATH  Raiz do projeto-alvo (default: diretorio corrente).
+#                        Os hooks vao para <PATH>/.claude/hooks/ e o merge
+#                        acontece em <PATH>/.claude/settings.json.
+#   --catalog DIR        Catalogo de origem (default: $HOME/.claude). Os
+#                        hooks sao lidos de
+#                        <DIR>/skills/agente-00c-runtime/hooks/.
+#   --dry-run            Reporta o plano sem escrever.
+#
+# Escopo de PROJETO apenas, por construcao: os hooks so fazem sentido
+# registrados no settings.json de um projeto (FR-009c — `--scope global`
+# sempre pulou o provisionamento). Apontar --project-path para $HOME e
+# recusado explicitamente.
+#
+# Exit codes:
+#   0  hooks provisionados (merged) ou plano exibido em --dry-run
+#   1  falha de I/O, catalogo sem hooks, ou --project-path invalido
+#   2  uso incorreto
+
+_hooks_print_help() {
+  cat >&2 <<'HELP'
+cstk hooks — provisiona os hooks do runtime 00c num projeto-alvo.
+
+USO:
+  cstk hooks install [--project-path PATH] [--catalog DIR] [--dry-run]
+
+Copia pretooluse-bash-guard.sh + posttooluse-tool-call-tick.sh +
+posttooluse-agent-usage.sh para <PATH>/.claude/hooks/ e mescla o bloco de
+registro em <PATH>/.claude/settings.json (via jq; sem jq, imprime o bloco
+para colagem manual).
+
+Diferenca para `cstk install --scope project agente-00c-runtime`: aquele
+comando tambem duplica skill+commands+agents dentro do repo; este toca
+APENAS os hooks e o settings.json.
+
+Para conferir o estado atual sem escrever nada:
+  guard-hooks-status.sh check --projeto-alvo-path PATH
+HELP
+}
+
+hooks_main() {
+  _hooks_sub="${1:-}"
+  [ "$#" -ge 1 ] && shift || :
+
+  case "$_hooks_sub" in
+    ''|-h|--help|help)
+      _hooks_print_help
+      [ -z "$_hooks_sub" ] && return 2
+      return 0
+      ;;
+    install) ;;
+    *)
+      log_error "hooks: subcomando desconhecido: $_hooks_sub (use: install)"
+      return 2
+      ;;
+  esac
+
+  _hooks_project_path="."
+  _hooks_catalog="${HOME:?HOME nao setado}/.claude"
+  _hooks_dry_run=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --project-path)
+        [ "$#" -ge 2 ] || { log_error "hooks install: --project-path exige valor"; return 2; }
+        _hooks_project_path=$2; shift 2 ;;
+      --project-path=*) _hooks_project_path=${1#--project-path=}; shift ;;
+      --catalog)
+        [ "$#" -ge 2 ] || { log_error "hooks install: --catalog exige valor"; return 2; }
+        _hooks_catalog=$2; shift 2 ;;
+      --catalog=*) _hooks_catalog=${1#--catalog=}; shift ;;
+      --dry-run) _hooks_dry_run=1; shift ;;
+      -h|--help) _hooks_print_help; return 0 ;;
+      *) log_error "hooks install: flag desconhecida: $1"; return 2 ;;
+    esac
+  done
+
+  if [ ! -d "$_hooks_project_path" ]; then
+    log_error "hooks install: --project-path nao e diretorio: $_hooks_project_path"
+    return 1
+  fi
+
+  # Normaliza para comparar com $HOME sem depender de realpath (nem todo
+  # ambiente POSIX tem). `cd` + `pwd -P` resolve symlinks e relativos.
+  _hooks_abs=$(CDPATH= cd -- "$_hooks_project_path" 2>/dev/null && pwd -P) \
+    || { log_error "hooks install: nao consegui resolver $_hooks_project_path"; return 1; }
+
+  if [ "$_hooks_abs" = "${HOME%/}" ]; then
+    log_error "hooks install: --project-path aponta para \$HOME — hooks 00c sao de escopo PROJETO (FR-009c)."
+    log_error "hooks install: aponte para a raiz de um projeto-alvo, nao para o diretorio home."
+    return 1
+  fi
+
+  _hooks_src="$_hooks_catalog/skills/agente-00c-runtime/hooks"
+  if [ ! -d "$_hooks_src" ]; then
+    log_error "hooks install: catalogo sem hooks 00c: $_hooks_src"
+    log_error "hooks install: rode 'cstk install' (ou 'cstk update') antes, ou passe --catalog DIR."
+    return 1
+  fi
+
+  _hooks_dest="$_hooks_abs/.claude"
+
+  _hooks_state=$(apply_guard_hooks "$_hooks_src" "$_hooks_dest" "$_hooks_dry_run")
+
+  case "$_hooks_state" in
+    merged)
+      if [ "$_hooks_dry_run" = 1 ]; then
+        log_info "hooks install: [dry-run] provisionaria os hooks 00c em $_hooks_dest"
+      else
+        log_info "hooks install: hooks 00c provisionados e registrados em $_hooks_dest"
+      fi
+      return 0
+      ;;
+    paste-instructed)
+      log_warn "hooks install: jq ausente — hooks copiados, mas o REGISTRO em settings.json"
+      log_warn "hooks install: precisa ser colado manualmente (bloco impresso acima)."
+      log_warn "hooks install: sem o registro os hooks NAO rodam."
+      return 0
+      ;;
+    hooks-only)
+      log_warn "hooks install: settings.snippet.json ausente no catalogo — hooks copiados"
+      log_warn "hooks install: mas NAO registrados; eles nao vao rodar. Atualize o catalogo."
+      return 0
+      ;;
+    not-applicable)
+      log_error "hooks install: catalogo nao trouxe os hooks 00c (nada a provisionar)"
+      return 1
+      ;;
+    *)
+      log_error "hooks install: falha ao provisionar (estado=$_hooks_state)"
+      return 1
+      ;;
+  esac
+}

--- a/tests/cstk/test_cstk-main.sh
+++ b/tests/cstk/test_cstk-main.sh
@@ -166,4 +166,32 @@ scenario_cstk_lib_override() {
   assert_stderr_contains "nao implementado" || return 1
 }
 
+# ==== dispatch de `cstk hooks` (5.27.0) ====
+#
+# `hooks` segue a convencao generica do dispatch (cli/lib/<cmd>.sh definindo
+# <cmd>_main), entao o que precisa de teste aqui e o WIRING: o comando existe,
+# aparece no help e nao cai no ramo "comando desconhecido".
+
+scenario_help_lista_hooks() {
+  assert_exit 0 sh "$CSTK" --help || return 1
+  assert_stdout_contains "hooks" || return 1
+}
+
+scenario_help_hooks_aponta_doc() {
+  assert_exit 0 sh "$CSTK" help hooks || return 1
+  assert_stdout_contains "hooks" || return 1
+}
+
+scenario_hooks_sem_subcomando_exit2() {
+  # Chega em hooks_main (nao no ramo de comando desconhecido, que tambem e 2):
+  # a mensagem de uso do proprio `cstk hooks` cita o subcomando install.
+  assert_exit 2 sh "$CSTK" hooks || return 1
+  assert_stderr_contains "install" || return 1
+}
+
+scenario_hooks_help_inline() {
+  assert_exit 0 sh "$CSTK" hooks --help || return 1
+  assert_stderr_contains "cstk hooks install" || return 1
+}
+
 run_all_scenarios

--- a/tests/cstk/test_hooks.sh
+++ b/tests/cstk/test_hooks.sh
@@ -346,4 +346,124 @@ scenario_apply_guard_hooks_catalogo_antigo_sem_tick() {
   return 0
 }
 
+# ==== hooks_main — comando `cstk hooks install` (5.27.0) ====
+#
+# Motivacao: ate 5.26.0 o unico caminho para provisionar os hooks 00c era
+# `cstk install --scope project agente-00c-runtime`, que tambem copiava
+# skill+6 commands+7 agents para dentro do repo-alvo. `cstk hooks install`
+# faz SO os hooks — delegando integralmente a apply_guard_hooks(), sem
+# regra nova.
+
+# _hooks_catalog_fixture: catalogo minimo no layout que hooks_main espera
+# (<catalog>/skills/agente-00c-runtime/hooks/), reusando _guard_src_fixture.
+_hooks_catalog_fixture() {
+  _hcf_cat="$TMPDIR_TEST/catalog"
+  _hcf_hooks="$_hcf_cat/skills/agente-00c-runtime/hooks"
+  mkdir -p "$_hcf_hooks"
+  _hcf_src=$(_guard_src_fixture)
+  cp "$_hcf_src"/* "$_hcf_hooks/" 2>/dev/null || :
+  chmod +x "$_hcf_hooks"/*.sh 2>/dev/null || :
+  printf '%s' "$_hcf_cat"
+}
+
+# Aspas SIMPLES no -c: o "$@" tem de ser expandido pelo sh INTERNO (a partir
+# dos posicionais depois do `_`), nao interpolado aqui — interpolar quebra
+# qualquer argumento com espaco e desbalanceia as aspas.
+_hooks_main_run() {
+  capture sh -c '. "$CSTK_LIB/hooks.sh" && hooks_main "$@"' _ "$@"
+}
+
+scenario_hooks_main_install_provisiona_so_hooks() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _proj="$TMPDIR_TEST/proj-hooks-main"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  for _h in pretooluse-bash-guard.sh posttooluse-tool-call-tick.sh posttooluse-agent-usage.sh; do
+    [ -x "$_proj/.claude/hooks/$_h" ] || { _fail "hook ausente" "$_h"; return 1; }
+  done
+  jq -e '.hooks.PreToolUse[0].matcher == "Bash"' "$_proj/.claude/settings.json" >/dev/null \
+    || { _fail "settings.json nao mesclado" ""; return 1; }
+  # A diferenca para `cstk install --scope project`: NAO duplica catalogo.
+  for _d in skills commands agents; do
+    [ -d "$_proj/.claude/$_d" ] \
+      && { _fail "duplicou catalogo" "$_d nao deveria existir — hooks install toca so hooks+settings"; return 1; }
+  done
+  return 0
+}
+
+scenario_hooks_main_dry_run_nao_escreve() {
+  _cat=$(_hooks_catalog_fixture)
+  _proj="$TMPDIR_TEST/proj-hooks-dry"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -e "$_proj/.claude" ] \
+    && { _fail "dry-run escreveu" ".claude nao deveria existir"; return 1; }
+  return 0
+}
+
+# Escopo de PROJETO por construcao (FR-009c): apontar para $HOME e recusado.
+scenario_hooks_main_recusa_home() {
+  _cat=$(_hooks_catalog_fixture)
+  _hooks_main_run install --project-path "$HOME" --catalog "$_cat"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "escopo PROJETO" || return 1
+  return 0
+}
+
+scenario_hooks_main_catalogo_sem_hooks_exit1() {
+  _proj="$TMPDIR_TEST/proj-nocat"
+  mkdir -p "$_proj" "$TMPDIR_TEST/catalog-vazio"
+  _hooks_main_run install --project-path "$_proj" --catalog "$TMPDIR_TEST/catalog-vazio"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "catalogo sem hooks" || return 1
+  return 0
+}
+
+scenario_hooks_main_project_path_inexistente_exit1() {
+  _cat=$(_hooks_catalog_fixture)
+  _hooks_main_run install --project-path "$TMPDIR_TEST/nao-existe" --catalog "$_cat"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+scenario_hooks_main_sem_subcomando_exit2() {
+  _hooks_main_run
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+scenario_hooks_main_subcomando_invalido_exit2() {
+  _hooks_main_run nao-existe
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+scenario_hooks_main_flag_desconhecida_exit2() {
+  _cat=$(_hooks_catalog_fixture)
+  _proj="$TMPDIR_TEST/proj-flag"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --nao-existe
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+# Idempotencia: rodar 2x nao duplica entradas no settings.json.
+scenario_hooks_main_idempotente() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _proj="$TMPDIR_TEST/proj-idem"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat"
+  _n1=$(jq '.hooks.PostToolUse | length' "$_proj/.claude/settings.json")
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "2a run exit" "$_CAPTURED_EXIT"; return 1; }
+  _n2=$(jq '.hooks.PostToolUse | length' "$_proj/.claude/settings.json")
+  [ "$_n1" = "$_n2" ] \
+    || { _fail "idempotencia" "PostToolUse foi de $_n1 para $_n2 entradas"; return 1; }
+  return 0
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Problema

A 5.26.0 entregou **detecção** de hooks 00c ausentes, mas não o provisionamento. Na prática o operador era avisado e não tinha um caminho barato para agir: o único jeito documentado era

```bash
cstk install --scope project agente-00c-runtime
```

que, além dos 3 hooks, copia **1 skill + 6 commands + 7 agents** para dentro do repo-alvo — 14 artefatos duplicados do catálogo global por projeto, com ruído no versionamento e superfície de drift (duas cópias do mesmo artefato para manter em sincronia).

Como sem os hooks a guarda fail-closed de Bash fica **inerte** e `tool_calls`/`agent_usage` ficam zerados em todas as ondas, o custo de ativação precisava cair.

## Solução

```bash
cstk hooks install [--project-path PATH] [--catalog DIR] [--dry-run]
```

Toca **apenas** `.claude/hooks/` e `.claude/settings.json`.

**Nenhuma regra nova**: `hooks_main` delega integralmente a `apply_guard_hooks()` (`cli/lib/hooks.sh`) — a mesma função usada por `install.sh` e `update.sh`, que segue sendo a fonte única da regra de provisionamento. Reimplementar a cópia aqui duplicaria a regra em dois lugares, exatamente o que o hook `PreToolUse` evita ao delegar a decisão para `bash-guard.sh`.

Escopo de projeto por construção (FR-009c): `--project-path` apontando para `$HOME` é recusado com exit 1.

## Testes

- `tests/cstk/test_hooks.sh` +9 cenários — incluindo idempotência (rodar 2× não duplica entradas no `settings.json`) e a asserção de que **não** cria `skills/`, `commands/` nem `agents/` no alvo, que é justamente a diferença para o comando antigo.
- `tests/cstk/test_cstk-main.sh` +4 cenários — wiring do dispatch, help e exit codes.

Suíte completa: **1870 cenários, 0 falhas**. Shellcheck limpo.

## Docs

README (`en` + `pt-BR`) ganha a seção "00c runtime hooks (`cstk hooks`)", explicando que os hooks só rodam quando copiados **e** registrados, e que sem eles a guarda de Bash é inerte.

Nota: o help de `cstk help hooks` descreve o comando inline em vez de apontar para `docs/specs/cstk-cli/contracts/cli-commands.md` — esse contrato foi arquivado em `docs/specs/_archived/`, e as referências existentes a ele já são fantasmas. Preferi não somar mais uma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h3LpRcNK55CHRA3sdVboe