### PR TITLE
fix(otel-usage): delta OTel por sessao (elimina onda bit-identica 212M/$88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.33.1] - 2026-07-28
+
+Corrige o delta OTel por onda que fabricava consumo. Caso real: com a porta
+9464 ocupada por um processo `claude -c` longevo, as 14 ondas da execucao
+`dashboard-refactor` (cstk-panel) gravaram `otel_usage` bit-identico
+(212.447.680 tokens / $88) — o "delta" era o acumulado congelado do
+exporter, nao o consumo da onda. A onda-015 caiu no guard e ficou `null`
+(comportamento correto que denunciou o resto).
+
+### Fixed
+
+- **`otel-usage.sh`: delta agora agrega por sessao.** Duas causas
+  combinadas: (1) o parse descartava o `session_id` das linhas — o mesmo
+  exporter pode expor MAIS de uma sessao, e o acumulado das sessoes
+  congeladas entrava na soma; o guard antigo comparava so o header
+  `# session_id` (primeira ocorrencia de cada arquivo) e passava com
+  mistura; (2) a chave do join `(source, model, type)` colide entre linhas
+  que o exporter separa por `agent_name`/`skill_name`/`effort` — o awk
+  sobrescrevia a base (`s[k]=$4`) e imprimia cada duplicata do end contra
+  essa base unica, transformando o "delta" em acumulado. O snapshot agora
+  emite TSV de 5 colunas (`session_id` por linha) e o delta SOMA duplicatas
+  nos dois lados, agrega por sessao e so aceita o resultado quando
+  EXATAMENTE UMA sessao cresceu entre os snapshots — crescimento que, por
+  construcao, ocorreu dentro da janela da onda.
+- **Ausente nunca e zero fabricado (Principio VI), agora tambem para
+  ambiguidade de sessao**: mais de uma sessao ativa no exporter, sessao do
+  start ausente no end (processo dono da porta trocou) e snapshot em
+  formato antigo (4 colunas) viram `null` com aviso em stderr — nunca
+  chute. O `session_id` do OTel NAO e usado como identidade da sessao
+  corrente (label ja observado apontando para outra sessao/projeto); a
+  atribuicao e por deteccao de crescimento, sem match contra env.
+- 5 cenarios novos em `tests/test_otel-usage.sh` (INV-6: soma de
+  duplicatas; INV-7: isolamento por sessao, incluindo reproducao do caso
+  real com sessao congelada de 212M tokens) e guard antigo renomeado para
+  `scenario_delta_sessao_do_start_sumida_e_null`.
+
+Nota de operacao: execucoes ja contaminadas nao se corrigem sozinhas —
+anular `.waves[].otel_usage` das ondas afetadas no `state.json` (seguido de
+`state-rw.sh sha256-update`) e rodar `cstk recall --ingest --state-dir
+<dir>` corrige `waves`; linhas orfas em `wave_model_usage` exigem DELETE
+manual, porque onda `null` nao regrava essa tabela por design (FR-004).
+
 ## [5.33.0] - 2026-07-28
 
 Fecha a perda de dimensoes do OTel na ingestao: o `state.json` sempre teve o
@@ -4279,6 +4321,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[5.33.1]: https://github.com/JotJunior/cstk/releases/tag/v5.33.1
 [5.33.0]: https://github.com/JotJunior/cstk/releases/tag/v5.33.0
   tabela por stack.
 

--- a/global/skills/agente-00c-runtime/scripts/otel-usage.sh
+++ b/global/skills/agente-00c-runtime/scripts/otel-usage.sh
@@ -52,14 +52,41 @@
 #
 #   otel-usage.sh snapshot --state-dir DIR --phase start|end [--endpoint URL]
 #       — Scrape + filtro + strip de PII -> <state-dir>/otel-<phase>.tsv
-#         (TSV: query_source \t model \t type \t value; `type` = "cost" na
-#         linha de custo). Best-effort: endpoint fora do ar -> exit 0 sem
-#         escrever, a onda segue normal.
+#         (TSV: session_id \t query_source \t model \t type \t value;
+#         `type` = "cost" na linha de custo). Best-effort: endpoint fora
+#         do ar -> exit 0 sem escrever, a onda segue normal.
 #
 #   otel-usage.sh delta --state-dir DIR
