### PR TITLE
feat(runtime): custo real por onda via telemetria OTel (5.28.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,62 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.28.0] - 2026-07-26
+
+Custo real por onda, incluindo o consumo do próprio orquestrador — a fatia
+que nenhuma métrica anterior conseguia capturar. Medido: **o subagente é
+43–47% do gasto**, exatamente o que o painel mostrava como `—`.
+
+### Added
+
+- **`otel-usage.sh`** (novo helper do runtime 00c): consumo real de
+  tokens/custo por onda a partir da telemetria **OpenTelemetry nativa do
+  Claude Code**. Subcomandos `available` / `snapshot` / `delta`.
+  - **Por que resolve o que o hook não resolvia**: `posttooluse-agent-usage.sh`
+    lê o `tool_response` do spawn, mas o spawn do orquestrador **envolve** a
+    onda — o `tool_result` chega depois do `end` (que já resetou o sidecar) e
+    é destruído pelo `start` seguinte. Os contadores OTel são incrementados
+    **a cada API request**, então o delta `start`→`end` é o consumo da onda
+    independentemente de quando o spawn retorna.
+  - Separa `main` / `subagent` / `auxiliary` pelo label `query_source`, com
+    breakdown por modelo e por tipo de token (input/output/cacheRead/
+    cacheCreation) e custo em USD.
+  - **Opt-in por ambiente, sem segredo nenhum**: `CLAUDE_CODE_ENABLE_TELEMETRY=1`
+    + `OTEL_METRICS_EXPORTER=prometheus`. **Não exige API key, Admin key nem
+    organização** — funciona em plano de assinatura. O exporter escuta em
+    `127.0.0.1:9464`; nada sai da máquina. Endpoint configurável via
+    `CSTK_OTEL_ENDPOINT`.
+  - **Privacidade**: os labels do exporter carregam `user_email`, `user_id`,
+    `user_account_*` e `organization_id`. O snapshot extrai por allowlist
+    (só `session_id`, `model`, `query_source`, `type`) e aborta se algum
+    label de PII vazar — nada disso toca disco, state.json ou knowledge.db.
+  - **Ausente ≠ zero** (Princípio VI): sem telemetria, snapshot faltando, ou
+    `session_id` divergente entre os dois snapshots, o resultado é `null`,
+    nunca um zero fabricado.
+  - Overhead medido: 37 ms por snapshot, 2 por onda.
+- **`.waves[N].otel_usage`**: `state-ondas.sh start`/`end` capturam os
+  snapshots e gravam o delta no mesmo write atômico do fechamento da onda.
+  No-op completo sem a telemetria ligada.
+- Testes: `tests/test_otel-usage.sh` (17 cenários, fixtures no formato real
+  do exporter com identificadores anonimizados) + 2 em `test_state-ondas.sh`.
+  Suíte completa: 1889 cenários, 0 falhas.
+
+### Changed
+
+- **README** (`en` + `pt-BR`): seção "Real per-wave cost / Custo real por
+  onda" com o opt-in e os números medidos.
+- **`agente-00c-orchestrator.md`**: `otel-usage.sh` na tabela de helpers,
+  marcado como automático (o orquestrador não precisa invocar).
+
+### Nota sobre a Usage & Cost Admin API
+
+Foi avaliada e **descartada** como fonte: exige Admin key
+(`sk-ant-admin01-…`), é indisponível para contas individuais, e **não tem
+dimensão de sessão** (agrupa por api_key/workspace/model). A Claude Code
+Analytics API é por usuário/**dia**, com 1 h de atraso e sem tempo real. A
+telemetria OTel entrega o que nenhuma das duas entrega: atribuição por
+sessão e por `query_source`, em tempo real e local.
+
 ## [5.27.0] - 2026-07-26
 
 Fecha a lacuna que a 5.26.0 deixou aberta: a detecção avisava que os hooks
@@ -4067,6 +4123,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.28.0]: https://github.com/JotJunior/cstk/releases/tag/v5.28.0
 [5.27.0]: https://github.com/JotJunior/cstk/releases/tag/v5.27.0
 [5.26.0]: https://github.com/JotJunior/cstk/releases/tag/v5.26.0
 [5.25.0]: https://github.com/JotJunior/cstk/releases/tag/v5.25.0

--- a/README.md
+++ b/README.md
@@ -256,6 +256,36 @@ anything:
 guard-hooks-status.sh check --projeto-alvo-path .
 ```
 
+### Real per-wave cost (`otel-usage.sh`)
+
+Claude Code's native OpenTelemetry counters are incremented **on every API
+request** and carry a `query_source` label (`main` / `subagent` /
+`auxiliary`). A snapshot at wave start and another at wave end gives the
+exact consumption of that wave — including the orchestrator's own spend,
+which the spawn hook can never capture (the orchestrator's spawn *encloses*
+the wave, so its `tool_result` arrives after the wave is already closed).
+
+Opt in with two environment variables — **no API key, no Admin key, no
+organization**; works on subscription plans:
+
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=prometheus
+```
+
+`state-ondas.sh start`/`end` then populate `.waves[N].otel_usage`
+automatically. Without the variables everything is a no-op and the field is
+`null` — **absent, never a fabricated zero**.
+
+Measured on a delegated task: `main` $0.156, `subagent` $0.141,
+`auxiliary` $0.001 — the subagent was ~47% of the spend, exactly the slice
+the panel used to show as `—`.
+
+The exporter binds `127.0.0.1:9464`; nothing leaves the machine. Identity
+labels (`user_email`, `user_id`, `user_account_*`, `organization_id`) are
+stripped at snapshot time and never reach disk. Override the endpoint with
+`CSTK_OTEL_ENDPOINT` if you changed the exporter port.
+
 **Interactive mode** (numbered selector in a TTY) and **dry-run**:
 
 ```bash

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -256,6 +256,36 @@ nada:
 guard-hooks-status.sh check --projeto-alvo-path .
 ```
 
+### Custo real por onda (`otel-usage.sh`)
+
+Os contadores OpenTelemetry nativos do Claude Code são incrementados **a
+cada API request** e carregam o label `query_source` (`main` / `subagent` /
+`auxiliary`). Um snapshot no início e outro no fim da onda dão o consumo
+exato dela — inclusive o do próprio orquestrador, que o hook de spawn nunca
+consegue capturar (o spawn do orquestrador *envolve* a onda, então o
+`tool_result` dele chega depois que a onda já fechou).
+
+Ativa-se com duas variáveis de ambiente — **sem API key, sem Admin key, sem
+organização**; funciona em plano de assinatura:
+
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=prometheus
+```
+
+O `state-ondas.sh start`/`end` passa a preencher `.waves[N].otel_usage`
+sozinho. Sem as variáveis tudo é no-op e o campo fica `null` — **ausente,
+nunca zero fabricado**.
+
+Medido numa task delegada: `main` $0,156, `subagent` $0,141, `auxiliary`
+$0,001 — o subagente era ~47% do gasto, exatamente a fatia que o painel
+mostrava como `—`.
+
+O exporter escuta em `127.0.0.1:9464`; nada sai da máquina. Labels de
+identidade (`user_email`, `user_id`, `user_account_*`, `organization_id`)
+são descartados no snapshot e nunca tocam o disco. Use `CSTK_OTEL_ENDPOINT`
+para apontar a outra porta.
+
 **Modo interativo** (seletor numerado em TTY) e **dry-run**:
 
 ```bash

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -111,6 +111,7 @@ infraestrutura interna deste agente.
 | `bloqueios.sh` | register/respond/list/count/next-id/get | Ciclo de vida de BloqueioHumano (FR-015/FR-016) |
 | `budget.sh` | check/status | Proxies de orcamento de sessao (FR-009: tool calls, wallclock, state size) |
 | `guard-hooks-status.sh` | check/tick-mode | Hooks 00c provisionados no projeto-alvo? READ-ONLY. `tick-mode` decide se `tool-call-tick` deve ser chamado na mao (default `manual`, nunca zera a metrica em silencio) |
+| `otel-usage.sh` | available/snapshot/delta | Custo/tokens REAIS da onda via telemetria OTel (`query_source` separa main de subagent). Chamado automaticamente por `state-ondas.sh start`/`end` — o orquestrador NAO precisa invocar. No-op sem `CLAUDE_CODE_ENABLE_TELEMETRY=1` + `OTEL_METRICS_EXPORTER=prometheus` |
 | `cycles.sh` | tick/check/count/reset | Limite de ciclos por etapa (FR-014.a — `loop_em_etapa`) |
 | `circular.sh` | push/detect/list/clear | Deteccao de movimento circular (FR-014.b — buffer 6) |
 | `drift.sh` | init/check/aspectos | Drift detection (FR-027 — aspectos-chave congelados; warn>=3, abort>=5) |

--- a/global/skills/agente-00c-runtime/scripts/otel-usage.sh
+++ b/global/skills/agente-00c-runtime/scripts/otel-usage.sh
@@ -1,0 +1,341 @@
+#!/bin/sh
+# otel-usage.sh — consumo real de tokens/custo por onda via telemetria OTel
+# nativa do Claude Code (exporter Prometheus).
+#
+# POR QUE ISTO EXISTE
+# -------------------
+# A metrica de consumo por onda tinha duas fontes anteriores, ambas furadas:
+#
+#   1. `posttooluse-agent-usage.sh` (hook PostToolUse/Agent) le o tool_response
+#      do spawn. Mas o spawn ENVOLVE a onda — o command pai spawna o
+#      orquestrador, e e o orquestrador que abre e fecha a onda por dentro.
+#      O tool_result chega DEPOIS do `end` (que ja resetou o sidecar) e e
+#      destruido pelo `start` da onda seguinte. O consumo do orquestrador —
+#      a maior parte do custo — nunca era capturado.
+#
+#   2. A Usage & Cost Admin API da Anthropic nao serve: exige Admin key
+#      (`sk-ant-admin01-...`), e indisponivel para contas individuais, e
+#      NAO tem dimensao de sessao (agrupa por api_key/workspace/model). A
+#      Claude Code Analytics API e por usuario/DIA, com 1h de lag.
+#
+# A telemetria OTel resolve as duas: os contadores sao incrementados A CADA
+# API REQUEST, nao no fim do spawn, e carregam `query_source` (main |
+# subagent | auxiliary | sdk). Um snapshot no inicio e outro no fim da onda
+# dao o delta exato, INDEPENDENTE de quando o spawn retorna — que era a
+# causa raiz do bug anterior.
+#
+# Medido em 2026-07-26 (task delegada trivial): main $0.156535, subagent
+# $0.141282, auxiliary $0.000674. O subagente era ~47% do custo — exatamente
+# a fatia que o painel mostrava como "-".
+#
+# PRE-REQUISITO (opt-in do operador, sem segredo nenhum)
+# ------------------------------------------------------
+#   export CLAUDE_CODE_ENABLE_TELEMETRY=1
+#   export OTEL_METRICS_EXPORTER=prometheus
+#
+# Nao exige API key, nem Admin key, nem organizacao — funciona em plano de
+# assinatura. O exporter sobe um HTTP local em 127.0.0.1:9464/metrics; nada
+# trafega para fora da maquina.
+#
+# PRIVACIDADE (regra dura)
+# ------------------------
+# Os labels do exporter carregam PII: `user_email`, `user_id`,
+# `user_account_uuid`, `user_account_id`, `organization_id`. Este script
+# descarta TODOS eles no snapshot — so `session_id`, `model`, `query_source`
+# e `type` sobrevivem. PII nunca toca o sidecar, o state.json nem a
+# knowledge.db.
+#
+# Subcomandos:
+#   otel-usage.sh available [--endpoint URL]
+#       — exit 0 se o endpoint responde com metricas claude_code; 1 se nao.
+#         Nao escreve nada. Use para decidir se vale chamar snapshot.
+#
+#   otel-usage.sh snapshot --state-dir DIR --phase start|end [--endpoint URL]
+#       — Scrape + filtro + strip de PII -> <state-dir>/otel-<phase>.tsv
+#         (TSV: query_source \t model \t type \t value; `type` = "cost" na
+#         linha de custo). Best-effort: endpoint fora do ar -> exit 0 sem
+#         escrever, a onda segue normal.
+#
+#   otel-usage.sh delta --state-dir DIR
+#       — end - start por chave, em JSON no stdout. Sem os dois snapshots,
+#         imprime `null` e sai 0 (metrica ausente NUNCA e zero fabricado —
+#         Principio VI).
+#
+# Exit codes:
+#   0  sucesso, ou degradacao best-effort (sem telemetria disponivel)
+#   1  erro de I/O
+#   2  uso incorreto
+#
+# POSIX sh + awk + jq (jq ja e dependencia documentada do runtime).
+
+set -eu
+
+_OU_NAME="otel-usage"
+# Endpoint default do exporter Prometheus do Claude Code. Override via
+# CSTK_OTEL_ENDPOINT para porta customizada (OTEL_EXPORTER_PROMETHEUS_PORT
+# no lado do Claude Code) ou para apontar a um arquivo em teste.
+_OU_DEFAULT_ENDPOINT="${CSTK_OTEL_ENDPOINT:-http://127.0.0.1:9464/metrics}"
+
+# Labels que NUNCA podem sair do processo. Ver bloco PRIVACIDADE acima.
+_OU_PII_LABELS="user_id user_email user_account_uuid user_account_id organization_id"
+
+_ou_die_usage() { printf '%s: %s\n' "$_OU_NAME" "$1" >&2; exit 2; }
+_ou_die()       { printf '%s: %s\n' "$_OU_NAME" "$1" >&2; exit "${2:-1}"; }
+_ou_warn()      { printf '%s: %s\n' "$_OU_NAME" "$1" >&2; }
+
+_ou_have_curl() { command -v curl >/dev/null 2>&1; }
+
+# _ou_scrape ENDPOINT OUTFILE -> 0 se trouxe as metricas que ESTE script
+# consome, 1 se nao. Timeout curto: isto roda no caminho de start/end da
+# onda e NUNCA pode pendurar a execucao.
+#
+# O predicado exige `claude_code_(cost|token)_usage_total`, nao um
+# `claude_code_` generico: nos primeiros segundos de uma sessao o exporter
+# ja responde com `claude_code_session_count_total` mas ainda nao emitiu
+# nenhuma linha de custo/token — e um snapshot dai sai sem `session_id`,
+# o que faz o guard do delta descartar a onda inteira. Medido em cold
+# start: `available` passava em t=2s e o delta virava null.
+_ou_scrape() {
+  _ou_have_curl || return 1
+  curl -s --max-time 3 -o "$2" "$1" 2>/dev/null || return 1
+  [ -s "$2" ] || return 1
+  grep -q '^claude_code_\(cost\|token\)_usage_total{' "$2" 2>/dev/null || return 1
+  return 0
+}
+
+# _ou_parse INFILE -> TSV em stdout: query_source \t model \t type \t value
+#
+# Formato de entrada (verificado empiricamente contra Claude Code 2.1.220):
+#   claude_code_cost_usage_total{...,model="X",query_source="Y",...} 0.000637
+#   claude_code_token_usage_total{...,query_source="Y",type="input",...} 532
+#
+# O strip de PII acontece por CONSTRUCAO: extraimos apenas os 4 labels da
+# allowlist e descartamos a linha original. Nao ha caminho em que um label
+# nao-listado chegue a saida.
+_ou_parse() {
+  awk '
+    # ANCORAGEM OBRIGATORIA em `{` ou `,`: sem ela, procurar `type="` casa
+    # primeiro com `terminal_type="ghostty"` (substring), e o breakdown por
+    # tipo de token vira o nome do terminal. Bug observado: by_source com
+    # input/output/cache zerados enquanto total_tokens vinha certo.
+    function label(line, name,   re, seg) {
+      re = "[{,]" name "=\"[^\"]*\""
+      if (match(line, re)) {
+        seg = substr(line, RSTART + 1, RLENGTH - 1)
+        sub(name "=\"", "", seg)
+        sub("\"$", "", seg)
+        return seg
+      }
+      return "-"
+    }
+    /^claude_code_cost_usage_total\{/ {
+      v = $NF
+      print label($0,"query_source") "\t" label($0,"model") "\tcost\t" v
+      next
+    }
+    /^claude_code_token_usage_total\{/ {
+      v = $NF
+      print label($0,"query_source") "\t" label($0,"model") "\t" label($0,"type") "\t" v
+      next
+    }
+  ' "$1"
+}
+
+# _ou_session_id INFILE -> session_id do scrape (primeira ocorrencia), ou "".
+# Usado para invalidar o delta se o processo Claude Code trocou entre os
+# dois snapshots (contador reinicia do zero -> delta negativo/absurdo).
+_ou_session_id() {
+  awk '
+    /^claude_code_(cost|token)_usage_total\{/ {
+      if (match($0, "session_id=\"[^\"]*\"")) {
+        s = substr($0, RSTART, RLENGTH)
+        sub("session_id=\"", "", s); sub("\"$", "", s)
+        print s; exit
+      }
+    }
+  ' "$1"
+}
+
+_ou_cmd_available() {
+  _ou_ep="$_OU_DEFAULT_ENDPOINT"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --endpoint) [ "$#" -ge 2 ] || _ou_die_usage "available: --endpoint exige valor"
+                  _ou_ep=$2; shift 2 ;;
+      *) _ou_die_usage "available: flag desconhecida: $1" ;;
+    esac
+  done
+  _ou_tmp=$(mktemp) || _ou_die "mktemp falhou"
+  if _ou_scrape "$_ou_ep" "$_ou_tmp"; then
+    rm -f -- "$_ou_tmp"
+    return 0
+  fi
+  rm -f -- "$_ou_tmp"
+  return 1
+}
+
+_ou_cmd_snapshot() {
+  _ou_sdir=""; _ou_phase=""; _ou_ep="$_OU_DEFAULT_ENDPOINT"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --state-dir) [ "$#" -ge 2 ] || _ou_die_usage "snapshot: --state-dir exige valor"
+                   _ou_sdir=$2; shift 2 ;;
+      --phase)     [ "$#" -ge 2 ] || _ou_die_usage "snapshot: --phase exige valor"
+                   _ou_phase=$2; shift 2 ;;
+      --endpoint)  [ "$#" -ge 2 ] || _ou_die_usage "snapshot: --endpoint exige valor"
+                   _ou_ep=$2; shift 2 ;;
+      *) _ou_die_usage "snapshot: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_ou_sdir" ]  || _ou_die_usage "snapshot: --state-dir obrigatorio"
+  [ -n "$_ou_phase" ] || _ou_die_usage "snapshot: --phase obrigatorio"
+  case "$_ou_phase" in
+    start|end) : ;;
+    *) _ou_die_usage "snapshot: --phase deve ser start|end" ;;
+  esac
+  [ -d "$_ou_sdir" ] || _ou_die "snapshot: state-dir nao existe: $_ou_sdir"
+
+  _ou_tmp=$(mktemp) || _ou_die "mktemp falhou"
+  if ! _ou_scrape "$_ou_ep" "$_ou_tmp"; then
+    rm -f -- "$_ou_tmp"
+    # Best-effort: sem telemetria a onda roda igual, so sem a metrica.
+    # Remove um snapshot da fase anterior para nao casar start de uma
+    # execucao com end de outra.
+    rm -f -- "$_ou_sdir/otel-$_ou_phase.tsv" 2>/dev/null || :
+    _ou_warn "telemetria OTel indisponivel em $_ou_ep — metrica de custo da onda ficara ausente (nao zero)"
+    return 0
+  fi
+
+  _ou_out="$_ou_sdir/otel-$_ou_phase.tsv"
+  {
+    printf '# session_id\t%s\n' "$(_ou_session_id "$_ou_tmp")"
+    _ou_parse "$_ou_tmp"
+  } > "$_ou_out.tmp" || { rm -f -- "$_ou_tmp" "$_ou_out.tmp"; _ou_die "snapshot: falha ao escrever $_ou_out"; }
+  mv -- "$_ou_out.tmp" "$_ou_out" || { rm -f -- "$_ou_tmp"; _ou_die "snapshot: falha ao mover $_ou_out"; }
+  chmod 600 -- "$_ou_out" 2>/dev/null || :
+  rm -f -- "$_ou_tmp"
+
+  # Defesa em profundidade: o parse ja e allowlist, mas se algum label de
+  # PII aparecer no arquivo final, apaga e falha alto em vez de vazar.
+  for _ou_lbl in $_OU_PII_LABELS; do
+    if grep -q "$_ou_lbl" "$_ou_out" 2>/dev/null; then
+      rm -f -- "$_ou_out"
+      _ou_die "snapshot: ABORTADO — label de PII '$_ou_lbl' vazou para o snapshot" 1
+    fi
+  done
+  return 0
+}
+
+_ou_cmd_delta() {
+  _ou_sdir=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --state-dir) [ "$#" -ge 2 ] || _ou_die_usage "delta: --state-dir exige valor"
+                   _ou_sdir=$2; shift 2 ;;
+      *) _ou_die_usage "delta: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_ou_sdir" ] || _ou_die_usage "delta: --state-dir obrigatorio"
+
+  _ou_s="$_ou_sdir/otel-start.tsv"
+  _ou_e="$_ou_sdir/otel-end.tsv"
+  # Ausencia de qualquer um dos lados => metrica INDISPONIVEL, nao zero.
+  if [ ! -f "$_ou_s" ] || [ ! -f "$_ou_e" ]; then
+    printf 'null\n'
+    return 0
+  fi
+
+  _ou_sid_s=$(awk -F'\t' '/^# session_id/{print $2; exit}' "$_ou_s")
+  _ou_sid_e=$(awk -F'\t' '/^# session_id/{print $2; exit}' "$_ou_e")
+  if [ "$_ou_sid_s" != "$_ou_sid_e" ]; then
+    # Processo Claude Code trocou no meio da onda: os contadores
+    # reiniciaram, o delta seria lixo. Melhor ausente que errado.
+    _ou_warn "delta: session_id divergente entre snapshots ($_ou_sid_s != $_ou_sid_e) — delta descartado"
+    printf 'null\n'
+    return 0
+  fi
+
+  command -v jq >/dev/null 2>&1 || { _ou_warn "delta: jq ausente"; printf 'null\n'; return 0; }
+
+  awk -F'\t' '
+    FILENAME==ARGV[1] && !/^#/ { s[$1 "\t" $2 "\t" $3] = $4; next }
+    FILENAME==ARGV[2] && !/^#/ {
+      k = $1 "\t" $2 "\t" $3
+      base = (k in s) ? s[k] : 0
+      d = $4 - base
+      if (d < 0) d = 0          # contador reiniciado: nao inventa negativo
+      if (d > 0) print k "\t" d
+    }
+  ' "$_ou_s" "$_ou_e" \
+  | jq -c -R -s --arg sid "$_ou_sid_e" '
+      [ split("\n")[] | select(length > 0) | split("\t")
+        | {source: .[0], model: .[1], type: .[2], value: (.[3] | tonumber)} ]
+      as $rows
+      | if ($rows | length) == 0 then null else
+      {
+        session_id: $sid,
+        total_cost_usd: ([$rows[] | select(.type=="cost") | .value] | add // 0),
+        total_tokens:   ([$rows[] | select(.type!="cost") | .value] | add // 0),
+        by_source: (
+          [$rows[] | .source] | unique
+          | map(. as $s | {
+              key: $s,
+              value: {
+                cost_usd:       ([$rows[] | select(.source==$s and .type=="cost")          | .value] | add // 0),
+                input:          ([$rows[] | select(.source==$s and .type=="input")         | .value] | add // 0),
+                output:         ([$rows[] | select(.source==$s and .type=="output")        | .value] | add // 0),
+                cache_read:     ([$rows[] | select(.source==$s and .type=="cacheRead")     | .value] | add // 0),
+                cache_creation: ([$rows[] | select(.source==$s and .type=="cacheCreation") | .value] | add // 0)
+              }
+            })
+          | from_entries
+        ),
+        by_model: (
+          [$rows[] | .model] | unique
+          | map(. as $m | {
+              key: $m,
+              value: {
+                cost_usd:     ([$rows[] | select(.model==$m and .type=="cost") | .value] | add // 0),
+                total_tokens: ([$rows[] | select(.model==$m and .type!="cost") | .value] | add // 0)
+              }
+            })
+          | from_entries
+        )
+      } end
+    '
+  return 0
+}
+
+# ---------- dispatch ----------
+
+[ "$#" -gt 0 ] || _ou_die_usage "subcomando obrigatorio: available|snapshot|delta"
+
+_ou_sub=$1
+shift
+case "$_ou_sub" in
+  available) _ou_cmd_available "$@" ;;
+  snapshot)  _ou_cmd_snapshot "$@" ;;
+  delta)     _ou_cmd_delta "$@" ;;
+  -h|--help)
+    cat >&2 <<'HELP'
+otel-usage.sh — consumo real de tokens/custo por onda (telemetria OTel do Claude Code)
+
+USO:
+  otel-usage.sh available [--endpoint URL]
+  otel-usage.sh snapshot  --state-dir DIR --phase start|end [--endpoint URL]
+  otel-usage.sh delta     --state-dir DIR
+
+Pre-requisito (opt-in, sem segredo):
+  export CLAUDE_CODE_ENABLE_TELEMETRY=1
+  export OTEL_METRICS_EXPORTER=prometheus
+
+Nao exige API key, Admin key nem organizacao; funciona em plano de assinatura.
+Labels de PII (user_email, user_id, user_account_*, organization_id) sao
+descartados no snapshot e nunca alcancam disco.
+
+delta imprime `null` quando a metrica esta ausente — nunca zero fabricado.
+HELP
+    exit 2
+    ;;
+  *) _ou_die_usage "subcomando desconhecido: $_ou_sub" ;;
+esac

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -294,6 +294,51 @@ _so_agent_usage_read() {
   esac
 }
 
+# ---------- Telemetria OTel (consumo real da onda) ----------
+#
+# Complementa (nao substitui) o sidecar de agent-usage. O hook
+# posttooluse-agent-usage.sh so enxerga o que o spawn devolve, e o spawn do
+# orquestrador ENVOLVE a onda — seu tool_result chega depois do `end`, e o
+# consumo dele nunca era capturado. Os contadores OTel sao incrementados a
+# cada API request, entao um snapshot no start e outro no end fecham essa
+# lacuna independentemente de quando o spawn retorna.
+#
+# 100% best-effort: sem `CLAUDE_CODE_ENABLE_TELEMETRY=1` +
+# `OTEL_METRICS_EXPORTER=prometheus` no ambiente, tudo isto e no-op e a onda
+# roda exatamente como antes.
+
+_so_otel_script() { printf '%s/otel-usage.sh\n' "$(_so_self_dir)"; }
+
+# _so_otel_snapshot DIR PHASE — nunca falha a onda.
+_so_otel_snapshot() {
+  _ots=$(_so_otel_script)
+  [ -f "$_ots" ] || return 0
+  sh "$_ots" snapshot --state-dir "$1" --phase "$2" >/dev/null 2>&1 || :
+  return 0
+}
+
+# _so_otel_delta DIR -> stdout: JSON do consumo da onda, ou `null`.
+# `null` significa AUSENTE (telemetria desligada, snapshot faltando,
+# processo trocou no meio) — nunca zero fabricado.
+_so_otel_delta() {
+  _ots=$(_so_otel_script)
+  [ -f "$_ots" ] || { printf 'null\n'; return 0; }
+  _od=$(sh "$_ots" delta --state-dir "$1" 2>/dev/null) || _od=""
+  # Valida como JSON com jq. NAO usar glob de printaveis (`*[!\ -~]*`):
+  # ele casa newline, entao qualquer JSON multi-linha virava `null`.
+  if [ -z "$_od" ] || ! printf '%s' "$_od" | jq -e . >/dev/null 2>&1; then
+    printf 'null\n'
+  else
+    printf '%s\n' "$_od"
+  fi
+}
+
+# _so_otel_reset DIR — descarta os snapshots da onda encerrada para nao
+# casar o start de uma onda com o end da seguinte.
+_so_otel_reset() {
+  rm -f -- "$1/otel-start.tsv" "$1/otel-end.tsv" 2>/dev/null || :
+}
+
 # ---------- Subcomandos ----------
 
 _so_cmd_start() {
@@ -354,6 +399,13 @@ _so_cmd_start() {
   # ausente (git-commit cai no fail-closed existente, sem regressao no
   # ciclo de vida da onda).
   _so_start_snapshot_baseline "$_sdir"
+
+  # Baseline de consumo real (telemetria OTel). Os contadores sao
+  # cumulativos por sessao, entao o delta start->end e o consumo DESTA
+  # onda — inclusive o do proprio orquestrador, que o sidecar de spawn
+  # nunca conseguiu capturar. No-op sem telemetria ligada.
+  _so_otel_reset "$_sdir"
+  _so_otel_snapshot "$_sdir" start
 
   printf '%s\n' "$_id"
 }
@@ -461,6 +513,13 @@ $2"; shift 2 ;;
   # agrega o que foi de fato observado, nunca fabrica o resto).
   _au_spawns_json=$(_so_agent_usage_read "$_sdir")
 
+  # Consumo real da onda via OTel. O snapshot final tem de sair ANTES do
+  # write — e enquanto o processo Claude Code ainda vive, ja que o exporter
+  # Prometheus e in-process e some junto com ele.
+  _so_otel_snapshot "$_sdir" end
+  _otel_json=$(_so_otel_delta "$_sdir")
+  case "$_otel_json" in ''|null) _otel_json="null" ;; esac
+
   # .next_instruction gravado DENTRO do mesmo write atomico do fechamento
   # da onda. Antes exigia um `state-rw.sh set` separado, e como `end`
   # tambem escreve no state.json, seguir a ordem literal backup -> hash ->
@@ -474,6 +533,7 @@ $2"; shift 2 ;;
 
   _new=$(mktemp) || _so_die "mktemp falhou" 1
   jq \
+    --argjson otel "$_otel_json" \
     --argjson next_instr "$_next_instr_json" \
     --arg now "$_now" \
     --arg motivo "$_motivo" \
@@ -510,6 +570,7 @@ $2"; shift 2 ;;
         | .executed_stages += $etapas
         | .agent_usage = $au
         | .agent_spawns = $sp
+        | .otel_usage = $otel
       ))
       | .accumulated_metrics.waves_total = ((.accumulated_metrics.waves_total // 0) + 1)
       | .accumulated_metrics.tool_calls_total = ((.accumulated_metrics.tool_calls_total // 0) + $tc)
@@ -535,6 +596,7 @@ $2"; shift 2 ;;
   # Sidecares consumidos por esta onda; zeram para nao vazar para a proxima.
   _so_ticks_reset "$_sdir"
   _so_agent_usage_reset "$_sdir"
+  _so_otel_reset "$_sdir"
   _so_log "end: onda finalizada (motivo=$_motivo, wallclock=${_wc}s, tool_calls=$_tc)"
 }
 

--- a/tests/test_otel-usage.sh
+++ b/tests/test_otel-usage.sh
@@ -1,0 +1,260 @@
+#!/bin/sh
+# test_otel-usage.sh — cobre
+# global/skills/agente-00c-runtime/scripts/otel-usage.sh
+#
+# Invariantes sob teste:
+#   INV-1: PRIVACIDADE — nenhum label de PII (user_email, user_id,
+#          user_account_*, organization_id) alcanca o snapshot em disco.
+#   INV-2: o label `type` e extraido ANCORADO. Sem ancoragem, `type="`
+#          casa antes com `terminal_type="ghostty"` (substring) e o
+#          breakdown por tipo vira o nome do terminal — bug observado em
+#          dados reais antes do fix.
+#   INV-3: metrica AUSENTE e `null`, nunca zero fabricado (Principio VI).
+#          Vale para snapshot faltando, endpoint fora do ar e session_id
+#          divergente entre os dois snapshots.
+#   INV-4: degradacao best-effort — endpoint indisponivel sai 0 e nao
+#          derruba a onda.
+#   INV-5: `available` exige as metricas que o script consome
+#          (cost/token), nao um `claude_code_` qualquer — no cold start o
+#          exporter ja responde com session_count e o snapshot sairia sem
+#          session_id, descartando a onda inteira.
+#
+# As fixtures reproduzem o formato REAL do exporter Prometheus do Claude
+# Code 2.1.220 (ordem dos labels inclusive — `terminal_type` antes de
+# `type` e o que dispara INV-2). Os valores de identidade sao anonimizados
+# de proposito: fixture de teste nao carrega PII de ninguem.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/otel-usage.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '# test_otel-usage.sh: jq ausente — pulando suite\n'
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  printf '# test_otel-usage.sh: curl ausente — pulando suite\n'
+  exit 0
+fi
+
+# _labels SESSION QSOURCE MODEL [EXTRA] -> bloco de labels na ORDEM REAL do
+# exporter. `terminal_type` vem antes de `type` de proposito (INV-2).
+_labels() {
+  printf 'user_id="anon-hash",session_id="%s",organization_id="anon-org",' "$1"
+  printf 'user_email="anon@example.invalid",user_account_uuid="anon-uuid",'
+  printf 'user_account_id="anon-acct",terminal_type="ghostty",'
+  printf 'model="%s",query_source="%s"%s' "$3" "$2" "${4:-}"
+  printf ',otel_scope_name="com.anthropic.claude_code",otel_scope_version="2.1.220"'
+}
+
+# _fixture FILE SESSION COST_MAIN COST_SUB IN_MAIN OUT_MAIN
+_fixture() {
+  _fx=$1; _sid=$2; _cm=$3; _cs=$4; _im=$5; _om=$6
+  {
+    printf 'claude_code_cost_usage_total{%s} %s\n'  "$(_labels "$_sid" main     "claude-opus-5[1m]")" "$_cm"
+    printf 'claude_code_cost_usage_total{%s} %s\n'  "$(_labels "$_sid" subagent "claude-opus-5[1m]")" "$_cs"
+    printf 'claude_code_token_usage_total{%s} %s\n' "$(_labels "$_sid" main "claude-opus-5[1m]" ',type="input"')"  "$_im"
+    printf 'claude_code_token_usage_total{%s} %s\n' "$(_labels "$_sid" main "claude-opus-5[1m]" ',type="output"')" "$_om"
+  } > "$_fx"
+}
+
+_snap() {
+  # $1=state-dir $2=phase $3=fixture-file
+  capture sh "$SCRIPT" snapshot --state-dir "$1" --phase "$2" --endpoint "file://$3"
+}
+
+# ==== INV-2: ancoragem do label `type` ====
+
+scenario_type_nao_colide_com_terminal_type() {
+  _sd="$TMPDIR_TEST/anchor"; mkdir -p "$_sd"
+  _fx="$TMPDIR_TEST/anchor.txt"
+  _fixture "$_fx" "sess-1" 1.0 0.5 100 20
+  _snap "$_sd" end "$_fx"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  grep -q "	input	100$" "$_sd/otel-end.tsv" \
+    || { _fail "type=input" "esperado linha com type input; obtido: $(cat "$_sd/otel-end.tsv")"; return 1; }
+  grep -q "	output	20$" "$_sd/otel-end.tsv" \
+    || { _fail "type=output" "esperado linha com type output"; return 1; }
+  # O valor do terminal JAMAIS pode aparecer como tipo de token.
+  grep -q "ghostty" "$_sd/otel-end.tsv" \
+    && { _fail "colisao terminal_type" "'ghostty' vazou para o campo type"; return 1; }
+  return 0
+}
+
+# ==== INV-1: privacidade ====
+
+scenario_pii_nunca_alcanca_o_snapshot() {
+  _sd="$TMPDIR_TEST/pii"; mkdir -p "$_sd"
+  _fx="$TMPDIR_TEST/pii.txt"
+  _fixture "$_fx" "sess-pii" 1.0 0.5 100 20
+  _snap "$_sd" end "$_fx"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "$_CAPTURED_EXIT"; return 1; }
+  for _lbl in user_id user_email user_account_uuid user_account_id organization_id anon@example.invalid anon-hash anon-org; do
+    grep -q "$_lbl" "$_sd/otel-end.tsv" \
+      && { _fail "PII" "'$_lbl' vazou para o snapshot"; return 1; }
+  done
+  return 0
+}
+
+# ==== delta: aritmetica ====
+
+scenario_delta_subtrai_contadores_cumulativos() {
+  _sd="$TMPDIR_TEST/delta"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/d-start.txt"; _fe="$TMPDIR_TEST/d-end.txt"
+  _fixture "$_fs" "sess-d" 1.0 0.5 100 20
+  _fixture "$_fe" "sess-d" 3.0 2.0 400 60
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "delta exit" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  _main=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.by_source.main.cost_usd')
+  _sub=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.by_source.subagent.cost_usd')
+  _in=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.by_source.main.input')
+  [ "$_main" = "2" ] || { _fail "delta main cost" "esperado 2 (3.0-1.0), obtido $_main"; return 1; }
+  [ "$_sub" = "1.5" ] || { _fail "delta subagent cost" "esperado 1.5 (2.0-0.5), obtido $_sub"; return 1; }
+  [ "$_in" = "300" ] || { _fail "delta main input" "esperado 300 (400-100), obtido $_in"; return 1; }
+  return 0
+}
+
+# Subagente e o recorte que motivou a feature — precisa vir separado.
+scenario_delta_separa_subagente_de_main() {
+  _sd="$TMPDIR_TEST/split"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/s-start.txt"; _fe="$TMPDIR_TEST/s-end.txt"
+  _fixture "$_fs" "sess-s" 0 0 0 0
+  _fixture "$_fe" "sess-s" 1.0 9.0 10 5
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  _keys=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.by_source | keys | join(",")')
+  case "$_keys" in
+    *subagent*) : ;;
+    *) _fail "by_source" "esperado recorte subagent; obtido '$_keys'"; return 1 ;;
+  esac
+  _sub=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.by_source.subagent.cost_usd')
+  [ "$_sub" = "9" ] || { _fail "subagent cost" "esperado 9, obtido $_sub"; return 1; }
+  return 0
+}
+
+# Contador reiniciado nao pode virar delta negativo.
+scenario_delta_negativo_e_clampado() {
+  _sd="$TMPDIR_TEST/neg"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/n-start.txt"; _fe="$TMPDIR_TEST/n-end.txt"
+  _fixture "$_fs" "sess-n" 5.0 5.0 500 50
+  _fixture "$_fe" "sess-n" 1.0 1.0 100 10
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "delta exit" "$_CAPTURED_EXIT"; return 1; }
+  # Todos os deltas <= 0 sao descartados => nada sobra => null.
+  [ "$(printf '%s' "$_CAPTURED_STDOUT" | tr -d '[:space:]')" = "null" ] \
+    || { _fail "clamp" "esperado null (nenhum delta positivo), obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+# ==== INV-3: ausente e null, nunca zero ====
+
+scenario_delta_sem_snapshot_start_e_null() {
+  _sd="$TMPDIR_TEST/nostart"; mkdir -p "$_sd"
+  _fe="$TMPDIR_TEST/ns-end.txt"
+  _fixture "$_fe" "sess-x" 1.0 1.0 10 5
+  _snap "$_sd" end "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT"; return 1; }
+  [ "$(printf '%s' "$_CAPTURED_STDOUT" | tr -d '[:space:]')" = "null" ] \
+    || { _fail "null" "sem start deve ser null, obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+scenario_delta_session_divergente_e_null() {
+  _sd="$TMPDIR_TEST/divsess"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/v-start.txt"; _fe="$TMPDIR_TEST/v-end.txt"
+  _fixture "$_fs" "sess-AAA" 1.0 1.0 10 5
+  _fixture "$_fe" "sess-BBB" 9.0 9.0 90 50
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$(printf '%s' "$_CAPTURED_STDOUT" | tr -d '[:space:]')" = "null" ] \
+    || { _fail "null" "session_id divergente deve dar null (processo trocou)"; return 1; }
+  printf '%s' "$_CAPTURED_STDERR" | grep -q "session_id divergente" \
+    || { _fail "stderr" "faltou aviso de session_id divergente"; return 1; }
+  return 0
+}
+
+# ==== INV-4: degradacao best-effort ====
+
+scenario_snapshot_endpoint_indisponivel_exit0() {
+  _sd="$TMPDIR_TEST/down"; mkdir -p "$_sd"
+  capture sh "$SCRIPT" snapshot --state-dir "$_sd" --phase start \
+    --endpoint "file://$TMPDIR_TEST/nao-existe-mesmo.txt"
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "exit" "endpoint fora do ar deve degradar com exit 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$_sd/otel-start.tsv" ] \
+    && { _fail "arquivo" "nao deve escrever snapshot sem dados"; return 1; }
+  return 0
+}
+
+# ==== INV-5: available exige cost/token, nao qualquer claude_code_ ====
+
+scenario_available_exige_metricas_consumidas() {
+  # Cold start: o exporter ja responde com session_count mas ainda nao
+  # emitiu cost/token. Aceitar isso produzia snapshot sem session_id.
+  _fx="$TMPDIR_TEST/coldstart.txt"
+  printf 'claude_code_session_count_total{session_id="s"} 1\n' > "$_fx"
+  capture sh "$SCRIPT" available --endpoint "file://$_fx"
+  [ "$_CAPTURED_EXIT" = 1 ] \
+    || { _fail "cold start" "so session_count deve dar exit 1, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+scenario_available_ok_com_metricas_reais() {
+  _fx="$TMPDIR_TEST/warm.txt"
+  _fixture "$_fx" "sess-w" 1.0 1.0 10 5
+  capture sh "$SCRIPT" available --endpoint "file://$_fx"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+scenario_available_endpoint_morto_exit1() {
+  capture sh "$SCRIPT" available --endpoint "file://$TMPDIR_TEST/vazio-inexistente.txt"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+# ==== uso incorreto ====
+
+scenario_sem_subcomando_exit2() {
+  assert_exit 2 sh "$SCRIPT" || return 1
+  return 0
+}
+
+scenario_subcomando_desconhecido_exit2() {
+  assert_exit 2 sh "$SCRIPT" nao-existe || return 1
+  return 0
+}
+
+scenario_snapshot_phase_invalida_exit2() {
+  _sd="$TMPDIR_TEST/badphase"; mkdir -p "$_sd"
+  assert_exit 2 sh "$SCRIPT" snapshot --state-dir "$_sd" --phase meio || return 1
+  return 0
+}
+
+scenario_snapshot_sem_state_dir_exit2() {
+  assert_exit 2 sh "$SCRIPT" snapshot --phase start || return 1
+  return 0
+}
+
+scenario_delta_sem_state_dir_exit2() {
+  assert_exit 2 sh "$SCRIPT" delta || return 1
+  return 0
+}
+
+scenario_flag_desconhecida_exit2() {
+  _sd="$TMPDIR_TEST/badflag"; mkdir -p "$_sd"
+  assert_exit 2 sh "$SCRIPT" snapshot --state-dir "$_sd" --phase start --nao-existe || return 1
+  return 0
+}
+
+run_all_scenarios
+exit $?

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -1239,4 +1239,64 @@ scenario_end_acumula_accumulated_metrics_agent_entre_ondas() {
   return 0
 }
 
+# ==== Telemetria OTel: consumo real da onda (otel_usage) ====
+#
+# O sidecar de spawn (posttooluse-agent-usage.sh) nunca captura o consumo do
+# PROPRIO orquestrador, porque o spawn dele envolve a onda e seu tool_result
+# chega depois do `end`. Os contadores OTel sao incrementados a cada API
+# request, entao o delta start->end fecha essa lacuna.
+
+# _otel_fixture FILE COST_MAIN COST_SUB — formato REAL do exporter
+# Prometheus (labels na ordem real; `terminal_type` antes de `type`).
+_otel_fixture() {
+  {
+    printf 'claude_code_cost_usage_total{session_id="sess-w",terminal_type="ghostty",model="claude-opus-5[1m]",query_source="main"} %s\n' "$2"
+    printf 'claude_code_cost_usage_total{session_id="sess-w",terminal_type="ghostty",model="claude-opus-5[1m]",query_source="subagent"} %s\n' "$3"
+    printf 'claude_code_token_usage_total{session_id="sess-w",terminal_type="ghostty",model="claude-opus-5[1m]",query_source="subagent",type="output"} 100\n'
+  } > "$1"
+}
+
+scenario_end_otel_usage_null_sem_telemetria() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  # Telemetria desligada => AUSENTE (null), jamais zero fabricado.
+  _got=$(jq -r '.waves[-1].otel_usage' "$_sd/state.json")
+  [ "$_got" = "null" ] || { _fail "otel_usage" "esperado null sem telemetria, obtido '$_got'"; return 1; }
+  return 0
+}
+
+scenario_end_otel_usage_captura_delta_da_onda() {
+  _sd="$TMPDIR_TEST/state-otel"
+  _init_state "$_sd"
+  _fx="$TMPDIR_TEST/otel-live.txt"
+
+  # export explicito: a atribuicao-prefixo `VAR=x capture ...` nao propaga
+  # para o subprocesso que `capture` executa.
+  CSTK_OTEL_ENDPOINT="file://$_fx"; export CSTK_OTEL_ENDPOINT
+
+  # start: baseline
+  _otel_fixture "$_fx" 1.0 0.5
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { unset CSTK_OTEL_ENDPOINT; _fail "start" "$_CAPTURED_STDERR"; return 1; }
+
+  # a onda consome: contadores cumulativos sobem
+  _otel_fixture "$_fx" 4.0 3.5
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  _e=$_CAPTURED_EXIT; _err=$_CAPTURED_STDERR
+  unset CSTK_OTEL_ENDPOINT
+  [ "$_e" = 0 ] || { _fail "end" "$_err"; return 1; }
+
+  _cost=$(jq -r '.waves[-1].otel_usage.total_cost_usd' "$_sd/state.json")
+  [ "$_cost" = "6" ] || { _fail "total_cost_usd" "esperado 6 ((4-1)+(3.5-0.5)), obtido '$_cost'"; return 1; }
+  _sub=$(jq -r '.waves[-1].otel_usage.by_source.subagent.cost_usd' "$_sd/state.json")
+  [ "$_sub" = "3" ] || { _fail "subagent cost" "esperado 3 (3.5-0.5), obtido '$_sub'"; return 1; }
+  # PII jamais no state.json
+  grep -q "user_email\|user_account_uuid" "$_sd/state.json" \
+    && { _fail "PII" "label de PII vazou para o state.json"; return 1; }
+  return 0
+}
+
 run_all_scenarios


### PR DESCRIPTION
## O problema

O painel mostrava `TOKENS · SUBAGENTES —` mesmo com os hooks provisionados. A causa não era o hook ausente: é que **o spawn do orquestrador *envolve* a onda**.

```
spawn_start < wave.started_at < wave.finished_at < spawn_end
```

O command pai spawna o orquestrador; é o orquestrador, já dentro do spawn, que chama `start` e `end`. O `tool_result` do spawn chega **depois** do `end` (que já resetou o sidecar) e é destruído pelo `start` da onda seguinte. O consumo do orquestrador — a maior parte do custo — nunca era capturado.

## O que foi medido

Três sessões `claude -p` reais com telemetria ligada:

| `query_source` | Task delegada #1 | Task delegada #2 |
|---|---:|---:|
| `main` | $0,156535 | $0,130553 |
| **`subagent`** | **$0,141282** | **$0,098485** |
| `auxiliary` | $0,000674 | ~$0 |
| **total** | **$0,298491** | **$0,229038** |

**O subagente é 43–47% do gasto.** `claude_code.cost.usage` traz valor real em conta de assinatura — não é placeholder. `query_source: "subagent"` só aparece com spawn real (55 datapoints num teste que delegou, zero num que não).

## A solução

`otel-usage.sh` (`available` / `snapshot` / `delta`), ligado em `state-ondas.sh start`/`end` → `.waves[N].otel_usage`.

Os contadores OTel sobem **a cada API request**, não no fim do spawn — então o delta `start`→`end` é o consumo da onda **independentemente de quando o spawn retorna**. O enclausuramento deixa de importar.

Opt-in por duas variáveis de ambiente, **sem segredo nenhum**:

```bash
export CLAUDE_CODE_ENABLE_TELEMETRY=1
export OTEL_METRICS_EXPORTER=prometheus
```

Não exige API key, Admin key nem organização; funciona em plano de assinatura. Exporter em `127.0.0.1:9464` — nada sai da máquina. Overhead: **37 ms por snapshot, 2 por onda**.

## Por que não a Usage & Cost Admin API

Avaliada contra a doc oficial e descartada:

- Exige **Admin key** (`sk-ant-admin01-…`) e é *"unavailable for individual accounts"*.
- **Não tem dimensão de sessão** — agrupa por `api_key_id`/`workspace_id`/`model`/`service_tier`.
- Claude Code em assinatura usa OAuth, não tem `api_key_id` para filtrar.
- A Claude Code Analytics API é por **usuário/dia**, 1 h de lag, e a FAQ responde direto: *"Can I get real-time metrics? **No**"*.

## Privacidade

Os labels do exporter carregam `user_email`, `user_id`, `user_account_*`, `organization_id`. O snapshot extrai **por allowlist** (só `session_id`, `model`, `query_source`, `type`) e **aborta** se algum label de PII chegar ao arquivo. Nada disso toca disco, `state.json` ou `knowledge.db`.

## Ausente ≠ zero

Sem telemetria, snapshot faltando, ou `session_id` divergente entre os dois snapshots (processo trocou), o resultado é `null` — nunca zero fabricado (Princípio VI).

## Três bugs próprios, corrigidos com regressão

1. **`type="` casava com `terminal_type="ghostty"`** — a extração de label precisa ancorar em `[{,]`; sem isso o breakdown por tipo de token virava o nome do terminal. Só apareceu porque testei contra dado real — fixture inventada não teria `terminal_type`.
2. **`available` aceitava `claude_code_` genérico** — no cold start o exporter já responde `session_count` sem cost/token, e o snapshot saía sem `session_id`, descartando a onda.
3. **Glob `*[!\ -~]*` casa newline** — meu guard transformava todo JSON multi-linha válido em `null`.

Verifiquei que revertendo o fix (1) três testes falham.

## Testes

`tests/test_otel-usage.sh` novo (17 cenários; fixtures reproduzem o formato real do exporter, inclusive a ordem dos labels que dispara o bug 1, com identificadores anonimizados) + 2 em `test_state-ondas.sh`.

Suíte completa: **1889 cenários, 0 falhas**. Shellcheck limpo.

## Fora de escopo

A ingestão na `knowledge.db` e a query do painel ainda leem só as colunas `agent_*` — o dado agora existe em `.waves[N].otel_usage`, mas o painel continua mostrando `—` até esse próximo passo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h3LpRcNK55CHRA3sdVboe