### PR TITLE
fix(retro): marco deterministico + retro tipada na knowledge.db (5.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.32.0] - 2026-07-27
+
+Fecha o buraco da **retrospectiva proativa por marco**: o gatilho nunca era
+confiavel e, quando rodava, o resultado nao chegava ao painel.
+
+Diagnostico que originou o fix (dois projetos reais, causas diferentes):
+
+- `gamedev-training` (66 ondas): as retros de 25 e 50 ondas **rodaram** e
+  estao no `state.json` como Decisoes (`dec-102`, `dec-194`), com bloqueio
+  humano respondido em cada marco. Mesmo assim o painel mostrava
+  "Sem retros ainda" — a tabela `retros` da `knowledge.db` tinha **0 linhas
+  no indice inteiro**, em todos os projetos, desde que foi criada.
+- `mcp-project-scafold` (31 ondas): nenhuma Decisao de marco, nenhum
+  `next_retrospective_milestone`. A retro simplesmente **nunca disparou**.
+
+### Fixed
+
+- **Retro executada nunca virava dado tipado (`type='retro'`).** O
+  orquestrador registra a retrospectiva de marco como Decisao cujo `context`
+  comeca com `Retrospectiva de marco`, mas `cstk recall --ingest` so lia
+  `.retros[]` do `state.json` — chave que **nenhum script do toolkit jamais
+  escreve** (`grep '\.retros'` em `global/` e `cli/`: zero writers). O
+  resultado era uma tabela permanentemente vazia alimentando um painel que
+  a consulta. O `--ingest` agora **projeta** essas Decisoes em `retros` +
+  FTS, com `source_id = retro-<dec-id>` e `wave` = a onda real da Decisao.
+  A projecao e **aditiva**: a Decisao original continua ingerida como
+  `type='decision'`, trilha de auditoria intacta. Historico recuperavel com
+  `cstk recall --reindex`. A fonte `.retros[]` continua funcionando e as
+  duas coexistem.
+- **Gatilho de marco era prosa, e falhava.** O hook "a cada 25 ondas" vivia
+  so como instrucao em `agente-00c-orchestrator.md` (passo 10) e
+  `agente-00c-feature-orchestrator.md`, dependendo de o orquestrador lembrar
+  de calcular `waves.length % 25` — mesma classe de falha das guardas
+  advisory que a feature `enforced-guards` fechou. Agora quem fecha a onda
+  dispara: `state-ondas.sh end` registra a Decisao, abre o bloqueio LEVE
+  (`sim-rodar-retro` | `nao-continuar`) e avanca
+  `.next_retrospective_milestone`.
+
+### Changed
+
+- **Gatilho de marco e self-healing.** A condicao passou de
+  `waves.length % 25 == 0` para `waves.length >= next_retrospective_milestone`
+  (default 25). Um marco pulado numa onda terminada em bloqueio/aborto passa
+  a disparar na proxima onda que avanca, em vez de se perder ate o proximo
+  multiplo de 25 — exatamente o caso das 31 ondas sem marco.
+- Motivos `bloqueio_humano`, `aborto` e `concluido` **nao** disparam o marco
+  (dois bloqueios competindo confundem a resposta do operador; execucao
+  encerrada nao tem o que fazer com a retro) e **nao consomem** a milestone.
+- A milestone so avanca **depois** de Decisao E bloqueio gravados: falha
+  parcial deixa o marco pendente para nova tentativa.
+- Hook best-effort por contrato: qualquer falha (script irmao ausente,
+  validacao de Principio I, I/O) vira aviso em stderr e **nunca** falha o
+  `end`. Kill-switch por `CSTK_RETRO_MILESTONE_DISABLED=1`.
+- Os dois orquestradores foram atualizados para **nao** registrar o marco na
+  mao (duplicaria Decisao e abriria dois bloqueios) e passaram a documentar
+  o contrato do prefixo `Retrospectiva de marco` no `context` da Decisao que
+  consolida a retro — e esse prefixo que a projecao do `--ingest` consome.
+
+Nenhuma mudanca de schema: `retros` ja existia desde a v1 da `knowledge.db`,
+e o painel ja a consulta. Nenhuma alteracao necessaria no `cstk-panel`.
+
 ## [5.31.0] - 2026-07-26
 
 Corrige os dois bugs que sobraram no `wave-usage-report.sh backfill` — a