-#       — end - start por chave, em JSON no stdout. Sem os dois snapshots,
-#         imprime `null` e sai 0 (metrica ausente NUNCA e zero fabricado —
-#         Principio VI).
+#       — end - start por chave (session, source, model, type), duplicatas
+#         SOMADAS, resultado atribuido a UNICA sessao que cresceu (ver
+#         bloco MULTIPLAS SESSOES). JSON no stdout. Sem os dois snapshots,
+#         mais de uma sessao ativa, processo trocado ou snapshot em
+#         formato antigo: imprime `null` e sai 0 (metrica ausente NUNCA e
+#         zero fabricado — Principio VI).
+#
+# MULTIPLAS SESSOES NO MESMO EXPORTER (bug real, 2026-07-28)
+# ----------------------------------------------------------
+# O processo dono da porta 9464 pode ser um claude -c longevo que expoe
+# metricas de MAIS DE UMA sessao — inclusive sessoes paradas ha horas,
+# congeladas com acumulado gigante. Na execucao dashboard-refactor, 14
+# ondas gravaram 212.447.680 tokens / $88 bit-identicos porque:
+#   (a) o parse descartava o session_id das linhas, somando o historico
+#       de todas as sessoes do processo; e
+#   (b) a chave do join (source, model, type) colide entre linhas que o
+#       exporter separa por agent_name/skill_name/effort — o awk
+#       sobrescrevia a base (s[k]=$4) e imprimia cada duplicata do end
+#       contra essa base unica, transformando o "delta" no acumulado.
+# O delta agora agrega por sessao (duplicatas somadas) e so aceita o
+# resultado quando EXATAMENTE UMA sessao cresceu entre os snapshots —
+# crescimento que, por construcao, aconteceu dentro da janela da onda.
+# Sessao congelada tem delta 0 e nao contamina. Dois casos continuam
+# indecidiveis e viram null (nunca chute):
+#   - mais de uma sessao cresceu (outro claude ativo no mesmo exporter);
+#   - sessao do start ausente no end (o processo dono da porta trocou;
+#     num exporter vivo sessao nunca some — contador e cumulativo).
+# NOTA: o session_id do OTel nao serve como IDENTIDADE da sessao corrente
+# (label ja observado apontando para outra sessao/projeto), por isso NAO
+# ha match contra env — apenas deteccao de crescimento por sessao.
 #
 # Exit codes:
 #   0  sucesso, ou degradacao best-effort (sem telemetria disponivel)
@@ -103,11 +130,16 @@ _ou_scrape() {
   return 0
 }
 
-# _ou_parse INFILE -> TSV em stdout: query_source \t model \t type \t value
+# _ou_parse INFILE -> TSV em stdout:
+#   session_id \t query_source \t model \t type \t value
 #
 # Formato de entrada (verificado empiricamente contra Claude Code 2.1.220):
 #   claude_code_cost_usage_total{...,model="X",query_source="Y",...} 0.000637
 #   claude_code_token_usage_total{...,query_source="Y",type="input",...} 532
+#
+# O session_id sai POR LINHA porque o mesmo exporter pode carregar varias
+# sessoes (ver bloco MULTIPLAS SESSOES no topo) — o delta precisa separar
+# o crescimento da sessao corrente do acumulado congelado das demais.
 #
 # O strip de PII acontece por CONSTRUCAO: extraimos apenas os 4 labels da
 # allowlist e descartamos a linha original. Nao ha caminho em que um label
