### PR TITLE
feat(otel): preflight deterministico de telemetria (5.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.34.0] - 2026-07-29
+
+Pre-flight determinístico de telemetria: a pergunta "ESTA sessão vai ser
+medida?" deixa de depender de diagnóstico manual e vira subcomando do
+runtime, invocado pelos commands 00c antes da onda-001.
+
+### Added
+
+- **`otel-usage.sh preflight [--endpoint URL]`.** Decide deterministicamente
+  se a telemetria OTel da sessão corrente vai ser medida, sem nunca
+  bloquear a pipeline: `status=ok` quando o dono da porta do endpoint é
+  ancestral do processo corrente (i.e. o exporter pertence a ESTA sessão —
+  dono via `lsof`, ancestralidade via walk de `ps -o ppid=`);
+  `status=port-conflict` (exit 3) com `owner_pid` e `owner_cwd` quando a
+  porta pertence a OUTRO processo — o modo de falha silencioso da 5.33.4,
+  agora detectável antes da onda-001; `status=exporter-down` (exit 4)
+  quando o opt-in está ligado mas nada responde; `status=disabled` (opt-in
+  ausente) e `status=unverified` (endpoint não-local/`file://` ou posse
+  indeterminável com scrape respondendo — nunca acusa conflito sem
+  evidência) saem com exit 0. Aviso de alta visibilidade em stderr nos
+  exits 3/4. +6 cenários em `test_otel-usage.sh` com `lsof` stubado no
+  PATH (dono ancestral = `$$` do teste; dono estranho = PID 1).
+
+### Changed
+
+- **Commands `/agente-00c` e `/feature-00c`**: o diagnóstico de coleta
+  (passo 2.bis / 8) agora roda `otel-usage.sh preflight` junto do
+  `guard-hooks-status.sh check` e instrui REPASSAR ao operador qualquer
+  `port-conflict`/`exporter-down` antes de seguir — a execução sairia
+  inteira com `otel_usage` null. Deliberadamente FORA do
+  `state-ondas.sh start`: rodar o preflight a cada onda poluiria stderr de
+  toda a suite em ambiente com telemetria ligada e duplicaria scrapes; o
+  ponto determinístico certo é o pre-flight único do command pai.
+- **READMEs + tabela de helpers do orquestrador**: documentam o subcomando
+  novo como alternativa ao diagnóstico manual via `lsof`.
+
 ## [5.33.4] - 2026-07-29
 
 Documentação do modo de falha silencioso da telemetria OTel com múltiplos
@@ -4414,6 +4450,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[5.34.0]: https://github.com/JotJunior/cstk/releases/tag/v5.34.0
 [5.33.4]: https://github.com/JotJunior/cstk/releases/tag/v5.33.4
 [5.33.3]: https://github.com/JotJunior/cstk/releases/tag/v5.33.3
 [5.33.2]: https://github.com/JotJunior/cstk/releases/tag/v5.33.2

--- a/README.md
+++ b/README.md
@@ -355,6 +355,13 @@ lsof -nP -iTCP:9464 -sTCP:LISTEN     # who owns the exporter port?
 lsof -p <PID> | grep cwd             # ...and from which project?
 ```
 
+Or let the runtime decide: `otel-usage.sh preflight` answers "will THIS
+session be measured?" deterministically — `status=ok` (exporter owned by an
+ancestor of this process), `port-conflict` with the owner's PID and cwd
+(exit 3), `exporter-down` (exit 4), `disabled` or `unverified`. The 00c
+launcher commands run it in their pre-flight diagnostics and relay any
+warning to the operator before wave 001.
+
 **Interactive mode** (numbered selector in a TTY) and **dry-run**:
 
 ```bash

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -357,6 +357,13 @@ lsof -nP -iTCP:9464 -sTCP:LISTEN     # quem e o dono da porta do exporter?
 lsof -p <PID> | grep cwd             # ...e de qual projeto?
 ```
 
+Ou deixe o runtime decidir: `otel-usage.sh preflight` responde "ESTA sessão
+vai ser medida?" deterministicamente — `status=ok` (exporter pertence a um
+ancestral deste processo), `port-conflict` com PID e cwd do dono (exit 3),
+`exporter-down` (exit 4), `disabled` ou `unverified`. Os commands 00c rodam
+o preflight no diagnóstico inicial e repassam qualquer aviso ao operador
+antes da onda-001.
+
 **Modo interativo** (seletor numerado em TTY) e **dry-run**:
 
 ```bash

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -111,7 +111,7 @@ infraestrutura interna deste agente.
 | `bloqueios.sh` | register/respond/list/count/next-id/get | Ciclo de vida de BloqueioHumano (FR-015/FR-016) |
 | `budget.sh` | check/status | Proxies de orcamento de sessao (FR-009: tool calls, wallclock, state size) |
 | `guard-hooks-status.sh` | check/tick-mode | Hooks 00c provisionados no projeto-alvo? READ-ONLY. `tick-mode` decide se `tool-call-tick` deve ser chamado na mao (default `manual`, nunca zera a metrica em silencio) |
