### PR TITLE
feat(00c): commands PEDEM instalação dos hooks, com custo em números (5.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.29.0] - 2026-07-26
+
+Os commands 00c passam a **pedir** a instalação dos hooks em vez de só
+avisar que faltam — com o propósito de cada um e o custo em números.
+
+### Changed
+
+- **`/agente-00c` (passo 2.bis) e `/feature-00c` (pré-flight 8)**: o passo
+  deixa de ser um aviso passivo e vira um **pedido explícito** ao operador,
+  com três pontos obrigatórios:
+  1. **O que instala e para que serve** — e por que nenhum dos três é
+     redundante: `pretooluse-bash-guard.sh` é segurança (não substituível);
+     `posttooluse-tool-call-tick.sh` é a **única** fonte de `tool_calls` (a
+     telemetria OTel conta API requests e tokens, não tool calls);
+     `posttooluse-agent-usage.sh` é a única fonte do detalhe **por spawn**
+     (o total por onda hoje vem do OTel, com mais precisão).
+  2. **O custo, com número medido** — não "tem um custo". Não há custo de
+     token (são scripts shell locais); o custo é latência:
+     `tool-call-tick` ~30 ms por tool call (matcher `*`, roda em todas —
+     ~6 s numa onda de ~200 chamadas), `bash-guard` ~177 ms por chamada
+     Bash, coleta OTel ~37 ms × 2 por onda.
+  3. **Como ativar** — dois opt-ins independentes: `cstk hooks install`
+     (hooks) e as duas variáveis de ambiente (custo/tokens reais por onda).
+- **Regra de decisão explícita**: recusa ou silêncio **não bloqueiam** a
+  pipeline, mas o que fica de fora é registrado sem eufemismo (guarda de
+  Bash não enforced; `tool_calls` ausente, não "zero medido"). E o
+  orquestrador **nunca instala sem consentimento** — `cstk hooks install`
+  escreve em `<projeto-alvo>/.claude/settings.json`, que pode estar
+  versionado no repo do operador.
+
 ## [5.28.0] - 2026-07-26
 
 Custo real por onda, incluindo o consumo do próprio orquestrador — a fatia
@@ -4123,6 +4153,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.29.0]: https://github.com/JotJunior/cstk/releases/tag/v5.29.0
 [5.28.0]: https://github.com/JotJunior/cstk/releases/tag/v5.28.0
 [5.27.0]: https://github.com/JotJunior/cstk/releases/tag/v5.27.0
 [5.26.0]: https://github.com/JotJunior/cstk/releases/tag/v5.26.0

--- a/global/commands/agente-00c.md
+++ b/global/commands/agente-00c.md
@@ -148,31 +148,64 @@ ja preparado fora do script), apenas defensivo.
   `/agente-00c-resume` ou `/agente-00c-abort`. Use
   `state-lock.sh check-execution-busy --state-dir <SD>`.
 
-### 2.bis Hooks 00c provisionados no projeto-alvo? (ADVISORY, nunca bloqueia)
+### 2.bis Coleta de consumo: PEDIR instalacao ao operador (nunca instalar sozinho)
 
-Os tres hooks do runtime (guarda de Bash + duas metricas) so chegam ao
-projeto-alvo via `cstk install --scope project agente-00c-runtime` rodado
-DENTRO dele. O default de `cstk install`/`update` e `--scope global`, que
-pula o provisionamento — entao o caso comum e o projeto-alvo NAO ter hook
-nenhum. Como o `cstk install` roda no repo do cstk e nao aqui, este e o
-unico momento do fluxo que esta dentro do projeto-alvo: e aqui que o
-operador precisa ser avisado.
+Rode primeiro o diagnostico:
 
 ```sh
 guard-hooks-status.sh check --projeto-alvo-path "<PROJETO_ALVO_PATH>" || :
 ```
 
-READ-ONLY: nunca copia hook nem edita `settings.json` (provisionar e
-trabalho do `cstk install`, unica fonte da regra). Exit 1 NAO aborta a
-execucao — mostre a saida ao operador e siga:
+READ-ONLY — nunca instala nada. Se os tres hooks ja estao ativos, siga para
+o passo 3 sem incomodar o operador.
 