@@ -130,20 +162,21 @@ _ou_parse() {
     }
     /^claude_code_cost_usage_total\{/ {
       v = $NF
-      print label($0,"query_source") "\t" label($0,"model") "\tcost\t" v
+      print label($0,"session_id") "\t" label($0,"query_source") "\t" label($0,"model") "\tcost\t" v
       next
     }
     /^claude_code_token_usage_total\{/ {
       v = $NF
-      print label($0,"query_source") "\t" label($0,"model") "\t" label($0,"type") "\t" v
+      print label($0,"session_id") "\t" label($0,"query_source") "\t" label($0,"model") "\t" label($0,"type") "\t" v
       next
     }
   ' "$1"
 }
 
 # _ou_session_id INFILE -> session_id do scrape (primeira ocorrencia), ou "".
-# Usado para invalidar o delta se o processo Claude Code trocou entre os
-# dois snapshots (contador reinicia do zero -> delta negativo/absurdo).
+# Hoje e so o header INFORMATIVO `# session_id` do snapshot (debug humano).
+# O delta NAO depende dele: compara sessoes POR LINHA — o header com a
+# "primeira ocorrencia" passava batido quando o scrape misturava sessoes.
 _ou_session_id() {
   awk '
     /^claude_code_(cost|token)_usage_total\{/ {
@@ -245,29 +278,73 @@ _ou_cmd_delta() {
     return 0
   fi
 
-  _ou_sid_s=$(awk -F'\t' '/^# session_id/{print $2; exit}' "$_ou_s")
-  _ou_sid_e=$(awk -F'\t' '/^# session_id/{print $2; exit}' "$_ou_e")
-  if [ "$_ou_sid_s" != "$_ou_sid_e" ]; then
-    # Processo Claude Code trocou no meio da onda: os contadores
-    # reiniciaram, o delta seria lixo. Melhor ausente que errado.
-    _ou_warn "delta: session_id divergente entre snapshots ($_ou_sid_s != $_ou_sid_e) — delta descartado"
-    printf 'null\n'
-    return 0
-  fi
-
   command -v jq >/dev/null 2>&1 || { _ou_warn "delta: jq ausente"; printf 'null\n'; return 0; }
 
+  # Join por chave COMPLETA (session, source, model, type), SOMANDO
+  # duplicatas nos dois lados — o exporter emite linhas separadas por
+  # agent_name/skill_name/effort que colidem nessa chave; sobrescrever
+  # congelava o "delta" no acumulado (ver bloco MULTIPLAS SESSOES).
+  # O resultado so vale se EXATAMENTE UMA sessao cresceu. Saidas do awk:
+  #   exit 0 — rows da sessao vencedora (vazio: nada cresceu -> null)
+  #   exit 3 — snapshot em formato antigo (4 colunas, sem session_id)
+  #   exit 4 — sessao do start ausente no end (processo do exporter trocou)
+  #   exit 5 — mais de uma sessao cresceu (linha "# ambiguous" lista quais)
+  _ou_rows=$(mktemp) || _ou_die "mktemp falhou"
+  _ou_rc=0
   awk -F'\t' '
-    FILENAME==ARGV[1] && !/^#/ { s[$1 "\t" $2 "\t" $3] = $4; next }
-    FILENAME==ARGV[2] && !/^#/ {
-      k = $1 "\t" $2 "\t" $3
-      base = (k in s) ? s[k] : 0
-      d = $4 - base
-      if (d < 0) d = 0          # contador reiniciado: nao inventa negativo
-      if (d > 0) print k "\t" d
+    BEGIN { OFMT = "%.12g"; CONVFMT = "%.12g" }
+    FILENAME==ARGV[1] && !/^#/ {
+      if (NF != 5) { legacy = 1; next }
+      s[$1 FS $2 FS $3 FS $4] += $5
+      seen_start[$1] = 1
+      next
     }
-  ' "$_ou_s" "$_ou_e" \
-  | jq -c -R -s --arg sid "$_ou_sid_e" '
+    FILENAME==ARGV[2] && !/^#/ {
+      if (NF != 5) { legacy = 1; next }
+      e[$1 FS $2 FS $3 FS $4] += $5
+      seen_end[$1] = 1
+    }
+    END {
+      if (legacy) exit 3
+      for (sid in seen_start) if (!(sid in seen_end)) exit 4
+      n = 0
+      for (k in e) {
+        base = (k in s) ? s[k] : 0
+        d = e[k] - base           # contador reiniciado (d<0): nao inventa
+        if (d > 0) {
+          split(k, p, FS)
+          if (!(p[1] in grown)) { n++; list = (n > 1) ? list "," p[1] : p[1] }
+          grown[p[1]] = 1
+          delta[k] = d
+        }
+      }
+      if (n == 0) exit 0
+      if (n > 1) { print "# ambiguous\t" list; exit 5 }
+      cur = list
+      print "# session_id\t" cur
+      for (k in delta) {
+        split(k, p, FS)
+        if (p[1] == cur) print p[2] FS p[3] FS p[4] FS delta[k]
+      }
+    }
+  ' "$_ou_s" "$_ou_e" > "$_ou_rows" || _ou_rc=$?
+
+  case "$_ou_rc" in
+    0) : ;;
+    3) _ou_warn "delta: snapshot em formato antigo (sem session_id por linha) — delta descartado nesta onda"
+       rm -f -- "$_ou_rows"; printf 'null\n'; return 0 ;;
+    4) _ou_warn "delta: sessao do snapshot inicial ausente no snapshot final — processo do exporter trocou, delta descartado"
+       rm -f -- "$_ou_rows"; printf 'null\n'; return 0 ;;
+    5) _ou_amb=$(awk -F'\t' '/^# ambiguous/{print $2; exit}' "$_ou_rows")
+       _ou_warn "delta: mais de uma sessao ativa no exporter ($_ou_amb) — atribuicao ambigua, delta descartado"
+       rm -f -- "$_ou_rows"; printf 'null\n'; return 0 ;;
+    *) _ou_warn "delta: falha inesperada no join (rc=$_ou_rc) — delta descartado"
+       rm -f -- "$_ou_rows"; printf 'null\n'; return 0 ;;
+  esac
+
+  _ou_sid=$(awk -F'\t' '/^# session_id/{print $2; exit}' "$_ou_rows")
+  grep -v '^#' "$_ou_rows" \
+  | jq -c -R -s --arg sid "$_ou_sid" '
       [ split("\n")[] | select(length > 0) | split("\t")
         | {source: .[0], model: .[1], type: .[2], value: (.[3] | tonumber)} ]
       as $rows
