### PR TITLE
docs(readme): destaca ativação da telemetria logo após a instalação

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh
 > track — adopt it when you want the SDD pipeline to run end to end without you
 > driving each step.
 
+### After installing: turn on cost and token capture
+
+Two environment variables — **no API key, no Admin key, no organization**;
+works on subscription plans:
+
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=prometheus
+```
+
+With these, every orchestrator wave records its **real** consumption (cost and
+tokens, separating `main` from `subagent`) in `.waves[N].otel_usage`, and the
+panel shows per-wave spend. Without them everything is a no-op and the field
+stays `null` — absent, never a fabricated zero. Put them in your
+`~/.zshrc`/`~/.bashrc` so you don't lose waves to forgetfulness.
+
+Nothing leaves the machine (exporter binds `127.0.0.1:9464`) and identity
+labels are stripped before touching disk. Details, measured numbers and how to
+change the port: [Real per-wave cost](#real-per-wave-cost-otel-usagesh).
+
 ## Structure
 
 ```

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -54,6 +54,26 @@ curl -fsSL https://github.com/JotJunior/cstk/releases/latest/download/install.sh
 > — adote quando quiser que o pipeline SDD rode de ponta a ponta sem você
 > conduzir cada etapa.
 
+### Depois de instalar: ative a captura de custo e tokens
+
+Duas variáveis de ambiente — **sem API key, sem Admin key, sem organização**;
+funciona em plano de assinatura:
+
+```bash
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=prometheus
+```
+
+Com elas, cada onda do orquestrador passa a registrar o consumo **real**
+(custo e tokens, separando `main` de `subagent`) em `.waves[N].otel_usage`,
+e o painel mostra o gasto por onda. Sem elas tudo é no-op e o campo fica
+`null` — ausente, nunca zero fabricado. Ponha no seu `~/.zshrc`/`~/.bashrc`
+para não perder ondas por esquecimento.
+
+Nada sai da máquina (exporter em `127.0.0.1:9464`) e labels de identidade são
+descartados antes de tocar o disco. Detalhes, números medidos e como mudar a
+porta: [Custo real por onda](#custo-real-por-onda-otel-usagesh).
+
 ## Estrutura
 
 ```


### PR DESCRIPTION
## Problema

As duas variáveis que ligam a captura de custo/tokens por onda **já estavam documentadas** — mas na linha 279, dentro de `## Instalação`, três subseções abaixo, depois de perfis e hooks do runtime 00c.

Na prática ninguém chega lá. Quem instala e começa a rodar ondas nunca vê, e `.waves[N].otel_usage` fica `null` na execução inteira sem a pessoa saber que era opt-in — foi exatamente o que aconteceu com o operador.

## Mudança

Sobe um bloco curto para logo depois da trilha básica de 3 passos:

```bash
export CLAUDE_CODE_ENABLE_TELEMETRY=1
export OTEL_METRICS_EXPORTER=prometheus
```

Com o mínimo acionável — o que muda ao ligar, que sem elas o campo fica `null` (ausente, nunca zero fabricado), sugestão de pôr no `~/.zshrc` — e link para a seção completa, que segue sendo a fonte dos detalhes: números medidos, `CSTK_OTEL_ENDPOINT` para porta customizada, política de descarte de labels de identidade.

Sem duplicar conteúdo: o bloco novo é ponteiro + o essencial. Aplicado nos **dois** READMEs (EN + pt-BR) para não criar drift.

## Verificação

- `tests/run.sh test_doc-counts` — 3/3 (a contagem de skills no README continua batendo)
- Âncoras conferidas contra os headings reais: `#custo-real-por-onda-otel-usagesh` (pt-BR, linha 279) e `#real-per-wave-cost-otel-usagesh` (EN, linha 279)
- README não é consumido pelo `docs-site/hooks/gen_pages.py`, então não há risco no build mkdocs `--strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxmKNj2FSigXVyzHsT9wn8