-- `pretooluse-bash-guard.sh` inativo → **avise com destaque**: a guarda
-  fail-closed de Bash NAO esta enforced nesta execucao. E o item grave;
-  o resto e metrica.
-- `posttooluse-tool-call-tick.sh` inativo → o orquestrador vai tickar
-  manualmente (ver passo 2 do orchestrator); `tool_calls` nao zera.
-- `posttooluse-agent-usage.sh` inativo → `agent_usage`/tokens ficam null
-  nas ondas; nao ha fallback manual, so o provisionamento resolve.
+**Se faltar algum, PECA a instalacao explicitamente** — nao instale por
+conta propria e nao siga em silencio. Apresente os tres pontos abaixo e
+espere a resposta:
+
+1. **O que sera instalado e para que serve** (cada hook tem proposito
+   distinto; nenhum e redundante):
+
+   | Hook | Serve para | Substituivel? |
+   |------|-----------|---------------|
+   | `pretooluse-bash-guard.sh` | Guarda fail-closed de Bash (sudo/push/deploy bloqueados, rede contra whitelist) | **Nao.** E seguranca, nao metrica. Sem ele a guarda que a doc promete simplesmente nao existe. |
+   | `posttooluse-tool-call-tick.sh` | Alimenta `tool_calls`, o proxy de orcamento que fecha a onda | **Nao.** A telemetria OTel conta API requests e tokens, nao tool calls — nao ha outra fonte. |
+   | `posttooluse-agent-usage.sh` | Consumo POR SPAWN (`agent_id`, `agent_type`) | **Parcialmente.** O total por onda hoje vem da telemetria OTel, com mais precisao; este hook ainda e a unica fonte do detalhe por spawn. |
+
+2. **O custo — diga o numero, nao "tem um custo"** (medido, macOS/zsh; nao ha
+   custo de token, os hooks sao shell local):
+
+   - `posttooluse-tool-call-tick.sh`: **~30 ms por tool call** (matcher `*`,
+     roda em TODAS). Numa onda de ~200 tool calls, ~6 s no total.
+   - `pretooluse-bash-guard.sh`: **~177 ms por chamada Bash** (so em Bash).
+   - Coleta de custo real por onda (opcional, ver item 3): ~37 ms por
+     snapshot, 2 por onda.
+
+3. **Como o operador ativa** — dois opt-ins independentes:
+
+   ```sh
+   # (a) hooks: guarda + tool_calls + detalhe por spawn — uma vez por projeto
+   cd <PROJETO_ALVO_PATH> && cstk hooks install
+
+   # (b) custo/tokens reais por onda (main vs subagent) — no ambiente
+   export CLAUDE_CODE_ENABLE_TELEMETRY=1
+   export OTEL_METRICS_EXPORTER=prometheus
+   ```
+
+   (b) nao exige API key, Admin key nem organizacao; funciona em plano de
+   assinatura e nada sai de `127.0.0.1`.
+
+**Regra de decisao** (o operador manda, o default nunca mente):
+
+- Respondeu **sim** -> peca que rode `cstk hooks install` e confirme; so
+  entao siga. Se ele preferir que voce rode, use exatamente o comando acima.
+- Respondeu **nao**, ou nao respondeu -> **siga a execucao normalmente**.
+  Nunca bloqueie a pipeline por metrica. Mas registre o que fica de fora,
+  sem eufemismo: a guarda de Bash NAO esta enforced nesta execucao, e
+  `tool_calls` ficara 0 em todas as ondas (ausente, nao "zero medido").
+- Nunca instale hook sem consentimento explicito: `cstk hooks install`
+  escreve em `<projeto-alvo>/.claude/settings.json`, que pode estar
+  versionado no repo do operador.
 
 ### 3. Aquisicao do lock + inicializacao de estado
 

--- a/global/commands/feature-00c.md
+++ b/global/commands/feature-00c.md
@@ -145,18 +145,43 @@ Exporte: `AGENTE_00C_STATE_DIR=<projeto>/.claude/feature-00c-state/<short_name>`
    state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR"
    - se ocupado, stderr "outra sessao ativa para $SHORT"; exit 3
 
-8. hooks 00c provisionados? (ADVISORY — exit 1 NAO aborta):
+8. coleta de consumo: PEDIR instalacao ao operador (nunca instalar sozinho)
    guard-hooks-status.sh check --projeto-alvo-path "$_proj" || :
