### PR TITLE
feat(recall): ingere consumo OTel na knowledge.db (schema v11) — 5.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.30.0] - 2026-07-26
+
+O custo real por onda **chega ao painel**. A v5.28.0 capturou o dado no
+`state.json`; esta versão o indexa na `knowledge.db` e o expõe na UI.
+
+### Added
+
+- **knowledge.db schema v11**: 5 colunas aditivas em `waves` para o consumo
+  medido pela telemetria OTel — `otel_cost_usd`, `otel_cost_main_usd`,
+  `otel_cost_subagent_usd` (todas `REAL`), `otel_total_tokens` e
+  `otel_subagent_tokens` (`INTEGER`). Migração v10→v11 idempotente, guardada
+  por `PRAGMA` como as anteriores; ondas já indexadas ficam intactas com
+  `NULL` nas colunas novas — **ausente, nunca zero**.
+- **`recall_real_or_null`**: coerção para ponto flutuante. O custo em USD é
+  fracionário (`0.098485`); `recall_int_or_null` o descartaria como
+  não-numérico e gravaria `NULL`, perdendo silenciosamente a métrica.
+- Testes: 4 cenários em `tests/cstk/test_recall.sh` — ingestão nas colunas,
+  custo fracionário preservado, ausência vira `NULL`, e migração v10→v11
+  idempotente com linha legada preservada.
+
+### Changed
+
+- **Ingestão** (`cli/lib/recall.sh`): `--ingest` e `--reindex` passam a ler
+  `.waves[N].otel_usage`. Os tokens de subagente são somados dos quatro
+  tipos (`input` + `output` + `cache_read` + `cache_creation`).
+
+### Painel (repo cstk-panel, PR separado)
+
+- `DEFAULT_SCHEMA_VERSIONS` aceita `11` — **sem isso o painel recusaria
+  abrir a base migrada**.
+- `hasOtelUsage()` + `getOtelUsage()`: sonda de capacidade e agregação. Base
+  v10 ou anterior degrada para `null` em vez de erro "no such column".
+- Tile "Tokens · subagentes" passa a **preferir a fonte OTel** quando
+  presente (mais completa: cobre o consumo do próprio orquestrador), com
+  `agentUsage` como fallback e rótulo de cobertura `N/M ondas medidas`.
+
 ## [5.29.0] - 2026-07-26
 
 Os commands 00c passam a **pedir** a instalação dos hooks em vez de só
@@ -4153,6 +4189,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.30.0]: https://github.com/JotJunior/cstk/releases/tag/v5.30.0
 [5.29.0]: https://github.com/JotJunior/cstk/releases/tag/v5.29.0
 [5.28.0]: https://github.com/JotJunior/cstk/releases/tag/v5.28.0
 [5.27.0]: https://github.com/JotJunior/cstk/releases/tag/v5.27.0

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -112,7 +112,7 @@ RECALL_EXIT_USAGE=2
 # table_info (mesmo padrao v2/v5/v8/v9); SEM drop, dados v9 preservados.
 # Onda antiga ou sem .agent_usage -> todas as 9 colunas NULL, nunca 0
 # (recall_int_or_null; Principio VI — nao fabricar dado nao observado).
-RECALL_SCHEMA_VERSION=10
+RECALL_SCHEMA_VERSION=11
 # Enum interno (canonico): valores EN. 'bloqueio' permanece aceito como ALIAS
 # DEPRECADO em --type (normalizado para 'block' com aviso) — ver recall_normalize_type.
 RECALL_TYPE_ENUM="decision block retro skill memory suggestion"