-| `otel-usage.sh` | available/snapshot/delta | Custo/tokens REAIS da onda via telemetria OTel (`query_source` separa main de subagent). Chamado automaticamente por `state-ondas.sh start`/`end` — o orquestrador NAO precisa invocar. No-op sem `CLAUDE_CODE_ENABLE_TELEMETRY=1` + `OTEL_METRICS_EXPORTER=prometheus` |
+| `otel-usage.sh` | available/snapshot/delta/preflight | Custo/tokens REAIS da onda via telemetria OTel (`query_source` separa main de subagent). snapshot/delta chamados automaticamente por `state-ondas.sh start`/`end` — o orquestrador NAO precisa invocar. `preflight` roda no diagnostico do command PAI (detecta porta do exporter presa por outro processo — exit 3 — antes da onda-001). No-op sem `CLAUDE_CODE_ENABLE_TELEMETRY=1` + `OTEL_METRICS_EXPORTER=prometheus` |
 | `cycles.sh` | tick/check/count/reset | Limite de ciclos por etapa (FR-014.a — `loop_em_etapa`) |
 | `circular.sh` | push/detect/list/clear | Deteccao de movimento circular (FR-014.b — buffer 6) |
 | `drift.sh` | init/check/aspectos | Drift detection (FR-027 — aspectos-chave congelados; warn>=3, abort>=5) |

--- a/global/commands/agente-00c.md
+++ b/global/commands/agente-00c.md
@@ -150,14 +150,19 @@ ja preparado fora do script), apenas defensivo.
 
 ### 2.bis Coleta de consumo: PEDIR instalacao ao operador (nunca instalar sozinho)
 
-Rode primeiro o diagnostico:
+Rode primeiro o diagnostico (ambos READ-ONLY — nunca instalam nada):
 
 ```sh
 guard-hooks-status.sh check --projeto-alvo-path "<PROJETO_ALVO_PATH>" || :
+otel-usage.sh preflight || :   # a telemetria DESTA sessao vai medir?
 ```
 
-READ-ONLY — nunca instala nada. Se os tres hooks ja estao ativos, siga para
-o passo 3 sem incomodar o operador.
+Se o preflight imprimir `status=port-conflict` (porta do exporter presa por
+OUTRO processo — `owner_pid`/`owner_cwd` na saida) ou `status=exporter-down`,
+REPASSE o aviso ao operador antes de seguir: a execucao inteira sairia com
+`otel_usage` null em toda onda. `ok`/`disabled`/`unverified` seguem sem
+mencao. Se os tres hooks ja estao ativos, siga para o passo 3 sem incomodar
+o operador.
 
 **Se faltar algum, PECA a instalacao explicitamente** — nao instale por
 conta propria e nao siga em silencio. Apresente os tres pontos abaixo e
@@ -195,10 +200,9 @@ espere a resposta:
    (b) nao exige API key, Admin key nem organizacao; funciona em plano de
    assinatura e nada sai de `127.0.0.1`. ATENCAO: so UM processo do Claude
    Code faz bind da porta fixa 9464 — com outro processo aberto antes, esta
-   sessao nao mede nada (otel_usage null em toda onda). Mitigacao: launcher
-   de porta dinamica por processo (ver README "Real per-wave cost") ou
-   garantir que nao ha outro claude segurando a porta
-   (`lsof -nP -iTCP:9464 -sTCP:LISTEN`).
+   sessao nao mede nada (otel_usage null em toda onda; o preflight do
+   diagnostico acima detecta). Mitigacao: launcher de porta dinamica por
+   processo (README "Real per-wave cost").
 
 **Regra de decisao** (o operador manda, o default nunca mente):
 

