### PR TITLE
fix(serve): bloqueia npm do Windows via interop de PATH do WSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.33.3] - 2026-07-29
+
+Guard de preflight para o único ambiente onde `cstk serve` quebrava sempre:
+Windows + WSL2 sem Node.js instalado dentro da distro.
+
+### Fixed
+
+- **`serve.sh`: bloqueia o npm do WINDOWS vazando via interop de PATH do
+  WSL.** Sem Node.js na distro, `command -v npm` resolve para o binário do
+  Windows (`/mnt/c/Program Files/nodejs/npm` — denunciado no caso real pelo
+  cache em `C:\Users\...\npm-cache`); esse npm enxerga a árvore Linux pelo
+  caminho UNC `\\wsl.localhost\<distro>\...`, onde os symlinks de
+  workspaces falham (`EISDIR` fatal em `node_modules/@cstk-panel/*`) e o
+  cleanup falha (`EPERM rmdir`) — `npm install` morria no meio com
+  stacktrace críptico. Novo `_serve_check_npm_interop` (WSL detectado via
+  `WSL_DISTRO_NAME` ou `/proc/version` contendo "microsoft"; binário
+  Windows por `/mnt/*`, `*.exe` ou `*.cmd`) aborta ANTES de qualquer
+  download com orientação acionável: instalar Node.js DENTRO da distro
+  (apt/nvm) ou usar `cstk serve --docker`, que nunca exige npm no host.
+  Git Bash/MSYS e ambientes não-WSL seguem intactos (guard inerte fora do
+  WSL). +5 cenários em `test_serve.sh` (bloqueio `/mnt/*` e `*.exe`,
+  não-bloqueio do npm da distro, não-bloqueio fora do WSL, fluxo feliz
+  completo sob WSL sem falso positivo).
+
 ## [5.33.2] - 2026-07-28
 
 Ciclo de arquivamento do portfolio (9 features 100%) que inaugura o corpus
@@ -4361,6 +4385,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[5.33.3]: https://github.com/JotJunior/cstk/releases/tag/v5.33.3
 [5.33.2]: https://github.com/JotJunior/cstk/releases/tag/v5.33.2
 [5.33.1]: https://github.com/JotJunior/cstk/releases/tag/v5.33.1
 [5.33.0]: https://github.com/JotJunior/cstk/releases/tag/v5.33.0

--- a/cli/lib/serve.sh
+++ b/cli/lib/serve.sh
@@ -75,6 +75,38 @@ _serve_check_host_allowlist() {
   trusted_host_check "$1"
 }
 