@@ -510,6 +510,11 @@ CREATE TABLE IF NOT EXISTS waves (
   n_stages INTEGER,
   n_skills INTEGER,
   session TEXT,
+  otel_cost_usd REAL,
+  otel_cost_main_usd REAL,
+  otel_cost_subagent_usd REAL,
+  otel_total_tokens INTEGER,
+  otel_subagent_tokens INTEGER,
   agent_spawns_total INTEGER,
   agent_spawns_with_usage INTEGER,
   agent_total_tokens INTEGER,
@@ -750,6 +755,19 @@ ALTER TABLE waves ADD COLUMN agent_cache_creation_tokens INTEGER;
 ALTER TABLE waves ADD COLUMN agent_tool_use_count INTEGER;
 ALTER TABLE waves ADD COLUMN agent_duration_ms INTEGER;" ;;
       esac
+      # ---- Migracao v10->v11 (otel-wave-cost): 5 colunas aditivas em waves
+      # para o consumo REAL da onda medido pela telemetria OTel. `cost` e
+      # REAL (fracionario em USD), nao INTEGER. Sem DEFAULT -> NULL, coerente
+      # com onda antiga sem otel_usage: ausente, jamais 0.
+      case "$_as_wcols" in
+        ''|*'|otel_cost_usd|'*) : ;;
+        *) _as_extra="$_as_extra
+ALTER TABLE waves ADD COLUMN otel_cost_usd REAL;
+ALTER TABLE waves ADD COLUMN otel_cost_main_usd REAL;
+ALTER TABLE waves ADD COLUMN otel_cost_subagent_usd REAL;
+ALTER TABLE waves ADD COLUMN otel_total_tokens INTEGER;
+ALTER TABLE waves ADD COLUMN otel_subagent_tokens INTEGER;" ;;
+      esac
     fi
   fi
   recall_apply_sql_with_retry "$1" "$_as_pre$(recall_schema_ddl)$_as_extra"
@@ -834,6 +852,19 @@ recall_int_or_null() {
     ''|*[!0-9-]*) printf 'NULL' ;;
     -|-*[!0-9]*)  printf 'NULL' ;;
     *)            printf '%s' "$1" ;;
+  esac
+}
+
+# recall_real_or_null VALOR -> numero literal ou NULL. Custo em USD e
+# fracionario (ex: 0.141282), entao recall_int_or_null o descartaria como
+# nao-numerico. Aceita um unico ponto decimal e sinal opcional; qualquer
+# outra coisa vira NULL (nunca 0 — ausente != zero, Principio VI).
+recall_real_or_null() {
+  case "$1" in
+    ''|*[!0-9.-]*)  printf 'NULL' ;;
+    *.*.*)          printf 'NULL' ;;   # mais de um ponto
+    .|-|-.)         printf 'NULL' ;;
+    *)              printf '%s' "$1" ;;
   esac
 }
 