@@ -4218,6 +4279,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[5.32.0]: https://github.com/JotJunior/cstk/releases/tag/v5.32.0
 [5.31.0]: https://github.com/JotJunior/cstk/releases/tag/v5.31.0
 [5.30.0]: https://github.com/JotJunior/cstk/releases/tag/v5.30.0
 [5.29.0]: https://github.com/JotJunior/cstk/releases/tag/v5.29.0

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -1480,6 +1480,54 @@ VALUES('$(sql_escape "$_f_txt")','retro','$(sql_escape "$_isj_project")','$(sql_
     IFS="$_isj_OLDIFS"
   fi
 
+  # ---- retros derivadas de Decisao de marco (source_id retro-<dec-id>) ----
+  # A retrospectiva proativa a cada 25 ondas NAO e gravada em `.retros[]`:
+  # o orquestrador a registra como Decisao cujo `context` comeca com
+  # "Retrospectiva de marco" (ver state-ondas.sh `end`, hook marco-aware).
+  # Sem esta derivacao a tabela `retros` fica permanentemente vazia mesmo em
+  # execucoes que rodaram a retro — foi o que aconteceu ate aqui: 0 linhas em
+  # `retros` no indice inteiro, enquanto o texto existia em `decisions`.
+  # A Decisao original CONTINUA ingerida como type='decision' (trilha de
+  # auditoria intacta); esta e uma projecao tipada aditiva, nao um move.
+  # wave preserva o `wave_id` da Decisao (provenancia real), diferente do
+  # 'onda' literal do bloco `.retros[]` acima.
+  _isj_retrodec_lines=$(jq -r '
+    ((.decisions // .decisoes) // [])
+    | to_entries[]
+    | .value as $d
+    | (($d.context // $d.contexto) // "") as $ctx
+    | select($ctx | test("^\\s*Retrospectiva de marco"; "i"))
+    | [($d.id // "dec-\(.key)"),
+       (($d.wave_id // $d.onda_id) // "onda"),
+       (($d.timestamp // $d.data) // ""),
+       ($ctx + " " + ((($d.rationale // $d.justificativa) // "")))]
+    | @base64' "$_isj_state" 2>/dev/null) || _isj_retrodec_lines=""
+  if [ -n "$_isj_retrodec_lines" ]; then
+    _isj_OLDIFS="$IFS"; IFS='
+'
+    for _isj_row in $_isj_retrodec_lines; do
+      _isj_decoded=$(printf '%s' "$_isj_row" | base64 -d 2>/dev/null) || continue
+      _f_decid=$(printf '%s' "$_isj_decoded" | jq -r '.[0]' 2>/dev/null | strip_nul)
+      _f_wave=$(printf '%s' "$_isj_decoded" | jq -r '.[1]' 2>/dev/null | strip_nul)
+      _f_ts=$(printf '%s' "$_isj_decoded" | jq -r '.[2]' 2>/dev/null | strip_nul)
+      _f_txt=$(printf '%s' "$_isj_decoded" | jq -r '.[3]' 2>/dev/null | strip_nul)
+      [ -n "$_f_decid" ] || continue
+      [ -n "$_f_txt" ] || continue
+      _f_txt=$(recall_scrub "$_f_txt")
+      _f_sid="retro-$_f_decid"
+      [ -n "$_f_wave" ] || _f_wave="onda"
+      _isj_sql="$_isj_sql
+INSERT INTO retros(project,feature,wave,execution_id,source_ts,source_id,text,ingested_at)
+VALUES('$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','$(sql_escape "$_f_wave")','$(sql_escape "$_isj_exec_id")','$(sql_escape "$_f_ts")','$(sql_escape "$_f_sid")','$(sql_escape "$_f_txt")','$(sql_escape "$_isj_now")')
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,text=excluded.text,ingested_at=excluded.ingested_at;
+DELETE FROM knowledge_fts WHERE type='retro' AND project='$(sql_escape "$_isj_project")' AND feature='$(sql_escape "$_isj_feature")' AND wave='$(sql_escape "$_f_wave")' AND source_id='$(sql_escape "$_f_sid")';
+INSERT INTO knowledge_fts(body,type,project,feature,wave,source_id,source_ts)
+VALUES('$(sql_escape "$_f_txt")','retro','$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','$(sql_escape "$_f_wave")','$(sql_escape "$_f_sid")','$(sql_escape "$_f_ts")');"
+      _isj_n_retro=$((_isj_n_retro + 1))
+    done
+    IFS="$_isj_OLDIFS"
+  fi
+
   # ---- skills (ondas[].skills_invoked[]; source_id skill-<wave>-<idx>) ----
   # skill_name NAO passa pelo filtro (estruturado, FR-017/INV-DM-3).
   # Entradas kind=gate (gates deterministicos de script, ex.

--- a/global/agents/agente-00c-feature-orchestrator.md
+++ b/global/agents/agente-00c-feature-orchestrator.md
@@ -386,10 +386,10 @@ Sequencia da onda corrente. Cada iteracao:
     knowledge.db (indice derivado/reconstruivel, isolado do state
     transacional). Pular este passo jamais altera o fluxo de
     fechamento/Schedule da onda.
-10.ter (ADITIVO — marco-aware retrospectiva proativa, paridade com
-    agente-00c): a cada 25 ondas (`.waves | length` multiplo de 25),
-    emitir bloqueio LEVE propondo retrospectiva proativa e atualizar
-    `.next_retrospective_milestone`. Ver "## Retrospectiva proativa por
+10.ter (AUTOMATICO — marco-aware retrospectiva proativa, paridade com
+    agente-00c): NAO EXECUTE NADA aqui. O proprio `state-ondas.sh end`
+    dispara o marco a cada 25 ondas (Decisao + bloqueio LEVE + avanco de
+    `.next_retrospective_milestone`). Ver "## Retrospectiva proativa por
     marco (a cada 25 ondas)" abaixo. REGRA: bloqueio LEVE (operador pode
     responder `nao-continuar`); NUNCA gateia a onda por conta propria.
 10.qua (ADITIVO — sugestao para skill global, FR-020): se durante a onda
@@ -1428,40 +1428,41 @@ por conta da camada de sugestoes.
 Paridade com o `agente-00c-orchestrator`. Execucoes longas (features com
 dezenas de ondas) se beneficiam de uma pausa periodica para revisar padroes
 acumulados e detectar falsos-positivos recorrentes ou desvio de finalidade
-ANTES do fim. Apos fechar a onda (passos 10/10.bis), se a contagem de ondas
-for multiplo de 25, emita um bloqueio LEVE:
+ANTES do fim.
 
-```bash
-_ondas_count=$(state-rw.sh get --state-dir "$STATE_DIR" --field '.waves | length')
-if [ $((_ondas_count % 25)) -eq 0 ] && [ "$_ondas_count" -gt 0 ]; then
-  FASE=$(state-rw.sh get --state-dir "$STATE_DIR" --field '.current_stage')
+**O gatilho e do `state-ondas.sh end`, nao seu.** Ao fechar a onda com motivo
+`etapa_concluida_avancando` ou `threshold_proxy_atingido`, se
+`waves.length >= next_retrospective_milestone` (default 25), o proprio `end`:
 
-  # 1. Decisao auditavel (register imprime o id em stdout)
-  DEC_ID=$(state-decisions.sh register --state-dir "$STATE_DIR" \
-    --agente "agente-00c-feature-orchestrator" --etapa "$FASE" \
-    --contexto "Marco de $_ondas_count ondas atingido — proposta de retro proativa" \
-    --opcoes '["solicitar-retro","prosseguir-sem-retro"]' \
-    --escolha "solicitar-retro" \
-    --justificativa "Execucao longa: marcos forcam aprendizado de meta-padroes")
+1. registra a Decisao `Marco de N ondas atingido - proposta de retro proativa`
+   (`solicitar-retro` | `prosseguir-sem-retro`, score 0);
+2. abre o bloqueio LEVE `sim-rodar-retro` | `nao-continuar`;
+3. avanca `.next_retrospective_milestone` para o proximo multiplo de 25.
 
-  # 2. Bloqueio LEVE — operador responde via /feature-00c-resume
-  bloqueios.sh register --state-dir "$STATE_DIR" \
-    --decisao-id "$DEC_ID" \
-    --pergunta "Atingimos $_ondas_count ondas. Revisar padroes acumulados antes de continuar?" \
-    --contexto-para-resposta "Marcos a cada 25 ondas ajudam a detectar falsos positivos recorrentes e desvios de finalidade antes do fim da execucao." \
-    --opcoes-recomendadas '["sim-rodar-retro","nao-continuar"]'
+Ate a versao anterior isto era prosa aqui, e dependia de o orquestrador
+lembrar de calcular `waves.length % 25` — e falhou na pratica (execucao de 31
+ondas sem nenhuma Decisao de marco registrada). Agora e deterministico.
 
-  # 3. Atualiza o proximo marco
-  state-rw.sh set --state-dir "$STATE_DIR" \
-    --field '.next_retrospective_milestone' \
-    --value "$(( (_ondas_count / 25 + 1) * 25 ))"
-fi
-```
+Consequencias para voce:
 
-Como qualquer bloqueio pendente, na proxima iteracao o passo 2 do loop o
-detecta, encerra a onda com `Schedule intent: none` e aguarda a resposta do
-operador (ver "Contrato de conclusao de turno"). Best-effort: falha de
-qualquer helper aqui NUNCA aborta a onda — logue e siga.
+- **NAO** chame `state-decisions.sh`/`bloqueios.sh` para o marco: duplica a
+  Decisao e abre dois bloqueios competindo pela mesma resposta.
+- Quando o marco dispara, `end` loga em stderr `end: marco de N ondas —
+  retrospectiva proposta (dec-NNN/block-NNN)`. Ha bloqueio pendente: o passo
+  2 do loop o detecta na proxima iteracao e encerra a onda com
+  `Schedule intent: none` (ver "Contrato de conclusao de turno").
+- Se o operador responder `sim-rodar-retro`, a retro roda na onda seguinte e
+  o **`context` da Decisao que a consolida DEVE comecar com `Retrospectiva de
+  marco`** — e esse prefixo que `cstk recall --ingest` usa para projetar a
+  retro como `type='retro'` na knowledge.db (e, portanto, exibi-la no
+  painel). Formato:
+  `Retrospectiva de marco (N ondas, block-NNN/dec-NNN): <consolidacao>`.
+- Ondas terminadas em `bloqueio_humano`/`aborto`/`concluido` nao disparam o
+  marco de proposito; ele fica pendente e dispara na proxima onda que
+  avancar.
+
+Best-effort por contrato: qualquer falha do hook NUNCA aborta a onda — `end`
+loga o aviso e a milestone fica intacta para nova tentativa.
 
 ## Gh issue exclusivo (FR-035 + task 4.1.11)
 

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -1681,41 +1681,35 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
     `commit-mode.sh finalize` no caminho de sucesso terminal (passo 9.ter
     acima). Modo desabilitado (default): comportamento atual intacto.
 
-    **Hook marco-aware (a cada 25 ondas):** apos o commit, calcular
-    `next_retrospective_milestone = (waves.length // 25 + 1) * 25`. Se
-    `waves.length` e multiplo de 25 (25, 50, 75, ...), emitir bloqueio
-    LEVE perguntando se o operador deseja revisao/retrospectiva
-    proativa:
+    **Hook marco-aware (a cada 25 ondas) — AUTOMATICO, NAO EXECUTE NA MAO.**
+    O proprio `state-ondas.sh end` dispara a retrospectiva proativa: quando
+    `waves.length >= next_retrospective_milestone` (default 25) e o motivo de
+    termino e `etapa_concluida_avancando` ou `threshold_proxy_atingido`, ele
+    registra a Decisao `Marco de N ondas atingido`, abre o bloqueio LEVE
+    `sim-rodar-retro | nao-continuar` e avanca
+    `.next_retrospective_milestone`.
 
-    ```bash
-    _ondas_count=$(state-rw.sh get --state-dir <SD> --field '.waves | length')
-    if [ $((_ondas_count % 25)) -eq 0 ] && [ "$_ondas_count" -gt 0 ]; then
-      # Registrar Decisao informativa
-      state-decisions.sh register --state-dir <SD> \
-        --agente "orquestrador-00c" --etapa "<atual>" \
-        --contexto "Marco de $_ondas_count ondas atingido — proposta de retro proativa" \
-        --opcoes '["solicitar-retro","prosseguir-sem-retro"]' \
-        --escolha "solicitar-retro" \
-        --justificativa "Execucao longa: marcos forcam aprendizado de meta-padroes (sug-045 da analise pos-execucao)"
+    Ate a versao anterior isto era prosa aqui, e dependia de voce lembrar de
+    calcular `waves.length % 25` — e falhou na pratica (execucao de 31 ondas
+    sem nenhuma Decisao de marco). Agora e deterministico.
 
-      # Bloqueio LEVE — operador pode prosseguir sem retro
-      bloqueios.sh register --state-dir <SD> \
-        --decisao-id <dec-NNN> \
-        --pergunta "Atingimos $_ondas_count ondas. Revisar padroes acumulados antes de continuar?" \
-        --contexto-para-resposta "Marcos a cada 25 ondas ajudam a detectar falsos positivos recorrentes e desvios de finalidade antes do fim da execucao." \
-        --opcoes-recomendadas '["sim-rodar-retro","nao-continuar"]'
-    fi
-    ```
+    Consequencias para voce:
 
-    Note que isto e bloqueio LEVE (operador pode responder
-    `nao-continuar` instantaneamente). Tambem atualizar campo de
-    estado:
-
-    ```bash
-    state-rw.sh set --state-dir <SD> \
-      --field '.next_retrospective_milestone' \
-      --value "$(( (_ondas_count / 25 + 1) * 25 ))"
-    ```
+    - **NAO** chame `state-decisions.sh`/`bloqueios.sh` para o marco. Fazer
+      isso duplica a Decisao e abre dois bloqueios competindo.
+    - Apos `end`, o `stderr` traz `end: marco de N ondas — retrospectiva
+      proposta (dec-NNN/block-NNN)` quando o marco disparou. Nesse caso ha
+      bloqueio pendente: o Schedule intent do passo 11 e
+      `none; motivo=bloqueio_humano`.
+    - Se o operador responder `sim-rodar-retro`, a retro roda na onda
+      seguinte e o **`context` da Decisao que a consolida DEVE comecar com
+      `Retrospectiva de marco`** — e esse prefixo que `cstk recall --ingest`
+      usa para projetar a retro como `type='retro'` na knowledge.db (e,
+      portanto, exibi-la no painel). Formato:
+      `Retrospectiva de marco (N ondas, block-NNN/dec-NNN): <consolidacao>`.
+    - Ondas terminadas em `bloqueio_humano`/`aborto`/`concluido` nao
+      disparam o marco de proposito; ele fica pendente e dispara na proxima
+      onda que avancar.
 
 11. **Preparar Schedule intent da proxima onda** — voce NAO chama
     ScheduleWakeup (o pai chama; ver "DIVISAO DE TRABALHO DE SCHEDULE"

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -309,6 +309,109 @@ _so_agent_usage_read() {
 
 _so_otel_script() { printf '%s/otel-usage.sh\n' "$(_so_self_dir)"; }
 
+# ---------------------------------------------------------------------------
+# Hook marco-aware de retrospectiva proativa (a cada 25 ondas).
+#
+# Antes vivia SO como prosa em agente-00c-orchestrator.md passo 10: dependia
+# do orquestrador lembrar de calcular `waves.length % 25` e disparar. Mesma
+# classe de falha das guardas advisory que a feature enforced-guards fechou —
+# e falhou de fato: mcp-project-scafold chegou a 31 ondas sem NENHUMA Decisao
+# de marco registrada. Aqui o gatilho e deterministico: quem fecha a onda
+# calcula e dispara.
+#
+# Regra de disparo (self-healing): dispara quando `waves.length >=
+# next_retrospective_milestone` (default 25 quando o campo esta ausente), e
+# nao apenas na igualdade exata. Assim um marco pulado por onda terminada em
+# bloqueio/aborto ainda dispara na onda seguinte, em vez de se perder ate o
+# proximo multiplo de 25.
+#
+# Motivos que NAO disparam: bloqueio_humano (ja ha bloqueio pendente — dois
+# bloqueios competindo confundem a resposta do operador), aborto e concluido
+# (execucao encerrada; retro proativa nao tem para onde levar). Nesses casos
+# `next_retrospective_milestone` fica INTACTO de proposito, para o marco
+# disparar na proxima onda que de fato avancar.
+#
+# Best-effort por contrato: qualquer falha aqui (script irmao ausente,
+# validacao de Principio I, I/O) vira aviso em stderr e NUNCA falha `end` —
+# fechar a onda e a operacao critica, registrar o marco nao e. Com a
+# milestone intacta, a proxima onda tenta de novo.
+# ---------------------------------------------------------------------------
+_so_retro_milestone_step() { printf '25\n'; }
+
+# Ecoa "1" se a onda recem-fechada cruzou o marco e o motivo permite disparo.
+_so_retro_milestone_due() {
+  _rm_sf=$1; _rm_motivo=$2
+  case "$_rm_motivo" in
+    etapa_concluida_avancando|threshold_proxy_atingido) ;;
+    *) return 1 ;;
+  esac
+  _rm_step=$(_so_retro_milestone_step)
+  _rm_len=$(jq -r '((.waves // .ondas) // []) | length' "$_rm_sf" 2>/dev/null) || return 1
+  case "$_rm_len" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$_rm_len" -gt 0 ] || return 1
+  _rm_next=$(jq -r '
+    (.next_retrospective_milestone // .proximo_marco_retrospectiva) // ""
+    | tostring' "$_rm_sf" 2>/dev/null) || _rm_next=""
+  case "$_rm_next" in ''|null|*[!0-9]*) _rm_next="$_rm_step" ;; esac
+  [ "$_rm_len" -ge "$_rm_next" ] || return 1
+  return 0
+}
+
+_so_retro_milestone_fire() {
+  _rm_sdir=$1
+  _rm_sf=$(_so_state_file "$_rm_sdir")
+  _rm_dir=$(_so_self_dir) || return 0
+  _rm_dec_sh="$_rm_dir/state-decisions.sh"
+  _rm_blo_sh="$_rm_dir/bloqueios.sh"
+  _rm_rw_sh="$_rm_dir/state-rw.sh"
+  for _rm_f in "$_rm_dec_sh" "$_rm_blo_sh" "$_rm_rw_sh"; do
+    if [ ! -x "$_rm_f" ] && [ ! -f "$_rm_f" ]; then
+      _so_log "end: hook de marco pulado (script irmao ausente: $_rm_f)"
+      return 0
+    fi
+  done
+
+  _rm_step=$(_so_retro_milestone_step)
+  _rm_len=$(jq -r '((.waves // .ondas) // []) | length' "$_rm_sf" 2>/dev/null) || return 0
+  case "$_rm_len" in ''|*[!0-9]*) return 0 ;; esac
+  _rm_etapa=$(jq -r '(.current_stage // .etapa_corrente) // "execute-task"' "$_rm_sf" 2>/dev/null) \
+    || _rm_etapa="execute-task"
+  case "$_rm_etapa" in ''|null) _rm_etapa="execute-task" ;; esac
+
+  _rm_dec=$(sh "$_rm_dec_sh" register --state-dir "$_rm_sdir" \
+    --agente "orquestrador-00c" --etapa "$_rm_etapa" \
+    --score 0 \
+    --contexto "Marco de $_rm_len ondas atingido - proposta de retro proativa (gatilho deterministico de state-ondas.sh end)" \
+    --opcoes '["solicitar-retro","prosseguir-sem-retro"]' \
+    --escolha "solicitar-retro" \
+    --justificativa "Execucao longa: marcos a cada $_rm_step ondas forcam aprendizado de meta-padroes e deteccao de desvio de proposito antes do fim da execucao." \
+    2>/dev/null) || _rm_dec=""
+  if [ -z "$_rm_dec" ]; then
+    _so_log "end: hook de marco pulado (falha ao registrar Decisao; marco continua pendente)"
+    return 0
+  fi
+
+  _rm_blk=$(sh "$_rm_blo_sh" register --state-dir "$_rm_sdir" \
+    --decisao-id "$_rm_dec" \
+    --pergunta "Atingimos $_rm_len ondas. Revisar padroes acumulados (retrospectiva de marco) antes de continuar?" \
+    --contexto-para-resposta "Marcos a cada $_rm_step ondas ajudam a detectar falsos positivos recorrentes, loops de etapa e desvios de finalidade antes do fim da execucao. Responder 'nao-continuar' prossegue sem custo." \
+    --opcoes-recomendadas '["sim-rodar-retro","nao-continuar"]' \
+    2>/dev/null) || _rm_blk=""
+  if [ -z "$_rm_blk" ]; then
+    _so_log "end: hook de marco parcial ($_rm_dec registrada, bloqueio falhou; marco continua pendente)"
+    return 0
+  fi
+
+  # So agora avanca a milestone: com Decisao E bloqueio no state, o marco
+  # esta de fato consumido e nao pode redisparar na proxima onda.
+  _rm_new=$(( (_rm_len / _rm_step + 1) * _rm_step ))
+  sh "$_rm_rw_sh" set --state-dir "$_rm_sdir" \
+    --field '.next_retrospective_milestone' --value "$_rm_new" >/dev/null 2>&1 \
+    || _so_log "end: marco disparado ($_rm_dec/$_rm_blk) mas falhou ao gravar next_retrospective_milestone=$_rm_new"
+
+  _so_log "end: marco de $_rm_len ondas — retrospectiva proposta ($_rm_dec/$_rm_blk); proximo marco=$_rm_new"
+}
+
 # _so_otel_snapshot DIR PHASE — nunca falha a onda.
 _so_otel_snapshot() {
   _ots=$(_so_otel_script)
@@ -598,6 +701,14 @@ $2"; shift 2 ;;
   _so_agent_usage_reset "$_sdir"
   _so_otel_reset "$_sdir"
   _so_log "end: onda finalizada (motivo=$_motivo, wallclock=${_wc}s, tool_calls=$_tc)"
+
+  # Hook marco-aware — DEPOIS do write/sha da onda, porque registra Decisao e
+  # bloqueio com writes atomicos proprios. Best-effort: nao altera o exit de
+  # `end`. Ver bloco de comentario em _so_retro_milestone_fire.
+  if [ "${CSTK_RETRO_MILESTONE_DISABLED:-0}" != 1 ] \
+     && _so_retro_milestone_due "$_sf" "$_motivo"; then
+    _so_retro_milestone_fire "$_sdir" || :
+  fi
 }
 
 _so_cmd_tool_call_tick() {

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -3490,4 +3490,127 @@ INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,session,
   return 0
 }
 
+# =========================================================================
+# Retro derivada de Decisao de marco.
+#
+# Regressao real: a retrospectiva proativa a cada 25 ondas e gravada como
+# Decisao (context com prefixo "Retrospectiva de marco"), nunca em
+# `.retros[]`. Como o --ingest so lia `.retros[]`, a tabela `retros` ficava
+# vazia mesmo em execucoes que RODARAM a retro — o indice global tinha 0
+# linhas em `retros` com duas retros reais em `decisions`.
+# =========================================================================
+
+# state.json com 1 Decisao de marco + 1 Decisao comum (controle).
+_write_state_retro_dec() {
+  _wr_dir="$1"; _wr_proj="$2"; _wr_feat="$3"
+  mkdir -p "$_wr_dir"
+  cat > "$_wr_dir/state.json" <<JSON
+{
+  "short_name": "$_wr_feat",
+  "execution": { "id": "exec-$_wr_feat", "target_project_path": "$_wr_proj" },
+  "decisions": [
+    { "id": "dec-050", "wave_id": "onda-025", "timestamp": "2026-02-01T00:00:00Z",
+      "stage": "execute-task", "agent": "orch", "choice": "solicitar-retro",
+      "options_considered": ["solicitar-retro", "prosseguir-sem-retro"],
+      "context": "Marco de 25 ondas atingido - proposta de retro proativa",
+      "rationale": "marcos forcam aprendizado de meta-padroes", "evidence": null },
+    { "id": "dec-051", "wave_id": "onda-026", "timestamp": "2026-02-02T00:00:00Z",
+      "stage": "execute-task", "agent": "orch", "choice": "prosseguir",
+      "options_considered": ["prosseguir"],
+      "context": "Retrospectiva de marco (25 ondas, block-004/dec-050): consolidacao de padroes zebra",
+      "rationale": "nenhum desvio de proposito encontrado nas 25 ondas", "evidence": null }
+  ]
+}
+JSON
+}
+
+scenario_retro_derivada_de_decisao_de_marco() {
+  _have_deps || return 0
+  _rd_sd="$TMPDIR_TEST/featRetro"
+  _rd_db="$TMPDIR_TEST/kretro.db"
+  _write_state_retro_dec "$_rd_sd" "/home/u/projRetro" "featRetro"
+  capture _rc --ingest --state-dir "$_rd_sd" --db "$_rd_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "ingest" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "1 retros" || return 1
+
+  # Apenas a Decisao com prefixo "Retrospectiva de marco" vira retro; a
+  # Decisao que apenas PROPOE a retro (dec-050) nao entra.
+  _got=$(sqlite3 "$_rd_db" "SELECT source_id||'|'||wave FROM retros;")
+  [ "$_got" = "retro-dec-051|onda-026" ]     || { _fail "retro derivada" "esperado 'retro-dec-051|onda-026', obtido '$_got'"; return 1; }
+
+  # Projecao ADITIVA: a Decisao original continua na trilha de auditoria.
+  _n=$(sqlite3 "$_rd_db" "SELECT count(*) FROM decisions;")
+  [ "$_n" = "2" ] || { _fail "decisions" "esperado 2 decisoes preservadas, obtido '$_n'"; return 1; }
+  _n=$(sqlite3 "$_rd_db" "SELECT count(*) FROM knowledge_fts WHERE type='decision' AND source_id='dec-051';")
+  [ "$_n" = "1" ] || { _fail "fts decision" "dec-051 sumiu do type=decision (esperado projecao, nao move)"; return 1; }
+
+  # Corpo da retro concatena context + rationale, EM UMA LINHA SO: o render
+  # da busca e line-based (while read), entao \n no body quebraria a saida.
+  _lines=$(sqlite3 "$_rd_db" "SELECT text FROM retros;" | wc -l | tr -d ' ')
+  [ "$_lines" = "1" ] || { _fail "body" "text da retro tem $_lines linhas, esperado 1"; return 1; }
+  _txt=$(sqlite3 "$_rd_db" "SELECT text FROM retros;")
+  case "$_txt" in
+    *"padroes zebra"*"nenhum desvio de proposito"*) : ;;
+    *) _fail "body" "esperado context + rationale concatenados, obtido '$_txt'"; return 1 ;;
+  esac
+  return 0
+}
+
+scenario_retro_derivada_busca_por_tipo() {
+  _have_deps || return 0
+  _rb_sd="$TMPDIR_TEST/featRetroB"
+  _rb_db="$TMPDIR_TEST/kretrob.db"
+  _write_state_retro_dec "$_rb_sd" "/home/u/projRetroB" "featRetroB"
+  capture _rc --ingest --state-dir "$_rb_sd" --db "$_rb_db"
+  capture _rc "zebra" --type retro --db "$_rb_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "busca" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "[retro]" || return 1
+  assert_stdout_contains "retro-dec-051" || return 1
+  assert_stdout_contains "onda-026" || return 1
+  return 0
+}
+
+scenario_retro_derivada_idempotente() {
+  _have_deps || return 0
+  _ri_sd="$TMPDIR_TEST/featRetroC"
+  _ri_db="$TMPDIR_TEST/kretroc.db"
+  _write_state_retro_dec "$_ri_sd" "/home/u/projRetroC" "featRetroC"
+  capture _rc --ingest --state-dir "$_ri_sd" --db "$_ri_db"
+  capture _rc --ingest --state-dir "$_ri_sd" --db "$_ri_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "ingest#2" "$_CAPTURED_STDERR"; return 1; }
+  _n=$(sqlite3 "$_ri_db" "SELECT count(*) FROM retros;")
+  [ "$_n" = "1" ] || { _fail "idempotencia" "esperado 1 retro apos 2 ingests, obtido '$_n'"; return 1; }
+  _n=$(sqlite3 "$_ri_db" "SELECT count(*) FROM knowledge_fts WHERE type='retro';")
+  [ "$_n" = "1" ] || { _fail "idempotencia fts" "esperado 1 entrada FTS, obtido '$_n'"; return 1; }
+  return 0
+}
+
+# As duas fontes coexistem: `.retros[]` (legado) e a projecao de Decisao.
+scenario_retro_derivada_coexiste_com_retros_array() {
+  _have_deps || return 0
+  _rx_sd="$TMPDIR_TEST/featRetroD"
+  _rx_db="$TMPDIR_TEST/kretrod.db"
+  mkdir -p "$_rx_sd"
+  cat > "$_rx_sd/state.json" <<'JSON'
+{
+  "short_name": "featRetroD",
+  "execution": { "id": "exec-featRetroD", "target_project_path": "/home/u/projRetroD" },
+  "retros": [ { "text": "retro legada em texto livre", "timestamp": "2026-02-03T00:00:00Z" } ],
+  "decisions": [
+    { "id": "dec-077", "wave_id": "onda-050", "timestamp": "2026-02-04T00:00:00Z",
+      "stage": "execute-task", "agent": "orch", "choice": "ok",
+      "options_considered": ["ok"],
+      "context": "Retrospectiva de marco (50 ondas): consolidacao girafa",
+      "rationale": "sem loop_em_etapa detectado", "evidence": null }
+  ]
+}
+JSON
+  capture _rc --ingest --state-dir "$_rx_sd" --db "$_rx_db"
+  [ "$_CAPTURED_EXIT" = "0" ] || { _fail "ingest" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "2 retros" || return 1
+  _got=$(sqlite3 "$_rx_db" "SELECT group_concat(source_id, ',') FROM (SELECT source_id FROM retros ORDER BY source_id);")
+  [ "$_got" = "retro-dec-077,retro-onda-0" ]     || { _fail "coexistencia" "esperado 'retro-dec-077,retro-onda-0', obtido '$_got'"; return 1; }
+  return 0
+}
+
 run_all_scenarios

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -1299,4 +1299,157 @@ scenario_end_otel_usage_captura_delta_da_onda() {
   return 0
 }
 
+# ---------------------------------------------------------------------------
+# Hook marco-aware de retrospectiva proativa (a cada 25 ondas).
+#
+# Regressao real: o gatilho vivia SO como prosa no agente-00c-orchestrator.md
+# e dependia de o orquestrador lembrar de calcular `waves.length % 25`.
+# Falhou em producao (execucao de 31 ondas sem NENHUMA Decisao de marco).
+# Aqui o gatilho e do proprio `end`, entao e testavel.
+# ---------------------------------------------------------------------------
+
+# Injeta N ondas JA FECHADAS direto no state (muito mais rapido que N
+# start/end reais, que so somariam custo de jq sem cobrir nada a mais).
+_seed_waves() {
+  _sw_sd=$1; _sw_n=$2
+  _sw_tmp="$_sw_sd/state.seed.json"
+  jq --argjson n "$_sw_n" '
+    .waves = [range(0; $n) | {
+      id: ("onda-" + (("00" + ((.+1)|tostring)) | .[-3:])),
+      started_at: "2026-01-01T00:00:00Z",
+      finished_at: "2026-01-01T00:01:00Z",
+      wallclock_seconds: 60,
+      tool_calls: 0,
+      termination_reason: "etapa_concluida_avancando",
+      next_wave_scheduled_for: null,
+      executed_stages: [],
+      skills_invoked: [],
+      touched_key_aspects: []
+    }]
+  ' "$_sw_sd/state.json" > "$_sw_tmp" && mv -f "$_sw_tmp" "$_sw_sd/state.json"
+  capture "$RW" sha256-update --state-dir "$_sw_sd"
+}
+
+# Fecha a onda de indice N (seed de N-1 + um start/end real).
+_close_wave_n() {
+  _cw_sd=$1; _cw_n=$2; _cw_motivo=$3
+  _seed_waves "$_cw_sd" "$((_cw_n - 1))"
+  capture "$SCRIPT" start --state-dir "$_cw_sd"
+  capture "$SCRIPT" end --state-dir "$_cw_sd" --motivo-termino "$_cw_motivo"
+}
+
+scenario_marco_25_dispara_decisao_e_bloqueio() {
+  _sd="$TMPDIR_TEST/state-marco25"
+  _init_state "$_sd"
+  _close_wave_n "$_sd" 25 etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "marco de 25 ondas" || return 1
+
+  _n=$(jq -r '.decisions | length' "$_sd/state.json")
+  [ "$_n" = 1 ] || { _fail "decisoes" "esperado 1 Decisao de marco, obtido $_n"; return 1; }
+  _ctx=$(jq -r '.decisions[-1].context' "$_sd/state.json")
+  case "$_ctx" in
+    "Marco de 25 ondas atingido"*) : ;;
+    *) _fail "context" "esperado prefixo 'Marco de 25 ondas atingido', obtido '$_ctx'"; return 1 ;;
+  esac
+  _n=$(jq -r '.human_blocks | length' "$_sd/state.json")
+  [ "$_n" = 1 ] || { _fail "bloqueios" "esperado 1 bloqueio LEVE, obtido $_n"; return 1; }
+  # Bloqueio linkado a Decisao (Principio I) e LEVE (operador pode recusar).
+  _dec=$(jq -r '.decisions[-1].id' "$_sd/state.json")
+  _lnk=$(jq -r '.human_blocks[-1].decision_id' "$_sd/state.json")
+  [ "$_dec" = "$_lnk" ] || { _fail "link" "bloqueio aponta '$_lnk', Decisao e '$_dec'"; return 1; }
+  jq -e '.human_blocks[-1].recommended_options | index("nao-continuar")' "$_sd/state.json" >/dev/null     || { _fail "opcoes" "bloqueio precisa oferecer 'nao-continuar' (LEVE)"; return 1; }
+  # Milestone so avanca DEPOIS de Decisao + bloqueio gravados.
+  _ms=$(jq -r '.next_retrospective_milestone' "$_sd/state.json")
+  [ "$_ms" = 50 ] || { _fail "milestone" "esperado 50, obtido '$_ms'"; return 1; }
+  _st=$(jq -r '.execution.status' "$_sd/state.json")
+  [ "$_st" = "aguardando_humano" ] || { _fail "status" "esperado aguardando_humano, obtido '$_st'"; return 1; }
+  return 0
+}
+
+scenario_marco_nao_redispara_na_onda_seguinte() {
+  _sd="$TMPDIR_TEST/state-marco-idem"
+  _init_state "$_sd"
+  _close_wave_n "$_sd" 25 etapa_concluida_avancando
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end onda 26" "$_CAPTURED_STDERR"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"marco de 26 ondas"*) _fail "idempotencia" "marco redisparou na onda 26"; return 1 ;;
+  esac
+  _n=$(jq -r '.decisions | length' "$_sd/state.json")
+  [ "$_n" = 1 ] || { _fail "idempotencia" "marco redisparou: $_n Decisoes"; return 1; }
+  _n=$(jq -r '.human_blocks | length' "$_sd/state.json")
+  [ "$_n" = 1 ] || { _fail "idempotencia" "marco redisparou: $_n bloqueios"; return 1; }
+  return 0
+}
+
+# Motivos terminais/bloqueados nao disparam, e — critico — NAO consomem a
+# milestone: ela fica pendente para a proxima onda que de fato avancar.
+scenario_marco_nao_dispara_em_motivo_terminal() {
+  for _m in bloqueio_humano aborto concluido; do
+    _sd="$TMPDIR_TEST/state-marco-$_m"
+    _init_state "$_sd"
+    _close_wave_n "$_sd" 25 "$_m"
+    [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end $_m" "$_CAPTURED_STDERR"; return 1; }
+    _n=$(jq -r '.decisions | length' "$_sd/state.json")
+    [ "$_n" = 0 ] || { _fail "motivo=$_m" "nao devia registrar Decisao de marco (obtido $_n)"; return 1; }
+    _ms=$(jq -r '.next_retrospective_milestone // "ausente"' "$_sd/state.json")
+    [ "$_ms" = "ausente" ] || { _fail "motivo=$_m" "milestone consumida sem disparo ('$_ms')"; return 1; }
+  done
+  return 0
+}
+
+# Self-healing: o gatilho e `>= milestone`, nao `% 25 == 0`. Uma execucao que
+# passou de 25 sem disparar (exatamente o caso mcp-project-scafold, 31 ondas
+# sem marco) dispara na primeira onda que avanca, em vez de esperar a 50a.
+scenario_marco_dispara_atrasado_quando_passou_do_multiplo() {
+  _sd="$TMPDIR_TEST/state-marco-atrasado"
+  _init_state "$_sd"
+  _close_wave_n "$_sd" 31 etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "marco de 31 ondas" || return 1
+  _ms=$(jq -r '.next_retrospective_milestone' "$_sd/state.json")
+  [ "$_ms" = 50 ] || { _fail "milestone" "esperado 50 para 31 ondas, obtido '$_ms'"; return 1; }
+  return 0
+}
+
+scenario_marco_desligavel_por_env() {
+  _sd="$TMPDIR_TEST/state-marco-off"
+  _init_state "$_sd"
+  CSTK_RETRO_MILESTONE_DISABLED=1; export CSTK_RETRO_MILESTONE_DISABLED
+  _close_wave_n "$_sd" 25 etapa_concluida_avancando
+  _e=$_CAPTURED_EXIT; _err=$_CAPTURED_STDERR
+  unset CSTK_RETRO_MILESTONE_DISABLED
+  [ "$_e" = 0 ] || { _fail "end" "$_err"; return 1; }
+  _n=$(jq -r '.decisions | length' "$_sd/state.json")
+  [ "$_n" = 0 ] || { _fail "kill-switch" "marco disparou com CSTK_RETRO_MILESTONE_DISABLED=1"; return 1; }
+  return 0
+}
+
+# Contrato best-effort: registrar o marco NUNCA pode derrubar o fechamento da
+# onda. Sem os scripts irmaos, `end` ainda fecha a onda com exit 0 e a
+# milestone fica intacta (nova tentativa na proxima onda).
+scenario_marco_falho_nao_derruba_end() {
+  _sd="$TMPDIR_TEST/state-marco-bestefort"
+  _init_state "$_sd"
+  _seed_waves "$_sd" 24
+  # Copia do diretorio de scripts SEM os irmaos que o hook precisa. Copia o
+  # diretorio inteiro porque state-ondas.sh sourceia _diag.sh — a ausencia
+  # sob teste e a dos helpers do HOOK, nao a do runtime de diagnostico.
+  _iso="$TMPDIR_TEST/iso-scripts"
+  rm -rf "$_iso"; mkdir -p "$_iso"
+  cp "$REPO_ROOT/global/skills/agente-00c-runtime/scripts/"*.sh "$_iso/"
+  rm -f "$_iso/state-decisions.sh" "$_iso/bloqueios.sh"
+  capture "$_iso/state-ondas.sh" start --state-dir "$_sd"
+  capture "$_iso/state-ondas.sh" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "hook derrubou o fechamento da onda: $_CAPTURED_STDERR"; return 1; }
+  # A onda FOI fechada de verdade.
+  _tr=$(jq -r '.waves[-1].termination_reason' "$_sd/state.json")
+  [ "$_tr" = "etapa_concluida_avancando" ] || { _fail "onda" "onda nao foi fechada ('$_tr')"; return 1; }
+  _ms=$(jq -r '.next_retrospective_milestone // "ausente"' "$_sd/state.json")
+  [ "$_ms" = "ausente" ] || { _fail "milestone" "consumida apesar do hook ter falhado ('$_ms')"; return 1; }
+  return 0
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Contexto

O operador reportou que as retrospectivas de marco de `mcp-project-scafold` e `gamedev-training` não apareciam no painel. A investigação achou **duas causas diferentes**, uma em cada projeto — e nenhuma delas era bug de UI.

| Projeto | Ondas | O que aconteceu |
|---|---|---|
| `gamedev-training` | 66 | Retros de 25 e 50 **rodaram** (`dec-102`, `dec-194`, com bloqueio humano respondido em cada marco), mas nunca viraram dado tipado |
| `mcp-project-scafold` | 31 | Nenhuma Decisão de marco, nenhum `next_retrospective_milestone` — a retro **nunca disparou** |

## Fix 1 — ingestão (`cli/lib/recall.sh`)

O orquestrador registra a retro como Decisão cujo `context` começa com `Retrospectiva de marco`, mas o `--ingest` só lia `.retros[]` do `state.json` — chave que **nenhum script do toolkit jamais escreve** (`grep '\.retros'` em `global/` e `cli/`: zero writers). Resultado: a tabela `retros` tinha **0 linhas no índice inteiro**, em todos os 15 projetos, desde que foi criada — alimentando um painel que a consulta.

O `--ingest` agora **projeta** essas Decisões em `retros` + FTS (`source_id = retro-<dec-id>`, `wave` = a onda real da Decisão).

- **Aditivo, não move**: a Decisão original continua ingerida como `type='decision'`, trilha de auditoria intacta
- Body concatena `context` + `rationale` em **uma linha só** — o render da busca é line-based e um `\n` quebraria a saída (coberto por teste)
- Histórico recuperável com `cstk recall --reindex`
- A fonte `.retros[]` legada continua funcionando; as duas coexistem

Verificado contra o `state.json` real do gamedev-training: 2 retros ingeridas, buscáveis por `--type retro`.

## Fix 2 — gatilho (`state-ondas.sh end`)

O hook "a cada 25 ondas" vivia só como prosa nos dois orquestradores, dependendo de o modelo lembrar de calcular `waves.length % 25` — mesma classe de falha das guardas advisory que a feature `enforced-guards` fechou. Agora quem fecha a onda dispara.

Mudanças de semântica:

- **Self-healing**: gatilho passou de `% 25 == 0` para `waves.length >= next_retrospective_milestone`. Marco pulado numa onda terminada em bloqueio/aborto dispara na próxima onda que avança, em vez de se perder até o próximo múltiplo — exatamente o caso das 31 ondas sem marco
- Motivos `bloqueio_humano`/`aborto`/`concluido` não disparam (dois bloqueios competindo confundem a resposta do operador) e **não consomem** a milestone
- A milestone só avança **depois** de Decisão E bloqueio gravados: falha parcial deixa o marco pendente para nova tentativa
- Best-effort por contrato: qualquer falha do hook vira aviso em stderr e **nunca** falha o `end`. Kill-switch: `CSTK_RETRO_MILESTONE_DISABLED=1`

Os dois orquestradores passaram a **não** registrar o marco na mão (duplicaria Decisão e abriria dois bloqueios) e documentam o contrato do prefixo `Retrospectiva de marco` — é ele que a projeção do `--ingest` consome.

## Sem mudança de schema

`retros` existe desde a v1 da knowledge.db e o `cstk-panel` já a consulta (`apps/server/src/db/queries/retros.ts` → `FeatureDetail.tsx`). O "Sem retros ainda" que o operador via era a tabela vazia. **Nenhuma alteração necessária no painel.**

## Testes

| Suite | Resultado |
|---|---|
| `tests/test_state-ondas.sh` | 84/84 (6 cenários novos) |
| `tests/cstk/test_recall.sh` | 125/125 (4 cenários novos) |
| Suíte completa | 1905 PASS |

Cobertura nova: dispara na onda 25 · não redispara na 26 · dispara atrasado com 31 ondas · não dispara em motivo terminal (e não consome a milestone) · kill-switch por env · hook falho não derruba o `end` · projeção só do prefixo certo · Decisão preservada como `type='decision'` · body em linha única · idempotência · coexistência com `.retros[]`.

> Nota de ambiente: a suíte completa acusa 1 falha em `test_otel-usage.sh::scenario_delta_subtrai_contadores_cumulativos` **apenas sob locale `pt_BR.UTF-8`** (vírgula decimal). Verificado como pré-existente num worktree limpo de `main` e passa 17/17 com `LC_ALL=C` — CI roda em locale C. Não relacionado a este PR; vale um fix de portabilidade separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxmKNj2FSigXVyzHsT9wn8