### PR TITLE
fix(backfill): atribuição por enclausuramento + toolUseResult string (5.31.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.31.0] - 2026-07-26
+
+Corrige os dois bugs que sobraram no `wave-usage-report.sh backfill` — a
+reconstrução histórica do consumo por onda, que estava **inteiramente
+inoperante**.
+
+### Fixed
+
+- **Backfill não cobria nenhuma onda** (`0/58` medido em gamedev-training).
+  A atribuição era por **contenção** (`started_at <= ts < finished_at`)
+  usando o timestamp do `tool_result` — mas a topologia real é o oposto: o
+  command pai spawna o orquestrador, e é o orquestrador que abre e fecha a
+  onda **por dentro** do spawn. Ou seja
+  `spawn_start < started_at < finished_at < spawn_end`: o `tool_result`
+  chega depois do fechamento, na lacuna entre ondas, e nunca casava.
+  A atribuição agora tenta **enclausuramento** primeiro (o spawn envolve a
+  onda) e cai na contenção como fallback — que continua valendo para spawns
+  feitos de dentro de uma onda já aberta. O fix é **aditivo**, não
+  substitutivo. Resultado no mesmo transcript: **62 de 65 spawns cobertos**.
+- **`toolUseResult` string derrubava o backfill inteiro.** Nem todo tool
+  result é objeto; vários devolvem string crua. `.agentId` sobre string
+  aborta o `jq` com `Cannot index string with string`, matando o
+  processamento do arquivo todo (observado em financial-support). Agora o
+  tipo é checado antes de indexar, e uma linha string apenas é ignorada —
+  os spawns válidos ao redor sobrevivem.
+- Testes: 3 cenários de regressão em `tests/test_wave-usage-report.sh`
+  (spawn que envolve a onda é atribuído; contenção continua valendo; linha
+  com `toolUseResult` string não derruba os spawns seguintes).
+
 ## [5.30.0] - 2026-07-26
 
 O custo real por onda **chega ao painel**. A v5.28.0 capturou o dado no
@@ -4189,6 +4218,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.31.0]: https://github.com/JotJunior/cstk/releases/tag/v5.31.0
 [5.30.0]: https://github.com/JotJunior/cstk/releases/tag/v5.30.0
 [5.29.0]: https://github.com/JotJunior/cstk/releases/tag/v5.29.0
 [5.28.0]: https://github.com/JotJunior/cstk/releases/tag/v5.28.0