-   - READ-ONLY (nunca copia hook nem edita settings.json; provisionar e
-     trabalho do `cstk install --scope project agente-00c-runtime`, unica
-     fonte da regra). O default do install e `--scope global`, que pula os
-     hooks — logo o caso comum e o projeto-alvo nao ter nenhum, e este e o
-     unico ponto do fluxo que roda DENTRO dele.
-   - guarda inativa (pretooluse-bash-guard.sh) => avisar com DESTAQUE: a
-     guarda fail-closed de Bash nao esta enforced nesta execucao (item
-     grave; o resto e metrica)
-   - tick-hook inativo => o orquestrador ticka manualmente (passo 4 dele)
-   - agent-usage inativo => agent_usage/tokens ficam null, sem fallback
+   - READ-ONLY: diagnostica, nunca instala. Os tres ativos => siga sem
+     incomodar o operador.
+   - Faltando algum => PECA a instalacao, apresentando os 3 pontos:
+
+     (1) O que instala e para que serve — nenhum e redundante:
+         . pretooluse-bash-guard.sh  -> guarda fail-closed de Bash.
+           NAO substituivel: e seguranca, nao metrica.
+         . posttooluse-tool-call-tick.sh -> alimenta tool_calls (proxy de
+           orcamento da onda). NAO substituivel: a telemetria OTel conta
+           API requests e tokens, nao tool calls.
+         . posttooluse-agent-usage.sh -> consumo POR SPAWN (agent_id,
+           agent_type). Parcialmente substituido: o total por onda hoje vem
+           do OTel com mais precisao; o detalhe por spawn so vem daqui.
+
+     (2) O custo — diga o NUMERO (medido; nao ha custo de token, sao shell
+         local):
+         . tick: ~30 ms por tool call (matcher "*", roda em TODAS) —
+           ~6 s numa onda de ~200 tool calls
+         . bash-guard: ~177 ms por chamada Bash
+         . coleta de custo real por onda (opcional): ~37 ms x2 por onda
+
+     (3) Como ativa — dois opt-ins independentes:
+         cd "$_proj" && cstk hooks install
+         export CLAUDE_CODE_ENABLE_TELEMETRY=1
+         export OTEL_METRICS_EXPORTER=prometheus
+         (o segundo nao exige API key, Admin key nem organizacao; funciona
+          em assinatura e nada sai de 127.0.0.1)
+
+   - Regra de decisao:
+     . sim  => pedir que rode `cstk hooks install` e confirmar antes de seguir
+     . nao / sem resposta => SEGUIR normalmente (metrica nunca bloqueia a
+       pipeline), mas registrar sem eufemismo: a guarda de Bash nao esta
+       enforced nesta execucao e tool_calls ficara 0 (ausente, nao medido)
+     . NUNCA instalar sem consentimento: `cstk hooks install` escreve em
+       <projeto-alvo>/.claude/settings.json, que pode estar versionado
 ```
 
 ### 3. Init do state.json


### PR DESCRIPTION
## O pedido

O passo de hooks nos commands 00c era um **aviso passivo** — imprimia o diagnóstico e seguia. Agora é um **pedido explícito** ao operador, explicando para que serve e quanto custa.

## Os hooks ainda são necessários depois do OTel?

Sim, os três — e cada um por um motivo diferente:

| Hook | Serve para | Substituível pelo OTel? |
|---|---|---|
| `pretooluse-bash-guard.sh` | Guarda fail-closed de Bash | **Não.** É segurança, não métrica. |
| `posttooluse-tool-call-tick.sh` | Alimenta `tool_calls` (proxy de orçamento) | **Não.** Verifiquei a lista de métricas emitidas: o OTel conta API requests e tokens, **não** tool calls. Não há outra fonte. |
| `posttooluse-agent-usage.sh` | Consumo **por spawn** (`agent_id`, `agent_type`) | **Parcialmente.** O total por onda agora vem do OTel com mais precisão; o detalhe por spawn só vem daqui. |

## O custo — medido, não estimado

Não há custo de token: os hooks são scripts shell locais. O custo é **latência**:

| | Custo | Frequência |
|---|---:|---|
| `posttooluse-tool-call-tick.sh` | **~30 ms** | por tool call (matcher `*` — **todas**). ~6 s numa onda de ~200 chamadas |
| `pretooluse-bash-guard.sh` | **~177 ms** | por chamada Bash |
| Coleta OTel (`otel-usage.sh`) | **~37 ms** | ×2 por onda |

Medido em macOS/zsh, 30 iterações cada.

## Regra de decisão

- **Sim** → o operador roda `cstk hooks install` e confirma antes de seguir.
- **Não ou silêncio** → a execução **segue normalmente**. Métrica nunca gateia a pipeline. Mas o que fica de fora é registrado sem eufemismo: a guarda de Bash não está enforced, e `tool_calls` fica **ausente** — não "zero medido".
- **Nunca instalar sem consentimento**: `cstk hooks install` escreve em `<projeto-alvo>/.claude/settings.json`, que pode estar versionado no repo do operador.

Dois opt-ins independentes ficam explícitos no pedido: `cstk hooks install` (hooks) e as duas variáveis de ambiente (custo/tokens reais por onda, sem API key nem organização).

## Testes

Suíte completa: **1889 cenários, 0 falhas**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h3LpRcNK55CHRA3sdVboe