+# _serve_check_npm_interop NPM_PATH
+# Guard contra o npm do WINDOWS vazando via interop de PATH do WSL: quando
+# Node.js nao esta instalado DENTRO da distro WSL, `command -v npm` resolve
+# para o binario do Windows (ex.: /mnt/c/Program Files/nodejs/npm). Esse npm
+# enxerga a arvore Linux pelo caminho UNC \\wsl.localhost\<distro>\... onde
+# symlinks de workspaces falham (EISDIR em node_modules/@cstk-panel/*) e o
+# cleanup falha (EPERM rmdir) — npm install quebra SEMPRE. Fail-fast aqui com
+# orientacao acionavel em vez de deixar o npm morrer no meio da instalacao.
+# Fora do WSL retorna 0 sem verificar nada (Git Bash/MSYS no Windows usa npm
+# nativo sobre filesystem local — cenario nao afetado).
+# NPM_PATH = caminho resolvido de `command -v npm`.
+# exit 0 = npm utilizavel; exit 1 = npm do Windows sob WSL (mensagem em stderr).
+_serve_check_npm_interop() {
+  _scni_npm="$1"
+  # Deteccao de WSL: WSL_DISTRO_NAME e exportada por padrao nas sessoes WSL2;
+  # /proc/version contendo "microsoft" cobre contextos sem a env (sudo, cron).
+  if [ -z "${WSL_DISTRO_NAME:-}" ] && ! grep -qi microsoft /proc/version 2>/dev/null; then
+    return 0
+  fi
+  # Binario do Windows via interop: vive sob o automount (/mnt/<drive>/ por
+  # padrao) ou termina em .exe/.cmd. npm instalado na distro (/usr/bin,
+  # ~/.nvm/...) nunca casa com esses padroes.
+  case "$_scni_npm" in
+    /mnt/*|*.exe|*.cmd) ;;
+    *) return 0 ;;
+  esac
+  printf 'cstk serve: erro: o npm encontrado no PATH e o npm do WINDOWS (%s) acessado via interop do WSL\n' "$_scni_npm" >&2
+  printf 'cstk serve: o npm do Windows nao consegue instalar dependencias na arvore de arquivos do Linux (symlinks de workspaces falham no caminho \\\\wsl.localhost\\...)\n' >&2
+  printf 'cstk serve: instale Node.js DENTRO da distro WSL (ex.: sudo apt install nodejs npm, ou via nvm) ou use: cstk serve --docker\n' >&2
+  return 1
+}
+
 # _serve_is_installed PANEL_DIR
 # Retorna 0 se o painel esta instalado (package.json presente e legivel).
 # Retorna 1 caso contrario.
@@ -696,6 +728,12 @@ HELP
 
   if ! command -v npm >/dev/null 2>&1; then
     printf 'cstk serve: erro: npm nao encontrado no PATH; instale Node.js em https://nodejs.org\n' >&2
+    return 1
+  fi
+
+  # Sob WSL, um npm "presente" pode ser o npm do Windows via interop de
+  # PATH — inutilizavel sobre a arvore Linux (ver _serve_check_npm_interop).
+  if ! _serve_check_npm_interop "$(command -v npm)"; then
     return 1
   fi
 

--- a/tests/cstk/test_serve-docker.sh
+++ b/tests/cstk/test_serve-docker.sh
@@ -550,6 +550,13 @@ scenario_docker_mentions_confined_to_serve_docker_lib() {
   # CLAUDE.md/CHANGELOG.md ficam DE FORA de proposito -- mencionam "docker"
   # em prosa/testes sem violar o confinamento de DEPENDENCIA de codigo.
   #
+  # 5o padrao exempto: a linha de orientacao do guard de interop WSL
+  # (_serve_check_npm_interop, "ou use: cstk serve --docker") — texto de
+  # erro voltado ao usuario sugerindo a flag como alternativa que dispensa
+  # npm no host; mesma natureza do help-text exempto abaixo, nao
+  # dependencia/orquestracao de docker (que segue confinada a
+  # serve-docker.sh).
+  #
   # 4o padrao exempto (task 6.1, FR-014): o range do heredoc de --help e
   # calculado DINAMICAMENTE a partir dos delimitadores reais `cat <<'HELP'`
   # / `HELP` em serve.sh (nunca numero de linha hardcoded) -- edicoes
@@ -574,13 +581,14 @@ scenario_docker_mentions_confined_to_serve_docker_lib() {
             | grep -vE '/cli/lib/serve\.sh:[0-9]+: *-*-docker\)[[:space:]]*$' \
             | grep -vE '/cli/lib/serve\.sh:[0-9]+: *\. "\$\{CSTK_LIB\}/serve-docker\.sh"$' \
             | grep -vE '/cli/lib/serve\.sh:[0-9]+: *_serve_docker_main ' \
+            | grep -vE '/cli/lib/serve\.sh:[0-9]+:.*ou use: cstk serve --docker' \
             | awk -F: -v s="$_help_start" -v e="$_help_end" '
                 $0 ~ /\/cli\/lib\/serve\.sh:/ { n = $2 + 0; if (n >= s && n <= e) next }
                 { print }
               ' \
           || :)
   if [ -n "$_hits" ]; then
-    _fail "docker_confinement" "mencoes a 'docker' fora de serve-docker.sh (ou dos 4 padroes exemptados do encaminhamento/help-text em serve.sh): $_hits"
+    _fail "docker_confinement" "mencoes a 'docker' fora de serve-docker.sh (ou dos 5 padroes exemptados do encaminhamento/help-text em serve.sh): $_hits"
     return 1
   fi
 }

--- a/tests/cstk/test_serve.sh
+++ b/tests/cstk/test_serve.sh
@@ -1791,4 +1791,92 @@ scenario_asset_host_fora_da_allowlist_exit1() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# Guard de interop WSL — _serve_check_npm_interop
+# Bug real (Windows + WSL2): sem Node.js dentro da distro, `command -v npm`
+# resolve para o npm do WINDOWS via interop de PATH (/mnt/c/...), que quebra
+# npm install na arvore Linux (EISDIR em symlink de workspace via UNC
+# \\wsl.localhost\...). O guard deve bloquear ANTES de qualquer download.
+# ---------------------------------------------------------------------------
+
+# _run_npm_interop_check WSL_VALUE NPM_PATH
+# Executa _serve_check_npm_interop unit-style: sourceia serve.sh num sh limpo
+# com WSL_DISTRO_NAME=WSL_VALUE e chama o helper com NPM_PATH. String vazia
+# em WSL_VALUE simula fora-do-WSL (o guard trata vazia como ausente; o
+# fallback via /proc/version so dispara em WSL de verdade, nunca no ambiente
+# de teste macOS/Linux).
+_run_npm_interop_check() {
+  capture env \
+    CSTK_LIB="$CSTK_LIB" \
+    WSL_DISTRO_NAME="$1" \
+    sh -c '. "$CSTK_LIB/serve.sh" && _serve_check_npm_interop "$1"' interop_test "$2"
+}
+
+scenario_wsl_npm_windows_mnt_bloqueado() {
+  _setup_serve_env
+  _run_npm_interop_check "Ubuntu-24.04" "/mnt/c/Program Files/nodejs/npm"
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "wsl_npm_mnt_exit" "npm do Windows (/mnt/...) sob WSL deve ser bloqueado (exit 1); obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  if ! printf '%s' "$_CAPTURED_STDERR" | grep -qi 'WINDOWS'; then
+    _fail "wsl_npm_mnt_msg" "stderr deveria identificar npm do Windows; stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if ! printf '%s' "$_CAPTURED_STDERR" | grep -qi 'docker'; then
+    _fail "wsl_npm_mnt_alt" "stderr deveria sugerir a alternativa --docker; stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+}
+
+scenario_wsl_npm_exe_bloqueado() {
+  _setup_serve_env
+  _run_npm_interop_check "Ubuntu-24.04" "/usr/local/bin/npm.exe"
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "wsl_npm_exe_exit" "npm *.exe sob WSL deve ser bloqueado (exit 1); obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+}
+
+scenario_wsl_npm_da_distro_permitido() {
+  _setup_serve_env
+  _run_npm_interop_check "Ubuntu-24.04" "/usr/bin/npm"
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "wsl_npm_distro_exit" "npm da distro (/usr/bin) sob WSL nao deve ser bloqueado; obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"
+    return 1
+  fi
+}
+
+scenario_fora_do_wsl_npm_mnt_permitido() {
+  # Fora do WSL o guard nao se aplica (ex.: layout de paths exotico num
+  # Linux comum) — nunca falso positivo.
+  _setup_serve_env
+  _run_npm_interop_check "" "/mnt/c/Program Files/nodejs/npm"
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "fora_wsl_exit" "fora do WSL o guard nao deve bloquear; obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"
+    return 1
+  fi
+}
+
+scenario_wsl_fluxo_completo_com_npm_da_distro_instala() {
+  # Regressao de falso positivo no fluxo real: WSL_DISTRO_NAME presente mas
+  # npm resolvendo para stub Linux-like (tmpdir) — serve_main segue ate o
+  # fim do caminho feliz normalmente.
+  _setup_serve_env
+  _make_bin_dir
+  _stub_curl_ok "$_STUB_BIN"
+  _stub_npm_ok "$_STUB_BIN"
+  WSL_DISTRO_NAME="Ubuntu-24.04"
+  export WSL_DISTRO_NAME
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "wsl_fluxo_exit" "esperado exit 0 (npm da distro sob WSL), obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"
+    return 1
+  fi
+  if printf '%s' "$_CAPTURED_STDERR" | grep -qi 'npm do WINDOWS'; then
+    _fail "wsl_fluxo_falso_positivo" "guard bloqueou npm legitimo da distro: $_CAPTURED_STDERR"
+    return 1
+  fi
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Problema

`cstk serve` falha sempre no Windows + WSL2 quando Node.js não está instalado dentro da distro: o interop de PATH do WSL faz `command -v npm` resolver para o npm do **Windows** (`/mnt/c/Program Files/nodejs/npm` — denunciado no caso real pelo cache em `C:\Users\...\npm-cache`). Esse npm enxerga a árvore Linux pelo caminho UNC `\\wsl.localhost\<distro>\...`, onde:

- os symlinks de workspaces falham (`EISDIR` fatal em `node_modules/@cstk-panel/*`);
- o cleanup falha (`EPERM rmdir`);

e o `npm install` morre no meio com stacktrace críptico.

## Correção

Novo `_serve_check_npm_interop` em `cli/lib/serve.sh`, chamado logo após o preflight de npm (antes de qualquer download):

- **Detecção de WSL**: `WSL_DISTRO_NAME` não-vazia ou `/proc/version` contendo "microsoft" (cobre sudo/cron);
- **Binário Windows**: caminho sob `/mnt/*` ou terminando em `.exe`/`.cmd`;
- **Ação**: aborta (exit 1) com orientação acionável — instalar Node.js DENTRO da distro (apt/nvm) **ou** usar `cstk serve --docker`, que nunca exige npm no host.

Git Bash/MSYS e ambientes não-WSL seguem intactos (guard inerte fora do WSL).

## Testes

- +5 cenários em `tests/cstk/test_serve.sh`: bloqueio de `/mnt/*` e `*.exe` sob WSL (mensagem identifica o npm do Windows e sugere `--docker`), não-bloqueio do npm da distro, não-bloqueio fora do WSL, fluxo feliz completo sob WSL sem falso positivo.
- 5ª isenção estreita no confinamento de menções a docker (`test_serve-docker.sh`): a linha de orientação do guard é texto voltado ao usuário, mesma natureza do help-text já exempto — a orquestração de docker segue confinada a `serve-docker.sh`.

## Verificação

- `test_serve.sh` 60/60, `test_serve-docker.sh` completo ok, `shellcheck -s sh` limpo no `serve.sh`.
- Suite completa local: 1926 PASS / 2 FAIL pré-existentes e ambientais (`test_otel-usage.sh` cenários 5 e 14 — porta 9464 ocupada por processo `claude` vivo nesta máquina; reproduzem na `main` limpa e não ocorrem no CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYVkHeozBUcff2z9whfXGc