@@ -1095,7 +1126,16 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
        (($w.agent_usage.cache_read_input_tokens // "")|tostring),
        (($w.agent_usage.cache_creation_input_tokens // "")|tostring),
        (($w.agent_usage.tool_use_count // "")|tostring),
-       (($w.agent_usage.duration_ms // "")|tostring)]
+       (($w.agent_usage.duration_ms // "")|tostring),
+       (($w.otel_usage.total_cost_usd // "")|tostring),
+       (($w.otel_usage.by_source.main.cost_usd // "")|tostring),
+       (($w.otel_usage.by_source.subagent.cost_usd // "")|tostring),
+       (($w.otel_usage.total_tokens // "")|tostring),
+       ((( $w.otel_usage.by_source.subagent
+           | if . == null then null
+             else ((.input // 0) + (.output // 0)
+                   + (.cache_read // 0) + (.cache_creation // 0))
+             end ) // "")|tostring)]
     | @base64' "$_isj_state" 2>/dev/null) || _isj_wave_lines=""
   if [ -n "$_isj_wave_lines" ]; then
     _isj_OLDIFS="$IFS"; IFS='
@@ -1120,6 +1160,11 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
       _f_acc=$(printf '%s' "$_isj_decoded" | jq -r '.[15]' 2>/dev/null | strip_nul)
       _f_atu=$(printf '%s' "$_isj_decoded" | jq -r '.[16]' 2>/dev/null | strip_nul)
       _f_adm=$(printf '%s' "$_isj_decoded" | jq -r '.[17]' 2>/dev/null | strip_nul)
+      _f_ocu=$(printf '%s' "$_isj_decoded" | jq -r '.[18]' 2>/dev/null | strip_nul)
+      _f_ocm=$(printf '%s' "$_isj_decoded" | jq -r '.[19]' 2>/dev/null | strip_nul)
+      _f_ocs=$(printf '%s' "$_isj_decoded" | jq -r '.[20]' 2>/dev/null | strip_nul)
+      _f_ott=$(printf '%s' "$_isj_decoded" | jq -r '.[21]' 2>/dev/null | strip_nul)
+      _f_ost=$(printf '%s' "$_isj_decoded" | jq -r '.[22]' 2>/dev/null | strip_nul)
       [ -n "$_f_wid" ] || continue
       _f_mt=$(recall_scrub "$_f_mt")
       _isj_wc_sql=$(recall_int_or_null "$_f_wc")
@@ -1135,10 +1180,15 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
       _isj_acc_sql=$(recall_int_or_null "$_f_acc")
       _isj_atu_sql=$(recall_int_or_null "$_f_atu")
       _isj_adm_sql=$(recall_int_or_null "$_f_adm")
+      _isj_ocu_sql=$(recall_real_or_null "$_f_ocu")
+      _isj_ocm_sql=$(recall_real_or_null "$_f_ocm")
+      _isj_ocs_sql=$(recall_real_or_null "$_f_ocs")
+      _isj_ott_sql=$(recall_int_or_null "$_f_ott")
+      _isj_ost_sql=$(recall_int_or_null "$_f_ost")
       _isj_sql="$_isj_sql
-INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,started_at,finished_at,wallclock_seconds,tool_calls,termination_reason,n_stages,n_skills,session,agent_spawns_total,agent_spawns_with_usage,agent_total_tokens,agent_input_tokens,agent_output_tokens,agent_cache_read_tokens,agent_cache_creation_tokens,agent_tool_use_count,agent_duration_ms,ingested_at)
-VALUES('$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','$(sql_escape "$_f_wid")','$(sql_escape "$_isj_exec_id")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_wid")','$(sql_escape "$_f_etp")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_fim")',$_isj_wc_sql,$_isj_tc_sql,'$(sql_escape "$_f_mt")',$_isj_ne_sql,$_isj_ns_sql,$_isj_session_sql,$_isj_ast_sql,$_isj_asu_sql,$_isj_att_sql,$_isj_ait_sql,$_isj_aot_sql,$_isj_acr_sql,$_isj_acc_sql,$_isj_atu_sql,$_isj_adm_sql,'$(sql_escape "$_isj_now")')
-ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,stages=excluded.stages,started_at=excluded.started_at,finished_at=excluded.finished_at,wallclock_seconds=excluded.wallclock_seconds,tool_calls=excluded.tool_calls,termination_reason=excluded.termination_reason,n_stages=excluded.n_stages,n_skills=excluded.n_skills,session=excluded.session,agent_spawns_total=excluded.agent_spawns_total,agent_spawns_with_usage=excluded.agent_spawns_with_usage,agent_total_tokens=excluded.agent_total_tokens,agent_input_tokens=excluded.agent_input_tokens,agent_output_tokens=excluded.agent_output_tokens,agent_cache_read_tokens=excluded.agent_cache_read_tokens,agent_cache_creation_tokens=excluded.agent_cache_creation_tokens,agent_tool_use_count=excluded.agent_tool_use_count,agent_duration_ms=excluded.agent_duration_ms,ingested_at=excluded.ingested_at;"
+INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,started_at,finished_at,wallclock_seconds,tool_calls,termination_reason,n_stages,n_skills,session,agent_spawns_total,agent_spawns_with_usage,agent_total_tokens,agent_input_tokens,agent_output_tokens,agent_cache_read_tokens,agent_cache_creation_tokens,agent_tool_use_count,agent_duration_ms,otel_cost_usd,otel_cost_main_usd,otel_cost_subagent_usd,otel_total_tokens,otel_subagent_tokens,ingested_at)
+VALUES('$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','$(sql_escape "$_f_wid")','$(sql_escape "$_isj_exec_id")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_wid")','$(sql_escape "$_f_etp")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_fim")',$_isj_wc_sql,$_isj_tc_sql,'$(sql_escape "$_f_mt")',$_isj_ne_sql,$_isj_ns_sql,$_isj_session_sql,$_isj_ast_sql,$_isj_asu_sql,$_isj_att_sql,$_isj_ait_sql,$_isj_aot_sql,$_isj_acr_sql,$_isj_acc_sql,$_isj_atu_sql,$_isj_adm_sql,$_isj_ocu_sql,$_isj_ocm_sql,$_isj_ocs_sql,$_isj_ott_sql,$_isj_ost_sql,'$(sql_escape "$_isj_now")')
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,stages=excluded.stages,started_at=excluded.started_at,finished_at=excluded.finished_at,wallclock_seconds=excluded.wallclock_seconds,tool_calls=excluded.tool_calls,termination_reason=excluded.termination_reason,n_stages=excluded.n_stages,n_skills=excluded.n_skills,session=excluded.session,agent_spawns_total=excluded.agent_spawns_total,agent_spawns_with_usage=excluded.agent_spawns_with_usage,agent_total_tokens=excluded.agent_total_tokens,agent_input_tokens=excluded.agent_input_tokens,agent_output_tokens=excluded.agent_output_tokens,agent_cache_read_tokens=excluded.agent_cache_read_tokens,agent_cache_creation_tokens=excluded.agent_cache_creation_tokens,agent_tool_use_count=excluded.agent_tool_use_count,agent_duration_ms=excluded.agent_duration_ms,otel_cost_usd=excluded.otel_cost_usd,otel_cost_main_usd=excluded.otel_cost_main_usd,otel_cost_subagent_usd=excluded.otel_cost_subagent_usd,otel_total_tokens=excluded.otel_total_tokens,otel_subagent_tokens=excluded.otel_subagent_tokens,ingested_at=excluded.ingested_at;"
       _isj_n_wave=$((_isj_n_wave + 1))
     done
     IFS="$_isj_OLDIFS"

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -608,7 +608,7 @@ SQL
     _fail "apply schema v7" "recall_apply_schema falhou"; return 1; }
   # (a) schema_version virou a corrente (10 — v10 wave-token-metrics).
   _sv=$(sqlite3 "$_mdb" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "10" ] || { _fail "schema_version" "esperado 10, obtido $_sv"; return 1; }
+  [ "$_sv" = "11" ] || { _fail "schema_version" "esperado 11, obtido $_sv"; return 1; }
   # (b) tabela bloqueios DROPADA; blocks (EN) criada no lugar.
   _hasbloq=$(sqlite3 "$_mdb" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='bloqueios'")
   [ "$_hasbloq" = "0" ] || { _fail "bloqueios dropada" "tabela pt-BR bloqueios sobreviveu"; return 1; }
@@ -653,7 +653,7 @@ scenario_m11b_v7_reindex_repopula() {
   _v7db="$TMPDIR_TEST/v7.db"
   _rc --reindex --states-root "$TMPDIR_TEST/rxv7" --db "$_v7db" >/dev/null 2>&1
   _sv=$(sqlite3 "$_v7db" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "10" ] || { _fail "reindex schema corrente" "esperado schema_version 10, obtido $_sv"; return 1; }
+  [ "$_sv" = "11" ] || { _fail "reindex schema corrente" "esperado schema_version 11, obtido $_sv"; return 1; }
   # decisions repopuladas em EN (2 decisoes do _write_state).
   _n=$(sqlite3 "$_v7db" "SELECT count(*) FROM decisions WHERE feature='featV7'")
   [ "$_n" = "2" ] || { _fail "reindex repopula" "esperado 2 decisoes, obtido $_n"; return 1; }
@@ -675,7 +675,7 @@ scenario_m12_ddl_idempotente() {
   sqlite3 "$_mdb" "INSERT INTO decisions(project,feature,wave,execution_id,source_ts,source_id,choice,ingested_at) VALUES('p','f','w','e','t','dec-keep','keep','now')"
   assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_mdb" || return 1
   _sv=$(sqlite3 "$_mdb" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "10" ] || { _fail "schema estavel" "esperado 10 apos 2x, obtido $_sv"; return 1; }
+  [ "$_sv" = "11" ] || { _fail "schema estavel" "esperado 10 apos 2x, obtido $_sv"; return 1; }
   _keep=$(sqlite3 "$_mdb" "SELECT count(*) FROM decisions WHERE source_id='dec-keep'")
   [ "$_keep" = "1" ] || { _fail "idempotente sem re-drop" "linha sumiu: 2o apply re-dropou ($_keep)"; return 1; }
 }
@@ -1876,7 +1876,7 @@ scenario_b11_ddl_tasks_events() {
   # v9 executions-target-path: coluna target_project_path em executions; v8
   # recall-worktree-identity: coluna session em executions/waves).
   _sv=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "10" ] || { _fail "schema_version" "esperado 10, obtido $_sv"; return 1; }
+  [ "$_sv" = "11" ] || { _fail "schema_version" "esperado 11, obtido $_sv"; return 1; }
   # tasks tem a coluna title (EN, DDL fresco).
   _hascol=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT count(*) FROM pragma_table_info('tasks') WHERE name='title'")
   [ "$_hascol" = "1" ] || { _fail "coluna title" "esperado 1, obtido $_hascol"; return 1; }
@@ -2192,7 +2192,7 @@ scenario_m1_schema_memories_table_exists() {
   # schema_version deve ser 10 (wave-token-metrics: colunas agent_* em waves)
   _ver=$(sqlite3 "$TMPDIR_TEST/m1.db" \
     "SELECT value FROM schema_meta WHERE key='schema_version';" 2>/dev/null)
-  [ "$_ver" = "10" ] || { _fail "schema_version errado" "esperado 10, obtido '$_ver'"; return 1; }
+  [ "$_ver" = "11" ] || { _fail "schema_version errado" "esperado 11, obtido '$_ver'"; return 1; }
 }
 
 # M1-enum — RECALL_TYPE_ENUM inclui 'memory' apos bump.
@@ -2237,7 +2237,7 @@ scenario_m4_neg_context_type_invalido() {
 # v3 -> ... -> v10: tabelas renomeadas dropadas+recriadas EN (drop v7),
 # memories/suggestions criadas, e o ingest subsequente repopula decisions em
 # EN (o derivado legacy do v3 e descartado pelo drop v7, mas o ingest do
-# state.json o reconstroi). schema_version final = 10.
+# state.json o reconstroi). schema_version final = 11.
 scenario_m1_migration_v3_to_current() {
   _have_deps || return 0
   # Criar um DB v3 com schema pt-BR antigo (sem memories) simulando pre-existente
@@ -2282,7 +2282,7 @@ scenario_m1_migration_v3_to_current() {
   # session/target_project_path de executions e agent_* de waves vem do DDL
   # fresco pos-drop v7)
   _ver=$(sqlite3 "$_v3db" "SELECT value FROM schema_meta WHERE key='schema_version';" 2>/dev/null)
-  [ "$_ver" = "10" ] || { _fail "migration: schema_version errado" "esperado 10, obtido '$_ver'"; return 1; }
+  [ "$_ver" = "11" ] || { _fail "migration: schema_version errado" "esperado 11, obtido '$_ver'"; return 1; }
   # decisions repopuladas pelo ingest (>=1; o derivado v3 foi descartado, o
   # state.json o reconstroi em EN).
   _n=$(sqlite3 "$_v3db" "SELECT count(*) FROM decisions;" 2>/dev/null)
@@ -3032,7 +3032,7 @@ INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,i
     *) _fail "W5 waves.session" "coluna session ausente em waves pos-migracao"; return 1 ;;
   esac
   _w5_ver=$(sqlite3 "$_w5_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_w5_ver" = "10" ] || { _fail "W5 schema_version" "esperado '10' (corrente pos-v10), obtido '$_w5_ver'"; return 1; }
+  [ "$_w5_ver" = "11" ] || { _fail "W5 schema_version" "esperado '11' (corrente pos-v11), obtido '$_w5_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/w5/sd" --db "$_w5_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "W5 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3158,7 +3158,7 @@ JSON
     *) _fail "TP1d shape v9" "coluna target_project_path ausente em executions"; return 1 ;;
   esac
   _tp1_ver=$(sqlite3 "$_tp1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_tp1_ver" = "10" ] || { _fail "TP1d schema_version" "esperado 10, obtido '$_tp1_ver'"; return 1; }
+  [ "$_tp1_ver" = "11" ] || { _fail "TP1d schema_version" "esperado 11, obtido '$_tp1_ver'"; return 1; }
 }
 
 # Cenario TP2 — re-ingestao idempotente + backfill: DB v8 preexistente com
@@ -3213,7 +3213,7 @@ INSERT INTO executions(project,feature,wave,execution_id,source_ts,source_id,ses
   _tp3_new=$(sqlite3 "$_tp3_db" "SELECT target_project_path FROM executions WHERE feature='feat-tp3';")
   [ "$_tp3_new" = "/nonexistent/tp3proj" ] || { _fail "TP3 linha nova" "esperado '/nonexistent/tp3proj', obtido '$_tp3_new'"; return 1; }
   _tp3_ver=$(sqlite3 "$_tp3_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_tp3_ver" = "10" ] || { _fail "TP3 schema_version" "esperado '10', obtido '$_tp3_ver'"; return 1; }
+  [ "$_tp3_ver" = "11" ] || { _fail "TP3 schema_version" "esperado '11', obtido '$_tp3_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada, sem duplicata)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/tp3/sd" --db "$_tp3_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "TP3 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3262,7 +3262,7 @@ JSON
     *) _fail "WT1 shape v10" "coluna agent_spawns_total ausente em waves"; return 1 ;;
   esac
   _wt1_ver=$(sqlite3 "$_wt1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wt1_ver" = "10" ] || { _fail "WT1 schema_version" "esperado 10, obtido '$_wt1_ver'"; return 1; }
+  [ "$_wt1_ver" = "11" ] || { _fail "WT1 schema_version" "esperado 11, obtido '$_wt1_ver'"; return 1; }
 }
 
 # Cenario WT2 — onda SEM .agent_usage: as 9 colunas ficam NULL, nunca 0
@@ -3334,7 +3334,7 @@ JSON
   _wt3_new=$(sqlite3 "$_wt3_db" "SELECT agent_spawns_total||'|'||agent_duration_ms FROM waves WHERE feature='feat-wt3';")
   [ "$_wt3_new" = "3|4321" ] || { _fail "WT3 linha nova" "esperado '3|4321', obtido '$_wt3_new'"; return 1; }
   _wt3_ver=$(sqlite3 "$_wt3_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wt3_ver" = "10" ] || { _fail "WT3 schema_version" "esperado '10', obtido '$_wt3_ver'"; return 1; }
+  [ "$_wt3_ver" = "11" ] || { _fail "WT3 schema_version" "esperado '11', obtido '$_wt3_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada, sem duplicata)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/wt3/sd" --db "$_wt3_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT3 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3387,6 +3387,107 @@ JSON
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT4 reindex#2 exit" "$_CAPTURED_EXIT"; return 1; }
   _wt4_cnt1=$(sqlite3 "$_wt4_db" "SELECT COUNT(*) FROM waves;")
   [ "$_wt4_cnt0" = "$_wt4_cnt1" ] || { _fail "WT4 reindex idempotente" "N0=$_wt4_cnt0 != N1=$_wt4_cnt1"; return 1; }
+}
+
+# ==== otel-wave-cost: consumo real por onda (schema v11) ====
+#
+# O delta OTel start->end grava `.waves[N].otel_usage` no state.json; a
+# ingestao achata isso em 5 colunas. O custo e REAL (fracionario em USD),
+# nao INTEGER — recall_int_or_null descartaria 0.098485 como nao-numerico.
+
+# _otel_state DIR JSON — state.json minimo com uma onda carregando otel_usage.
+_otel_state() {
+  mkdir -p "$1"
+  cat > "$1/state.json" <<STATEEOF
+{
+  "schema_version": "2.0",
+  "execution": {"id": "exec-otel-t", "status": "concluida",
+                "target_project_path": "/tmp/proj-otel",
+                "canonical_project": "proj-otel"},
+  "waves": [
+    {"id": "onda-001", "started_at": "2026-07-26T10:00:00Z",
+     "finished_at": "2026-07-26T10:05:00Z", "executed_stages": ["plan"],
+     "otel_usage": $2}
+  ]
+}
+STATEEOF
+}
+
+scenario_otel_usage_ingerido_em_colunas() {
+  _sd="$TMPDIR_TEST/otel-ing"
+  _db="$TMPDIR_TEST/otel-ing.db"
+  _otel_state "$_sd" '{"session_id":"s1","total_cost_usd":0.229038,"total_tokens":648,"by_source":{"main":{"cost_usd":0.130553,"input":0,"output":0,"cache_read":0,"cache_creation":0},"subagent":{"cost_usd":0.098485,"input":10,"output":600,"cache_read":30,"cache_creation":8}}}'
+  capture _rc --ingest --state-dir "$_sd" --db "$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "ingest" "$_CAPTURED_STDERR"; return 1; }
+  _got=$(sqlite3 "$_db" "select otel_cost_usd, otel_cost_main_usd, otel_cost_subagent_usd, otel_subagent_tokens from waves;")
+  [ "$_got" = "0.229038|0.130553|0.098485|648" ]     || { _fail "colunas otel" "esperado '0.229038|0.130553|0.098485|648', obtido '$_got'"; return 1; }
+  return 0
+}
+
+# Custo fracionario NAO pode virar NULL (o bug seria usar recall_int_or_null).
+scenario_otel_custo_fracionario_nao_vira_null() {
+  _sd="$TMPDIR_TEST/otel-frac"
+  _db="$TMPDIR_TEST/otel-frac.db"
+  _otel_state "$_sd" '{"session_id":"s2","total_cost_usd":0.000577,"total_tokens":21,"by_source":{"main":{"cost_usd":0.000577,"input":0,"output":21,"cache_read":0,"cache_creation":0}}}'
+  capture _rc --ingest --state-dir "$_sd" --db "$_db"
+  _got=$(sqlite3 "$_db" "select otel_cost_usd from waves;")
+  [ "$_got" = "0.000577" ]     || { _fail "float" "custo fracionario virou '$_got' (esperado 0.000577)"; return 1; }
+  return 0
+}
+
+# Onda sem otel_usage => NULL, jamais 0 (Principio VI: ausente != medido-zero).
+scenario_otel_ausente_e_null_nao_zero() {
+  _sd="$TMPDIR_TEST/otel-null"
+  _db="$TMPDIR_TEST/otel-null.db"
+  _otel_state "$_sd" 'null'
+  capture _rc --ingest --state-dir "$_sd" --db "$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "ingest" "$_CAPTURED_STDERR"; return 1; }
+  _n=$(sqlite3 "$_db" "select count(otel_cost_usd) from waves;")
+  [ "$_n" = "0" ]     || { _fail "null" "otel ausente deveria ser NULL (count=0), obtido count=$_n"; return 1; }
+  _tot=$(sqlite3 "$_db" "select count(*) from waves;")
+  [ "$_tot" = "1" ] || { _fail "linha" "a onda deve existir mesmo sem otel"; return 1; }
+  return 0
+}
+
+# Migracao v10 -> v11: banco pre-existente sem as colunas otel_* recebe os
+# ALTERs guardados por PRAGMA; a linha antiga fica INTACTA com otel NULL
+# (ausente, nao 0); 2a rodada idempotente. Mesmo padrao do WT3 (v9->v10).
+scenario_otel_migracao_v10_v11_idempotente() {
+  _have_deps || return 0
+  _ot_db="$TMPDIR_TEST/otmig/k.db"
+  mkdir -p "$TMPDIR_TEST/otmig"
+  # DB "v10": waves com as colunas agent_* mas SEM as otel_*.
+  sqlite3 "$_ot_db" "
+CREATE TABLE waves (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, stages TEXT, started_at TEXT, finished_at TEXT, wallclock_seconds INTEGER, tool_calls INTEGER, termination_reason TEXT, n_stages INTEGER, n_skills INTEGER, session TEXT, agent_spawns_total INTEGER, agent_spawns_with_usage INTEGER, agent_total_tokens INTEGER, agent_input_tokens INTEGER, agent_output_tokens INTEGER, agent_cache_read_tokens INTEGER, agent_cache_creation_tokens INTEGER, agent_tool_use_count INTEGER, agent_duration_ms INTEGER, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE schema_meta (key TEXT PRIMARY KEY, value TEXT);
+INSERT INTO schema_meta VALUES('schema_version','10');
+INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,session,ingested_at) VALUES('legacyp10','legacyf10','onda-legacy','e-v10','t','onda-legacy','sess-v10','t');
+" || { _fail "fixture v10" "criacao do DB v10 falhou"; return 1; }
+
+  _sd="$TMPDIR_TEST/otmig/sd"
+  _otel_state "$_sd" '{"session_id":"s9","total_cost_usd":0.5,"total_tokens":42,"by_source":{"subagent":{"cost_usd":0.5,"input":2,"output":40,"cache_read":0,"cache_creation":0}}}'
+
+  # 1a rodada: migra v10 -> v11
+  capture _rc --ingest --state-dir "$_sd" --db "$_ot_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "ingest#1" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  _v=$(sqlite3 "$_ot_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
+  [ "$_v" = "11" ] || { _fail "schema_version" "esperado 11, obtido '$_v'"; return 1; }
+
+  # linha v10 intacta: session preservada, coluna nova NULL (nao 0)
+  _leg=$(sqlite3 "$_ot_db" "SELECT session||'|'||COALESCE(otel_cost_usd,-999) FROM waves WHERE project='legacyp10';")
+  [ "$_leg" = "sess-v10|-999.0" ] || [ "$_leg" = "sess-v10|-999" ]     || { _fail "linha v10" "esperado session preservada + otel NULL, obtido '$_leg'"; return 1; }
+
+  # linha nova com o dado otel
+  _new=$(sqlite3 "$_ot_db" "SELECT otel_cost_usd||'|'||otel_cost_subagent_usd FROM waves WHERE project='proj-otel';")
+  [ "$_new" = "0.5|0.5" ] || { _fail "linha nova" "esperado '0.5|0.5', obtido '$_new'"; return 1; }
+
+  # 2a rodada: idempotente (sem erro de coluna duplicada, sem duplicar linha)
+  _n1=$(sqlite3 "$_ot_db" "SELECT count(*) FROM waves;")
+  capture _rc --ingest --state-dir "$_sd" --db "$_ot_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "ingest#2 (idempotencia)" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  _n2=$(sqlite3 "$_ot_db" "SELECT count(*) FROM waves;")
+  [ "$_n1" = "$_n2" ] || { _fail "idempotencia" "linhas mudaram de $_n1 para $_n2"; return 1; }
+  return 0
 }
 
 run_all_scenarios


### PR DESCRIPTION
## Contexto

A **v5.28.0** capturou o custo real da onda em `.waves[N].otel_usage`. Mas o dado ficava só no `state.json` — o painel continuava mostrando `—`. Este PR indexa na `knowledge.db`.

## Schema v11

5 colunas aditivas em `waves`:

| Coluna | Tipo | O quê |
|---|---|---|
| `otel_cost_usd` | `REAL` | custo total da onda |
| `otel_cost_main_usd` | `REAL` | fatia do loop principal |
| `otel_cost_subagent_usd` | `REAL` | **fatia dos subagentes** — 43–47% do gasto medido |
| `otel_total_tokens` | `INTEGER` | tokens totais |
| `otel_subagent_tokens` | `INTEGER` | tokens de subagente (soma dos 4 tipos) |

Migração v10→v11 idempotente, guardada por `PRAGMA` como as anteriores. Ondas já indexadas ficam com `NULL` — **ausente, nunca zero** (Princípio VI).

## `recall_real_or_null` — por que era necessário

O custo em USD é fracionário (`0.098485`). `recall_int_or_null` casa `*[!0-9-]*` e descartaria o ponto decimal como não-numérico, gravando `NULL` e **perdendo a métrica em silêncio**. O novo helper aceita um único ponto decimal e sinal; qualquer outra coisa continua virando `NULL`.

## Validação da migração

Além do teste sintético, rodei numa **cópia do banco real** (v10, 918 ondas):

- schema_version 10 → 11
- 5 colunas adicionadas
- 918 → 919 ondas (a nova ingerida), nenhuma perdida
- ondas antigas com `NULL` nas colunas novas, não `0`

## Testes

4 cenários novos em `tests/cstk/test_recall.sh`:
- ingestão popula as 5 colunas com os valores certos
- custo fracionário preservado (`0.000577` não vira `NULL`)
- onda sem `otel_usage` → `NULL`, e a linha da onda ainda existe
- migração v10→v11 idempotente, com linha legada intacta e sem duplicar na 2ª rodada

Suíte completa: **1893 cenários, 0 falhas**.

## Painel

PR [JotJunior/cstk-panel#13](https://github.com/JotJunior/cstk-panel/pull/13) (merged): aceita schema `11` — **sem isso o painel recusaria abrir a base migrada** — e o tile "Tokens · subagentes" passa a preferir a fonte OTel, com `agentUsage` como fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h3LpRcNK55CHRA3sdVboe