### PR TITLE
fix(state-ondas,recall): waves.stages so aceita tokens de etapa (5.34.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [5.34.1] - 2026-07-30
+
+`waves.stages` no knowledge.db é uma lista de tokens de etapa — mas 3 ondas
+reais (2 execuções `agente-00c`, 1 `feature-00c`) tinham prosa de conclusão
+no campo e `n_stages=1`, porque `state-ondas.sh end --add-etapa` aceitava
+texto livre e o ingest confiava cegamente. Correção nas duas pontas +
+backfill das 3 linhas com valor rastreável.
+
+### Fixed
+
+- **`state-ondas.sh end --add-etapa` valida token de etapa (fail-closed).**
+  Cada valor deve casar `[A-Za-z0-9][A-Za-z0-9._-]{0,63}` (LC_ALL=C; newline
+  embutido também rejeitado — viraria 2+ etapas no split por linha). Valor
+  inválido = erro de uso no parse, ANTES de qualquer write; a mensagem
+  orienta que resumo de onda vai em Decisão (`state-decisions.sh register`),
+  nunca em `executed_stages`. Novo cenário
+  `scenario_end_add_etapa_rejeita_prosa` em `tests/test_state-ondas.sh`.
+- **Ingest de waves em `cli/lib/recall.sh` filtra não-tokens de
+  `executed_stages`.** Entrada que não é token é descartada do CSV e da
+  contagem com `log_warn` (nunca etapa silenciosa); lista não-vazia sem
+  nenhum token válido grava `stages` e `n_stages` como NULL (NULL honesto —
+  a prosa não é re-alojada: `waves` não tem coluna de resumo e a narrativa
+  segue no state.json de origem); lista vazia legítima preserva `''`/0.
+  `n_stages` passa a refletir SEMPRE a lista validada. Novo cenário
+  `scenario_m32_stages_prosa_nao_vira_etapa` em `tests/cstk/test_recall.sh`.
+- **Docs dos orquestradores** (`agente-00c-orchestrator.md` passo 9,
+  `agente-00c-feature-orchestrator.md` passo 4) declaram o contrato de token
+  de `--add-etapa` — a lacuna de prompt que originou as 3 gravações erradas.
+- **Backfill das 3 ondas afetadas** (operacional, fora do tarball): etapa
+  real `execute-task` recuperada de fonte rastreável em cada state.json
+  (dec-141 mcp-project-scafold onda-029; `skills_invoked` financial-support
+  onda-010; dec-005 cstk/model-routing-por-onda onda-002), com backup em
+  `state-history/` + sha256 atualizado; re-ingest zerou as linhas com prosa
+  (`instr(stages,' ')>0` → 0 linhas, 551 preenchidas intactas).
+
 ## [5.34.0] - 2026-07-29
 
 Pre-flight determinístico de telemetria: a pergunta "ESTA sessão vai ser
@@ -4450,6 +4485,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[5.34.1]: https://github.com/JotJunior/cstk/releases/tag/v5.34.1
 [5.34.0]: https://github.com/JotJunior/cstk/releases/tag/v5.34.0
 [5.33.4]: https://github.com/JotJunior/cstk/releases/tag/v5.33.4
 [5.33.3]: https://github.com/JotJunior/cstk/releases/tag/v5.33.3

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -1149,6 +1149,13 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
   # Deriva etapas (join ","), inicio/fim, wallclock_seconds, tool_calls,
   # motivo_termino (texto livre filtrado), n_etapas, n_skills (derivados via
   # length). Onda aberta (fim null) -> fim vazio, sem erro (1.3.5).
+  # stages e uma LISTA DE TOKENS ([A-Za-z0-9._-]): entrada de
+  # executed_stages que nao e token (prosa/resumo de onda — caso real: 3
+  # ondas legadas com narrativa de conclusao) e DESCARTADA do CSV e da
+  # contagem, com aviso (nunca etapa silenciosa). Se nada valido restar de
+  # uma lista nao-vazia, stages e n_stages viram NULL (NULL honesto; a
+  # prosa nao tem coluna em waves e nao e re-alojada — segue no state.json
+  # de origem). Lista vazia legitima segue '' + 0 (comportamento antigo).
   # v10 (wave-token-metrics): +9 campos de .agent_usage (agregado por onda).
   # .agent_usage ausente/null -> cada subcampo "" via `//` -> recall_int_or_null
   # produz NULL (nunca 0 fabricado; 0 legitimo de fato observado e preservado,
@@ -1159,15 +1166,21 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
     | to_entries[]
     | .key as $wi
     | .value as $w
-    | (($w.executed_stages // $w.etapas_executadas) // []) as $stages
+    | (($w.executed_stages // $w.etapas_executadas) // []) as $stages_raw
+    | ($stages_raw | map(strings)
+       | map(select(test("^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")))) as $stages
+    | (if ($stages_raw | length) > 0 and ($stages | length) == 0
+       then {csv: "", n: ""}
+       else {csv: ($stages | join(",")), n: ($stages | length | tostring)}
+       end) as $stg
     | [($w.id // "onda-\($wi)"),
-       ($stages | join(",")),
+       $stg.csv,
        ($w.started_at // $w.inicio // ""),
        ($w.finished_at // $w.fim // ""),
        (($w.wallclock_seconds // "")|tostring),
        (($w.tool_calls // "")|tostring),
        ($w.termination_reason // $w.motivo_termino // ""),
-       ($stages | length | tostring),
+       $stg.n,
        (($w.skills_invoked // [])
         | map(select((.kind // "skill") != "gate"))
         | length | tostring),
@@ -1196,7 +1209,8 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
        (($w.otel_usage.by_source.subagent.input // "")|tostring),
        (($w.otel_usage.by_source.subagent.output // "")|tostring),
        (($w.otel_usage.by_source.subagent.cache_read // "")|tostring),
-       (($w.otel_usage.by_source.subagent.cache_creation // "")|tostring)]
+       (($w.otel_usage.by_source.subagent.cache_creation // "")|tostring),
+       (($stages_raw | length) - ($stages | length) | tostring)]
     | @base64' "$_isj_state" 2>/dev/null) || _isj_wave_lines=""
   if [ -n "$_isj_wave_lines" ]; then
     _isj_OLDIFS="$IFS"; IFS='
@@ -1234,11 +1248,26 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
       _f_oso=$(printf '%s' "$_isj_decoded" | jq -r '.[28]' 2>/dev/null | strip_nul)
       _f_oscr=$(printf '%s' "$_isj_decoded" | jq -r '.[29]' 2>/dev/null | strip_nul)
       _f_oscc=$(printf '%s' "$_isj_decoded" | jq -r '.[30]' 2>/dev/null | strip_nul)
+      _f_inv=$(printf '%s' "$_isj_decoded" | jq -r '.[31]' 2>/dev/null | strip_nul)
       [ -n "$_f_wid" ] || continue
       _f_mt=$(recall_scrub "$_f_mt")
+      # Descartes de executed_stages nunca sao silenciosos (ver comentario
+      # do bloco jq acima): loga quantas entradas nao-token foram ignoradas.
+      case "$_f_inv" in
+        ''|0) : ;;
+        *) log_warn "recall: $_isj_feature/$_f_wid: $_f_inv entrada(s) de executed_stages descartada(s) (prosa/nao-token nao vira etapa; stages fica NULL se nada valido restar)" ;;
+      esac
       _isj_wc_sql=$(recall_int_or_null "$_f_wc")
       _isj_tc_sql=$(recall_int_or_null "$_f_tc")
       _isj_ne_sql=$(recall_int_or_null "$_f_ne")
+      # n vazio = lista invalidada por inteiro (so prosa) -> stages NULL
+      # junto com n_stages NULL. Lista vazia legitima chega como n=0 e
+      # preserva stages='' (comportamento historico).
+      if [ "$_isj_ne_sql" = "NULL" ]; then
+        _isj_etp_sql="NULL"
+      else
+        _isj_etp_sql="'$(sql_escape "$_f_etp")'"
+      fi
       _isj_ns_sql=$(recall_int_or_null "$_f_ns")
       _isj_ast_sql=$(recall_int_or_null "$_f_ast")
       _isj_asu_sql=$(recall_int_or_null "$_f_asu")
@@ -1264,7 +1293,7 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
       _isj_oscc_sql=$(recall_int_or_null "$_f_oscc")
       _isj_sql="$_isj_sql
 INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,started_at,finished_at,wallclock_seconds,tool_calls,termination_reason,n_stages,n_skills,session,agent_spawns_total,agent_spawns_with_usage,agent_total_tokens,agent_input_tokens,agent_output_tokens,agent_cache_read_tokens,agent_cache_creation_tokens,agent_tool_use_count,agent_duration_ms,otel_cost_usd,otel_cost_main_usd,otel_cost_subagent_usd,otel_total_tokens,otel_subagent_tokens,otel_main_input_tokens,otel_main_output_tokens,otel_main_cache_read_tokens,otel_main_cache_creation_tokens,otel_subagent_input_tokens,otel_subagent_output_tokens,otel_subagent_cache_read_tokens,otel_subagent_cache_creation_tokens,ingested_at)
-VALUES('$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','$(sql_escape "$_f_wid")','$(sql_escape "$_isj_exec_id")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_wid")','$(sql_escape "$_f_etp")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_fim")',$_isj_wc_sql,$_isj_tc_sql,'$(sql_escape "$_f_mt")',$_isj_ne_sql,$_isj_ns_sql,$_isj_session_sql,$_isj_ast_sql,$_isj_asu_sql,$_isj_att_sql,$_isj_ait_sql,$_isj_aot_sql,$_isj_acr_sql,$_isj_acc_sql,$_isj_atu_sql,$_isj_adm_sql,$_isj_ocu_sql,$_isj_ocm_sql,$_isj_ocs_sql,$_isj_ott_sql,$_isj_ost_sql,$_isj_omi_sql,$_isj_omo_sql,$_isj_omcr_sql,$_isj_omcc_sql,$_isj_osi_sql,$_isj_oso_sql,$_isj_oscr_sql,$_isj_oscc_sql,'$(sql_escape "$_isj_now")')
+VALUES('$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','$(sql_escape "$_f_wid")','$(sql_escape "$_isj_exec_id")','$(sql_escape "$_f_ini")','$(sql_escape "$_f_wid")',$_isj_etp_sql,'$(sql_escape "$_f_ini")','$(sql_escape "$_f_fim")',$_isj_wc_sql,$_isj_tc_sql,'$(sql_escape "$_f_mt")',$_isj_ne_sql,$_isj_ns_sql,$_isj_session_sql,$_isj_ast_sql,$_isj_asu_sql,$_isj_att_sql,$_isj_ait_sql,$_isj_aot_sql,$_isj_acr_sql,$_isj_acc_sql,$_isj_atu_sql,$_isj_adm_sql,$_isj_ocu_sql,$_isj_ocm_sql,$_isj_ocs_sql,$_isj_ott_sql,$_isj_ost_sql,$_isj_omi_sql,$_isj_omo_sql,$_isj_omcr_sql,$_isj_omcc_sql,$_isj_osi_sql,$_isj_oso_sql,$_isj_oscr_sql,$_isj_oscc_sql,'$(sql_escape "$_isj_now")')
 ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,stages=excluded.stages,started_at=excluded.started_at,finished_at=excluded.finished_at,wallclock_seconds=excluded.wallclock_seconds,tool_calls=excluded.tool_calls,termination_reason=excluded.termination_reason,n_stages=excluded.n_stages,n_skills=excluded.n_skills,session=excluded.session,agent_spawns_total=excluded.agent_spawns_total,agent_spawns_with_usage=excluded.agent_spawns_with_usage,agent_total_tokens=excluded.agent_total_tokens,agent_input_tokens=excluded.agent_input_tokens,agent_output_tokens=excluded.agent_output_tokens,agent_cache_read_tokens=excluded.agent_cache_read_tokens,agent_cache_creation_tokens=excluded.agent_cache_creation_tokens,agent_tool_use_count=excluded.agent_tool_use_count,agent_duration_ms=excluded.agent_duration_ms,otel_cost_usd=excluded.otel_cost_usd,otel_cost_main_usd=excluded.otel_cost_main_usd,otel_cost_subagent_usd=excluded.otel_cost_subagent_usd,otel_total_tokens=excluded.otel_total_tokens,otel_subagent_tokens=excluded.otel_subagent_tokens,otel_main_input_tokens=excluded.otel_main_input_tokens,otel_main_output_tokens=excluded.otel_main_output_tokens,otel_main_cache_read_tokens=excluded.otel_main_cache_read_tokens,otel_main_cache_creation_tokens=excluded.otel_main_cache_creation_tokens,otel_subagent_input_tokens=excluded.otel_subagent_input_tokens,otel_subagent_output_tokens=excluded.otel_subagent_output_tokens,otel_subagent_cache_read_tokens=excluded.otel_subagent_cache_read_tokens,otel_subagent_cache_creation_tokens=excluded.otel_subagent_cache_creation_tokens,ingested_at=excluded.ingested_at;"
       _isj_n_wave=$((_isj_n_wave + 1))
     done

--- a/global/agents/agente-00c-feature-orchestrator.md
+++ b/global/agents/agente-00c-feature-orchestrator.md
@@ -173,7 +173,10 @@ retomada sempre segue onda fechada" apos o Loop.
 
 4. **Iniciar onda** via `state-ondas.sh start --state-dir <SD>` (o `start`
    NAO aceita `--fase`; a etapa `specify` e registrada no fechamento via
-   `state-ondas.sh end --add-etapa specify`).
+   `state-ondas.sh end --add-etapa specify`). `--add-etapa` aceita SOMENTE
+   token de etapa (`[A-Za-z0-9._-]`, sem espaco/prosa) — resumo de onda vai
+   em Decisao, nunca nesse campo (o knowledge.db deriva `waves.stages` dele);
+   valor invalido e rejeitado com erro de uso.
 
 5. **Skill(specify)** via tool `Skill` (FR-008). Aguardar geracao de
    `<projeto>/docs/specs/<short-name>/spec.md`.

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -1593,6 +1593,12 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
    --motivo-termino <M> [--add-etapa <S>] [--proxima-agendada-para <ISO>]`.
    Motivos validos: `etapa_concluida_avancando`, `threshold_proxy_atingido`,
    `bloqueio_humano`, `aborto`, `concluido`.
+   `--add-etapa` aceita SOMENTE token de etapa (`specify`, `plan`,
+   `execute-task`, `execute-task-F3.1`... — `[A-Za-z0-9._-]`, sem espaco).
+   NUNCA passe resumo/narrativa da onda: o knowledge.db deriva
+   `waves.stages`/`n_stages` desse campo, e prosa o corrompe. Resumo de
+   conclusao vai em Decisao (`state-decisions.sh register`); valor invalido
+   e rejeitado com erro de uso.
 
 9.bis. **Ingestao na memoria de conhecimento (best-effort, ADITIVO —
    FASE 7 cstk-knowledge-db, FR-006/FR-018)**: apos o `end`, ingerir o

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -32,6 +32,13 @@
 #         manuais) + linhas do sidecar tool-call-ticks.log (ticks do hook
 #         PostToolUse) — sidecar resetado apos o fechamento.
 #         --add-etapa pode ser passada N vezes para append em executed_stages.
+#         Cada valor DEVE ser um token de etapa ([A-Za-z0-9._-], ate 64
+#         chars, sem espaco/prosa) — o knowledge.db deriva waves.stages e
+#         n_stages deste campo, e um resumo narrativo gravado aqui corrompe
+#         o indice (caso real: 3 ondas com prosa de conclusao e n_stages=1).
+#         Resumo de onda pertence a Decisao (state-decisions.sh register),
+#         nunca a executed_stages. Valor invalido => erro de uso ANTES de
+#         qualquer write (fail-closed).
 #         --next-instruction grava .next_instruction NO MESMO write atomico
 #         (dispensa o `state-rw.sh set` separado ANTES de end — que deixava
 #         backup/sha defasados, ja que `end` tambem escreve no state.json).
@@ -178,6 +185,21 @@ _so_require_jq() {
 
 _so_iso_now() { date -u +%FT%TZ; }
 _so_state_file() { printf '%s/state.json\n' "$1"; }
+
+# Token de etapa valido para executed_stages: identificador curto tipo
+# "specify" / "execute-task-F3.1". Prosa (espaco, pontuacao narrativa,
+# acento, newline) NAO e etapa — o knowledge.db deriva waves.stages e
+# n_stages deste campo. LC_ALL=C evita que ranges casem acentuados em
+# locale pt_BR.
+_so_is_stage_token() {
+  _t=$1
+  [ -n "$_t" ] || return 1
+  # newline embutido viraria 2+ etapas no split por linha de `end`.
+  _nl='
+'
+  case "$_t" in *"$_nl"*) return 1 ;; esac
+  printf '%s' "$_t" | LC_ALL=C grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$'
+}
 
 # Diretorio do proprio script — resolve scripts irmaos (pipeline.sh, state-rw.sh)
 # usados por reconcile-wave. Deriva de $0 (mesmo padrao de model-routing.sh).
@@ -564,7 +586,10 @@ _so_cmd_end() {
       --motivo-termino)        _motivo=$2; shift 2 ;;
       --proxima-agendada-para) _proxima=$2; shift 2 ;;
       --next-instruction)      _next_instr=$2; _next_instr_set=1; shift 2 ;;
-      --add-etapa)             _etapas="$_etapas
+      --add-etapa)
+        _so_is_stage_token "$2" || _so_die_usage \
+          "end: --add-etapa aceita token de etapa ([A-Za-z0-9._-], ate 64 chars, sem espaco/prosa); recebido: '$2'. Resumo de onda vai em Decisao (state-decisions.sh register), nao em executed_stages."
+        _etapas="$_etapas
 $2"; shift 2 ;;
       *) _so_die_usage "end: flag desconhecida: $1" ;;
     esac

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -922,6 +922,43 @@ JSON
 }
 
 # =========================================================================
+# Cenario M3.2 — waves.stages e lista de TOKENS: prosa em executed_stages
+# nao vira etapa (caso real: 3 ondas legadas com resumo de conclusao no
+# campo e n_stages=1). Entrada nao-token e descartada do CSV e da contagem;
+# lista 100% invalida -> stages NULL + n_stages NULL (NULL honesto, nunca a
+# prosa nem contagem fabricada); lista vazia legitima preserva ''/0.
+# =========================================================================
+scenario_m32_stages_prosa_nao_vira_etapa() {
+  _have_deps || return 0
+  _mdir="$TMPDIR_TEST/featPr"
+  mkdir -p "$_mdir"
+  cat > "$_mdir/state.json" <<'JSON'
+{
+  "short_name": "featPr",
+  "etapa_corrente": "execute-task",
+  "execucao": { "id": "exec-featPr", "projeto_alvo_path": "/home/u/projPr", "status": "concluida", "iniciada_em": "2026-01-01T00:00:00Z", "terminada_em": "2026-01-01T01:00:00Z" },
+  "metricas_acumuladas": { "ondas_total": 3 },
+  "decisoes": [], "bloqueios_humanos": [],
+  "ondas": [
+    { "id": "onda-001", "inicio": "2026-01-01T00:00:00Z", "fim": "2026-01-01T00:20:00Z", "etapas_executadas": ["onda-001 concluida: task 5.3 avancou de 8/16 para 9/16 patterns"], "tool_calls": 1, "motivo_termino": "etapa_concluida" },
+    { "id": "onda-002", "inicio": "2026-01-01T00:20:00Z", "fim": "2026-01-01T00:40:00Z", "etapas_executadas": ["specify", "resumo em prosa que nao e etapa"], "tool_calls": 1, "motivo_termino": "etapa_concluida" },
+    { "id": "onda-003", "inicio": "2026-01-01T00:40:00Z", "fim": "2026-01-01T01:00:00Z", "etapas_executadas": [], "tool_calls": 0, "motivo_termino": "etapa_concluida" }
+  ]
+}
+JSON
+  assert_exit 0 _rc --ingest --state-dir "$_mdir" --db "$TMPDIR_TEST/k.db" || return 1
+  # onda-001: so prosa -> stages NULL e n_stages NULL (nunca a prosa, nunca 1).
+  _r=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT (stages IS NULL)||'|'||(n_stages IS NULL) FROM waves WHERE feature='featPr' AND wave='onda-001'")
+  [ "$_r" = "1|1" ] || { _fail "prosa->NULL" "obtido [$_r]"; return 1; }
+  # onda-002: token valido preservado, prosa descartada, n_stages conta so validos.
+  _r=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT stages||'|'||n_stages FROM waves WHERE feature='featPr' AND wave='onda-002'")
+  [ "$_r" = "specify|1" ] || { _fail "filtra prosa" "obtido [$_r]"; return 1; }
+  # onda-003: lista vazia legitima segue '' + 0 (comportamento inalterado).
+  _r=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT (stages='')||'|'||n_stages FROM waves WHERE feature='featPr' AND wave='onda-003'")
+  [ "$_r" = "1|0" ] || { _fail "vazio inalterado" "obtido [$_r]"; return 1; }
+}
+
+# =========================================================================
 # Cenario M4.1 — re-ingestao N vezes: delta de linhas executions/waves = 0
 # (task 1.4.2; SC-004, Acceptance US1.4). Valor reflete estado mais recente.
 # =========================================================================

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -1461,4 +1461,30 @@ scenario_marco_falho_nao_derruba_end() {
   return 0
 }
 
+# --add-etapa e token de etapa, nunca prosa: o knowledge.db deriva
+# waves.stages/n_stages de executed_stages, e um resumo de conclusao gravado
+# aqui corrompia o indice (caso real: 3 ondas com narrativa e n_stages=1).
+scenario_end_add_etapa_rejeita_prosa() {
+  _sd="$TMPDIR_TEST/state-etapa-token"
+  _init_state "$_sd"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando \
+    --add-etapa "onda-029 concluida: task 5.3 avancou de 8/16 para 9/16 patterns"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "prosa aceita" "end deveria rejeitar --add-etapa com prosa"; return 1; }
+  # Rejeicao acontece no parse, ANTES de qualquer write: a onda segue aberta.
+  _fim=$(jq -r '.waves[-1].finished_at // "aberta"' "$_sd/state.json")
+  [ "$_fim" = "aberta" ] || { _fail "write parcial" "onda foi fechada apesar do erro ($_fim)"; return 1; }
+  # Valor com newline embutido viraria 2+ etapas no split por linha: rejeita.
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando \
+    --add-etapa "specify
+prosa contrabandeada na segunda linha"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "newline aceito" "token multi-linha deveria ser rejeitado"; return 1; }
+  # Tokens legitimos (ponto, maiuscula, hifen) seguem aceitos.
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando \
+    --add-etapa execute-task-F3.1 --add-etapa execute-task-F3.2
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "token valido" "$_CAPTURED_STDERR"; return 1; }
+  _st=$(jq -r '.waves[-1].executed_stages | join(",")' "$_sd/state.json")
+  [ "$_st" = "execute-task-F3.1,execute-task-F3.2" ] || { _fail "etapas" "obtido $_st"; return 1; }
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Problema

3 ondas reais no knowledge.db tinham prosa de conclusao em `waves.stages` (ate 2766 chars) e `n_stages=1`: `state-ondas.sh end --add-etapa` aceitava texto livre em `executed_stages` e o ingest do recall fazia `join(",")` + `length` sem validar.

## Correcao (nas duas pontas)

- **Origem**: `--add-etapa` valida token `[A-Za-z0-9][A-Za-z0-9._-]{0,63}` fail-closed no parse (rejeita prosa e newline embutido ANTES de qualquer write); docs dos 2 orquestradores declaram o contrato.
- **Ingest**: nao-tokens sao descartados do CSV/contagem com `log_warn`; lista 100% invalida grava `stages`/`n_stages` NULL (nunca etapa silenciosa, nunca contagem fabricada); lista vazia legitima preserva `''`/0.
- **Backfill** (operacional, fora do diff): 3 ondas corrigidas na origem com etapa real `execute-task` rastreavel (dec-141 / skills_invoked / dec-005); `instr(stages,' ')>0` agora retorna 0 linhas.

## Testado

- Suite completa local: **1937 PASS / 0 FAIL** (973s, `LC_ALL=C`)
- `--check-coverage`: zero orfaos
- Novos cenarios: `scenario_end_add_etapa_rejeita_prosa` + `scenario_m32_stages_prosa_nao_vira_etapa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjSpnXM7eo93DL3Km7S5xv