@@ -303,6 +380,7 @@ _ou_cmd_delta() {
         )
       } end
     '
+  rm -f -- "$_ou_rows"
   return 0
 }
 
@@ -333,7 +411,11 @@ Nao exige API key, Admin key nem organizacao; funciona em plano de assinatura.
 Labels de PII (user_email, user_id, user_account_*, organization_id) sao
 descartados no snapshot e nunca alcancam disco.
 
-delta imprime `null` quando a metrica esta ausente — nunca zero fabricado.
+delta agrega por sessao (duplicatas de chave SOMADAS) e atribui o resultado
+a unica sessao que cresceu entre os snapshots. Imprime `null` quando a
+metrica esta ausente OU quando a atribuicao e ambigua (mais de uma sessao
+ativa, processo do exporter trocado, snapshot em formato antigo) — nunca
+zero fabricado.
 HELP
     exit 2
     ;;

--- a/tests/test_otel-usage.sh
+++ b/tests/test_otel-usage.sh
@@ -10,14 +10,27 @@
 #          breakdown por tipo vira o nome do terminal — bug observado em
 #          dados reais antes do fix.
 #   INV-3: metrica AUSENTE e `null`, nunca zero fabricado (Principio VI).
-#          Vale para snapshot faltando, endpoint fora do ar e session_id
-#          divergente entre os dois snapshots.
+#          Vale para snapshot faltando, endpoint fora do ar, sessao do
+#          start sumida no end (processo do exporter trocou), mais de uma
+#          sessao ativa entre os snapshots (atribuicao ambigua) e
+#          snapshot em formato antigo (4 colunas, pre-fix).
 #   INV-4: degradacao best-effort — endpoint indisponivel sai 0 e nao
 #          derruba a onda.
 #   INV-5: `available` exige as metricas que o script consome
 #          (cost/token), nao um `claude_code_` qualquer — no cold start o
 #          exporter ja responde com session_count e o snapshot sairia sem
 #          session_id, descartando a onda inteira.
+#   INV-6: duplicatas da mesma chave (session, source, model, type) sao
+#          SOMADAS nos dois lados do join, nunca sobrescritas. O exporter
+#          emite linhas separadas por agent_name/skill_name/effort; o awk
+#          antigo fazia s[k]=$4 (ultima vence) e imprimia CADA duplicata
+#          do end contra essa base unica — o "delta" virava ~acumulado
+#          congelado. Bug real 2026-07-28 (feature-00c dashboard-refactor):
+#          14 ondas bit-identicas de 212.447.680 tokens / $88.
+#   INV-7: linhas de OUTRAS sessoes do mesmo exporter (processo claude -c
+#          longevo expoe mais de uma sessao) nao contaminam o delta: a
+#          sessao congelada e ignorada e o resultado e atribuido a UNICA
+#          sessao que cresceu entre os snapshots.
 #
 # As fixtures reproduzem o formato REAL do exporter Prometheus do Claude
 # Code 2.1.220 (ordem dos labels inclusive — `terminal_type` antes de