--- a/global/commands/feature-00c.md
+++ b/global/commands/feature-00c.md
@@ -147,8 +147,13 @@ Exporte: `AGENTE_00C_STATE_DIR=<projeto>/.claude/feature-00c-state/<short_name>`
 
 8. coleta de consumo: PEDIR instalacao ao operador (nunca instalar sozinho)
    guard-hooks-status.sh check --projeto-alvo-path "$_proj" || :
-   - READ-ONLY: diagnostica, nunca instala. Os tres ativos => siga sem
-     incomodar o operador.
+   otel-usage.sh preflight || :
+   - READ-ONLY: diagnosticam, nunca instalam. Os tres hooks ativos => siga
+     sem incomodar o operador.
+   - preflight com `status=port-conflict` (porta do exporter presa por
+     OUTRO processo; owner_pid/owner_cwd na saida) ou `status=exporter-down`
+     => REPASSE o aviso ao operador antes de seguir (execucao sairia com
+     otel_usage null em toda onda). ok/disabled/unverified => siga.
    - Faltando algum => PECA a instalacao, apresentando os 3 pontos:
 
      (1) O que instala e para que serve — nenhum e redundante:
@@ -175,10 +180,9 @@ Exporte: `AGENTE_00C_STATE_DIR=<projeto>/.claude/feature-00c-state/<short_name>`
          (o segundo nao exige API key, Admin key nem organizacao; funciona
           em assinatura e nada sai de 127.0.0.1. ATENCAO: so UM processo do
           Claude Code faz bind da porta fixa 9464 — com outro processo aberto
-          antes, esta sessao nao mede nada, otel_usage null em toda onda.
-          Mitigacao: launcher de porta dinamica por processo, ver README
-          "Real per-wave cost"; diagnostico:
-          `lsof -nP -iTCP:9464 -sTCP:LISTEN`)
+          antes, esta sessao nao mede nada, otel_usage null em toda onda; o
+          preflight do diagnostico acima detecta. Mitigacao: launcher de
+          porta dinamica por processo, ver README "Real per-wave cost")
 
    - Regra de decisao:
      . sim  => pedir que rode `cstk hooks install` e confirmar antes de seguir

--- a/global/skills/agente-00c-runtime/scripts/otel-usage.sh
+++ b/global/skills/agente-00c-runtime/scripts/otel-usage.sh
@@ -398,9 +398,125 @@ _ou_cmd_delta() {
   return 0
 }
 