--- a/global/skills/agente-00c-runtime/scripts/wave-usage-report.sh
+++ b/global/skills/agente-00c-runtime/scripts/wave-usage-report.sh
@@ -438,10 +438,15 @@ def add_null(existing; delta): if delta == null then existing else ((existing //
 ($tr[0] // []) as $records
 
 # tool_use(name="Agent") -> agent_type, indexado por tool_use_id.
-| ([$records[] | select(.type=="assistant") | (.message.content // [])[]
+| ([$records[] | select(.type=="assistant") | . as $arec
+     | (.message.content // [])[]
      | select(.type=="tool_use" and .name=="Agent")
-     | {id: .id, agent_type: (.input.subagent_type // null)}]) as $agent_calls
+     | {id: .id, agent_type: (.input.subagent_type // null),
+        start_ts: $arec.timestamp}]) as $agent_calls
 | ($agent_calls | map({(.id): .agent_type}) | add // {}) as $agent_type_by_id
+# INICIO do spawn (timestamp do tool_use). Necessario para atribuir por
+# ENCLAUSURAMENTO — ver o bloco de atribuicao abaixo.
+| ($agent_calls | map({(.id): .start_ts}) | add // {}) as $agent_start_by_id
 
 # tool_result cujo tool_use_id casa com uma chamada Agent E cujo
 # toolUseResult carrega agentId (mesma condicao de "empty" do hook: sem
@@ -452,6 +457,11 @@ def add_null(existing; delta): if delta == null then existing else ((existing //
      | (((.message.content // [])[] | select(.type=="tool_result") | .tool_use_id) // null) as $tuid
      | select($tuid != null and ($agent_type_by_id | has($tuid)))
      | ($rec.toolUseResult) as $trr
+     # `toolUseResult` NEM SEMPRE e objeto — varios tools devolvem string
+     # crua. `.agentId` sobre string aborta o jq inteiro com
+     # "Cannot index string with string", derrubando o backfill do arquivo
+     # todo (observado em financial-support). Checar o type ANTES de indexar.
+     | select(($trr | type) == "object")
      | ($trr.agentId // null) as $aid
      | select($aid != null)
      | ($trr.status // "") as $status_raw
@@ -473,22 +483,41 @@ def add_null(existing; delta): if delta == null then existing else ((existing //
          duration_ms: (if $derived=="indisponivel" then null else ($trr.totalDurationMs // null) end),
          source: "backfill",
          observed_at: ($rec.timestamp // null),
-         _ts_epoch: epoch($rec.timestamp)
+         _ts_epoch: epoch($rec.timestamp),
+         _start_epoch: epoch($agent_start_by_id[$tuid])
        }
    ]) as $extracted
 
 | (.waves // []) as $waves_orig
 | ($waves_orig | map({id: .id, s: epoch(.started_at), f: epoch(.finished_at)})) as $windows
 
-# Atribuicao por janela temporal: started_at <= ts < finished_at (onda
-# aberta, finished_at=null -> sem limite superior). Primeiro match vence
-# (ondas nao se sobrepoem em condicoes normais).
+# Atribuicao em DUAS regras, nesta ordem.
+#
+# (1) ENCLAUSURAMENTO — spawn_start <= wave.started_at e
+#     wave.finished_at <= spawn_end. E a topologia real do agente-00c: o
+#     command pai spawna o orquestrador, e e o orquestrador que abre e
+#     fecha a onda POR DENTRO do spawn. Logo o spawn ENVOLVE a onda.
+#
+# (2) CONTENCAO (regra antiga) — started_at <= ts < finished_at, como
+#     fallback para spawns feitos de DENTRO de uma onda ja aberta.
+#
+# So a regra (2) existia, e por isso o backfill nao cobria nada: o
+# tool_result do orquestrador chega DEPOIS de finished_at, caindo na lacuna
+# entre ondas. Medido em gamedev-training: 58 spawns, 56 janelas, 0
+# cobertos.
 | ($extracted | map(
      . as $sp
      | (reduce $windows[] as $w (null;
-         if . == null and $w.s != null and $sp._ts_epoch != null
-            and $sp._ts_epoch >= $w.s and ($w.f == null or $sp._ts_epoch < $w.f)
-         then $w.id else . end)) as $wid
+         if . == null and $w.s != null and $w.f != null
+            and $sp._start_epoch != null and $sp._ts_epoch != null
+            and $sp._start_epoch <= $w.s and $w.f <= $sp._ts_epoch
+         then $w.id else . end)) as $encl
+     | (if $encl != null then $encl
+        else (reduce $windows[] as $w (null;
+                if . == null and $w.s != null and $sp._ts_epoch != null
+                   and $sp._ts_epoch >= $w.s and ($w.f == null or $sp._ts_epoch < $w.f)
+                then $w.id else . end))
+        end) as $wid
      | $sp + {wave_id: $wid}
    )) as $assigned_all
 
@@ -515,13 +544,13 @@ def add_null(existing; delta): if delta == null then existing else ((existing //
       ($ORIG_STATE
         | .waves = (.waves | map(
             . as $w
-            | (($new_spawns | map(select(.wave_id == $w.id)) | map(del(.wave_id, ._ts_epoch)))) as $add
+            | (($new_spawns | map(select(.wave_id == $w.id)) | map(del(.wave_id, ._ts_epoch, ._start_epoch)))) as $add
             | if ($add | length) > 0 then
                 (.agent_spawns = ((.agent_spawns // []) + $add))
                 | (.agent_usage = wave_usage_of(.agent_spawns))
               else . end
           ))
-        | (wave_usage_of($new_spawns | map(del(.wave_id, ._ts_epoch)))) as $delta
+        | (wave_usage_of($new_spawns | map(del(.wave_id, ._ts_epoch, ._start_epoch)))) as $delta
         | .accumulated_metrics.agent_spawns_total = ((.accumulated_metrics.agent_spawns_total // 0) + $new_total)
         | .accumulated_metrics.agent_spawns_with_usage_total =
             ((.accumulated_metrics.agent_spawns_with_usage_total // 0) + ([$new_spawns[] | select(.status != "indisponivel")] | length))

--- a/tests/test_wave-usage-report.sh
+++ b/tests/test_wave-usage-report.sh
@@ -693,4 +693,79 @@ scenario_shebang_posix_e_set_eu() {
   grep -q '^set -eu$' "$SCRIPT" || { _fail "set -eu presente" "nao encontrado"; return 1; }
 }
 
+# ==== Regressoes de campo: enclausuramento + toolUseResult string ====
+
+# Topologia REAL do agente-00c: o command pai spawna o orquestrador, e e o
+# orquestrador que abre e fecha a onda POR DENTRO do spawn. Logo
+#   spawn_start < wave.started_at < wave.finished_at < spawn_end
+# O tool_result chega DEPOIS de finished_at, na lacuna entre ondas — a regra
+# antiga (contencao: started_at <= ts < finished_at) nunca casava.
+# Medido em gamedev-training antes do fix: 58 spawns, 56 janelas, 0 cobertos.
+_wur_write_state_enclausurado() {
+  mkdir -p "$1"
+  cat > "$1/state.json" <<'JSON'
+{
+  "execution": {"id":"exec-encl","status":"concluida"},
+  "waves": [
+    {"id":"onda-001","started_at":"2026-07-25T20:05:00Z","finished_at":"2026-07-25T20:10:00Z","agent_usage":null,"agent_spawns":[]}
+  ],
+  "accumulated_metrics": {"waves_total":1,"agent_spawns_total":0,"agent_spawns_with_usage_total":0}
+}
+JSON
+}
+
+# Spawn que ENVOLVE a onda: comeca antes de started_at, termina depois de
+# finished_at. Sob a regra antiga isso ficava sem atribuicao.
+_wur_write_transcript_enclausurado() {
+  cat > "$TMPDIR_TEST/tr-encl.jsonl" <<'EOF'
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_E1","name":"Agent","input":{"subagent_type":"agente-00c-orchestrator"}}]},"timestamp":"2026-07-25T20:04:00.000Z"}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_E1"}]},"toolUseResult":{"agentId":"agent-encl","status":"completed","totalTokens":5000,"totalDurationMs":300000,"totalToolUseCount":9,"usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":4900,"cache_creation_input_tokens":70}},"timestamp":"2026-07-25T20:11:00.000Z"}
+EOF
+}
+
+scenario_backfill_atribui_spawn_que_envolve_a_onda() {
+  _wur_write_state_enclausurado "$TMPDIR_TEST/encl"
+  _wur_write_transcript_enclausurado
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST/encl"     --transcript "$TMPDIR_TEST/tr-encl.jsonl" --dry-run
+  # Sob a regra antiga isto era exit 3 ("nao cobre nenhuma onda").
+  [ "$_CAPTURED_EXIT" = 0 ]     || { _fail "enclausuramento" "esperado exit 0, obtido $_CAPTURED_EXIT — spawn que envolve a onda nao foi atribuido"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | grep -q "onda-001"     || { _fail "atribuicao" "esperado onda-001 no plano; obtido: $_CAPTURED_STDOUT"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | grep -q "agent-encl"     || { _fail "agent_id" "esperado agent-encl no plano"; return 1; }
+  return 0
+}
+
+# A regra antiga (contencao) tem de continuar valendo para spawns feitos de
+# DENTRO de uma onda ja aberta — o fix e aditivo, nao substitutivo.
+scenario_backfill_contencao_continua_valendo() {
+  _wur_have_jq || { _error "jq ausente"; return 2; }
+  mktemp_test || return 2
+  _wur_write_backfill_state
+  _wur_write_transcript_valida
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST" --transcript "$TMPDIR_TEST/transcript.jsonl" --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "contencao" "exit $_CAPTURED_EXIT"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | grep -q "agent-001"     || { _fail "contencao" "spawn contido na onda deixou de ser atribuido"; return 1; }
+  return 0
+}
+
+# `toolUseResult` nem sempre e objeto: varios tools devolvem string crua.
+# `.agentId` sobre string aborta o jq com "Cannot index string with string",
+# derrubando o backfill do arquivo TODO (observado em financial-support).
+scenario_backfill_tooluseresult_string_nao_derruba() {
+  _wur_write_state_enclausurado "$TMPDIR_TEST/strres"
+  {
+    # linha venenosa: toolUseResult e STRING, nao objeto
+    printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_S1","name":"Agent","input":{"subagent_type":"x"}}]},"timestamp":"2026-07-25T20:04:00.000Z"}'
+    printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_S1"}]},"toolUseResult":"resultado em texto puro","timestamp":"2026-07-25T20:06:00.000Z"}'
+    # spawn valido depois dela: se o jq abortasse, este tambem se perderia
+    printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_E1","name":"Agent","input":{"subagent_type":"agente-00c-orchestrator"}}]},"timestamp":"2026-07-25T20:04:00.000Z"}'
+    printf '%s\n' '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_E1"}]},"toolUseResult":{"agentId":"agent-ok","status":"completed","totalTokens":100,"usage":{"input_tokens":1,"output_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-07-25T20:11:00.000Z"}'
+  } > "$TMPDIR_TEST/tr-string.jsonl"
+  capture sh "$SCRIPT" backfill --state-dir "$TMPDIR_TEST/strres"     --transcript "$TMPDIR_TEST/tr-string.jsonl" --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ]     || { _fail "string result" "esperado exit 0, obtido $_CAPTURED_EXIT — toolUseResult string derrubou o backfill"; return 1; }
+  printf '%s' "$_CAPTURED_STDERR" | grep -qi "jq falhou"     && { _fail "crash" "jq abortou por causa de toolUseResult string"; return 1; }
+  # o spawn valido tem de sobreviver a linha venenosa
+  printf '%s' "$_CAPTURED_STDOUT" | grep -q "agent-ok"     || { _fail "sobrevivencia" "spawn valido perdido junto com a linha string"; return 1; }
+  return 0
+}
+
 run_all_scenarios "$0"


### PR DESCRIPTION
Os dois bugs que sobravam no `wave-usage-report.sh backfill`. Juntos, deixavam a reconstrução histórica do consumo por onda **inteiramente inoperante**.

## Bug A — não cobria nenhuma onda (0/58 medido)

A atribuição era por **contenção** (`started_at <= ts < finished_at`) usando o timestamp do `tool_result`. Mas a topologia real é o oposto:

```
spawn_start < wave.started_at < wave.finished_at < spawn_end
```

O command pai spawna o orquestrador, e é o orquestrador que abre e fecha a onda **por dentro** do spawn. O `tool_result` chega depois do fechamento, na lacuna entre ondas — nunca casava.

**Fix**: tenta **enclausuramento** primeiro (o spawn envolve a onda), com a contenção como fallback — que continua valendo para spawns feitos de dentro de uma onda já aberta. **Aditivo, não substitutivo.** Para isso o timestamp do `tool_use` (início do spawn) passou a ser capturado, não só o do result.

| | Antes | Depois |
|---|---:|---:|
| gamedev-training | **0** / 58 | **62** / 65 |

## Bug C — `toolUseResult` string derrubava o arquivo todo

Nem todo tool result é objeto; vários devolvem string crua. `.agentId` sobre string aborta o `jq` com `Cannot index string with string`, matando o processamento do transcript inteiro (observado em financial-support).

**Fix**: o tipo é checado antes de indexar. A linha string é ignorada e os spawns válidos ao redor sobrevivem — o teste verifica exatamente isso (spawn válido *depois* da linha venenosa).

## Testes

3 cenários de regressão em `tests/test_wave-usage-report.sh`:
- spawn que envolve a onda é atribuído (era `exit 3` antes)
- contenção continua valendo (garante que o fix é aditivo)
- linha com `toolUseResult` string não derruba os spawns seguintes

Verifiquei que revertendo o fix de C o teste falha.

Suíte completa: **1896 cenários, 0 falhas**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h3LpRcNK55CHRA3sdVboe