### PR TITLE
docs(otel): disputa da porta 9464 do exporter + launcher por processo (5.33.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.33.4] - 2026-07-29
+
+Documentação do modo de falha silencioso da telemetria OTel com múltiplos
+processos do Claude Code abertos — diagnóstico de caso real em que uma
+execução inteira de 16 ondas não mediu consumo nenhum.
+
+### Fixed
+
+- **Disputa da porta fixa 9464 do exporter OTel documentada em todas as
+  frentes.** Só UM processo do Claude Code consegue o bind da porta do
+  exporter Prometheus — o primeiro lançado ganha; qualquer outro processo
+  simultâneo (outra aba de terminal, outro projeto) falha o bind em
+  silêncio: as métricas dele não são expostas em lugar nenhum, os snapshots
+  por onda scrapeiam as sessões velhas do processo vencedor e o guard do
+  delta descarta o resultado corretamente (Princípio VI) — `otel_usage`
+  fica `null` em TODAS as ondas da execução e o painel não mostra custo.
+  Caso real (2026-07-29): um `claude -c` de dois dias de outro projeto
+  segurava a porta e a execução de 16 ondas da feature webhooks não mediu
+  nada. Mitigação documentada: função-launcher no shell rc que sorteia
+  porta livre por processo (bind na porta `0` → kernel escolhe) e exporta
+  `OTEL_EXPORTER_PROMETHEUS_PORT` + `CSTK_OTEL_ENDPOINT` correspondentes —
+  zero configuração por sessão, cada processo mede isolado, e o guard
+  "exatamente uma sessão cresceu" passa a ver só as sessões daquele
+  processo (descartes por ambiguidade praticamente desaparecem). Snippet
+  completo + diagnóstico via `lsof` nos READMEs (seção "Real per-wave
+  cost" / "Custo real por onda"), bloco "DISPUTA DA PORTA FIXA" no header
+  do `otel-usage.sh`, e aviso no pre-flight de telemetria dos commands
+  `/agente-00c` e `/feature-00c`.
+
 ## [5.33.3] - 2026-07-29
 
 Guard de preflight para o único ambiente onde `cstk serve` quebrava sempre:
@@ -4385,6 +4414,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[5.33.4]: https://github.com/JotJunior/cstk/releases/tag/v5.33.4
 [5.33.3]: https://github.com/JotJunior/cstk/releases/tag/v5.33.3
 [5.33.2]: https://github.com/JotJunior/cstk/releases/tag/v5.33.2
 [5.33.1]: https://github.com/JotJunior/cstk/releases/tag/v5.33.1

--- a/README.md
+++ b/README.md
@@ -71,8 +71,13 @@ stays `null` — absent, never a fabricated zero. Put them in your
 `~/.zshrc`/`~/.bashrc` so you don't lose waves to forgetfulness.
 
 Nothing leaves the machine (exporter binds `127.0.0.1:9464`) and identity
-labels are stripped before touching disk. Details, measured numbers and how to
-change the port: [Real per-wave cost](#real-per-wave-cost-otel-usagesh).
+labels are stripped before touching disk.
+
+> **Running more than one Claude Code process at a time?** Only the first can
+> bind the fixed port — the others silently measure nothing (`otel_usage`
+> `null` on every wave). Use the per-process port launcher shown in
+> [Real per-wave cost](#real-per-wave-cost-otel-usagesh) to give each process
+> its own exporter automatically.
 
 ## Structure
 
@@ -305,6 +310,50 @@ The exporter binds `127.0.0.1:9464`; nothing leaves the machine. Identity
 labels (`user_email`, `user_id`, `user_account_*`, `organization_id`) are
 stripped at snapshot time and never reach disk. Override the endpoint with
 `CSTK_OTEL_ENDPOINT` if you changed the exporter port.
+
+**Multiple Claude Code processes at once? Give each one its own port.** Only
+ONE process can bind the fixed port `9464` — the first one launched wins.
+Every other process (another terminal tab, another project) fails the bind
+silently: its metrics are exposed nowhere, the per-wave snapshots scrape the
+*winner's* stale sessions, and the delta guard correctly discards the result —
+so `otel_usage` comes out `null` for **every wave** of that execution, with the
+panel showing no cost at all. Real case: a two-day-old `claude -c` from an
+unrelated project held the port and an entire 16-wave run measured nothing.
+
+The fix is a launcher function in your `~/.zshrc` that asks the OS for a free
+port at every launch (binding port `0` lets the kernel pick) and points the
+cstk scraper at it via `CSTK_OTEL_ENDPOINT` — hooks and runtime scripts run
+inside the Claude process, so they inherit both variables:
+
+```zsh
+# One OTel exporter per claude process: OS picks a free port at each launch.
+claude() {
+  local _otel_port
+  _otel_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null)
+  if [ -n "$_otel_port" ]; then
+    OTEL_EXPORTER_PROMETHEUS_PORT=$_otel_port \
+    CSTK_OTEL_ENDPOINT="http://127.0.0.1:${_otel_port}/metrics" \
+    command claude "$@"
+  else
+    command claude "$@"   # no python3: fall back to the fixed default port
+  fi
+}
+```
+
+Zero per-session configuration: each `claude` you type gets an isolated
+exporter and an isolated measurement. As a bonus, the delta's
+"exactly-one-session-grew" guard only ever sees that process's sessions, so
+ambiguity discards (`null` from concurrent sessions) all but disappear. The
+wrapper only covers processes launched from your shell — anything launched
+outside it (IDE, desktop app) still uses the fixed default port.
+
+Quick diagnosis when the panel shows no cost for any wave: check who owns the
+port and whether its working directory is the project you're actually running:
+
+```bash
+lsof -nP -iTCP:9464 -sTCP:LISTEN     # who owns the exporter port?
+lsof -p <PID> | grep cwd             # ...and from which project?
+```
 
 **Interactive mode** (numbered selector in a TTY) and **dry-run**:
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -71,8 +71,13 @@ e o painel mostra o gasto por onda. Sem elas tudo é no-op e o campo fica
 para não perder ondas por esquecimento.
 
 Nada sai da máquina (exporter em `127.0.0.1:9464`) e labels de identidade são
-descartados antes de tocar o disco. Detalhes, números medidos e como mudar a
-porta: [Custo real por onda](#custo-real-por-onda-otel-usagesh).
+descartados antes de tocar o disco.
+
+> **Mais de um processo do Claude Code ao mesmo tempo?** Só o primeiro
+> consegue o bind da porta fixa — os demais não medem nada em silêncio
+> (`otel_usage` `null` em toda onda). Use o launcher de porta por processo
+> mostrado em [Custo real por onda](#custo-real-por-onda-otel-usagesh) para
+> cada processo ganhar seu próprio exporter automaticamente.
 
 ## Estrutura
 
@@ -305,6 +310,52 @@ O exporter escuta em `127.0.0.1:9464`; nada sai da máquina. Labels de
 identidade (`user_email`, `user_id`, `user_account_*`, `organization_id`)
 são descartados no snapshot e nunca tocam o disco. Use `CSTK_OTEL_ENDPOINT`
 para apontar a outra porta.
+
+**Vários processos do Claude Code ao mesmo tempo? Dê uma porta a cada um.**
+Só UM processo consegue o bind da porta fixa `9464` — o primeiro que abrir
+ganha. Qualquer outro processo (outra aba do terminal, outro projeto) falha o
+bind em silêncio: as métricas dele não são expostas em lugar nenhum, os
+snapshots por onda scrapeiam as sessões velhas do processo *vencedor*, e o
+guard do delta descarta o resultado corretamente — `otel_usage` sai `null` em
+**todas as ondas** daquela execução, com o painel sem custo nenhum. Caso real:
+um `claude -c` de dois dias de outro projeto segurava a porta e uma execução
+inteira de 16 ondas não mediu nada.
+
+A correção é uma função-launcher no seu `~/.zshrc` que pede ao OS uma porta
+livre a cada lançamento (bind na porta `0` deixa o kernel escolher) e aponta o
+scraper do cstk para ela via `CSTK_OTEL_ENDPOINT` — hooks e scripts do runtime
+rodam dentro do processo do Claude, então herdam as duas variáveis:
+
+```zsh
+# Um exporter OTel por processo do claude: OS sorteia porta livre a cada lancamento.
+claude() {
+  local _otel_port
+  _otel_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null)
+  if [ -n "$_otel_port" ]; then
+    OTEL_EXPORTER_PROMETHEUS_PORT=$_otel_port \
+    CSTK_OTEL_ENDPOINT="http://127.0.0.1:${_otel_port}/metrics" \
+    command claude "$@"
+  else
+    command claude "$@"   # sem python3: cai na porta default fixa
+  fi
+}
+```
+
+Zero configuração por sessão: cada `claude` que você digita ganha um exporter
+isolado e uma medição isolada. De bônus, o guard "exatamente uma sessão
+cresceu" do delta passa a ver só as sessões daquele processo — os descartes
+por ambiguidade (`null` por sessões concorrentes) praticamente desaparecem.
+O wrapper só cobre processos lançados do seu shell — o que nascer por fora
+(IDE, app desktop) continua na porta default fixa.
+
+Diagnóstico rápido quando o painel não mostra custo em onda nenhuma: veja
+quem é o dono da porta e se o diretório de trabalho dele é mesmo o projeto
+da execução:
+
+```bash
+lsof -nP -iTCP:9464 -sTCP:LISTEN     # quem e o dono da porta do exporter?
+lsof -p <PID> | grep cwd             # ...e de qual projeto?
+```
 
 **Modo interativo** (seletor numerado em TTY) e **dry-run**:
 

--- a/global/commands/agente-00c.md
+++ b/global/commands/agente-00c.md
@@ -193,7 +193,12 @@ espere a resposta:
    ```
 
    (b) nao exige API key, Admin key nem organizacao; funciona em plano de
-   assinatura e nada sai de `127.0.0.1`.
+   assinatura e nada sai de `127.0.0.1`. ATENCAO: so UM processo do Claude
+   Code faz bind da porta fixa 9464 — com outro processo aberto antes, esta
+   sessao nao mede nada (otel_usage null em toda onda). Mitigacao: launcher
+   de porta dinamica por processo (ver README "Real per-wave cost") ou
+   garantir que nao ha outro claude segurando a porta
+   (`lsof -nP -iTCP:9464 -sTCP:LISTEN`).
 
 **Regra de decisao** (o operador manda, o default nunca mente):
 

--- a/global/commands/feature-00c.md
+++ b/global/commands/feature-00c.md
@@ -173,7 +173,12 @@ Exporte: `AGENTE_00C_STATE_DIR=<projeto>/.claude/feature-00c-state/<short_name>`
          export CLAUDE_CODE_ENABLE_TELEMETRY=1
          export OTEL_METRICS_EXPORTER=prometheus
          (o segundo nao exige API key, Admin key nem organizacao; funciona
-          em assinatura e nada sai de 127.0.0.1)
+          em assinatura e nada sai de 127.0.0.1. ATENCAO: so UM processo do
+          Claude Code faz bind da porta fixa 9464 — com outro processo aberto
+          antes, esta sessao nao mede nada, otel_usage null em toda onda.
+          Mitigacao: launcher de porta dinamica por processo, ver README
+          "Real per-wave cost"; diagnostico:
+          `lsof -nP -iTCP:9464 -sTCP:LISTEN`)
 
    - Regra de decisao:
      . sim  => pedir que rode `cstk hooks install` e confirmar antes de seguir

--- a/global/skills/agente-00c-runtime/scripts/otel-usage.sh
+++ b/global/skills/agente-00c-runtime/scripts/otel-usage.sh
@@ -37,6 +37,20 @@
 # assinatura. O exporter sobe um HTTP local em 127.0.0.1:9464/metrics; nada
 # trafega para fora da maquina.
 #
+# DISPUTA DA PORTA FIXA (caso real, 2026-07-29)
+# ---------------------------------------------
+# So UM processo do Claude Code consegue o bind da porta 9464 — o primeiro
+# lancado ganha. Qualquer outro processo simultaneo (outra aba, outro projeto)
+# falha o bind EM SILENCIO: as metricas dele nao sao expostas em lugar nenhum,
+# o snapshot scrapeia as sessoes do processo vencedor e o guard do delta
+# descarta (corretamente) o resultado — otel_usage null em TODAS as ondas da
+# execucao. Caso observado: um `claude -c` de 2 dias de outro projeto segurou
+# a porta e uma execucao de 16 ondas nao mediu nada. Mitigacao recomendada:
+# launcher no shell rc que sorteia porta livre por processo
+# (OTEL_EXPORTER_PROMETHEUS_PORT dinamico) e exporta CSTK_OTEL_ENDPOINT
+# correspondente — ver README "Real per-wave cost". Diagnostico:
+# `lsof -nP -iTCP:9464 -sTCP:LISTEN` + `lsof -p <PID> | grep cwd`.
+#
 # PRIVACIDADE (regra dura)
 # ------------------------
 # Os labels do exporter carregam PII: `user_email`, `user_id`,


### PR DESCRIPTION
## Resumo

Documenta o modo de falha silencioso da telemetria OTel com múltiplos processos do Claude Code abertos: só UM processo consegue o bind da porta fixa 9464 — os demais não medem nada (`otel_usage` null em toda onda), sem aviso nenhum.

Caso real (2026-07-29): um `claude -c` de dois dias de outro projeto segurava a porta e a execução de 16 ondas da feature webhooks (meta-gob-ms) não mediu consumo nenhum — painel sem custo, tokens só do fallback por spawn.

## Mudanças

- **README.md / README.pt-BR.md**: seção "Real per-wave cost"/"Custo real por onda" ganha o bloco da disputa de porta, o caso real, a função-launcher (porta livre sorteada pelo OS por processo + `CSTK_OTEL_ENDPOINT`) e o diagnóstico via `lsof`; callout no quickstart.
- **`otel-usage.sh`**: bloco "DISPUTA DA PORTA FIXA" no header (comentário; zero mudança de comportamento).
- **`agente-00c.md` / `feature-00c.md`**: pre-flight de telemetria avisa o operador sobre a disputa e cita a mitigação.

## Testes

- `test_otel-usage.sh` 22/0, `test_doc-counts.sh` 3/0 (LC_ALL=C)
- Suite completa: 1927 pass / 2 fail — os 2 são o falso-FAIL conhecido de locale pt_BR no `test_otel-usage.sh` (passam com `LC_ALL=C`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjSpnXM7eo93DL3Km7S5xv