+# ---------- preflight ----------
+# A telemetria DESTA sessao vai ser medida? Checagem deterministica para o
+# inicio da execucao — os commands 00c invocam e repassam o aviso ao
+# operador; `state-ondas.sh start` tambem chama best-effort. Modo de falha
+# real que motivou isto (2026-07-29): porta 9464 presa por um `claude -c`
+# de outro projeto — a sessao corrente nao faz bind, nada e exportado e
+# otel_usage sai null em todas as ondas, sem nenhum aviso (ver bloco
+# DISPUTA DA PORTA FIXA no topo).
+#
+# Saida (stdout, 1 linha estavel):  status=<estado> endpoint=<url> [k=v...]
+# Exit: 0 = ok | disabled | unverified (nada a corrigir / indeterminavel)
+#       3 = port-conflict  (porta do endpoint pertence a OUTRO processo)
+#       4 = exporter-down  (opt-in ligado mas nada responde no endpoint)
+# NUNCA bloqueia: quem chama decide o que fazer com o aviso (best-effort,
+# como todo o resto deste script).
+
+# _ou_ep_port ENDPOINT -> porta quando o endpoint e HTTP local (127.0.0.1
+# ou localhost); exit 1 caso contrario (file://, host remoto: sem dono
+# local verificavel).
+_ou_ep_port() {
+  case "$1" in
+    http://127.0.0.1:[0-9]*|http://localhost:[0-9]*)
+      _ou_p=${1#http://*:}
+      _ou_p=${_ou_p%%/*}
+      printf '%s\n' "$_ou_p"
+      return 0 ;;
+  esac
+  return 1
+}
+
+# _ou_port_owner PORT -> PID do processo em LISTEN na porta, ou exit 1
+# (porta livre, ou lsof ausente/sem visibilidade — caller decide pelo
+# scrape nesse caso).
+_ou_port_owner() {
+  command -v lsof >/dev/null 2>&1 || return 1
+  _ou_own=$(lsof -nP -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null | head -n 1)
+  [ -n "$_ou_own" ] || return 1
+  printf '%s\n' "$_ou_own"
+}
+
+# _ou_owner_cwd PID -> diretorio de trabalho do processo (best-effort;
+# vazio se indeterminavel). `-Fn` emite `n/caminho` para o descriptor cwd.
+_ou_owner_cwd() {
+  lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -n 1
+}
+
+# _ou_is_ancestor PID -> 0 se PID e ancestral do processo corrente — i.e.
+# o exporter pertence a ESTA sessao do Claude Code (o script roda como
+# descendente do processo claude). 1 caso contrario.
+_ou_is_ancestor() {
+  _ou_walk=$$
+  while [ "$_ou_walk" -gt 1 ] 2>/dev/null; do
+    [ "$_ou_walk" = "$1" ] && return 0
+    _ou_walk=$(ps -o ppid= -p "$_ou_walk" 2>/dev/null | tr -d '[:space:]')
+    [ -n "$_ou_walk" ] || return 1
+  done
+  return 1
+}
+
+_ou_cmd_preflight() {
+  _ou_ep="$_OU_DEFAULT_ENDPOINT"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --endpoint) [ "$#" -ge 2 ] || _ou_die_usage "preflight: --endpoint exige valor"
+                  _ou_ep=$2; shift 2 ;;
+      *) _ou_die_usage "preflight: flag desconhecida: $1" ;;
+    esac
+  done
+
+  if [ "${CLAUDE_CODE_ENABLE_TELEMETRY:-}" != "1" ] || \
+     [ "${OTEL_METRICS_EXPORTER:-}" != "prometheus" ]; then
+    printf 'status=disabled endpoint=%s\n' "$_ou_ep"
+    return 0
+  fi
+
+  if _ou_port=$(_ou_ep_port "$_ou_ep"); then
+    if _ou_owner=$(_ou_port_owner "$_ou_port"); then
+      if _ou_is_ancestor "$_ou_owner"; then
+        printf 'status=ok endpoint=%s owner_pid=%s\n' "$_ou_ep" "$_ou_owner"
+        return 0
+      fi
+      _ou_cwd=$(_ou_owner_cwd "$_ou_owner")
+      printf 'status=port-conflict endpoint=%s owner_pid=%s owner_cwd=%s\n' \
+        "$_ou_ep" "$_ou_owner" "${_ou_cwd:--}"
+      _ou_warn "AVISO: a porta de $_ou_ep pertence a OUTRO processo (PID $_ou_owner${_ou_cwd:+, cwd $_ou_cwd}) — o consumo DESTA sessao NAO sera medido (otel_usage null em toda onda). Encerre o processo dono ou de a cada processo sua porta (OTEL_EXPORTER_PROMETHEUS_PORT + CSTK_OTEL_ENDPOINT — ver README 'Real per-wave cost')."
+      return 3
+    fi
+    # Porta local sem dono visivel: se ainda assim alguem responde com as
+    # metricas, a posse e indeterminavel (lsof ausente/sem visibilidade) —
+    # nao acusar conflito sem evidencia. Se nada responde: exporter-down.
+    _ou_tmp=$(mktemp) || _ou_die "mktemp falhou"
+    if _ou_scrape "$_ou_ep" "$_ou_tmp"; then
+      rm -f -- "$_ou_tmp"
+      printf 'status=unverified endpoint=%s\n' "$_ou_ep"
+      return 0
+    fi
+    rm -f -- "$_ou_tmp"
+    printf 'status=exporter-down endpoint=%s\n' "$_ou_ep"
+    _ou_warn "AVISO: telemetria ligada mas nada escuta em $_ou_ep — consumo NAO sera medido nesta sessao."
+    return 4
+  fi
+
+  # Endpoint nao-local (file://, host custom): sem dono verificavel;
+  # decide pelo scrape.
+  _ou_tmp=$(mktemp) || _ou_die "mktemp falhou"
+  if _ou_scrape "$_ou_ep" "$_ou_tmp"; then
+    rm -f -- "$_ou_tmp"
+    printf 'status=unverified endpoint=%s\n' "$_ou_ep"
+    return 0
+  fi
+  rm -f -- "$_ou_tmp"
+  printf 'status=exporter-down endpoint=%s\n' "$_ou_ep"
+  _ou_warn "AVISO: telemetria ligada mas o endpoint $_ou_ep nao responde com metricas claude_code — consumo NAO sera medido nesta sessao."
+  return 4
+}
+
 # ---------- dispatch ----------
 
-[ "$#" -gt 0 ] || _ou_die_usage "subcomando obrigatorio: available|snapshot|delta"
+[ "$#" -gt 0 ] || _ou_die_usage "subcomando obrigatorio: available|snapshot|delta|preflight"
 
 _ou_sub=$1
 shift
@@ -408,6 +524,7 @@ case "$_ou_sub" in
   available) _ou_cmd_available "$@" ;;
   snapshot)  _ou_cmd_snapshot "$@" ;;
   delta)     _ou_cmd_delta "$@" ;;
+  preflight) _ou_cmd_preflight "$@" ;;
   -h|--help)
     cat >&2 <<'HELP'
 otel-usage.sh — consumo real de tokens/custo por onda (telemetria OTel do Claude Code)
@@ -416,6 +533,7 @@ USO:
   otel-usage.sh available [--endpoint URL]
   otel-usage.sh snapshot  --state-dir DIR --phase start|end [--endpoint URL]
   otel-usage.sh delta     --state-dir DIR
+  otel-usage.sh preflight [--endpoint URL]
 
 Pre-requisito (opt-in, sem segredo):
   export CLAUDE_CODE_ENABLE_TELEMETRY=1
@@ -430,6 +548,11 @@ a unica sessao que cresceu entre os snapshots. Imprime `null` quando a
 metrica esta ausente OU quando a atribuicao e ambigua (mais de uma sessao
 ativa, processo do exporter trocado, snapshot em formato antigo) — nunca
 zero fabricado.
+
+preflight responde "a telemetria DESTA sessao vai ser medida?" sem nunca
+bloquear: exit 0 (ok|disabled|unverified), 3 (porta do endpoint pertence a
+OUTRO processo — dono nao e ancestral deste), 4 (opt-in ligado mas nada
+responde). stdout: `status=<estado> endpoint=<url> [owner_pid=N owner_cwd=D]`.
 HELP
     exit 2
     ;;

--- a/tests/test_otel-usage.sh
+++ b/tests/test_otel-usage.sh
@@ -408,5 +408,115 @@ scenario_flag_desconhecida_exit2() {
   return 0
 }
 
+# ==== preflight: a telemetria DESTA sessao vai ser medida? ====
+#
+# O dono da porta e detectado via lsof e comparado com a cadeia de
+# ancestrais do processo (ps -o ppid=). Nos cenarios, lsof e STUBADO no
+# PATH (nunca escondido — ver feedback PATH-stub): o stub responde as duas
+# invocacoes que o script faz (-tiTCP:... para o PID dono; -d cwd -Fn para
+# o diretorio). Dono "ancestral" usa $$ do proprio test (que E ancestral
+# do SUT); dono "estranho" usa PID 1 (launchd/init: existe sempre e nunca
+# e ancestral — o walk para em pid > 1).
+
+# _pf_stub_lsof DIR OWNER_PID CWD_PATH — stub de lsof que devolve um dono
+# fixo para a porta e um cwd fixo para esse dono. OWNER_PID vazio simula
+# porta livre (nada em LISTEN).
+_pf_stub_lsof() {
+  mkdir -p "$1"
+  cat > "$1/lsof" <<EOF
+#!/bin/sh
+case "\$*" in
+  *-tiTCP:*)  [ -n '$2' ] && printf '%s\n' '$2'; exit 0 ;;
+  *"-d cwd"*) [ -n '$3' ] && printf 'n%s\n' '$3'; exit 0 ;;
+esac
+exit 1
+EOF
+  chmod +x "$1/lsof"
+}
+
+_pf_run() {
+  # $1=stub-dir(ou "-" p/ PATH real) $2=endpoint; telemetria LIGADA.
+  if [ "$1" = "-" ]; then
+    capture env CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_METRICS_EXPORTER=prometheus \
+      sh "$SCRIPT" preflight --endpoint "$2"
+  else
+    capture env CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_METRICS_EXPORTER=prometheus \
+      PATH="$1:$PATH" sh "$SCRIPT" preflight --endpoint "$2"
+  fi
+}
+
+scenario_preflight_disabled_sem_optin() {
+  # Env vazio (nao unset: o script exige exatamente "1"/"prometheus").
+  capture env CLAUDE_CODE_ENABLE_TELEMETRY= OTEL_METRICS_EXPORTER= \
+    sh "$SCRIPT" preflight --endpoint "http://127.0.0.1:29464/metrics"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    status=disabled*) : ;;
+    *) _fail "stdout" "esperado status=disabled, obtido: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+scenario_preflight_ok_dono_ancestral() {
+  _stub="$TMPDIR_TEST/pf-anc"
+  _pf_stub_lsof "$_stub" "$$" "/qualquer/cwd"
+  _pf_run "$_stub" "http://127.0.0.1:29464/metrics"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    status=ok*owner_pid=$$*) : ;;
+    *) _fail "stdout" "esperado status=ok owner_pid=$$, obtido: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+scenario_preflight_conflito_dono_nao_ancestral_exit3() {
+  _stub="$TMPDIR_TEST/pf-conf"
+  _pf_stub_lsof "$_stub" "1" "/Users/outro/projeto-alheio"
+  _pf_run "$_stub" "http://127.0.0.1:29464/metrics"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "exit" "esperado 3, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    status=port-conflict*owner_pid=1*owner_cwd=/Users/outro/projeto-alheio*) : ;;
+    *) _fail "stdout" "esperado port-conflict com dono+cwd, obtido: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *AVISO*) : ;;
+    *) _fail "stderr" "esperado AVISO de conflito em stderr, obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  return 0
+}
+
+scenario_preflight_exporter_down_porta_livre_exit4() {
+  # Stub devolve porta livre (sem dono); endpoint local sem ninguem
+  # escutando (porta 9 / discard) -> scrape falha -> exporter-down.
+  _stub="$TMPDIR_TEST/pf-down"
+  _pf_stub_lsof "$_stub" "" ""
+  _pf_run "$_stub" "http://127.0.0.1:9/metrics"
+  [ "$_CAPTURED_EXIT" = 4 ] || { _fail "exit" "esperado 4, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    status=exporter-down*) : ;;
+    *) _fail "stdout" "esperado status=exporter-down, obtido: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+scenario_preflight_unverified_endpoint_arquivo() {
+  # Endpoint nao-local (file://): sem dono verificavel; scrape com as
+  # metricas presentes -> unverified, exit 0, sem aviso.
+  _fx="$TMPDIR_TEST/pf-file.txt"
+  _fixture "$_fx" "sess-pf" 1.0 0.5 100 20
+  _pf_run "-" "file://$_fx"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    status=unverified*) : ;;
+    *) _fail "stdout" "esperado status=unverified, obtido: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+scenario_preflight_flag_desconhecida_exit2() {
+  assert_exit 2 sh "$SCRIPT" preflight --nao-existe || return 1
+  return 0
+}
+
 run_all_scenarios
 exit $?


### PR DESCRIPTION
## Resumo

Fecha o gap de UX da 5.33.4: a disputa da porta do exporter OTel deixava a execução inteira sem medição **em silêncio**. Agora `otel-usage.sh preflight` responde deterministicamente "a telemetria DESTA sessão vai ser medida?" e os commands 00c o rodam no diagnóstico inicial, antes da onda-001.

## Como decide

- Dono da porta do endpoint via `lsof`; ancestralidade via walk de `ps -o ppid=` (o exporter desta sessão pertence a um ancestral do processo).
- `status=ok` exit 0 · `port-conflict` exit 3 (com `owner_pid`/`owner_cwd`, AVISO em stderr) · `exporter-down` exit 4 · `disabled`/`unverified` exit 0.
- Nunca acusa conflito sem evidência (posse indeterminável + scrape respondendo → `unverified`); nunca bloqueia a pipeline.

## Mudanças

- `otel-usage.sh`: subcomando `preflight` + help.
- `agente-00c.md` / `feature-00c.md`: preflight no diagnóstico de coleta, com instrução de repassar o aviso ao operador. Deliberadamente FORA do `state-ondas.sh start` (por onda poluiria stderr da suite inteira com telemetria ligada no ambiente do dev).
- READMEs + tabela de helpers do orquestrador.
- `test_otel-usage.sh`: +6 cenários (`lsof` stubado no PATH; dono ancestral = `$$` do teste, dono estranho = PID 1).

## Testes

- `test_otel-usage.sh` 28/0 (LC_ALL=C)
- Suite completa: **1935 pass / 0 fail** (LC_ALL=C, 1013s)
- shellcheck limpo no script modificado

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjSpnXM7eo93DL3Km7S5xv