@@ -63,6 +76,18 @@ _fixture() {
 _snap() {
   # $1=state-dir $2=phase $3=fixture-file
   capture sh "$SCRIPT" snapshot --state-dir "$1" --phase "$2" --endpoint "file://$3"
+}
+
+# Linhas avulsas para fixtures multi-sessao / com duplicata de chave.
+# _cost_line SID SOURCE MODEL VALUE [EXTRA_LABELS]
+_cost_line() {
+  printf 'claude_code_cost_usage_total{%s} %s\n' \
+    "$(_labels "$1" "$2" "$3" "${5:-}")" "$4"
+}
+# _tok_line SID SOURCE MODEL TYPE VALUE [EXTRA_LABELS]
+_tok_line() {
+  printf 'claude_code_token_usage_total{%s} %s\n' \
+    "$(_labels "$1" "$2" "$3" ",type=\"$4\"${6:-}")" "$5"
 }
 
 # ==== INV-2: ancoragem do label `type` ====
@@ -153,6 +178,130 @@ scenario_delta_negativo_e_clampado() {
   return 0
 }
 
+# ==== INV-6: duplicatas da mesma chave sao somadas, nunca sobrescritas ====
+
+scenario_delta_soma_duplicatas_da_mesma_chave() {
+  _sd="$TMPDIR_TEST/dup"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/dup-s.txt"; _fe="$TMPDIR_TEST/dup-e.txt"
+  # Mesma chave (sess, subagent, sonnet, cacheRead) em DUAS linhas que so
+  # diferem no agent_name — exatamente o que o exporter real emite.
+  {
+    _tok_line sess-dup subagent "claude-sonnet-5" cacheRead 100 ',agent_name="general-purpose"'
+    _tok_line sess-dup subagent "claude-sonnet-5" cacheRead 200 ',agent_name="custom"'
+  } > "$_fs"
+  {
+    _tok_line sess-dup subagent "claude-sonnet-5" cacheRead 150 ',agent_name="general-purpose"'
+    _tok_line sess-dup subagent "claude-sonnet-5" cacheRead 400 ',agent_name="custom"'
+  } > "$_fe"
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "delta exit" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  _tot=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.total_tokens')
+  # (150+400) - (100+200) = 250. Com sobrescrita, sairia 200 (400-200,
+  # com a duplicata de 150 clampada contra base errada de 200).
+  [ "$_tot" = "250" ] || { _fail "soma duplicatas" "esperado 250, obtido '$_tot'"; return 1; }
+  _cr=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.by_source.subagent.cache_read')
+  [ "$_cr" = "250" ] || { _fail "cache_read" "esperado 250, obtido '$_cr'"; return 1; }
+  return 0
+}
+
+# ==== INV-7: isolamento por sessao dentro do mesmo exporter ====
+
+# Reproducao do bug real (2026-07-28): exporter de um processo claude -c
+# longevo expoe uma sessao antiga CONGELADA com acumulado gigante ao lado
+# da sessao corrente. O acumulado nao pode vazar para o delta da onda.
+scenario_delta_ignora_sessao_congelada_de_outro_processo() {
+  _sd="$TMPDIR_TEST/frozen"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/fz-s.txt"; _fe="$TMPDIR_TEST/fz-e.txt"
+  {
+    _tok_line sess-old main "claude-opus-5[1m]" input 212000000
+    _cost_line sess-old main "claude-opus-5[1m]" 88.0
+    _tok_line sess-cur main "claude-opus-5[1m]" input 100
+    _cost_line sess-cur main "claude-opus-5[1m]" 1.0
+  } > "$_fs"
+  {
+    _tok_line sess-old main "claude-opus-5[1m]" input 212000000
+    _cost_line sess-old main "claude-opus-5[1m]" 88.0
+    _tok_line sess-cur main "claude-opus-5[1m]" input 400
+    _cost_line sess-cur main "claude-opus-5[1m]" 2.5
+  } > "$_fe"
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "delta exit" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  _tot=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.total_tokens')
+  [ "$_tot" = "300" ] || { _fail "tokens da onda" "esperado 300 (so a sessao corrente), obtido '$_tot'"; return 1; }
+  _cost=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.total_cost_usd')
+  [ "$_cost" = "1.5" ] || { _fail "custo da onda" "esperado 1.5, obtido '$_cost'"; return 1; }
+  _sid=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.session_id')
+  [ "$_sid" = "sess-cur" ] || { _fail "atribuicao" "esperado sess-cur, obtido '$_sid'"; return 1; }
+  return 0
+}
+
+# Duas sessoes crescendo ao mesmo tempo: impossivel atribuir a onda a uma
+# delas — melhor ausente que errado (Principio VI).
+scenario_delta_duas_sessoes_ativas_e_null() {
+  _sd="$TMPDIR_TEST/ambig"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/am-s.txt"; _fe="$TMPDIR_TEST/am-e.txt"
+  {
+    _tok_line sess-a main "claude-opus-5[1m]" input 100
+    _tok_line sess-b main "claude-opus-5[1m]" input 500
+  } > "$_fs"
+  {
+    _tok_line sess-a main "claude-opus-5[1m]" input 300
+    _tok_line sess-b main "claude-opus-5[1m]" input 900
+  } > "$_fe"
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT"; return 1; }
+  [ "$(printf '%s' "$_CAPTURED_STDOUT" | tr -d '[:space:]')" = "null" ] \
+    || { _fail "null" "duas sessoes ativas deve dar null, obtido '$_CAPTURED_STDOUT'"; return 1; }
+  printf '%s' "$_CAPTURED_STDERR" | grep -q "ambigua" \
+    || { _fail "stderr" "faltou aviso de atribuicao ambigua"; return 1; }
+  return 0
+}
+
+# Sessao que nasce DEPOIS do snapshot inicial (ex.: nova conversa no mesmo
+# processo): todo o consumo dela aconteceu dentro da janela da onda, entao
+# conta a partir de base 0 — desde que seja a unica que cresceu.
+scenario_delta_sessao_nova_no_end_atribuida_do_zero() {
+  _sd="$TMPDIR_TEST/newsess"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/nw-s.txt"; _fe="$TMPDIR_TEST/nw-e.txt"
+  _tok_line sess-a main "claude-opus-5[1m]" input 100 > "$_fs"
+  {
+    _tok_line sess-a main "claude-opus-5[1m]" input 100
+    _tok_line sess-b main "claude-opus-5[1m]" input 50
+  } > "$_fe"
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT"; return 1; }
+  _tot=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.total_tokens')
+  [ "$_tot" = "50" ] || { _fail "sessao nova" "esperado 50, obtido '$_tot'"; return 1; }
+  _sid=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.session_id')
+  [ "$_sid" = "sess-b" ] || { _fail "atribuicao" "esperado sess-b, obtido '$_sid'"; return 1; }
+  return 0
+}
+
+# Transicao de upgrade: snapshot start gravado pela versao antiga (4
+# colunas, sem session_id por linha) nao permite delta confiavel.
+scenario_delta_snapshot_legado_4col_vira_null() {
+  _sd="$TMPDIR_TEST/legacy"; mkdir -p "$_sd"
+  printf '# session_id\tsess-l\nmain\tclaude-opus-5[1m]\tinput\t100\n' > "$_sd/otel-start.tsv"
+  _fe="$TMPDIR_TEST/lg-e.txt"
+  _tok_line sess-l main "claude-opus-5[1m]" input 400 > "$_fe"
+  _snap "$_sd" end "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT"; return 1; }
+  [ "$(printf '%s' "$_CAPTURED_STDOUT" | tr -d '[:space:]')" = "null" ] \
+    || { _fail "null" "snapshot legado deve dar null, obtido '$_CAPTURED_STDOUT'"; return 1; }
+  printf '%s' "$_CAPTURED_STDERR" | grep -q "formato antigo" \
+    || { _fail "stderr" "faltou aviso de formato antigo"; return 1; }
+  return 0
+}
+
 # ==== INV-3: ausente e null, nunca zero ====
 
 scenario_delta_sem_snapshot_start_e_null() {
@@ -167,7 +316,10 @@ scenario_delta_sem_snapshot_start_e_null() {
   return 0
 }
 
-scenario_delta_session_divergente_e_null() {
+# Sessao inteira do start ausente no end = o processo dono do exporter
+# trocou no meio da onda (num exporter vivo, sessao nunca desaparece do
+# /metrics — contadores sao cumulativos por processo).
+scenario_delta_sessao_do_start_sumida_e_null() {
   _sd="$TMPDIR_TEST/divsess"; mkdir -p "$_sd"
   _fs="$TMPDIR_TEST/v-start.txt"; _fe="$TMPDIR_TEST/v-end.txt"
   _fixture "$_fs" "sess-AAA" 1.0 1.0 10 5
@@ -176,9 +328,9 @@ scenario_delta_session_divergente_e_null() {
   _snap "$_sd" end   "$_fe"
   capture sh "$SCRIPT" delta --state-dir "$_sd"
   [ "$(printf '%s' "$_CAPTURED_STDOUT" | tr -d '[:space:]')" = "null" ] \
-    || { _fail "null" "session_id divergente deve dar null (processo trocou)"; return 1; }
-  printf '%s' "$_CAPTURED_STDERR" | grep -q "session_id divergente" \
-    || { _fail "stderr" "faltou aviso de session_id divergente"; return 1; }
+    || { _fail "null" "sessao do start sumida deve dar null (processo trocou)"; return 1; }
+  printf '%s' "$_CAPTURED_STDERR" | grep -q "ausente no snapshot final" \
+    || { _fail "stderr" "faltou aviso de sessao ausente no snapshot final"; return 1; }
   return 0
 }
 


### PR DESCRIPTION
## Resumo

Corrige o delta OTel por onda (`otel-usage.sh`) que fabricava consumo. Caso real (2026-07-28, execucao `feature-00c dashboard-refactor` do cstk-panel): as ondas 001–014 gravaram `otel_usage` **bit-identico** — 212.447.680 tokens / $88.00 — no `state.json`, espelhado fielmente pela ingest e pelo painel. O dado nascia errado no delta; a onda-015 caiu no guard e ficou `null` (unico comportamento correto).

### Causas raiz (ambas confirmadas no codigo e em scrape real)

1. **`session_id` fora da agregacao**: o exporter Prometheus em `127.0.0.1:9464` pertencia a um processo `claude -c` longevo expondo metricas de MAIS de uma sessao. `_ou_parse` descartava o `session_id` das linhas — o acumulado congelado das sessoes antigas entrava na soma. O guard comparava so o header `# session_id` (primeira ocorrencia), entao passava mesmo com mistura.
2. **Colisao de chaves no join start/end**: o exporter emite linhas separadas por `agent_name`/`skill_name`/`effort`, mas a chave do delta era so `(query_source, model, type)`. O awk fazia `s[k]=$4` (ultima duplicata SOBRESCREVE no start) e imprimia CADA duplicata do end contra essa base unica — o "delta" virava o acumulado congelado, identico onda apos onda.

### Fix

- Snapshot TSV ganha `session_id` **por linha** (5 colunas).
- Delta **soma** duplicatas de chave nos dois lados do join e agrega por sessao; o resultado so e aceito quando **exatamente uma** sessao cresceu entre os snapshots (crescimento que, por construcao, ocorreu na janela da onda).
- Principio VI preservado e ampliado — `null` (nunca zero/chute) para: mais de uma sessao ativa (atribuicao ambigua), sessao do start ausente no end (processo do exporter trocou; substitui o guard fraco de header) e snapshot em formato antigo (transicao de upgrade).
- Sem match contra env: o `session_id` do OTel nao identifica a sessao corrente (label ja observado apontando para outro projeto) — filtrar por env descartaria dado legitimo.

Shape do JSON `otel_usage` inalterado: `state-ondas.sh`, `recall.sh` e o painel nao mudam.

## Testes

- TDD: 5 cenarios novos falharam no codigo antigo e passam no novo (`INV-6` soma de duplicatas; `INV-7` isolamento por sessao, incluindo reproducao do caso real com sessao congelada de 212M tokens; sessao nova atribuida de base 0; ambiguidade => null; formato legado => null).
- `tests/test_otel-usage.sh`: 22/22. `tests/test_state-ondas.sh` (consumidor do delta): 84/84.
- Suite completa local verde (gate de release roda a suite inteira de novo no CI).

## Saneamento (ja aplicado, fora deste diff)

State da execucao contaminada: ondas 001–014 anuladas + `sha256-update` + reingest (backup feito). GOTCHA documentado no CHANGELOG: `wave_model_usage` e upsert-only — as 15 linhas orfas ($88 por modelo) precisaram de DELETE manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DX5N8qvnVvggTxCAMLHpDk
