### PR TITLE
feat(state-db-foundation): state.db SQLite como fonte de verdade transacional (fase 1/v6.0.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,13 @@ jobs:
           set -eu
           TAG="${{ steps.tag.outputs.tag }}"
           BARE="${{ steps.tag.outputs.bare }}"
-          gh release create "$TAG" \
+          # Sufixo SemVer de pre-release (v6.0.0-alpha.1, v1.2.3-rc.1) publica
+          # como prerelease — fora de releases/latest, canal estavel intacto.
+          PRERELEASE=""
+          case "$BARE" in
+            *-*) PRERELEASE="--prerelease" ;;
+          esac
+          gh release create "$TAG" $PRERELEASE \
             --title "cstk $TAG" \
             --generate-notes \
             "dist/cstk-${BARE}.tar.gz" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [6.0.0-alpha.1] - 2026-07-31
+
+Abertura da linha v6.0.0 (pre-release): fundação do `state.db` SQLite como
+fonte de verdade transacional das execuções 00c, entregue pela feature
+`state-db-foundation` (pipeline feature-00c completa: 20 ondas, 31 tarefas,
+spec em `docs/specs/state-db-foundation/`). Nesta fase o backend é **opt-in
+por projeto** via migração explícita — sem `state.db` presente, tudo segue
+em `state.json` exatamente como antes. O cutover (init em SQLite por
+default, config global e `cstk state enable-sqlite`) fica para as próximas
+alphas da linha v6.
+
+### Added
+
+- **Schema do `state.db` (9 entidades).**
+  `global/skills/agente-00c-runtime/references/state-db-schema.sql` +
+  `state-db-schema.sh create` (WAL, `chmod 600` em db+sidecars): execution,
+  wave, decision, human_block, task, event, skill_invocation, agent_spawn e
+  migration_run, com UNIQUE/CHECK/triggers (onda única aberta, fechamento
+  único, CHECKs de score/evidência e status×finished_at). Testes de
+  invariantes em `tests/test_state-db-schema.sh`.
+- **Primitivas de acesso dual-backend.** `state-rw.sh`, `state-ondas.sh`,
+  `state-decisions.sh`, `bloqueios.sh` e `spawn-tracker.sh` despacham por
+  presença de `state.db` (contrato C2) para as novas implementações
+  `_state-rw-db.sh`, `_state-ondas-db.sh`, `_state-decisions-db.sh`,
+  `_bloqueios-db.sh` e `_spawn-tracker-db.sh`, com paridade de stdout/exit
+  code (C1), escape obrigatório de texto de origem LLM (C8, payload hostil
+  testado) e helpers compartilhados em `_state-db.sh` (pragmas, retry sob
+  lock, permissões). IDs (`dec-NNN`, `block-NNN`) gerados por subquery na
+  própria transação — sem colisão sob concorrência (15 writers simultâneos
+  testados; `tests/test_state-db-concurrency.sh` cobre kill -9 sem corrupção
+  e leitor não-bloqueado sob WAL).
+- **Export derivado para compat.** `_so_export_snapshot` gera `state.json`
+  derivado no fim de cada onda SQLite (gatilho automático) e sob demanda via
+  `state-ondas.sh export-snapshot` — painel/recall seguem funcionando sem
+  mudança.
+- **Migração explícita `state.json` → `state.db`.**
+  `state-db-migrate.sh` (gate de equivalência round-trip: reprova e não
+  publica nada se o export do banco divergir da origem) + subcomando
+  `cstk state migrate` (`cli/lib/state.sh`). Recusa execução `em_andamento`;
+  permite `aguardando_humano`. Exit 3 dedicado para recusa por pré-condição.
+- **Ingestão SQL→SQL no knowledge.db.** `cli/lib/recall.sh` ingere direto do
+  `state.db` via `ATTACH DATABASE mode=ro&immutable=1` + `INSERT...SELECT`
+  (7 entidades), com fixtures de equivalência contra a ingestão JSON.
+- **Constitution 1.3.0.** Amendment ratificado: carve-out disciplinado de
+  dependência obrigatória restrito à camada de estado transacional
+  (`sqlite3` >= 3.45.1; regulariza a condição pré-existente de `jq`).
+
+### Fixed
+
+- **4 bugs pré-existentes expostos pelo trabalho da feature**: padrão
+  `x=$(cmd); rc=$?` sob `set -e` matava o shell antes do tratamento de erro
+  (retry/backoff e mapeamento de FK inalcançáveis); `PRAGMA busy_timeout`
+  ecoava o valor no stdout do CLI `sqlite3` corrompendo `SELECT`s;
+  `decisions[].wave_id="init"` e ordem de emissão skill→decision violavam FK
+  na reconstrução com dados reais; `jq '.campo // null'` colapsava booleanos
+  `false` para NULL na migração.
+
+### CI
+
+- **`release.yml` publica tag com sufixo SemVer como prerelease.** Tag
+  `vX.Y.Z-suffix` recebe `--prerelease` no `gh release create` — pre-release
+  não vira `releases/latest`, preservando o canal estável de
+  `cstk update`/install one-liner.
+
 ## [5.34.1] - 2026-07-30
 
 `waves.stages` no knowledge.db é uma lista de tokens de etapa — mas 3 ondas
@@ -4485,6 +4549,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[6.0.0-alpha.1]: https://github.com/JotJunior/cstk/releases/tag/v6.0.0-alpha.1
 [5.34.1]: https://github.com/JotJunior/cstk/releases/tag/v5.34.1
 [5.34.0]: https://github.com/JotJunior/cstk/releases/tag/v5.34.0
 [5.33.4]: https://github.com/JotJunior/cstk/releases/tag/v5.33.4

--- a/cli/cstk
+++ b/cli/cstk
@@ -143,6 +143,7 @@ COMANDOS:
                 tambem --ingest (pos-onda) e --reindex (reconstrucao)
   show-tip      Exibe uma dica sobre uma skill do toolkit (aleatoria ou por SKILL/--phase)
   serve         Inicia o painel web cstk; baixa e instala na primeira execucao
+  state         Operacoes sobre o estado transacional 00c (state migrate)
   hooks         Provisiona os hooks do runtime 00c num projeto-alvo
                 (so hooks + settings.json; nao duplica skill/commands/agents)
   00c <path>    Bootstrap interativo de projeto-alvo do agente-00C
@@ -170,6 +171,11 @@ HELP
       printf 'Para help inline, rode: cstk hooks --help\n'
       exit "$CSTK_EXIT_OK"
       ;;
+    state)
+      printf 'cstk help state: consulte docs/specs/state-db-foundation/contracts/migration.md\n'
+      printf 'Para help inline, rode: cstk state --help\n'
+      exit "$CSTK_EXIT_OK"
+      ;;
     install|update|self-update|list|doctor|session|serve)
       printf 'cstk help %s: consulte docs/specs/cstk-cli/contracts/cli-commands.md §%s\n' \
         "$_sub" "$_sub"
@@ -195,7 +201,7 @@ HELP
       ;;
     *)
       printf 'cstk: comando desconhecido para help: %s\n' "$_sub" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, 00c\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, 00c\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac
@@ -228,7 +234,7 @@ _dispatch() {
       . "$_lib_file"
       serve_main "$@"
       ;;
-    install|update|self-update|list|doctor|session|recall|show-tip|hooks)
+    install|update|self-update|list|doctor|session|recall|show-tip|hooks|state)
       # Boot-check para todos exceto self-update (que e o caminho de recovery
       # da janela transiente — bloquea-lo aqui causaria deadlock).
       case "$_cmd" in
@@ -277,7 +283,7 @@ _dispatch() {
       ;;
     *)
       printf 'cstk: comando desconhecido: %s\n' "$_cmd" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, 00c, help, --version\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, 00c, help, --version\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -842,6 +842,54 @@ recall_query_sql() {
   printf '%s\n' "$2" | sqlite3 -cmd '.timeout 5000' -- "$1" 2>/dev/null
 }
 
+# recall_sqlite_ro_uri PATH -> imprime a URI `file:PATH?mode=ro&immutable=1`
+# com os caracteres especiais de URI (%, ?, #, espaco, aspa simples,
+# ampersand) percent-encoded — a aspa simples e percent-encoded porque a URI
+# e, no caso de recall_query_sql_ro, entregue via o dot-command
+# `.open '<uri>'` (tokenizer proprio do shell sqlite3, que nao entende
+# escaping de aspa embutida; ver comentario de recall_query_sql_ro).
+#
+# `immutable=1` e OBRIGATORIO junto de `mode=ro` (nao apenas um dos dois):
+# testado empiricamente que `mode=ro` SOZINHO falha ("unable to open
+# database file") sempre que o state.db esta em journal_mode=WAL SEM os
+# sidecars `-shm`/`-wal` presentes no disco — o caso COMUM logo apos
+# `state-db-migrate.sh migrate` (que fecha a conexao de escrita e
+# tipicamente faz checkpoint, removendo os sidecars) ou entre ondas do
+# orquestrador (cada invocacao da CLI abre/fecha sua propria conexao). Um
+# leitor mode=ro precisaria criar o `-shm` para coordenar o indice WAL, mas
+# mode=ro proibe qualquer criacao de arquivo — falha em exatamente o caso
+# mais comum. `immutable=1` informa ao SQLite que o arquivo nao mudara
+# durante a conexao, dispensando o `-shm` inteiramente, MANTENDO a mesma
+# rejeicao de escrita a nivel de driver ("attempt to write a readonly
+# database", exit 8) — verificado com e sem sidecars presentes. Usada para
+# TODA leitura do state.db pela ingestao SQL->SQL (FR-009): a fonte NUNCA
+# pode ser escrita por este caminho — dec-037 (refinado empiricamente nesta
+# FASE 8; `mode=ro` isolado, como a Decisao original propunha, se mostrou
+# insuficiente na pratica).
+recall_sqlite_ro_uri() {
+  printf 'file:%s?mode=ro&immutable=1' \
+    "$(printf '%s' "$1" | sed "s/%/%25/g; s/?/%3F/g; s/#/%23/g; s/ /%20/g; s/'/%27/g; s/&/%26/g")"
+}
+
+# recall_query_sql_ro DB_PATH SQL_TEXT -> como recall_query_sql, mas abre
+# DB_PATH estritamente read-only via a URI de recall_sqlite_ro_uri. Uso
+# exclusivo: ler o state.db a partir da ingestao SQL->SQL
+# (recall_ingest_state_db) — a fonte NUNCA pode ser escrita por este
+# caminho, mesmo em consultas de leitura pontual (contagens/proveniencia).
+#
+# IMPORTANTE: passar a URI como argumento FILENAME posicional do sqlite3 NAO
+# ativa o parsing de URI nesta CLI (testado empiricamente: build Apple do
+# sqlite3 3.51.0 nao reconhece `file:...?mode=ro` como FILENAME direto —
+# "unable to open database file"; so `-uri` ativaria, mas essa flag nao
+# existe nesta build). O dot-command `.open '<uri>'` SEMPRE reconhece URI
+# (mesmo codigo usado por `ATTACH DATABASE 'file:...'`, que ja funciona
+# passado direto em SQL — ATTACH sempre interpreta URI, independente da
+# CLI). Abre um `:memory:` inicial (nunca tocado) e troca via `.open`.
+recall_query_sql_ro() {
+  printf '%s\n' "$2" \
+    | sqlite3 -cmd '.timeout 5000' -cmd ".open '$(recall_sqlite_ro_uri "$1")'" -- :memory: 2>/dev/null
+}
+
 # ==========================================================================
 # Dispatcher de modos (parsing de argv: busca | --ingest | --reindex)
 # ==========================================================================
@@ -946,28 +994,41 @@ recall_derive_canonical() {
     printf '%s' "$_rdc_name" | strip_nul
     return 0
   fi
+  recall_derive_canonical_from_path "$_rdc_pap"
+  return 0
+}
+
+# recall_derive_canonical_from_path TARGET_PROJECT_PATH -> stdout: nome
+# canonico, camadas 2+3 de recall_derive_canonical (git ao vivo -> basename).
+# Extraido para ser reusado pelo caminho SQL de ingestao
+# (recall_ingest_state_db): a camada 1 la vem de uma COLUNA (execution.
+# canonical_project), nao de jq sobre um state.json — so as camadas 2/3
+# (que nao dependem de JSON) sao compartilhaveis. Mesmas garantias: nunca
+# falha, stdout nao-vazio quando TARGET_PROJECT_PATH nao-vazio.
+recall_derive_canonical_from_path() {
+  _rdcp_pap="$1"
   # Camada 2: git ao vivo — somente quando `.git` e ARQUIVO (worktree).
-  if [ -n "$_rdc_pap" ] && [ -f "$_rdc_pap/.git" ] \
+  if [ -n "$_rdcp_pap" ] && [ -f "$_rdcp_pap/.git" ] \
      && command -v git >/dev/null 2>&1; then
-    _rdc_common=$(git -C "$_rdc_pap" rev-parse --git-common-dir 2>/dev/null) \
-      || _rdc_common=""
-    if [ -n "$_rdc_common" ]; then
+    _rdcp_common=$(git -C "$_rdcp_pap" rev-parse --git-common-dir 2>/dev/null) \
+      || _rdcp_common=""
+    if [ -n "$_rdcp_common" ]; then
       # Normalizacao relativo->absoluto (CHK026): git pode retornar `.git`
       # relativo; prefixar o proprio path-alvo antes do dirname.
-      case "$_rdc_common" in
+      case "$_rdcp_common" in
         /*) : ;;
-        *)  _rdc_common="$_rdc_pap/$_rdc_common" ;;
+        *)  _rdcp_common="$_rdcp_pap/$_rdcp_common" ;;
       esac
-      _rdc_name=$(basename -- "$(dirname -- "$_rdc_common" 2>/dev/null)" 2>/dev/null) \
-        || _rdc_name=""
-      if [ -n "$_rdc_name" ] && [ "$_rdc_name" != "/" ] && [ "$_rdc_name" != "." ]; then
-        printf '%s' "$_rdc_name" | strip_nul
+      _rdcp_name=$(basename -- "$(dirname -- "$_rdcp_common" 2>/dev/null)" 2>/dev/null) \
+        || _rdcp_name=""
+      if [ -n "$_rdcp_name" ] && [ "$_rdcp_name" != "/" ] && [ "$_rdcp_name" != "." ]; then
+        printf '%s' "$_rdcp_name" | strip_nul
         return 0
       fi
     fi
   fi
   # Camada 3: fallback final = basename do path-alvo (comportamento atual).
-  basename -- "$_rdc_pap" 2>/dev/null | strip_nul
+  basename -- "$_rdcp_pap" 2>/dev/null | strip_nul
   return 0
 }
 
@@ -1918,6 +1979,381 @@ COMMIT;"
   return "$RECALL_EXIT_OK"
 }
 
+# ==========================================================================
+# FASE 8 (state-db-foundation) — Ingestao SQL->SQL a partir de state.db
+# ==========================================================================
+#
+# recall_ingest_state_db STATE_DB STATE_DIR DB -> ingere um unico state.db
+# (backend SQLite dual do state-db-foundation) no indice DB. Caminho ADITIVO
+# a recall_ingest_state_json (FR-012): so acionado quando state.db existe
+# (recall_mode_ingest decide qual dos dois chamar — o caminho JSON permanece
+# intocado para projetos ainda nao migrados).
+#
+# Mecanismo (dec-037, D7-a): `ATTACH DATABASE 'file:...?mode=ro' AS src;`
+# seguido de `INSERT ... SELECT` por entidade (research.md Decision 7).
+# `mode=ro` e ENFORCED pelo driver SQLite — a fonte nunca pode ser escrita
+# por este caminho (FR-009), sem depender de disciplina de codigo.
+#
+# Duas passagens (dec auditavel registrada pelo caller apos o 1o ingest):
+#   PASS 1 (ATTACH + INSERT...SELECT, uma unica transacao): copia em bloco
+#     as 7 entidades (executions, waves, decisions, blocks, tasks, events,
+#     skills) com TODAS as colunas, incluindo os campos de texto livre
+#     AINDA NAO filtrados. json_extract()/json_each() (JSON1, piso
+#     sqlite3 3.45.1 — research.md Decision 10) extraem os blobs JSON de
+#     wave.agent_usage/agent_spawns/otel_usage e filtram/normalizam
+#     wave.executed_stages em SQL puro, sem shell/jq.
+#   PASS 2 (fixup, mesma conexao knowledge.db, SEM ATTACH): secrets-filter.sh
+#     e um processo externo — nenhuma extensao SQL o substitui. Os poucos
+#     campos de texto livre (executions.termination_reason;
+#     decisions.context/rationale/evidence; blocks.question/
+#     context_for_answer/answer; tasks.title; events.description) sao lidos
+#     de volta (JSON via json_group_array, mesmo idioma de
+#     recall_ingest_state_json), filtrados via recall_scrub e regravados via
+#     UPDATE ... WHERE id=<pk interno>. Encerra reconstruindo knowledge_fts
+#     (decisions/blocks) so com o corpo ja filtrado, escopado por
+#     execution_id (nunca apaga FTS de outras execucoes da mesma feature).
+#
+# Idempotencia: mesma chave UNIQUE(project,feature,wave,source_id) +
+# ON CONFLICT DO UPDATE do caminho JSON. Best-effort: qualquer falha
+# degrada gracioso (aviso + exit 0), nunca aborta a onda.
+recall_ingest_state_db() {
+  _isd_state_db="$1"
+  _isd_state_dir="$2"
+  _isd_db="$3"
+
+  if [ ! -r "$_isd_state_db" ]; then
+    log_warn "recall: state.db ausente ou ilegivel: $_isd_state_db (ingestao pulada)"
+    return "$RECALL_EXIT_OK"
+  fi
+
+  _isd_now=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || _isd_now="1970-01-01T00:00:00Z"
+
+  # ---- Proveniencia (grao = 1 execucao por state.db) ----
+  _isd_prov_json=$(recall_query_sql_ro "$_isd_state_db" \
+    "SELECT json_object('id',id,'canonical_project',canonical_project,'short_name',short_name,'target_project_path',target_project_path,'session_name',session_name) FROM execution LIMIT 1;")
+  if [ -z "$_isd_prov_json" ]; then
+    log_warn "recall: state.db sem linha em 'execution': $_isd_state_db (ingestao pulada)"
+    return "$RECALL_EXIT_OK"
+  fi
+  _isd_exec_id=$(printf '%s' "$_isd_prov_json" | jq -r '.id // ""' 2>/dev/null | strip_nul)
+  _isd_canon=$(printf '%s' "$_isd_prov_json" | jq -r '.canonical_project // ""' 2>/dev/null | strip_nul)
+  _isd_short=$(printf '%s' "$_isd_prov_json" | jq -r '.short_name // ""' 2>/dev/null | strip_nul)
+  _isd_proj_path=$(printf '%s' "$_isd_prov_json" | jq -r '.target_project_path // ""' 2>/dev/null | strip_nul)
+  _isd_session=$(printf '%s' "$_isd_prov_json" | jq -r '.session_name // ""' 2>/dev/null | strip_nul)
+  if [ -z "$_isd_exec_id" ]; then
+    log_warn "recall: state.db com execution.id vazio: $_isd_state_db (ingestao pulada)"
+    return "$RECALL_EXIT_OK"
+  fi
+
+  # project: camada 1 (coluna canonical_project, congelada no init) ->
+  # camadas 2/3 compartilhadas com o caminho JSON.
+  if [ -n "$_isd_canon" ]; then
+    _isd_project="$_isd_canon"
+  else
+    _isd_project=$(recall_derive_canonical_from_path "$_isd_proj_path") || _isd_project=""
+  fi
+  [ -n "$_isd_project" ] || _isd_project="unknown"
+
+  # feature: coluna short_name -> fallback por layout de diretorio (mesma
+  # heuristica do caminho JSON, aplicada sobre STATE_DIR: parent =
+  # dirname(STATE_DIR), leaf = basename(STATE_DIR) — equivalente a
+  # dirname/basename do state.json dentro daquele diretorio).
+  _isd_feature="$_isd_short"
+  if [ -z "$_isd_feature" ]; then
+    _isd_parent=$(dirname -- "$_isd_state_dir" 2>/dev/null) || _isd_parent=""
+    if [ "$(basename -- "$_isd_parent" 2>/dev/null)" = "feature-00c-state" ]; then
+      _isd_feature=$(basename -- "$_isd_state_dir" 2>/dev/null) || _isd_feature=""
+    elif [ "$(basename -- "$_isd_state_dir" 2>/dev/null)" = "agente-00c-state" ]; then
+      _isd_feature="$_isd_project"
+    fi
+  fi
+  [ -n "$_isd_feature" ] || _isd_feature="unknown"
+
+  _isd_project_sql="'$(sql_escape "$_isd_project")'"
+  _isd_feature_sql="'$(sql_escape "$_isd_feature")'"
+  _isd_exec_id_sql="'$(sql_escape "$_isd_exec_id")'"
+  _isd_now_sql="'$(sql_escape "$_isd_now")'"
+  if [ -n "$_isd_session" ]; then
+    _isd_session_sql="'$(sql_escape "$_isd_session")'"
+  else
+    _isd_session_sql="NULL"
+  fi
+  if [ -n "$_isd_proj_path" ]; then
+    _isd_path_sql="'$(sql_escape "$_isd_proj_path")'"
+  else
+    _isd_path_sql="NULL"
+  fi
+
+  # ---- Contagens (mesma semantica dos contadores do caminho JSON: linhas
+  # de origem processadas, nao delta real do UPSERT) — lidas do state.db. ----
+  _isd_counts_json=$(recall_query_sql_ro "$_isd_state_db" "
+SELECT json_object(
+  'n_wave',(SELECT count(*) FROM wave WHERE execution_id=$_isd_exec_id_sql),
+  'n_dec',(SELECT count(*) FROM decision WHERE execution_id=$_isd_exec_id_sql),
+  'n_bloq',(SELECT count(*) FROM human_block WHERE execution_id=$_isd_exec_id_sql),
+  'n_task',(SELECT count(*) FROM task_outcome WHERE execution_id=$_isd_exec_id_sql),
+  'n_event',(SELECT count(*) FROM event WHERE execution_id=$_isd_exec_id_sql),
+  'n_skill',(SELECT count(*) FROM skill_invocation si JOIN wave w ON w.id=si.wave_id WHERE w.execution_id=$_isd_exec_id_sql AND si.kind != 'gate')
+);")
+  _isd_n_exec=1
+  _isd_n_wave=$(printf '%s' "$_isd_counts_json" | jq -r '.n_wave // 0' 2>/dev/null)
+  _isd_n_dec=$(printf '%s' "$_isd_counts_json" | jq -r '.n_dec // 0' 2>/dev/null)
+  _isd_n_bloq=$(printf '%s' "$_isd_counts_json" | jq -r '.n_bloq // 0' 2>/dev/null)
+  _isd_n_task=$(printf '%s' "$_isd_counts_json" | jq -r '.n_task // 0' 2>/dev/null)
+  _isd_n_event=$(printf '%s' "$_isd_counts_json" | jq -r '.n_event // 0' 2>/dev/null)
+  _isd_n_skill=$(printf '%s' "$_isd_counts_json" | jq -r '.n_skill // 0' 2>/dev/null)
+
+  # ==== PASS 1: ATTACH + INSERT...SELECT em bloco (texto livre AINDA cru) ====
+  _isd_attach_val="$(sql_escape "$(recall_sqlite_ro_uri "$_isd_state_db")")"
+  _isd_p1="ATTACH DATABASE '$_isd_attach_val' AS src;
+BEGIN;
+INSERT INTO executions(project,feature,wave,execution_id,source_ts,source_id,status,termination_reason,current_stage,started_at,finished_at,duration_seconds,suggested_stack,waves_total,tool_calls_total,wallclock_total_seconds,subagents_spawned,max_depth,decisions_total,human_blocks_total,skill_suggestions_total,toolkit_issues_opened,session,target_project_path,ingested_at)
+SELECT $_isd_project_sql,$_isd_feature_sql,'-',e.id,e.started_at,e.id,
+  e.status, e.termination_reason,
+  CASE WHEN e.status='concluida' THEN 'concluido' ELSE e.current_stage END,
+  e.started_at, e.finished_at,
+  CAST(unixepoch(e.finished_at) - unixepoch(e.started_at) AS INTEGER),
+  e.suggested_stack,
+  (SELECT count(*) FROM src.wave WHERE execution_id=e.id),
+  (SELECT sum(tool_calls) FROM src.wave WHERE execution_id=e.id),
+  (SELECT sum(wallclock_seconds) FROM src.wave WHERE execution_id=e.id),
+  NULL, e.subagent_depth,
+  (SELECT count(*) FROM src.decision WHERE execution_id=e.id),
+  (SELECT count(*) FROM src.human_block WHERE execution_id=e.id),
+  NULL, NULL,
+  $_isd_session_sql,$_isd_path_sql,$_isd_now_sql
+FROM src.execution e
+WHERE 1=1 -- disambigua parser INSERT...SELECT...ON CONFLICT apos FROM sem JOIN (empirico)
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,status=excluded.status,termination_reason=excluded.termination_reason,current_stage=excluded.current_stage,started_at=excluded.started_at,finished_at=excluded.finished_at,duration_seconds=excluded.duration_seconds,suggested_stack=excluded.suggested_stack,waves_total=excluded.waves_total,tool_calls_total=excluded.tool_calls_total,wallclock_total_seconds=excluded.wallclock_total_seconds,subagents_spawned=excluded.subagents_spawned,max_depth=excluded.max_depth,decisions_total=excluded.decisions_total,human_blocks_total=excluded.human_blocks_total,skill_suggestions_total=excluded.skill_suggestions_total,toolkit_issues_opened=excluded.toolkit_issues_opened,session=excluded.session,target_project_path=excluded.target_project_path,ingested_at=excluded.ingested_at;
+
+INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,started_at,finished_at,wallclock_seconds,tool_calls,termination_reason,n_stages,n_skills,session,agent_spawns_total,agent_spawns_with_usage,agent_total_tokens,agent_input_tokens,agent_output_tokens,agent_cache_read_tokens,agent_cache_creation_tokens,agent_tool_use_count,agent_duration_ms,otel_cost_usd,otel_cost_main_usd,otel_cost_subagent_usd,otel_total_tokens,otel_subagent_tokens,otel_main_input_tokens,otel_main_output_tokens,otel_main_cache_read_tokens,otel_main_cache_creation_tokens,otel_subagent_input_tokens,otel_subagent_output_tokens,otel_subagent_cache_read_tokens,otel_subagent_cache_creation_tokens,ingested_at)
+SELECT $_isd_project_sql,$_isd_feature_sql,w.id,w.execution_id,w.started_at,w.id,
+  CASE WHEN coalesce(json_array_length(w.executed_stages),0) > 0
+        AND coalesce((SELECT count(*) FROM json_each(w.executed_stages) je WHERE je.value GLOB '[A-Za-z0-9]*' AND je.value NOT GLOB '*[^A-Za-z0-9._-]*' AND length(je.value)<=64),0)=0
+       THEN NULL
+       ELSE coalesce((SELECT group_concat(je.value,',' ORDER BY je.key) FROM json_each(w.executed_stages) je WHERE je.value GLOB '[A-Za-z0-9]*' AND je.value NOT GLOB '*[^A-Za-z0-9._-]*' AND length(je.value)<=64),'')
+  END,
+  w.started_at, w.finished_at, w.wallclock_seconds, w.tool_calls, w.termination_reason,
+  CASE WHEN coalesce(json_array_length(w.executed_stages),0) > 0
+        AND coalesce((SELECT count(*) FROM json_each(w.executed_stages) je WHERE je.value GLOB '[A-Za-z0-9]*' AND je.value NOT GLOB '*[^A-Za-z0-9._-]*' AND length(je.value)<=64),0)=0
+       THEN NULL
+       ELSE coalesce((SELECT count(*) FROM json_each(w.executed_stages) je WHERE je.value GLOB '[A-Za-z0-9]*' AND je.value NOT GLOB '*[^A-Za-z0-9._-]*' AND length(je.value)<=64),0)
+  END,
+  (SELECT count(*) FROM src.skill_invocation si WHERE si.wave_id=w.id AND si.kind != 'gate'),
+  $_isd_session_sql,
+  json_extract(w.agent_usage,'\$.spawns_total'), json_extract(w.agent_usage,'\$.spawns_with_usage'),
+  json_extract(w.agent_usage,'\$.total_tokens'), json_extract(w.agent_usage,'\$.input_tokens'),
+  json_extract(w.agent_usage,'\$.output_tokens'), json_extract(w.agent_usage,'\$.cache_read_input_tokens'),
+  json_extract(w.agent_usage,'\$.cache_creation_input_tokens'), json_extract(w.agent_usage,'\$.tool_use_count'),
+  json_extract(w.agent_usage,'\$.duration_ms'),
+  json_extract(w.otel_usage,'\$.total_cost_usd'), json_extract(w.otel_usage,'\$.by_source.main.cost_usd'),
+  json_extract(w.otel_usage,'\$.by_source.subagent.cost_usd'), json_extract(w.otel_usage,'\$.total_tokens'),
+  (CASE WHEN json_extract(w.otel_usage,'\$.by_source.subagent') IS NULL THEN NULL
+        ELSE coalesce(json_extract(w.otel_usage,'\$.by_source.subagent.input'),0)
+           + coalesce(json_extract(w.otel_usage,'\$.by_source.subagent.output'),0)
+           + coalesce(json_extract(w.otel_usage,'\$.by_source.subagent.cache_read'),0)
+           + coalesce(json_extract(w.otel_usage,'\$.by_source.subagent.cache_creation'),0)
+   END),
+  json_extract(w.otel_usage,'\$.by_source.main.input'), json_extract(w.otel_usage,'\$.by_source.main.output'),
+  json_extract(w.otel_usage,'\$.by_source.main.cache_read'), json_extract(w.otel_usage,'\$.by_source.main.cache_creation'),
+  json_extract(w.otel_usage,'\$.by_source.subagent.input'), json_extract(w.otel_usage,'\$.by_source.subagent.output'),
+  json_extract(w.otel_usage,'\$.by_source.subagent.cache_read'), json_extract(w.otel_usage,'\$.by_source.subagent.cache_creation'),
+  $_isd_now_sql
+FROM src.wave w
+WHERE 1=1 -- disambigua parser INSERT...SELECT...ON CONFLICT apos FROM sem JOIN (empirico)
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,stages=excluded.stages,started_at=excluded.started_at,finished_at=excluded.finished_at,wallclock_seconds=excluded.wallclock_seconds,tool_calls=excluded.tool_calls,termination_reason=excluded.termination_reason,n_stages=excluded.n_stages,n_skills=excluded.n_skills,session=excluded.session,agent_spawns_total=excluded.agent_spawns_total,agent_spawns_with_usage=excluded.agent_spawns_with_usage,agent_total_tokens=excluded.agent_total_tokens,agent_input_tokens=excluded.agent_input_tokens,agent_output_tokens=excluded.agent_output_tokens,agent_cache_read_tokens=excluded.agent_cache_read_tokens,agent_cache_creation_tokens=excluded.agent_cache_creation_tokens,agent_tool_use_count=excluded.agent_tool_use_count,agent_duration_ms=excluded.agent_duration_ms,otel_cost_usd=excluded.otel_cost_usd,otel_cost_main_usd=excluded.otel_cost_main_usd,otel_cost_subagent_usd=excluded.otel_cost_subagent_usd,otel_total_tokens=excluded.otel_total_tokens,otel_subagent_tokens=excluded.otel_subagent_tokens,otel_main_input_tokens=excluded.otel_main_input_tokens,otel_main_output_tokens=excluded.otel_main_output_tokens,otel_main_cache_read_tokens=excluded.otel_main_cache_read_tokens,otel_main_cache_creation_tokens=excluded.otel_main_cache_creation_tokens,otel_subagent_input_tokens=excluded.otel_subagent_input_tokens,otel_subagent_output_tokens=excluded.otel_subagent_output_tokens,otel_subagent_cache_read_tokens=excluded.otel_subagent_cache_read_tokens,otel_subagent_cache_creation_tokens=excluded.otel_subagent_cache_creation_tokens,ingested_at=excluded.ingested_at;
+
+INSERT INTO decisions(project,feature,wave,execution_id,source_ts,source_id,agent,stage,choice,options,score,context,rationale,evidence,ingested_at)
+SELECT $_isd_project_sql,$_isd_feature_sql,coalesce(d.wave_id,'onda'),d.execution_id,d.timestamp,d.id,
+  d.agent,
+  CASE WHEN d.stage='model-routing' AND substr(d.context,-1,1)=')' AND instr(d.context,'(fase ')>0
+       THEN substr(d.context, instr(d.context,'(fase ')+6, length(d.context)-instr(d.context,'(fase ')-6)
+       ELSE d.stage END,
+  d.choice, d.options_considered, d.justification_score,
+  d.context, d.rationale, d.evidence,
+  $_isd_now_sql
+FROM src.decision d
+WHERE 1=1 -- disambigua parser INSERT...SELECT...ON CONFLICT apos FROM sem JOIN (empirico)
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,agent=excluded.agent,stage=excluded.stage,choice=excluded.choice,options=excluded.options,score=excluded.score,context=excluded.context,rationale=excluded.rationale,evidence=excluded.evidence,ingested_at=excluded.ingested_at;
+
+INSERT INTO blocks(project,feature,wave,execution_id,source_ts,source_id,status,question,context_for_answer,answer,decision_id,triggered_at,answered_at,latency_seconds,ingested_at)
+SELECT $_isd_project_sql,$_isd_feature_sql,'bloq',h.execution_id,coalesce(h.answered_at,h.triggered_at),h.id,
+  h.status, h.question, h.context_for_answer, h.human_answer, h.decision_id, h.triggered_at, h.answered_at,
+  CASE WHEN h.triggered_at IS NOT NULL AND h.answered_at IS NOT NULL
+       THEN CAST(unixepoch(h.answered_at) - unixepoch(h.triggered_at) AS INTEGER) ELSE NULL END,
+  $_isd_now_sql
+FROM src.human_block h
+WHERE 1=1 -- disambigua parser INSERT...SELECT...ON CONFLICT apos FROM sem JOIN (empirico)
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,status=excluded.status,question=excluded.question,context_for_answer=excluded.context_for_answer,answer=excluded.answer,decision_id=excluded.decision_id,triggered_at=excluded.triggered_at,answered_at=excluded.answered_at,latency_seconds=excluded.latency_seconds,ingested_at=excluded.ingested_at;
+
+INSERT INTO tasks(project,feature,wave,execution_id,source_ts,source_id,title,outcome,tests_run,tests_passed,lint_ok,touched_files,ingested_at)
+SELECT $_isd_project_sql,$_isd_feature_sql,t.wave_id,t.execution_id,'',t.task_id,
+  t.title, t.outcome, t.tests_run, t.tests_passed, t.lint_ok,
+  coalesce(json_array_length(t.touched_files),0),
+  $_isd_now_sql
+FROM src.task_outcome t
+WHERE 1=1 -- disambigua parser INSERT...SELECT...ON CONFLICT apos FROM sem JOIN (empirico)
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,title=excluded.title,outcome=excluded.outcome,tests_run=excluded.tests_run,tests_passed=excluded.tests_passed,lint_ok=excluded.lint_ok,touched_files=excluded.touched_files,ingested_at=excluded.ingested_at;
+
+INSERT INTO events(project,feature,wave,execution_id,source_ts,source_id,event_type,timestamp,description,ingested_at)
+SELECT $_isd_project_sql,$_isd_feature_sql,'-',ev.execution_id,ev.timestamp,ev.event_type || ':' || ev.timestamp,
+  ev.event_type, ev.timestamp, ev.description,
+  $_isd_now_sql
+FROM src.event ev
+WHERE 1=1 -- disambigua parser INSERT...SELECT...ON CONFLICT apos FROM sem JOIN (empirico)
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,event_type=excluded.event_type,timestamp=excluded.timestamp,description=excluded.description,ingested_at=excluded.ingested_at;
+
+INSERT INTO skills(project,feature,wave,execution_id,source_ts,source_id,skill_name,decision_id,ingested_at)
+SELECT $_isd_project_sql,$_isd_feature_sql,si.wave_id,w2.execution_id,si.timestamp,
+  'skill-' || si.wave_id || '-' || (ord.rn - 1),
+  si.skill, si.decision_id, $_isd_now_sql
+FROM src.skill_invocation si
+JOIN src.wave w2 ON w2.id = si.wave_id
+JOIN (SELECT id, ROW_NUMBER() OVER (PARTITION BY wave_id ORDER BY id) AS rn FROM src.skill_invocation) ord ON ord.id = si.id
+WHERE si.kind != 'gate'
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,skill_name=excluded.skill_name,decision_id=excluded.decision_id,ingested_at=excluded.ingested_at;
+
+DELETE FROM knowledge_fts WHERE type='skill' AND project=$_isd_project_sql AND feature=$_isd_feature_sql AND source_id IN (SELECT source_id FROM skills WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql);
+INSERT INTO knowledge_fts(body,type,project,feature,wave,source_id,source_ts)
+SELECT skill_name,'skill',project,feature,wave,source_id,source_ts FROM skills WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql;
+
+COMMIT;
+DETACH DATABASE src;"
+
+  recall_apply_sql_with_retry "$_isd_db" "$_isd_p1" || {
+    log_warn "recall: ingestao SQL->SQL de $_isd_state_db degradou (lock persistente apos retries); pulada"
+    return "$RECALL_EXIT_OK"
+  }
+
+  # ==== PASS 2: fixup de scrub (secrets-filter.sh e processo externo, sem
+  # equivalente em SQL puro) + reconstrucao de knowledge_fts com o corpo ja
+  # filtrado. Sem ATTACH — opera so sobre knowledge.db. Escopado por
+  # execution_id em toda consulta/():nunca toca linhas de outras execucoes. ====
+  _isd_fix="BEGIN;"
+
+  _isd_tr_json=$(recall_query_sql "$_isd_db" \
+    "SELECT json_object('tr',termination_reason) FROM executions WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql AND wave='-';")
+  _isd_tr=$(printf '%s' "$_isd_tr_json" | jq -r '.tr // empty' 2>/dev/null | strip_nul)
+  if [ -n "$_isd_tr" ]; then
+    _isd_tr=$(recall_scrub "$_isd_tr")
+    _isd_fix="$_isd_fix
+UPDATE executions SET termination_reason='$(sql_escape "$_isd_tr")' WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql AND wave='-';"
+  fi
+
+  _isd_dec_json=$(recall_query_sql "$_isd_db" \
+    "SELECT coalesce(json_group_array(json_object('id',id,'context',context,'rationale',rationale,'evidence',evidence)),'[]') FROM decisions WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql;")
+  _isd_rows=$(printf '%s' "$_isd_dec_json" | jq -r '.[] | @base64' 2>/dev/null)
+  if [ -n "$_isd_rows" ]; then
+    _isd_OLDIFS="$IFS"; IFS='
+'
+    for _isd_row in $_isd_rows; do
+      _isd_dec=$(printf '%s' "$_isd_row" | base64 -d 2>/dev/null) || continue
+      _isd_rid=$(printf '%s' "$_isd_dec" | jq -r '.id' 2>/dev/null)
+      case "$_isd_rid" in ''|*[!0-9]*) continue ;; esac
+      _isd_ctx=$(printf '%s' "$_isd_dec" | jq -r '.context // ""' 2>/dev/null | strip_nul)
+      _isd_rat=$(printf '%s' "$_isd_dec" | jq -r '.rationale // ""' 2>/dev/null | strip_nul)
+      _isd_evd=$(printf '%s' "$_isd_dec" | jq -r '.evidence // ""' 2>/dev/null | strip_nul)
+      _isd_ctx=$(recall_scrub "$_isd_ctx")
+      _isd_rat=$(recall_scrub "$_isd_rat")
+      _isd_evd=$(recall_scrub "$_isd_evd")
+      _isd_fix="$_isd_fix
+UPDATE decisions SET context='$(sql_escape "$_isd_ctx")',rationale='$(sql_escape "$_isd_rat")',evidence='$(sql_escape "$_isd_evd")' WHERE id=$_isd_rid;"
+    done
+    IFS="$_isd_OLDIFS"
+  fi
+
+  _isd_bloq_json=$(recall_query_sql "$_isd_db" \
+    "SELECT coalesce(json_group_array(json_object('id',id,'question',question,'context_for_answer',context_for_answer,'answer',answer)),'[]') FROM blocks WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql;")
+  _isd_rows=$(printf '%s' "$_isd_bloq_json" | jq -r '.[] | @base64' 2>/dev/null)
+  if [ -n "$_isd_rows" ]; then
+    _isd_OLDIFS="$IFS"; IFS='
+'
+    for _isd_row in $_isd_rows; do
+      _isd_b=$(printf '%s' "$_isd_row" | base64 -d 2>/dev/null) || continue
+      _isd_rid=$(printf '%s' "$_isd_b" | jq -r '.id' 2>/dev/null)
+      case "$_isd_rid" in ''|*[!0-9]*) continue ;; esac
+      _isd_q=$(printf '%s' "$_isd_b" | jq -r '.question // ""' 2>/dev/null | strip_nul)
+      _isd_cpr=$(printf '%s' "$_isd_b" | jq -r '.context_for_answer // ""' 2>/dev/null | strip_nul)
+      _isd_ans=$(printf '%s' "$_isd_b" | jq -r '.answer // ""' 2>/dev/null | strip_nul)
+      _isd_q=$(recall_scrub "$_isd_q")
+      _isd_cpr=$(recall_scrub "$_isd_cpr")
+      _isd_ans=$(recall_scrub "$_isd_ans")
+      _isd_fix="$_isd_fix
+UPDATE blocks SET question='$(sql_escape "$_isd_q")',context_for_answer='$(sql_escape "$_isd_cpr")',answer='$(sql_escape "$_isd_ans")' WHERE id=$_isd_rid;"
+    done
+    IFS="$_isd_OLDIFS"
+  fi
+
+  _isd_task_json=$(recall_query_sql "$_isd_db" \
+    "SELECT coalesce(json_group_array(json_object('id',id,'title',title)),'[]') FROM tasks WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql;")
+  _isd_rows=$(printf '%s' "$_isd_task_json" | jq -r '.[] | @base64' 2>/dev/null)
+  if [ -n "$_isd_rows" ]; then
+    _isd_OLDIFS="$IFS"; IFS='
+'
+    for _isd_row in $_isd_rows; do
+      _isd_t=$(printf '%s' "$_isd_row" | base64 -d 2>/dev/null) || continue
+      _isd_rid=$(printf '%s' "$_isd_t" | jq -r '.id' 2>/dev/null)
+      case "$_isd_rid" in ''|*[!0-9]*) continue ;; esac
+      _isd_tit=$(printf '%s' "$_isd_t" | jq -r '.title // ""' 2>/dev/null | strip_nul)
+      _isd_tit=$(recall_scrub "$_isd_tit")
+      _isd_fix="$_isd_fix
+UPDATE tasks SET title='$(sql_escape "$_isd_tit")' WHERE id=$_isd_rid;"
+    done
+    IFS="$_isd_OLDIFS"
+  fi
+
+  _isd_event_json=$(recall_query_sql "$_isd_db" \
+    "SELECT coalesce(json_group_array(json_object('id',id,'description',description)),'[]') FROM events WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql;")
+  _isd_rows=$(printf '%s' "$_isd_event_json" | jq -r '.[] | @base64' 2>/dev/null)
+  if [ -n "$_isd_rows" ]; then
+    _isd_OLDIFS="$IFS"; IFS='
+'
+    for _isd_row in $_isd_rows; do
+      _isd_e=$(printf '%s' "$_isd_row" | base64 -d 2>/dev/null) || continue
+      _isd_rid=$(printf '%s' "$_isd_e" | jq -r '.id' 2>/dev/null)
+      case "$_isd_rid" in ''|*[!0-9]*) continue ;; esac
+      _isd_isnull=$(printf '%s' "$_isd_e" | jq -r '.description == null' 2>/dev/null)
+      [ "$_isd_isnull" = "true" ] && continue
+      _isd_desc=$(printf '%s' "$_isd_e" | jq -r '.description // ""' 2>/dev/null | strip_nul)
+      _isd_desc=$(recall_scrub "$_isd_desc")
+      _isd_fix="$_isd_fix
+UPDATE events SET description='$(sql_escape "$_isd_desc")' WHERE id=$_isd_rid;"
+    done
+    IFS="$_isd_OLDIFS"
+  fi
+
+  # Reconstrucao de knowledge_fts (decisions/blocks) com o corpo ja
+  # filtrado — escopada por execution_id (nunca apaga FTS de outras
+  # execucoes da mesma feature/projeto). Ordem do corpo espelha
+  # recall_ingest_state_json: decision=choice+options+context+rationale+
+  # evidence; block=question+context_for_answer+answer.
+  _isd_fix="$_isd_fix
+DELETE FROM knowledge_fts WHERE type='decision' AND project=$_isd_project_sql AND feature=$_isd_feature_sql AND source_id IN (SELECT source_id FROM decisions WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql);
+INSERT INTO knowledge_fts(body,type,project,feature,wave,source_id,source_ts)
+SELECT coalesce(choice,'')||' '||coalesce(options,'')||' '||coalesce(context,'')||' '||coalesce(rationale,'')||' '||coalesce(evidence,''),'decision',project,feature,wave,source_id,source_ts
+FROM decisions WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql;
+
+DELETE FROM knowledge_fts WHERE type='block' AND project=$_isd_project_sql AND feature=$_isd_feature_sql AND source_id IN (SELECT source_id FROM blocks WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql);
+INSERT INTO knowledge_fts(body,type,project,feature,wave,source_id,source_ts)
+SELECT coalesce(question,'')||' '||coalesce(context_for_answer,'')||' '||coalesce(answer,''),'block',project,feature,wave,source_id,source_ts
+FROM blocks WHERE execution_id=$_isd_exec_id_sql AND project=$_isd_project_sql AND feature=$_isd_feature_sql;
+
+COMMIT;"
+
+  recall_apply_sql_with_retry "$_isd_db" "$_isd_fix" || {
+    log_warn "recall: fixup de scrub (PASS 2) de $_isd_state_db degradou (lock persistente); dados PASS 1 ficam sem filtro de segredo ate proxima ingestao"
+  }
+
+  RECALL_TOTAL_EXEC=$((${RECALL_TOTAL_EXEC:-0} + _isd_n_exec))
+  RECALL_TOTAL_WAVE=$((${RECALL_TOTAL_WAVE:-0} + _isd_n_wave))
+  RECALL_TOTAL_DEC=$((${RECALL_TOTAL_DEC:-0} + _isd_n_dec))
+  RECALL_TOTAL_BLOQ=$((${RECALL_TOTAL_BLOQ:-0} + _isd_n_bloq))
+  RECALL_TOTAL_TASK=$((${RECALL_TOTAL_TASK:-0} + _isd_n_task))
+  RECALL_TOTAL_EVENT=$((${RECALL_TOTAL_EVENT:-0} + _isd_n_event))
+  RECALL_TOTAL_SKILL=$((${RECALL_TOTAL_SKILL:-0} + _isd_n_skill))
+  return "$RECALL_EXIT_OK"
+}
+
 # recall_backoff_sleep TRY -> dorme ~TRY segundos + jitter fracionario [0,1)s
 # derivado do PID. Sem jitter, dois writers que colidiram dormem o MESMO tempo
 # e re-colidem em lockstep (thundering herd) ate esgotar retries; o jitter
@@ -2185,8 +2621,18 @@ recall_mode_ingest() {
   RECALL_TOTAL_EXEC=0; RECALL_TOTAL_WAVE=0; RECALL_TOTAL_ALERT=0
   RECALL_TOTAL_TASK=0; RECALL_TOTAL_EVENT=0; RECALL_TOTAL_MEMORY=0
   RECALL_TOTAL_SUGGESTION=0; RECALL_TOTAL_WAVE_MODEL=0
-  recall_ingest_state_json "$_ing_state_dir/state.json" "$_ing_db"
-  # Passo aditivo (CQ2): ingerir memorias do projeto apos state.json.
+  # FR-008/FR-012 (state-db-foundation, task 8.2.1): presenca de state.db
+  # escolhe o caminho SQL->SQL (recall_ingest_state_db); ausencia preserva
+  # o caminho JSON atual SEM ALTERACAO (projeto ainda nao migrado — US4
+  # AS-2). Os dois caminhos sao mutuamente exclusivos por execucao: um
+  # state-dir tem OU state.json OU state.db como fonte de verdade corrente
+  # (nunca ambos simultaneamente pos-migracao — contracts/migration.md).
+  if [ -r "$_ing_state_dir/state.db" ]; then
+    recall_ingest_state_db "$_ing_state_dir/state.db" "$_ing_state_dir" "$_ing_db"
+  else
+    recall_ingest_state_json "$_ing_state_dir/state.json" "$_ing_db"
+  fi
+  # Passo aditivo (CQ2): ingerir memorias do projeto apos state.json/state.db.
   recall_ingest_memories "$_ing_state_dir" "$_ing_db"
 
   printf 'ingested: %d decisions, %d blocks, %d retros, %d skills, %d executions, %d waves, %d alerts, %d tasks, %d events, %d memories, %d suggestions, %d wave_model_usage\n' \

--- a/cli/lib/state.sh
+++ b/cli/lib/state.sh
@@ -1,0 +1,108 @@
+# state.sh — subcomando `cstk state` (feature state-db-foundation, FASE 6).
+#
+# Ref: docs/specs/state-db-foundation/contracts/migration.md §Nomeacao
+#      (dec-034: "B para a UX do operador, delegando a A a implementacao")
+#
+# Esta lib NAO implementa migracao: ela e a SUPERFICIE DE OPERADOR que delega
+# a global/skills/agente-00c-runtime/scripts/state-db-migrate.sh, mantendo a
+# logica testavel pelo harness POSIX do runtime e dando ao operador um verbo
+# coerente com o resto do CLI.
+#
+# Por que `cstk state migrate` e nao `state-rw.sh migrate`: este ultimo JA
+# EXISTE com outro significado (migracao do schema interno do state.json,
+# pt-BR -> EN). Dois sentidos sob o mesmo verbo e armadilha de operador.
+#
+# Subcomandos:
+#   cstk state migrate --state-dir DIR   — migra state.json -> state.db
+#
+# Exit codes (repassados VERBATIM do script delegado, para o operador poder
+# distinguir "recusado" de "falhou"):
+#   0 sucesso   1 falha   2 uso incorreto   3 recusado por pre-condicao (M1)
+#
+# POSIX sh puro. Sem bash-isms.
+
+if [ -n "${_CSTK_STATE_LOADED:-}" ]; then
+  return 0 2>/dev/null
+fi
+_CSTK_STATE_LOADED=1
+
+if [ -n "${CSTK_LIB:-}" ] && [ -f "$CSTK_LIB/common.sh" ]; then
+  # shellcheck source=./common.sh
+  . "$CSTK_LIB/common.sh"
+fi
+
+# _state_migrate_script_path -> imprime o caminho de state-db-migrate.sh.
+# Procura, em ordem: (1) PATH; (2) layout repo/CLI relativo a CSTK_LIB
+# (cli/lib -> ../../global/skills/agente-00c-runtime/scripts); (3) layout
+# instalado em ~/.claude/skills/agente-00c-runtime/scripts.
+#
+# A camada (2) e essencial fora de uma instalacao: testes e CI rodam o CLI da
+# arvore do repo (CSTK_LIB=cli/lib) SEM ter o runtime em ~/.claude. Mesmo
+# padrao (e mesma licao de campo) de recall_secrets_filter_path em recall.sh:
+# resolver SO via ~/.claude passa local e quebra no CI fresh-checkout.
+_state_migrate_script_path() {
+  if command -v state-db-migrate.sh >/dev/null 2>&1; then
+    command -v state-db-migrate.sh
+    return 0
+  fi
+  if [ -n "${CSTK_LIB:-}" ]; then
+    _sm_repo="$CSTK_LIB/../../global/skills/agente-00c-runtime/scripts/state-db-migrate.sh"
+    if [ -f "$_sm_repo" ]; then
+      printf '%s\n' "$_sm_repo"
+      return 0
+    fi
+  fi
+  _sm_default="${HOME:-/tmp}/.claude/skills/agente-00c-runtime/scripts/state-db-migrate.sh"
+  if [ -f "$_sm_default" ]; then
+    printf '%s\n' "$_sm_default"
+    return 0
+  fi
+  return 1
+}
+
+_state_usage() {
+  cat <<'HELP'
+cstk state — operacoes sobre o estado transacional de execucoes 00c
+
+USO:
+  cstk state migrate --state-dir DIR   Migra <DIR>/state.json para <DIR>/state.db
+
+MIGRATE:
+  Migracao EXPLICITA e nunca automatica (FR-005). Recusa se a execucao estiver
+  ativa (status em_andamento), se o estado for invalido, se a integridade do
+  state.json divergir, ou se ja existir um state.db de outra execucao.
+  O state.json de origem e sempre PRESERVADO como export/legado.
+
+EXIT CODES:
+  0 sucesso   1 falha   2 uso incorreto   3 recusado por pre-condicao
+HELP
+}
+
+state_main() {
+  _st_sub="${1:-}"
+  [ "$#" -ge 1 ] && shift || :
+
+  case "$_st_sub" in
+    ''|-h|--help|help)
+      _state_usage
+      return 0
+      ;;
+    migrate)
+      if ! _st_script=$(_state_migrate_script_path); then
+        printf 'cstk state: state-db-migrate.sh nao encontrado.\n' >&2
+        printf 'cstk state: instale o runtime 00c ("cstk install") ou rode a partir da arvore do repo.\n' >&2
+        return 1
+      fi
+      # Delegacao pura: flags e exit code repassados verbatim. `sh "$script"`
+      # (em vez de exec direto) evita depender do bit de execucao preservado
+      # pelo empacotamento do tarball.
+      sh "$_st_script" migrate "$@"
+      return $?
+      ;;
+    *)
+      printf 'cstk state: subcomando desconhecido: %s\n' "$_st_sub" >&2
+      printf 'Subcomandos validos: migrate\n' >&2
+      return 2
+      ;;
+  esac
+}

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -3,6 +3,7 @@ Sync Impact Report
 - Version: (none) → 1.0.0  [initial ratification]
 - Version: 1.0.0 → 1.1.0  [MINOR: optional-deps carve-out]
 - Version: 1.1.0 → 1.2.0  [MINOR: novo Principio VI — Veracidade de Dados / Zero Fabricacao]
+- Version: 1.2.0 → 1.3.0  [MINOR: mandatory-dep carve-out — camada de estado transacional (sqlite3; regulariza jq)]
 - Bump rationale: constituicao inexistente antes; criacao inicial versao 1.0.0.
   Amendment 1.1.0 adiciona subsecao no Principio II disciplinando "deps opcionais
   com fallback graceful" em tres condicoes cumulativas; nota complementar no
@@ -13,6 +14,13 @@ Sync Impact Report
   valores concretos) sem fonte rastreavel — esgotadas as fontes, bloqueio humano.
   Generaliza o aterramento de evidencia de seguranca dos orquestradores
   (anti-confabulacao) para qualquer dado factual produzido pelo toolkit.
+  Amendment 1.3.0 adiciona subsecao no Principio II disciplinando dependencia
+  OBRIGATORIA (sem fallback) restrita a camada de estado transacional dos
+  orquestradores: reconhece `sqlite3` (state.db, feature state-db-foundation)
+  e regulariza a condicao ja vigente de `jq` (state-rw.sh L116-118 e ~23
+  scripts do runtime encerram com exit 1 quando ausente). Quatro condicoes
+  cumulativas (confinamento de camada, fail-fast diagnostico, consumidores
+  derivados degradam gracioso, declaracao na spec/plan da feature).
 - Principios criados (1.0.0):
   I.   SDD como regra recursiva (NON-NEGOTIABLE)
   II.  POSIX sh puro para scripts (NON-NEGOTIABLE)
@@ -27,6 +35,8 @@ Sync Impact Report
 - Secoes adicionadas (1.0.0): Quality Standards, Decision Framework, Governance
 - Secoes modificadas (1.1.0): Principio II recebe subsecao "Optional dependencies
   with graceful fallback"; Decision Framework item 4 recebe nota clarificadora.
+- Secoes modificadas (1.3.0): Principio II recebe subsecao "Mandatory dependency
+  carve-out: transactional state layer"; I/III/IV/V/VI inalterados.
 - Artefatos que precisam atualizacao (resolver quando conveniente):
   * CLAUDE.md: adicionar secao curta "Principios" apontando para docs/constitution.md (NAO URGENTE — os principios ja sao seguidos de facto). Avaliado novamente em 2026-04-24 durante amendment 1.1.0: mantido nao-urgente; Principio V favorece profundidade sobre marketing; rastreabilidade essencial ja existe via spec↔plan↔constitution.
   * docs/specs/shell-scripts-tests/plan.md §Constitution Check: atualmente diz "Constitution nao presente"; re-rodar /analyze ou re-checar manualmente agora que existe
@@ -119,6 +129,43 @@ em `metrics.sh` (`grep -c` sem matches concatenando "0\n0" via fallback `|| prin
 mostrou que mesmo POSIX puro exige disciplina — introduzir Bash seria degradar o padrao,
 nao proteger dele. Adicionar dependencia externa transforma "clone e uso" em "clone,
 instale, configure", contrariando o modelo de distribuicao via `cp -r`.
+
+#### Mandatory dependency carve-out: transactional state layer (amendment 1.3.0)
+
+Excecao disciplinada a proibicao de dependencias obrigatorias (sem fallback)
+do bloco MUST acima, RESTRITA a camada de estado transacional dos
+orquestradores autonomos (`agente-00c`/`feature-00c`). Uma ferramenta
+nao-POSIX PODE ser dependencia obrigatoria dessa camada desde que as quatro
+condicoes abaixo sejam CUMULATIVAS (todas MUST ser satisfeitas):
+
+(a) **Confinamento de camada.** A obrigatoriedade vale apenas para o runtime
+    de estado transacional (`state.db` e primitivas de acesso; condicao ja
+    vigente de `jq` no runtime `agente-00c-runtime`). Nenhuma outra parte do
+    toolkit (skills de documentacao, CLI de catalogo, hooks) pode exigir a
+    ferramenta como pre-requisito de funcionamento.
+(b) **Fail-fast diagnostico.** Ausencia da ferramenta MUST produzir erro
+    imediato, claro e com instrucao de instalacao (nunca comportamento
+    silenciosamente incorreto), coberto por teste automatizado.
+(c) **Consumidores derivados degradam gracioso.** Camadas best-effort que
+    consomem o estado (knowledge.db/recall, painel, relatorios) MUST manter
+    sua degradacao graciosa propria — a dependencia obrigatoria nao se
+    propaga transitivamente a elas.
+(d) **Declaracao explicita na feature que a introduz.** A dep aparece em
+    `spec.md`/`plan.md` da feature com justificativa de por que fallback e
+    impossivel (fonte de verdade transacional nao pode ter implementacao
+    alternativa divergente).
+
+**Casos concretos sob esta regra**: `sqlite3` para o `state.db` (feature
+`state-db-foundation`, linha v6.0.0 — ver
+[specs/state-db-foundation/plan.md](specs/state-db-foundation/plan.md)
+§Constitution Check); `jq` no runtime de estado (`state-rw.sh` L116-118 e
+demais scripts do `agente-00c-runtime` ja encerram com exit 1 e mensagem de
+instalacao — condicao pre-existente regularizada por este amendment).
+
+**O que NAO muda:** POSIX sh puro segue obrigatorio em todos os scripts;
+ferramentas banidas nominalmente (`ripgrep`, `fd`, `bats`) seguem vetadas;
+o carve-out 1.1.0 (deps opcionais com fallback) permanece o caminho padrao
+para toda dep fora da camada de estado transacional.
 
 ### III. Formato Canonico de Skill: Progressive Disclosure, Gotchas, Description-como-Trigger
 
@@ -297,4 +344,4 @@ Quando principios entram em tensao, a ordem de desempate e:
 - Datas em ISO YYYY-MM-DD.
 - Versao inicial 1.0.0 — qualquer amendment futuro muda este rodape.
 
-**Version**: 1.2.0 | **Ratified**: 2026-04-20 | **Last Amended**: 2026-06-18
+**Version**: 1.3.0 | **Ratified**: 2026-04-20 | **Last Amended**: 2026-07-30

--- a/docs/specs/state-db-foundation/checklists/requirements.md
+++ b/docs/specs/state-db-foundation/checklists/requirements.md
@@ -1,0 +1,283 @@
+# Requirements Checklist: Fundação state.db
+
+**Purpose**: Validar a qualidade dos requisitos de `state-db-foundation`
+(spec.md + plan.md + research.md + data-model.md + contracts/) antes de
+`/create-tasks` — completude, clareza, consistência, mensurabilidade,
+cobertura de cenários/edge cases, dependências e ambiguidades.
+**Created**: 2026-07-30
+**Feature**: [spec.md](../spec.md)
+
+## Completude de Requisitos
+
+- [x] CHK001 - Cada uma das 12 FRs numeradas (FR-001..FR-012) tem pelo menos
+  um cenário de aceite ou edge case associado? [Completude, Spec §Requirements]
+  {auto} — evidência: gate determinístico
+  `requirement-coverage.sh docs/specs/state-db-foundation/spec.md` →
+  `RESULT|...|requirements=12|covered=12|errors=0` (exit 0, sem `FINDING`).
+- [x] CHK002 - As "Decisões de infraestrutura auditáveis" (backup,
+  idempotência) têm requisito próprio, e não ficam implícitas nos FRs
+  funcionais? [Completude, Spec §FR-013-INFRA-BACKUP, §FR-014-INFRA-IDEMP]
+  {auto} — ambos existem como FRs nomeados e rotulados explicitamente como
+  categoria de infraestrutura, com as demais categorias do checklist de
+  infra (scheduling, rotação de chave, refresh de token, mutex
+  multi-réplica) marcadas como N/A explícito, não omitidas.
+- [x] CHK003 - Toda entidade citada nos FRs/User Stories (Wave, Decision,
+  HumanBlock, TaskOutcome, Event, SkillInvocation, SpawnUsage,
+  MigrationRun, ExportSnapshot) tem definição em Key Entities? [Completude,
+  Spec §Key Entities] {auto} — as 9 entidades citadas na spec aparecem
+  listadas com descrição em `spec.md` §Key Entities, e cada uma tem seção
+  própria em `data-model.md` (`execution`, `wave`, `decision`,
+  `human_block`, `task_outcome`, `event`, `skill_invocation`,
+  `migration_run`, e `ExportSnapshot` deliberadamente não-tabela).
+- [ ] CHK004 - Existe um requisito que declare a versão mínima de `sqlite3`
+  suportada pela feature (da qual dependem `JSON1`/`json_valid` no schema e
+  `.param set` na camada de escrita)? [Gap, Spec §FR-001; data-model.md
+  L227-231; contracts/primitives.md §C8] {auto} — **gap real**: o
+  `data-model.md` exige `JSON1` (presente por padrão desde SQLite 3.38,
+  2022) para as constraints de `decision`, e `contracts/primitives.md`
+  §C8 deixa em aberto (C8-a) se `.param set` existe na versão mínima — mas
+  nenhum artefato desta feature declara qual é essa versão mínima. Sem
+  isso, C8-a e a ressalva de JSON1 não têm piso para ser verificados
+  contra. Ação: `/create-tasks` deve gerar uma tarefa de descoberta
+  ("determinar versão mínima de `sqlite3` suportada pelo toolkit") antes
+  da task de schema.
+- [ ] CHK005 - O comando/interface operacional da migração (nome do
+  subcomando, flags) está definido, ou só a semântica? [Gap,
+  contracts/migration.md] {humano} — `contracts/export.md` §Interface do
+  comando marca a assinatura como `[PROPOSTA]` (não fechada); decisão de
+  nomenclatura final de CLI é escolha de produto/consistência com os
+  scripts existentes, não deriva só da spec.
+
+## Clareza de Requisitos
+
+- [x] CHK006 - FR-002 e FR-003 ("atômica", "não deixa rastro parcial") são
+  quantificados com garantia de mecanismo concreto, não só adjetivo vago?
+  [Clareza, Spec §FR-003] {auto} — `data-model.md` e
+  `contracts/primitives.md` §C4 aterram "atômica" em transação SQLite
+  (`BEGIN IMMEDIATE`/commit único por mutação), não deixando o termo como
+  aspiração de prosa.
+- [x] CHK007 - "Corrupção/adulteração silenciosa" (FR-010) tem escopo
+  explícito do que é e não é coberto? [Clareza, Spec §FR-010] {auto} —
+  research.md Decision 4 (agora fechada via `dec-025`) declara
+  explicitamente que a operação escolhida (`PRAGMA integrity_check`) cobre
+  corrupção estrutural mas **não** adulteração bem-formada — o termo do
+  FR-010 não fica subespecificado, o limite está documentado com
+  honestidade em vez de implícito.
+- [x] CHK008 - SC-004 ("em até 5 segundos") é mensurável por teste
+  automatizado sem ambiguidade de ponto de partida/chegada? [Mensurabilidade,
+  Spec §SC-004] {auto} — `contracts/export.md` §E5 (Frescor) define o
+  gatilho e a janela de forma operacional o suficiente para um teste
+  cronometrar do commit da mutação até o export refletir a mudança.
+
+## Consistência de Requisitos
+
+- [ ] CHK009 - O número de "campos obrigatórios de auditoria" de uma
+  Decision é usado de forma consistente entre spec.md, data-model.md e
+  research.md? [Conflict, Spec §FR-002 + §US1 AS-2 + §Key Entities;
+  data-model.md L202 e L419; research.md L185] {auto} — **conflito real**:
+  `spec.md` (FR-002, US1 AS-2, Key Entities) fala em "**cinco** campos
+  obrigatórios de auditoria" mas enumera **seis** termos entre parênteses
+  (`agente, etapa, contexto, opções consideradas, escolha, justificativa`).
+  `data-model.md` L202 repete "5 campos obrigatórios" como título mas a
+  tabela de `CHECK` logo abaixo (L204-217) implementa **seis** constraints
+  de não-vacuidade (`agent`, `stage`, `choice`, `context`, `rationale`,
+  `options_considered`) — e a linha L419 chama isso de "6 `CHECK` em
+  `decision`" para cobrir "os 5 campos obrigatórios", reafirmando a mesma
+  inconsistência numérica. `research.md` L185, em contraste, lista **cinco**
+  campos (`context, options_considered, choice, rationale, agent` — sem
+  `stage`/etapa), o que bate com o runtime real hoje (`state-decisions.sh`
+  comentário L163: "Validacao Principio I (5 campos): contexto, opcoes,
+  escolha, justificativa, agente" — `--etapa` é obrigatório na CLI mas fora
+  da contagem dos "5 campos" de auditoria). A spec e o data-model, portanto,
+  divergem entre si e do próprio runtime que estão especificando. Isto não
+  é um bloqueio de implementação (o schema em `data-model.md` já implementa
+  a superfície certa, 6 CHECKs cobrindo os 6 campos reais incluindo etapa),
+  mas o texto prosa da spec deveria dizer "seis" (ou remover "etapa" da
+  lista) para não confundir quem lê os FRs isoladamente. Ação: `/clarify`
+  ou correção editorial direta na spec antes de `/create-tasks` gerar uma
+  task ancorada no número errado.
+- [x] CHK010 - A precedência de fonte de verdade entre `state.json` e
+  `state.db` (Edge Case) é consistente com FR-012 (projeto não migrado
+  continua em JSON)? [Consistência, Spec §Edge Cases + §FR-012] {auto} —
+  ambos os trechos concordam: `state.db` com migração verificada sempre
+  vence; ausência de `state.db` mantém o comportamento atual sem alteração,
+  sem afirmação contraditória entre as duas seções.
+- [x] CHK011 - O tratamento do lock de diretório é consistente entre
+  FR-011, Edge Cases e a nota de infraestrutura (mutex multi-réplica)?
+  [Consistência, Spec §FR-011 + §Edge Cases + nota infra] {auto} — as três
+  menções concordam: WAL é o mecanismo primário, o lock de diretório é
+  rebaixado a "camada extra opcional", nunca reintroduzido como requisito;
+  nenhuma das três contradiz as demais.
+
+## Qualidade de Critérios de Aceite
+
+- [x] CHK012 - SC-001 (100% dos registros preservados na migração) define o
+  método de verificação, não só a métrica-alvo? [Mensurabilidade, Spec
+  §SC-001] {auto} — o próprio SC-001 nomeia o método ("comparação
+  campo-a-campo entre o export pós-migração e o `state.json` original"), e
+  `contracts/migration.md` §M3 detalha M3.1 (contagem por entidade) e M3.2
+  (comparação campo-a-campo via round-trip) como implementação concreta
+  desse método.
+- [x] CHK013 - SC-002 ("taxa de atualização perdida é 0%") especifica o
+  cenário de carga que o mede? [Mensurabilidade, Spec §SC-002] {auto} — o
+  próprio SC-002 declara o cenário ("duas mutações de estado simultâneas no
+  mesmo projeto... medido em teste de carga concorrente"), consistente com
+  US1 AS-3.
+- [x] CHK014 - SC-006 (recusa de migração sobre dados inconsistentes) tem
+  exemplo concreto de inconsistência coberta, não só a categoria abstrata?
+  [Mensurabilidade, Spec §SC-006] {auto} — SC-006 cita o exemplo "bloqueio
+  humano órfão", e `contracts/migration.md` §M1 (Pré-condições) enumera a
+  lista completa de checagens que reaproveita `state-validate.sh`.
+- [ ] CHK015 - SC-005 ("100% de equivalência num conjunto de projetos de
+  amostra") define o que conta como "conjunto de amostra" (tamanho,
+  critério de seleção)? [Ambiguity, Spec §SC-005] {humano} — a métrica é
+  clara na condição de equivalência, mas "conjunto de projetos de amostra"
+  não tem tamanho nem critério mínimo definido na spec; decidir isso é
+  escolha de escopo de teste (quantos projetos reais/sintéticos bastam para
+  a garantia), não algo que os artefatos técnicos já resolvem.
+
+## Cobertura de Cenários
+
+- [x] CHK016 - Cada User Story (US1..US4) declara um teste independente que
+  não depende de nenhuma capability de prioridade inferior? [Cobertura,
+  Spec §US1-4 "Independent Test"] {auto} — todas as 4 possuem seção
+  "Independent Test" explícita, e as dependências entre stories (US2 exige
+  US1 pronta, US3 exige US1+US2, US4 exige US1) são declaradas na própria
+  seção "Why this priority" de cada uma, sem contradição entre elas.
+- [x] CHK017 - US1 (persistência íntegra) cobre tanto o caminho feliz quanto
+  interrupção no meio da mutação (crash/timeout/sinal)? [Cobertura, Spec
+  §US1] {auto} — a User Story declara explicitamente "mesmo que uma
+  mutação seja interrompida no meio (crash, timeout, sinal)" no corpo, e
+  `contracts/primitives.md` §C4 (Transacionalidade) aterra isso em
+  `BEGIN`/`COMMIT`/`ROLLBACK` atômico do SQLite.
+- [x] CHK018 - US4 (ingestão SQL→SQL) cobre o caso de projeto ainda não
+  migrado, sem assumir que todo projeto já está em `state.db`? [Cobertura,
+  Spec §US4 AS-2] {auto} — AS-2 cobre exatamente esse caso: "mecanismo
+  atual (via JSON) continua funcionando sem alteração — a ingestão
+  SQL-para-SQL é aditiva".
+
+## Cobertura de Edge Cases
+
+- [x] CHK019 - O edge case de coexistência `state.json` + `state.db`
+  simultâneos tem resolução declarada (não fica em aberto)? [Cobertura,
+  Spec §Edge Cases] {auto} — resolvido por referência à Clarifications
+  Session 2026-07-30: presença de `state.db` verificado sempre vence.
+- [x] CHK020 - O edge case de escrita concorrente entre agente-00c e
+  feature-00c tem mecanismo nomeado, não só "resolver depois"? [Cobertura,
+  Spec §Edge Cases] {auto} — resolvido via `block-001`/`dec-014`: WAL mode
+  nativo do SQLite.
+- [x] CHK021 - O edge case de falha da geração do export durante fechamento
+  de onda declara explicitamente que a fonte de verdade não fica
+  condicionada ao export? [Cobertura, Spec §Edge Cases] {auto} — texto
+  explícito: "a falha de export degrada, não bloqueia a fonte de verdade",
+  espelhado em `contracts/export.md` §E6.
+- [x] CHK022 - O edge case de migração sobre `state.json` corrompido/com
+  hash divergente declara o comportamento esperado (recusa, não conserto
+  silencioso)? [Cobertura, Spec §Edge Cases] {auto} — texto explícito: "a
+  migração deve recusar e reportar, nunca 'consertar' silenciosamente
+  dados suspeitos", espelhado em `contracts/migration.md` §M1/§M4.
+- [ ] CHK023 - O edge case sobre continuidade dos backups por onda
+  (`state-history/`) pós-migração é uma pergunta em aberto no próprio texto
+  da spec — foi de fato respondida em algum artefato subsequente? [Gap,
+  Spec §Edge Cases (formulado como pergunta, não afirmação)] {auto} — a
+  spec formula o item como pergunta ("...eles continuam sendo gerados... ou
+  são substituídos...?"), mas a resposta **existe**: research.md Decision 6
+  e FR-013-INFRA-BACKUP fecham isto explicitamente (continuam via export
+  serializado, sem mecanismo novo). O `[Gap]` é editorial — a pergunta na
+  spec deveria ser reescrita como afirmação já resolvida, apontando para
+  Decision 6, para não parecer um edge case ainda sem resposta.
+- [x] CHK024 - O edge case de ingestão do knowledge.db durante transação em
+  andamento no `state.db` do projeto tem garantia de isolamento nomeada?
+  [Cobertura, Spec §Edge Cases] {auto} — resolvido via WAL (leitura
+  consistente da última transação concluída), consistente com FR-011 e
+  `contracts/primitives.md` §C6.
+
+## Requisitos Não-Funcionais
+
+- [x] CHK025 - O requisito de concorrência (FR-011) especifica o mecanismo
+  primário sem deixá-lo genérico ("deve suportar concorrência")? [Clareza,
+  Spec §FR-011] {auto} — FR-011 nomeia o mecanismo primário (`PRAGMA
+  journal_mode=WAL`) e o papel residual do lock de diretório, não fica em
+  nível de intenção abstrata.
+- [x] CHK026 - Os achados de segurança do gate `owasp-security` da onda-004
+  (S1..S5) foram todos endereçados (remediados, escalados ou marcados
+  informativos) antes do fechamento desta fase, sem finding `high`/`critical`
+  pendente sem tratamento? [Requisito Não-Funcional / Segurança, plan.md
+  §Achados do gate de segurança] {auto} — S1 (injeção SQL) e S3/S4 (permissão
+  de arquivo, TOCTOU) remediados diretamente nos contratos; S2 (regressão de
+  detecção de adulteração) escalado como bloqueio humano `block-002` e
+  **respondido** via `dec-025` (opção 1, aceito e documentado) nesta mesma
+  onda; S5 é informativo e amplifica S2 (mesma resolução). Nenhum finding
+  `high`/`critical` permanece sem uma decisão registrada.
+- [ ] CHK027 - Existe um requisito (ou critério de sucesso) que declare o
+  overhead de performance aceitável do WAL/transação por mutação face ao
+  mecanismo RMW+lock atual, ou a feature assume implicitamente que "mais
+  rigoroso" nunca é "mais lento o suficiente para importar"? [Gap] {humano}
+  — nenhum FR/SC desta spec fala de latência por mutação individual (só
+  SC-004, que é sobre frescor do export, não da escrita primária); decidir
+  se vale a pena um SC de performance de escrita é chamada de produto (a
+  onda de execução já é limitada por chamadas de LLM, não por I/O local, o
+  que pode tornar esse SC desnecessário — mas isso é julgamento, não fato
+  extraível dos artefatos).
+
+## Dependências e Premissas
+
+- [x] CHK028 - A dependência externa do amendment de constitution
+  (Princípio II, `sqlite3` obrigatório) está declarada como bloqueante e
+  fora do escopo do pipeline `feature-00c`, sem ambiguidade sobre quem a
+  conduz? [Dependência, Spec §Clarifications Session 2026-07-30 primeiro
+  item] {auto} — texto explícito: "Dependência externa a esta feature: o
+  amendment da constitution está fora do escopo do pipeline `feature-00c`
+  ... precisa ser conduzido separadamente antes de `plan` assumir `sqlite3`
+  como mandatório sem ressalva." `plan.md` §Constitution Check reforça:
+  Princípio II "CONDICIONAL" enquanto o amendment não for ratificado.
+- [ ] CHK029 - As 4 decisões de design deliberadamente abertas para
+  `/create-tasks` (D7-a, E5-a, M1-a, C8-a) têm, cada uma, opções enumeradas
+  E um requisito/contrato que fica bloqueado até a decisão ser tomada — ou
+  alguma delas corre risco de ser esquecida por não ter task-gate
+  explícito? [Dependência, plan.md §Decisões em aberto] {humano} — as 4
+  têm opções enumeradas e artefato de origem citado (research.md/
+  export.md/migration.md/primitives.md), mas apenas D4-a (agora fechada)
+  tinha sido escalada como bloqueio humano formal nesta onda; D7-a, E5-a,
+  M1-a e C8-a dependem de `/create-tasks` de fato gerar uma task-gate
+  dedicada para cada uma antes da task de implementação correspondente —
+  julgamento de processo do dono do produto/próxima fase, não algo que os
+  artefatos garantem sozinhos.
+
+## Ambiguidades e Conflitos
+
+- [x] CHK030 - D4-a (cobertura de adulteração deliberada) permanece com
+  opções em aberto nos artefatos publicados, ou já reflete a decisão
+  fechada nesta onda? [Ambiguity — verificação de reconciliação]
+  {auto} — **fechada nesta onda**: `research.md` Decision 4,
+  `plan.md` (tabela de decisões em aberto, achados do gate S2, re-check
+  pós-Phase 1), `quickstart.md` cenário 7.a e `contracts/primitives.md`
+  §C7 foram todos atualizados para refletir `dec-025` (opção 1,
+  `integrity_check` apenas, regresso aceito e documentado) como
+  write-back desta retomada — nenhum desses artefatos ainda apresenta
+  D4-a como pendente.
+- [ ] CHK031 - D7-a (forma de acesso `ATTACH` vs. processo separado na
+  ingestão SQL→SQL) tem trade-off de segurança/simplicidade suficiente
+  descrito para o dono do produto decidir sem reabrir a pesquisa, ou falta
+  informação (ex.: overhead de processo separado)? [Ambiguity, research.md
+  Decision 7 §D7-a] {humano} — as duas opções e o motivo de cada uma
+  (`ATTACH` mais direto; processo separado evita escrita acidental) estão
+  descritos, mas a escolha entre "mais direto" e "mais defensivo" é
+  trade-off de apetite de risco, não fato technical a ser extraído.
+
+## Notes
+
+- Items `{auto}` já vêm resolvidos pelo agente (`[x]` com citação, ou
+  marcador `[Gap]`/`[Ambiguity]`/`[Conflict]`).
+- Items `{humano}` ficam `[ ]` aguardando decisão do dono do produto.
+- **CHK009** é o achado mais acionável deste checklist: a spec fala em
+  "cinco campos obrigatórios de auditoria" mas enumera seis termos (inclui
+  `etapa`), enquanto `data-model.md`/runtime real usam seis `CHECK`s e
+  `research.md` lista cinco campos sem `etapa`. Recomenda-se correção
+  editorial na spec (trocar "cinco" por "seis", ou remover `etapa` da
+  enumeração) antes de `/create-tasks` gerar uma task ancorada no número.
+- **CHK004** e **CHK029** revelam que nenhuma versão mínima de `sqlite3` é
+  declarada em lugar nenhum da feature, apesar de duas decisões em aberto
+  (C8-a, o JSON1 de `data-model.md`) dependerem dela — vale a pena resolver
+  como parte da mesma rodada de fechamento de D7-a/E5-a/M1-a/C8-a em
+  `/create-tasks`.

--- a/docs/specs/state-db-foundation/contracts/export.md
+++ b/docs/specs/state-db-foundation/contracts/export.md
@@ -1,0 +1,177 @@
+# Contract: Export derivado state.db → state.json (FR-007)
+
+**Feature**: `state-db-foundation` | **Phase**: 1
+**Status**: o *formato de destino* é fato verificável (é o `state.json` que
+`state-rw.sh init` produz hoje e que `state-validate.sh` valida). A
+*interface do comando de export* é `[PROPOSTA — a validar na implementação]`.
+
+---
+
+## Propósito
+
+Manter os consumidores atuais do `state.json` funcionando sem reescrita
+durante a transição (spec US3). O export é **derivado e descartável**: a
+fonte de verdade é o `state.db`; regenerar o export nunca perde informação.
+
+---
+
+## Consumidores reais a preservar
+
+Verificado por varredura do repo — scripts que leem `state.json`:
+
+**Fora do runtime** (4): `cli/lib/recall.sh` (ingestão do knowledge.db),
+`cli/lib/00c-bootstrap.sh`, `global/skills/model-selector/scripts/report.sh`,
+`global/skills/decision-tree/scripts/render-decision-tree.sh`.
+
+**Dentro do runtime** (~20), incluindo os 3 hooks provisionados por projeto:
+`hooks/pretooluse-bash-guard.sh`, `hooks/posttooluse-agent-usage.sh`,
+`hooks/posttooluse-tool-call-tick.sh`; e os scripts `cycles.sh`,
+`circular.sh`, `retro.sh`, `pipeline.sh`, `bash-guard.sh`,
+`guard-hooks-status.sh`, `otel-usage.sh`, `report.sh`, `secrets-filter.sh`,
+além dos de estado já listados em [primitives.md](./primitives.md).
+
+**Consumidor externo ao repo**: o painel `cstk-panel`, que lê o
+`knowledge.db` (não o `state.json` diretamente) — logo é protegido
+indiretamente, via FR-008/FR-009.
+
+> **Consequência de escopo**: o export não é conveniência, é o que evita
+> reescrever ~24 consumidores nesta fase. Qualquer divergência estrutural
+> entre o export e o `state.json` nativo quebra consumidores silenciosamente.
+
+---
+
+## Contrato de saída
+
+### E1 — Equivalência estrutural (MUST)
+
+O export MUST produzir um documento JSON que:
+
+1. Passa em `state-validate.sh --state-dir <dir>` com **exit 0** (spec US3
+   AS-1). Esse script é o oráculo de conformidade — ele já valida
+   `schema_version`, tipos dos campos obrigatórios, consistência
+   `status` × `finished_at`, os tetos de `budgets`, os 5 campos de cada
+   decisão e a integridade referencial dos bloqueios.
+2. Declara `schema_version` igual ao do formato corrente (`"1.0.0"`).
+3. Contém **todos** os campos de topo que `state-rw.sh init` cria:
+   `schema_version`, `short_name` (só modo-feature), `execution`,
+   `prerequisites` (só modo-feature), `current_stage`, `next_instruction`,
+   `waves`, `decisions`, `human_blocks`, `budgets`, `accumulated_metrics`,
+   `external_urls_whitelist`, `circular_movement_history`,
+   `initial_key_aspects`, `atomic_commit_enabled` — mais os campos que os
+   demais scripts acrescentam ao longo da execução: `tasks`, `events`,
+   `suggestions`, `retros`, `briefing_cache`, `constitution_cache`,
+   `push_pr_result`, `next_retrospective_milestone`.
+
+### E2 — Fidelidade de nomes (MUST)
+
+Nomes de campo e formatos de ID MUST ser preservados **literalmente**:
+
+- IDs: `dec-NNN`, `block-NNN`, `onda-NNN` (3 dígitos, zero-padded).
+- O campo de score da decisão é `justification_score` (a flag é `--score`;
+  os nomes não coincidem — preservar o do campo).
+- Campos de onda: `id`, `started_at`, `finished_at`, `executed_stages`,
+  `tool_calls`, `wallclock_seconds`, `termination_reason`,
+  `next_wave_scheduled_for`, `skills_invoked`, e quando presentes
+  `agent_usage`, `agent_spawns`, `otel_usage`.
+- Campos de task: `task_id`, `title`, `wave_id`, `outcome`, `tests_run`,
+  `tests_passed`, `lint_ok`, `touched_files`, `recorded_at`, `source`.
+- Campos de bloqueio: `id`, `decision_id`, `question`, `context_for_answer`,
+  `recommended_options`, `status`, `human_answer`, `answered_at`,
+  `triggered_at`.
+
+Chaves em inglês (a canonicalização pt-BR→EN já é vigente via
+`_SR_RENAME_MAP` em `state-rw.sh`). O export **não** reintroduz chaves
+pt-BR — os consumidores já leem EN-first com fallback.
+
+### E3 — Ordem e aninhamento (MUST)
+
+- `waves`, `decisions`, `human_blocks`, `tasks`, `events` são **arrays**, na
+  mesma ordem cronológica de hoje. Convenções que dependem disso e MUST ser
+  preservadas: `.waves[-1]` é a onda corrente (usado por `wave-status`,
+  `current-id`, `record-skill`); a ordem de `events` é a de append.
+- `skills_invoked` volta a ser **aninhado dentro de cada onda**
+  (`.waves[N].skills_invoked[]`), embora no banco seja tabela própria. A
+  ingestão do recall lê exatamente esse caminho aninhado, filtrando
+  `kind == "gate"`.
+- Campos ausentes vs. nulos: `state-rw.sh init` omite as chaves
+  `canonical_project`/`session_name` quando as flags não são passadas (a
+  chave fica **ausente**, não `null`). O export MUST reproduzir essa
+  distinção — `state-validate.sh` aceita "string ou ausente", e emitir
+  `null` onde hoje há ausência muda o que os consumidores veem.
+
+### E4 — Campos derivados (MUST)
+
+`accumulated_metrics` é agregação (ver data-model.md): os totais MUST ser
+computados a partir das tabelas no momento do export, não lidos de um
+contador materializado. Campos: `waves_total`, `tool_calls_total`,
+`wallclock_total_seconds`, `max_depth_reached`, `subagents_spawned`,
+`decisions_total`, `human_blocks_total`, `global_skill_suggestions_total`,
+`toolkit_issues_opened`, além dos acumuladores de agente
+(`agent_spawns_total`, `agent_spawns_with_usage_total`,
+`agent_tokens_total`, `agent_tool_use_count_total`,
+`agent_duration_ms_total`).
+
+Ganho colateral: hoje esses contadores são incrementados manualmente por
+vários scripts e podem divergir da realidade. Derivá-los no export elimina
+a divergência por construção.
+
+### E5 — Frescor (MUST, SC-004)
+
+O export MUST refletir uma mutação em **até 5 segundos** após ela ser
+aplicada. Satisfeito trivialmente se o export for regenerado sob demanda.
+**DECISÃO EM ABERTO (E5-a)**: gatilho do export — (a) sob demanda por
+comando explícito; (b) automático ao fim de cada onda (`state-ondas.sh end`,
+que já é o ponto onde o snapshot de `state-history/` é gerado); (c) ambos.
+A opção (b) atende SC-004 e FR-013-INFRA-BACKUP no mesmo ponto de código.
+
+### E6 — Falha de export não bloqueia a fonte de verdade (MUST)
+
+Spec §Edge Cases, literal: *"o fechamento da onda no `state.db` não pode
+ficar condicionado ao sucesso do export — a falha de export degrada, não
+bloqueia a fonte de verdade"*.
+
+Logo: falha ao gerar o export (disco cheio, interrupção) MUST ser reportada
+em stderr e MUST NOT reverter nem impedir o commit da transação que fechou a
+onda. O export é regenerável a qualquer momento a partir do banco.
+
+### E7 — Filtro de segredos (MUST NOT alterar)
+
+O export é o `state.json` **bruto** — o filtro de segredos permanece onde
+está hoje: aplicado na geração de backup (`secrets-filter.sh for-backup`) e
+na ingestão do recall. O export **não** aplica scrub por conta própria; se
+aplicasse, o `state.json` derivado deixaria de ser equivalente ao nativo e
+E1 quebraria.
+
+---
+
+## Interface do comando `[PROPOSTA]`
+
+Duas formas possíveis, ambas compatíveis com C1 de
+[primitives.md](./primitives.md):
+
+**Opção A — reusar `state-rw.sh read`** (preferida): sob backend
+`state.db`, `read` já precisa devolver o estado como JSON. O export vira
+`state-rw.sh read --state-dir <dir> > state.json`, sem subcomando novo.
+Vantagem: consumidores que hoje chamam `read` passam a funcionar sem
+qualquer mudança.
+
+**Opção B — subcomando dedicado** (ex.: `state-rw.sh export`): explícito
+quanto à materialização em disco, ao custo de superfície nova.
+
+Decidir na task de FR-007. Em ambos os casos, o oráculo de aceitação é o
+mesmo: `state-validate.sh` sai 0 sobre o resultado.
+
+---
+
+## Cenário de aceitação (spec US3 AS-3)
+
+> *Um consumidor que só sabe ler `state.json` não percebe diferença
+> estrutural em relação a um `state.json` escrito diretamente pelo mecanismo
+> atual.*
+
+Teste operacional: gerar o export de um projeto migrado e comparar com o
+`state.json` original **canonicalizado** (chaves ordenadas, whitespace
+normalizado — ex. `jq -S .`). Diferença aceitável: nenhuma em nomes de
+campo, IDs, valores ou aninhamento. Diferença tolerada: apenas formatação
+não-semântica (indentação, ordem de chaves em objeto), já que nenhum
+consumidor real depende da ordem de chaves de um objeto JSON.

--- a/docs/specs/state-db-foundation/contracts/migration.md
+++ b/docs/specs/state-db-foundation/contracts/migration.md
@@ -1,0 +1,187 @@
+# Contract: Migração state.json → state.db (FR-005 / FR-006 / FR-014-INFRA-IDEMP)
+
+**Feature**: `state-db-foundation` | **Phase**: 1
+**Status**: `[PROPOSTA — a validar na implementação]` para a interface do
+comando. As pré-condições reaproveitam verificadores que já existem e são
+fato verificável.
+
+---
+
+## Nomeação — colisão a evitar
+
+`state-rw.sh` **já possui** um subcomando `migrate` (migração de schema
+interno do `state.json`). A migração `state.json → state.db` **MUST NOT**
+reusar esse nome — dois significados sob o mesmo verbo, no mesmo script, é
+armadilha de operador.
+
+Opções `[PROPOSTA]`:
+
+- **A**: script novo dedicado, ex.: `state-db-migrate.sh` no mesmo diretório
+  de runtime. Sem colisão; testável isoladamente (`tests/test_state-db-migrate.sh`
+  pela convenção do harness).
+- **B**: subcomando do `cstk` (ex.: `cstk state migrate --state-dir …`),
+  alinhado a FR-005 ("comando explícito do operador") por ser a superfície
+  que o operador já usa.
+
+Recomendação: **B para a UX do operador, delegando a A a implementação** —
+mantém a lógica testável pelo harness POSIX e dá ao operador um verbo
+coerente com o resto do CLI. Decidir na task de FR-005.
+
+---
+
+## M1 — Pré-condições (MUST recusar antes de tocar em qualquer coisa)
+
+A migração MUST recusar, com diagnóstico claro e exit não-zero, se:
+
+| # | Condição | Como verificar | Requisito |
+|---|---|---|---|
+| 1 | Execução ativa | `.execution.status == "em_andamento"` | FR-005 (literal) |
+| 2 | Estado inválido | `state-validate.sh --state-dir <dir>` sai != 0 | FR-005, SC-006 |
+| 3 | Integridade divergente | `state-rw.sh sha256-verify --state-dir <dir>` sai != 0 | spec §Edge Cases |
+| 4 | `state.json` ausente/ilegível | arquivo não existe ou `jq` não parseia | — |
+| 5 | `state.db` já presente | ver M5 (idempotência) | FR-014-INFRA-IDEMP |
+
+**Reaproveitamento deliberado**: a condição 2 já cobre o cenário de SC-006 e
+US2 AS-3 (bloqueio humano órfão) — `state-validate.sh` valida que todo
+`decision_id` de `.human_blocks[]` existe em `.decisions[].id`. Nenhum
+verificador novo precisa ser escrito para atender SC-006.
+
+**Sobre `aguardando_humano`**: FR-005 nomeia explicitamente apenas
+`em_andamento`, e admite "concluída, abortada ou pausada". Uma execução em
+`aguardando_humano` está pausada — logo é migrável pela letra do requisito.
+**DECISÃO EM ABERTO (M1-a)**: confirmar se `aguardando_humano` deve ser
+permitido ou recusado por prudência (o lock pode estar retido pelo command
+pai). Fechar antes da task de FR-005.
+
+---
+
+## M2 — Sequência (MUST)
+
+Quatro tempos — **recusar → construir fora → verificar → publicar**:
+
+```
+1. RECUSAR    aplica M1; qualquer falha ⇒ aborta sem escrever nada
+2. CONSTRUIR  cria temporário via `mktemp` no <state-dir> (mesmo filesystem)
+              aplica schema + PRAGMAs + insere na ordem de FK
+              [MUST usar mktemp, não nome derivado de PID — primitives.md §C10]
+3. VERIFICAR  aplica M3; falha ⇒ remove o temporário e aborta
+4. PUBLICAR   mv atômico .state.db.tmp.<pid> -> state.db
+```
+
+**Ordem de inserção** (imposta pelas FKs): `execution` → `wave` →
+`decision` → `human_block` / `skill_invocation` / `task_outcome` /
+`event` → `migration_run`.
+
+**IDs preservados**: `dec-NNN`, `block-NNN`, `onda-NNN` entram com o valor
+original. Nenhuma renumeração (FR-005: "com seus identificadores e
+timestamps originais").
+
+**Por que rename atômico**: garante que um `state.db` visível seja sempre
+completo e verificado — é o que sustenta a regra de precedência do FR-006 /
+Decision 9 (a mera presença do arquivo pode decidir a fonte de verdade) e o
+cenário US2 AS-4 (migração interrompida deixa o projeto operável).
+
+---
+
+## M3 — Verificação pós-migração (MUST, FR-006 / SC-001)
+
+A migração **não** é considerada concluída sem passar em ambas:
+
+### M3.1 — Contagem por entidade
+
+Para cada entidade, `COUNT(*)` no destino MUST igualar o `length` do array
+correspondente na origem:
+
+| Origem (jq) | Destino (SQL) |
+|---|---|
+| `.decisions \| length` | `SELECT COUNT(*) FROM decision` |
+| `.waves \| length` | `SELECT COUNT(*) FROM wave` |
+| `.human_blocks \| length` | `SELECT COUNT(*) FROM human_block` |
+| `.tasks \| length` | `SELECT COUNT(*) FROM task_outcome` |
+| `.events \| length` | `SELECT COUNT(*) FROM event` |
+| `[.waves[].skills_invoked[]] \| length` | `SELECT COUNT(*) FROM skill_invocation` |
+
+Resultado gravado em `migration_run.counts_source` / `counts_target` como
+evidência auditável.
+
+### M3.2 — Comparação campo-a-campo via round-trip
+
+Em vez de escrever um comparador novo, gerar o export
+([export.md](./export.md)) a partir do `state.db` recém-construído e
+compará-lo com o `state.json` de origem, ambos canonicalizados
+(`jq -S .`). Divergência em nome de campo, ID, valor ou aninhamento ⇒
+migração recusada.
+
+É literalmente o que SC-001 pede: *"comparação campo-a-campo entre o export
+pós-migração e o `state.json` original"*. Efeito colateral virtuoso: a
+migração **testa o export** a cada execução — FR-006 e FR-007 se validam
+mutuamente.
+
+---
+
+## M4 — Falha e recuperação (MUST, US2 AS-4)
+
+| Ponto de falha | Estado resultante |
+|---|---|
+| Durante M1 | nada escrito; `state.json` intacto |
+| Durante M2 (construção) | só o temporário existe; `state.json` intacto e ainda é a fonte |
+| Durante M3 (verificação) | temporário removido; `state.json` intacto |
+| Durante M4 (`mv`) | atômico: ou o nome antigo ou o novo, nunca meio-termo |
+
+Em todos os casos o projeto **continua operável** pelo `state.json`
+original — nunca fica sem fonte de verdade válida.
+
+**O `state.json` de origem MUST NOT ser apagado pela migração.** Após a
+publicação ele passa a ser tratado como export/legado (Decision 9); removê-lo
+descartaria a rota de recuperação sem ganho algum.
+
+---
+
+## M5 — Idempotência (MUST, FR-014-INFRA-IDEMP)
+
+**Chave de idempotência**: identidade da execução de origem —
+`.execution.id` (o campo que `state-rw.sh init` grava e que a ingestão do
+recall já usa como `execution_id`).
+
+Reexecutar a migração sobre um projeto já migrado MUST NOT duplicar nem
+corromper (spec US2 AS-2). Garantido por construção: a migração é sempre
+**reconstrução completa** a partir da origem seguida de publicação atômica —
+nunca append incremental sobre um banco existente.
+
+Comportamento ao encontrar `state.db` pré-existente `[PROPOSTA]`:
+
+- Se `execution.id` do banco existente == `execution.id` da origem ⇒
+  reconstruir e republicar (idempotente), **ou** no-op reportando "já
+  migrado". Ambos satisfazem AS-2.
+- Se diferirem ⇒ **recusar**: é outro projeto/execução no mesmo diretório,
+  situação que exige intervenção humana e não deve ser resolvida
+  automaticamente.
+
+Toda tentativa — inclusive as recusadas — é registrada em `migration_run`
+com `result` ∈ `success` \| `refused` \| `failed` e `diagnostic`.
+
+---
+
+## M6 — O que a migração MUST NOT fazer
+
+- **MUST NOT** rodar automaticamente numa invocação de orquestrador
+  (FR-005, literal: "nunca automática ou transparente"). Nenhum caminho de
+  `/agente-00c`, `/feature-00c` ou seus resumes pode dispará-la.
+- **MUST NOT** "consertar" dados inconsistentes silenciosamente (spec
+  §Edge Cases). Recusa e reporta.
+- **MUST NOT** escrever no `knowledge.db` (FR-009).
+- **MUST NOT** apagar `state.json`, `state.json.sha256` ou `state-history/`.
+
+---
+
+## Cenários de teste (harness POSIX, `tests/test_<nome>.sh`)
+
+| # | Cenário | Requisito |
+|---|---|---|
+| 1 | `state.json` com N decisões/M ondas/K tasks/J eventos/L bloqueios ⇒ banco com contagens idênticas e IDs/timestamps preservados | US2 AS-1, SC-001 |
+| 2 | Migração reexecutada sobre projeto já migrado ⇒ sem duplicação/corrupção | US2 AS-2, FR-014 |
+| 3 | Bloqueio humano órfão ⇒ recusa com diagnóstico apontando o registro | US2 AS-3, SC-006 |
+| 4 | `status == "em_andamento"` ⇒ recusa | FR-005 |
+| 5 | Interrupção após construção e antes da publicação ⇒ `state.json` intacto e operável | US2 AS-4 |
+| 6 | `sha256-verify` divergente ⇒ recusa | Edge Cases |
+| 7 | Round-trip: export do banco migrado == origem canonicalizada | SC-001, US3 AS-1 |

--- a/docs/specs/state-db-foundation/contracts/primitives.md
+++ b/docs/specs/state-db-foundation/contracts/primitives.md
@@ -204,9 +204,12 @@ aceitável por ser índice derivado).
 
 `sha256-update` / `sha256-verify` mantêm o nome e o contrato de exit code.
 A implementação sob `state.db` passa a executar `PRAGMA integrity_check`.
-**A cobertura de adulteração deliberada é decisão em aberto (D4-a do
-research.md)** e MUST ser fechada antes da task que implementa FR-010 —
-`integrity_check` sozinho não detecta edição externa bem-formada.
+**A cobertura de adulteração deliberada é decisão fechada (D4-a do
+research.md, `dec-025` em resposta ao bloqueio `block-002`)**: opção 1,
+`integrity_check` apenas — `integrity_check` sozinho não detecta edição
+externa bem-formada, e esse regresso frente ao `sha256-verify` anterior é
+**aceito e documentado**, não um item pendente. Modelo de ameaça assumido:
+operador local confiável.
 
 ### C8 — Escape de texto livre em SQL (MUST) — A05/CWE-89
 

--- a/docs/specs/state-db-foundation/contracts/primitives.md
+++ b/docs/specs/state-db-foundation/contracts/primitives.md
@@ -1,0 +1,299 @@
+# Contract: Primitivas de acesso ao state.db (FR-004)
+
+**Feature**: `state-db-foundation` | **Phase**: 1
+**Status**: `[PROPOSTA — a validar na implementação]` para toda assinatura
+marcada como NOVA. As assinaturas marcadas ATUAL foram extraídas por leitura
+direta dos scripts em `global/skills/agente-00c-runtime/scripts/` e são fato
+verificável, não proposta.
+
+---
+
+## Princípio do contrato: paridade de verbo, não reinvenção
+
+FR-004 exige cobrir "os mesmos verbos que os orquestradores usam hoje em
+todo caminho de escrita". A restrição de projeto que decorre disso:
+
+> **A superfície de CLI não muda.** Os orquestradores (`agente-00c` e
+> `feature-00c`) invocam os mesmos scripts, com os mesmos subcomandos e as
+> mesmas flags. O que muda é o *backend* de persistência por trás deles.
+
+Motivo: os arquivos de agente (`global/agents/agente-00c-orchestrator.md`,
+`agente-00c-feature-orchestrator.md`) e os slash commands documentam essas
+invocações literalmente, com flags exatas. Mudar a superfície obrigaria a
+reescrever a prosa de todos eles — risco desproporcional para uma feature de
+fundação, e fora do que a spec pede.
+
+---
+
+## Inventário da superfície ATUAL (a preservar)
+
+Fonte: leitura direta dos scripts. Esta é a superfície que o backend
+`state.db` deve honrar sem alteração observável.
+
+### `state-rw.sh`
+
+| Subcomando | Flags | Exit |
+|---|---|---|
+| `init` | `--state-dir` `--execucao-id` `--projeto-alvo-path` `--descricao` `--stack-json` `--whitelist-urls` `--short-name` `--briefing-path` `--briefing-sha256` `--constitution-path` `--constitution-sha256` `--constitution-version` `--key-aspects` `--canonical-project` `--session-name` `--atomic-commit` | 0/1/2 |
+| `read` | `--state-dir` | 0/1/2 |
+| `write` | `--state-dir` (JSON por stdin) | 0/1/2 |
+| `get` | `--state-dir` `--field` | 0/1/2 |
+| `set` | `--state-dir` `--field` `--value` | 0/1/2 |
+| `sha256-update` | `--state-dir` | 0/1/2 |
+| `sha256-verify` | `--state-dir` | 0/1/2 |
+| `path-check` | `--projeto-alvo-path` `--create` | 0/1/2 |
+| `infer-aspectos` | `--state-dir` `--projeto-alvo-path` | 0/1/2 |
+| `migrate` | `--state-dir` | 0/1/2 |
+
+Modo-feature ativado por `--short-name`, que torna obrigatórios
+`--briefing-path`, `--briefing-sha256`, `--constitution-path`,
+`--constitution-sha256`, `--constitution-version`. Modo-projeto exige
+`--execucao-id`.
+
+> **Colisão de nome a resolver**: `state-rw.sh` **já tem** um subcomando
+> `migrate` (migração de schema interno do state.json). A migração
+> `state.json → state.db` (FR-005) **não pode** reusar esse nome sem
+> ambiguidade. Ver [migration.md](./migration.md) §Nomeação.
+
+### `state-ondas.sh`
+
+| Subcomando | Flags principais |
+|---|---|
+| `start` | `--state-dir` |
+| `end` | `--state-dir` `--motivo-termino` `--proxima-agendada-para` `--next-instruction` `--add-etapa` (repetível) |
+| `tool-call-tick` | `--state-dir` |
+| `record-skill` | `--state-dir` `--skill` `--decisao-id` `--kind` (`skill`\|`gate`) |
+| `record-task` | `--state-dir` `--task-id` `--titulo` `--wave-id` `--outcome` `--testes-rodados` `--testes-passados` `--lint-ok` `--arquivos` `--origem` `--if-absent` |
+| `reconcile-tasks` | `--state-dir` `--tasks-md` `--wave-id` `--dry-run` |
+| `wave-status` | `--state-dir` → stdout `none`\|`open`\|`closed` |
+| `reconcile-wave` | `--state-dir` `--phase` `--tasks-md` `--terminal-phase` `--dry-run` |
+| `current-id` | `--state-dir` → stdout `onda-NNN` |
+| `git-commit` | `--state-dir` `--projeto-alvo-path` `--motivo` `--onda-id` |
+
+`--motivo-termino` ∈ `etapa_concluida_avancando` \| `threshold_proxy_atingido`
+\| `bloqueio_humano` \| `aborto` \| `concluido`.
+
+### `state-decisions.sh`
+
+| Subcomando | Flags |
+|---|---|
+| `register` | `--state-dir` `--agente` `--etapa` `--contexto` `--opcoes` `--escolha` `--justificativa` (7 obrigatórias) + `--score` `--evidencia` `--referencias` `--artefato-originador` |
+| `count` | `--state-dir` `--agente` |
+| `next-id` | `--state-dir` |
+| `list` | `--state-dir` `--agente` `--etapa` |
+
+`register` imprime o id novo (`dec-NNN`) em stdout.
+
+### `bloqueios.sh`
+
+| Subcomando | Flags |
+|---|---|
+| `register` | `--state-dir` `--decisao-id` `--pergunta` `--contexto-para-resposta` (4 obrigatórias) + `--opcoes-recomendadas` |
+| `respond` | `--state-dir` `--block-id` `--resposta` |
+| `list` | `--state-dir` `--status` |
+| `count` | `--state-dir` `--pending-only` |
+| `next-id` | `--state-dir` |
+| `get` | `--state-dir` `--block-id` |
+
+`register` imprime `block-NNN` em stdout e seta
+`.execution.status = "aguardando_humano"`.
+
+### `spawn-tracker.sh`
+
+| Subcomando | Flags | Exit relevante |
+|---|---|---|
+| `check` | `--state-dir` | **3** = teto atingido |
+| `enter` | `--state-dir` | **3** = teto atingido (não grava) |
+| `leave` | `--state-dir` | idempotente em depth <= 1 |
+| `current` | `--state-dir` | imprime depth |
+
+Teto: `_ST_MAX=3`.
+
+### `state-validate.sh` / `state-lock.sh`
+
+`state-validate.sh` — sem subcomandos; `--state-dir`; exit 0 válido / 1
+inválido / 2 uso. `state-lock.sh` — `acquire` \| `release` \| `check` \|
+`check-execution-busy`, `--state-dir`; exit 3 = conflito.
+
+---
+
+## Contrato de comportamento sob backend `state.db`
+
+### C1 — Compatibilidade de invocação (MUST)
+
+Toda invocação listada acima produz, sob `state.db`, o **mesmo stdout, o
+mesmo exit code e o mesmo efeito observável** que produz hoje sob
+`state.json`. Isto inclui:
+
+- `state-decisions.sh register` continua imprimindo `dec-NNN` em stdout —
+  os orquestradores capturam esse valor em variável (`DEC_ID=$(…)`).
+- `state-ondas.sh current-id` continua imprimindo `onda-NNN`.
+- `state-ondas.sh wave-status` continua imprimindo exatamente
+  `none`\|`open`\|`closed`.
+- `bloqueios.sh count --pending-only` continua imprimindo um inteiro.
+- `spawn-tracker.sh check` continua saindo **3** no teto.
+
+### C2 — Seleção de backend (MUST)
+
+Cada script resolve o backend na entrada, por presença de arquivo:
+
+```
+existe <state-dir>/state.db  ⇒ backend SQLite   (fonte de verdade)
+senão                        ⇒ backend JSON      (comportamento atual, FR-012)
+```
+
+Por Decision 9 do research, um `state.db` **visível** é sempre completo e
+verificado (a migração publica por rename atômico). Um `state.json`
+coexistente é tratado como export/legado e **nunca** consultado como fonte.
+
+### C3 — Semântica de erro nova, autorizada pelo FR-002 (MUST)
+
+Constraints do banco criam falhas que hoje não existem. Elas MUST ser
+reportadas com exit code convencional e mensagem em stderr, **nunca**
+silenciadas:
+
+| Situação | Constraint | Exit proposto |
+|---|---|---|
+| `start` com onda já aberta | `ux_wave_single_open` | **1** + stderr |
+| `end` sobre onda já fechada | `trg_wave_close_once` | **1** + stderr |
+| `register` de decisão com campo faltando | `CHECK` | 1 (paridade com hoje) |
+| `bloqueios register` com `--decisao-id` inexistente | `FOREIGN KEY` | 1 (paridade com hoje) |
+| `enter` acima do teto | `CHECK subagent_depth` | **3** (paridade com hoje) |
+
+> **Mudança de comportamento a declarar explicitamente**: hoje
+> `state-ondas.sh start` faz append cego e **duplica** a onda se chamado com
+> onda aberta — é justamente por isso que o orquestrador carrega a guarda
+> `wave-status` no passo 3.bis. Sob `state.db` a segunda chamada **falha**.
+> Isso é uma melhoria (a duplicação era o bug), mas é observável: qualquer
+> caminho que hoje dependa do append silencioso passa a receber erro. A
+> guarda `wave-status` do orquestrador continua válida e vira defesa em
+> profundidade, não requisito.
+
+### C4 — Transacionalidade (MUST, FR-003)
+
+Cada subcomando de escrita é **uma** transação `BEGIN IMMEDIATE; …; COMMIT;`.
+Nenhum subcomando deixa escrita parcial. Subcomandos que hoje fazem múltiplas
+mutações (ex.: `state-ondas.sh end`, que fecha a onda **e** atualiza
+`.accumulated_metrics`; `bloqueios.sh register`, que grava o bloqueio **e**
+muda `.execution.status`) passam a fazê-las na mesma transação — hoje são
+sequências de escritas independentes, cada uma um RMW completo do arquivo.
+
+### C5 — PRAGMAs obrigatórios por conexão (MUST)
+
+Toda invocação de `sqlite3` sobre o `state.db` MUST emitir, antes do SQL:
+
+```sql
+PRAGMA foreign_keys = ON;    -- default é OFF; sem isto a FK é decorativa
+PRAGMA busy_timeout = <ms>;  -- espera o escritor concorrente
+```
+
+`PRAGMA journal_mode = WAL` é aplicado **uma vez na criação** e persiste no
+header do arquivo — não precisa ser reemitido por conexão.
+
+### C6 — Concorrência (MUST, FR-011)
+
+Leitores (`get`, `read`, `list`, `count`, `current-id`, `wave-status`) MUST
+poder executar durante uma escrita em andamento, sem bloquear o escritor e
+sem leitura parcial. Garantido por WAL. Escritores concorrentes são
+serializados pelo banco; sob `database is locked` persistente após retries, a
+operação MUST falhar com exit não-zero — **nunca** degradar silenciosamente
+(diferença deliberada face ao `recall.sh`, cuja degradação silenciosa é
+aceitável por ser índice derivado).
+
+### C7 — Verificação de integridade (FR-010)
+
+`sha256-update` / `sha256-verify` mantêm o nome e o contrato de exit code.
+A implementação sob `state.db` passa a executar `PRAGMA integrity_check`.
+**A cobertura de adulteração deliberada é decisão em aberto (D4-a do
+research.md)** e MUST ser fechada antes da task que implementa FR-010 —
+`integrity_check` sozinho não detecta edição externa bem-formada.
+
+### C8 — Escape de texto livre em SQL (MUST) — A05/CWE-89
+
+> Adicionado pelo gate de segurança da onda-004 (finding S1). Sem esta
+> cláusula o contrato especificava constraints e transações mas **não** dizia
+> como o texto entra no SQL — a omissão mais perigosa do desenho.
+
+Todo valor de **texto livre** que entra numa string literal SQL MUST passar,
+cumulativamente, por:
+
+1. `strip_nul` — remoção de bytes NUL (o `sqlite3` trunca em NUL);
+2. `sql_escape` — duplicação de aspa simples (`'` → `''`).
+
+Ambos **já existem e estão testados** em `cli/lib/recall.sh`:
+
+```sh
+sql_escape() { printf '%s' "$1" | sed "s/'/''/g"; }
+strip_nul()  { tr -d '\000'; }
+```
+
+MUST reusar esses helpers (extraindo-os para um ponto compartilhável), **não**
+reimplementar. Campos afetados — todos de origem LLM ou de artefato lido:
+
+| Campo | Origem |
+|---|---|
+| `decision.context` / `rationale` / `evidence` / `choice` | `--contexto` `--justificativa` `--evidencia` `--escolha` |
+| `decision.options_considered` | `--opcoes` (JSON) |
+| `human_block.question` / `context_for_answer` / `human_answer` | `--pergunta` `--contexto-para-resposta` `--resposta` |
+| `task_outcome.title` / `touched_files` | `--titulo` `--arquivos` (paths do repo) |
+| `event.description` | descrição do evento |
+| `wave.termination_reason`, `executed_stages` | `--motivo-termino`, `--add-etapa` |
+| `execution.target_project_description` | `--descricao` |
+
+**Por que é MUST e não SHOULD**:
+
+- O `sqlite3` CLI executa **múltiplos statements** separados por `;` a partir
+  de stdin/heredoc. Uma aspa simples não escapada não causa só erro de
+  sintaxe — permite terminar o literal e emendar comando arbitrário
+  (`'; DROP TABLE decision; --`), incluindo `ATTACH`, que dá escrita em
+  arquivo fora do banco.
+- O escritor é um **agente LLM**, não um formulário: `--justificativa` e
+  `--contexto` são prosa livre, e apóstrofo em português é rotineiro. A
+  falha acidental é praticamente certa sem escape.
+- Vetor deliberado real (LLM01/ASI06): texto de artefato lido pelo agente
+  (spec, doc do projeto, saída de skill) pode chegar a `--contexto`. O
+  próprio runtime já trata artefato lido como **conteúdo não-confiável**.
+
+**Alternativa preferível quando disponível**: parâmetros nomeados do
+`sqlite3` (`.param set`) em vez de interpolação. **DECISÃO EM ABERTO
+(C8-a)**: verificar disponibilidade de `.param` na versão mínima suportada;
+se indisponível, `strip_nul` + `sql_escape` é o piso obrigatório.
+
+**Teste obrigatório**: registrar decisão cujo `--justificativa` contenha
+`'; DROP TABLE decision; --` e apóstrofo simples; verificar que (a) o texto
+é persistido **literalmente**, (b) a tabela `decision` continua existindo,
+(c) `state-validate.sh` sai 0. Paridade com o teste que
+`tests/test_model-routing.sh` já faz para o mesmo payload.
+
+### C9 — Permissões de arquivo (MUST) — finding S3
+
+O `state.db` e seus sidecars WAL (`state.db-wal`, `state.db-shm`) e o export
+MUST ser criados com modo `0600`, por `chmod` **explícito** após a criação.
+
+**Fato verificado**: hoje o `state.json` está em `0600`, mas **não há
+nenhum `chmod` no runtime de estado** — a única chamada `chmod 600` em todo
+`agente-00c-runtime/scripts/` está em `otel-usage.sh:262`. O `0600` atual é,
+portanto, **ambiente** (herdado do umask do processo que criou), não
+imposto: sob `umask 022` (o valor do shell do operador) um arquivo novo
+nasceria `0644`.
+
+Trocar 1 arquivo por 3 (banco + 2 sidecars) triplica a superfície desse
+acidente — e o `-wal` contém as transações mais recentes em claro. Logo o
+`chmod` explícito deixa de ser detalhe e vira requisito, seguindo o padrão
+que `otel-usage.sh` já aplica.
+
+### C10 — Arquivo temporário da migração (MUST) — finding S5
+
+O temporário de [migration.md](./migration.md) §M2 MUST ser criado por
+`mktemp` no diretório de destino, **não** por nome previsível derivado de
+PID (`.state.db.tmp.$$`). Nome previsível em diretório onde outro processo
+escreve é vetor clássico de symlink/TOCTOU. `mktemp` preserva a propriedade
+essencial (mesmo filesystem ⇒ `mv` atômico).
+
+### C11 — O que NÃO muda (MUST NOT)
+
+- `state-lock.sh` **não é removido** e sua superfície não muda. Deixa de ser
+  requisito de serialização (FR-011), vira camada opcional.
+- `path-check` e `infer-aspectos` (`state-rw.sh`) não tocam estado
+  transacional — permanecem idênticos.
+- Nenhum script passa a escrever no `knowledge.db` (FR-009).

--- a/docs/specs/state-db-foundation/data-model.md
+++ b/docs/specs/state-db-foundation/data-model.md
@@ -1,0 +1,421 @@
+# Data Model: state.db
+
+**Feature**: `state-db-foundation` | **Date**: 2026-07-30 | **Phase**: 1
+**Spec**: [spec.md](./spec.md) | **Research**: [research.md](./research.md)
+
+Schema relacional do `state.db` (um banco por projeto, em
+`<projeto-alvo>/.claude/{agente-00c-state,feature-00c-state/<short-name>}/state.db`).
+
+> **Origem dos nomes de campo**: todos os campos abaixo derivam do
+> `state.json` real produzido por `state-rw.sh init` e mutado pelos demais
+> scripts do runtime — nomes em inglês, conforme a canonicalização pt-BR→EN
+> já vigente (`_SR_RENAME_MAP` em `state-rw.sh`). Nenhum nome foi inventado.
+> As colunas espelham os campos que hoje existem; onde esta feature propõe
+> um campo **novo**, ele está marcado `[PROPOSTA]`.
+>
+> **Status do DDL**: o SQL abaixo é **especificação de contrato**, não
+> implementação. `/execute-task` é quem escreve o DDL definitivo.
+
+---
+
+## Visão geral
+
+```mermaid
+erDiagram
+    execution   ||--o{ wave              : "tem"
+    execution   ||--o{ decision          : "tem"
+    execution   ||--o{ task_outcome      : "tem"
+    execution   ||--o{ event             : "tem"
+    execution   ||--o{ migration_run     : "registra"
+    wave        ||--o{ skill_invocation  : "contém"
+    wave        ||--o{ decision          : "contextualiza"
+    decision    ||--o{ human_block       : "motiva"
+    decision    ||--o| skill_invocation  : "pode originar"
+```
+
+Convenção geral: **uma linha em `execution`** por banco (o `state.json` de
+hoje descreve exatamente uma execução). A tabela existe como entidade real —
+e não como colunas soltas — para que as FKs tenham um alvo e para que a
+unicidade seja declarável.
+
+---
+
+## Entity: execution
+
+A execução 00c corrente. Espelha `.execution` + `.budgets` +
+`.accumulated_metrics` + campos de topo do `state.json`.
+
+| Coluna | Tipo | Constraint | Origem no state.json |
+|---|---|---|---|
+| `id` | TEXT | PK | `.execution.id` |
+| `schema_version` | TEXT | NOT NULL | `.schema_version` (`"1.0.0"`) |
+| `short_name` | TEXT | NULL (só feature-00c) | `.short_name` |
+| `target_project_path` | TEXT | NOT NULL | `.execution.target_project_path` |
+| `target_project_description` | TEXT | NOT NULL | `.execution.target_project_description` |
+| `suggested_stack` | TEXT | NULL (JSON) | `.execution.suggested_stack` |
+| `status` | TEXT | NOT NULL + CHECK enum | `.execution.status` |
+| `termination_reason` | TEXT | NULL | `.execution.termination_reason` |
+| `started_at` | TEXT | NOT NULL | `.execution.started_at` |
+| `finished_at` | TEXT | NULL | `.execution.finished_at` |
+| `canonical_project` | TEXT | NULL | `.execution.canonical_project` |
+| `session_name` | TEXT | NULL | `.execution.session_name` |
+| `current_stage` | TEXT | NOT NULL | `.current_stage` |
+| `next_instruction` | TEXT | NOT NULL | `.next_instruction` |
+| `atomic_commit_enabled` | INTEGER | NULL (0/1) | `.atomic_commit_enabled` |
+| `initial_key_aspects` | TEXT | NULL (JSON array) | `.initial_key_aspects` |
+| `subagent_depth` | INTEGER | NOT NULL DEFAULT 1 | `.budgets.current_subagent_depth` |
+| `max_recursion` | INTEGER | NOT NULL DEFAULT 3 | `.budgets.max_recursion` |
+| `cycles_consumed_current_stage` | INTEGER | NOT NULL DEFAULT 0 | `.budgets.cycles_consumed_current_stage` |
+| `max_cycles_per_stage` | INTEGER | NOT NULL DEFAULT 5 | `.budgets.max_cycles_per_stage` |
+| `retro_executions_consumed` | INTEGER | NOT NULL DEFAULT 0 | `.budgets.retro_executions_consumed` |
+| `max_retro_executions_per_feature` | INTEGER | NOT NULL DEFAULT 2 | `.budgets.max_retro_executions_per_feature` |
+
+Demais campos de `.budgets` (thresholds de onda), `.accumulated_metrics`,
+`.external_urls_whitelist`, `.circular_movement_history`, `.prerequisites`
+(briefing/constitution sha256), `briefing_cache`/`constitution_cache` e
+`.push_pr_result`: **[PROPOSTA]** manter como colunas adicionais ou tabelas
+satélite — decisão de granularidade delegada à task de schema, desde que o
+export FR-007 os reconstitua integralmente. Os contadores acumulados
+(`.accumulated_metrics.*`) são **deriváveis** por agregação das tabelas
+(ex.: `decisions_total = COUNT(*) FROM decision`), o que remove uma classe
+inteira de divergência que hoje só é mantida correta por incremento manual
+em cada script.
+
+### Constraints que materializam FR-002
+
+```sql
+-- 1. Enum de status (hoje só validado a posteriori por state-validate.sh)
+CHECK (status IN ('em_andamento','aguardando_humano','abortada','concluida'))
+
+-- 2. Consistência status x finished_at
+CHECK (
+  (status IN ('abortada','concluida') AND finished_at IS NOT NULL)
+  OR
+  (status IN ('em_andamento','aguardando_humano') AND finished_at IS NULL)
+)
+
+-- 3. Teto de profundidade de subagente (FR-002; _ST_MAX=3 em spawn-tracker.sh)
+CHECK (subagent_depth >= 1 AND subagent_depth <= max_recursion)
+
+-- 4. Tetos de ciclo e retro (hoje em state-validate.sh)
+CHECK (cycles_consumed_current_stage <= max_cycles_per_stage)
+CHECK (retro_executions_consumed <= max_retro_executions_per_feature)
+```
+
+> **Nota sobre o teto de spawn**: o valor 3 vem da constante `_ST_MAX=3`
+> em `spawn-tracker.sh` (comentário no fonte: "FR-013: max 3 niveis
+> (filho, neto, bisneto)"), coerente com `.budgets.max_recursion` gravado
+> por `state-rw.sh init`. Ao virar `CHECK`, a tentativa de exceder o teto
+> passa a ser rejeitada **na escrita** — hoje `spawn-tracker.sh enter` sai
+> 3 sem gravar, mas nada impede outro caminho de escrita de furar o teto.
+
+---
+
+## Entity: wave (Onda)
+
+Espelha `.waves[]`. IDs no formato `onda-NNN` (`printf 'onda-%03d'`).
+
+| Coluna | Tipo | Constraint | Origem |
+|---|---|---|---|
+| `id` | TEXT | PK | `.waves[].id` |
+| `execution_id` | TEXT | FK → execution(id), NOT NULL | — |
+| `seq` | INTEGER | NOT NULL, UNIQUE(execution_id, seq) | ordinal (1-based) |
+| `started_at` | TEXT | NOT NULL | `.waves[].started_at` |
+| `finished_at` | TEXT | NULL ⇒ onda aberta | `.waves[].finished_at` |
+| `wallclock_seconds` | INTEGER | NULL | `.waves[].wallclock_seconds` |
+| `tool_calls` | INTEGER | NOT NULL DEFAULT 0 | `.waves[].tool_calls` |
+| `termination_reason` | TEXT | NULL ⇒ aberta; CHECK enum | `.waves[].termination_reason` |
+| `next_wave_scheduled_for` | TEXT | NULL | `.waves[].next_wave_scheduled_for` |
+| `executed_stages` | TEXT | JSON array | `.waves[].executed_stages` |
+| `agent_usage` | TEXT | NULL (JSON) | `.waves[].agent_usage` |
+| `agent_spawns` | TEXT | NULL (JSON) | `.waves[].agent_spawns` |
+| `otel_usage` | TEXT | NULL (JSON) | `.waves[].otel_usage` |
+
+### Constraints que materializam FR-002
+
+```sql
+-- Enum de motivo de término — os 5 valores validados hoje por state-ondas.sh
+CHECK (termination_reason IS NULL OR termination_reason IN (
+  'etapa_concluida_avancando','threshold_proxy_atingido',
+  'bloqueio_humano','aborto','concluido'))
+
+-- INVARIANTE CENTRAL: no máximo UMA onda aberta por execução.
+-- Índice UNIQUE parcial: só indexa linhas com termination_reason IS NULL,
+-- logo permite N ondas fechadas e no máximo 1 aberta.
+CREATE UNIQUE INDEX ux_wave_single_open
+  ON wave(execution_id) WHERE termination_reason IS NULL;
+
+-- Coerência: onda fechada tem os dois campos de fechamento preenchidos
+CHECK ((termination_reason IS NULL AND finished_at IS NULL)
+    OR (termination_reason IS NOT NULL AND finished_at IS NOT NULL))
+```
+
+O índice parcial `ux_wave_single_open` é o que substitui, com garantia real,
+a guarda hoje escrita em prosa no arquivo do orquestrador (o passo 3.bis do
+Loop principal, que manda checar `wave-status` antes de chamar `start`
+porque `state-ondas.sh start` **não é idempotente** e faz append cego em
+`.waves[]`). Com o índice, uma segunda abertura falha na camada de
+armazenamento em vez de duplicar a onda.
+
+**"Uma onda fechada uma única vez" (FR-002)**: não é expressável por
+`CHECK` (que só enxerga a linha final, não a transição). Requer
+`TRIGGER BEFORE UPDATE`:
+
+```sql
+CREATE TRIGGER trg_wave_close_once BEFORE UPDATE ON wave
+WHEN OLD.termination_reason IS NOT NULL
+     AND NEW.termination_reason IS NOT OLD.termination_reason
+BEGIN
+  SELECT RAISE(ABORT, 'wave already closed');
+END;
+```
+
+---
+
+## Entity: decision (Decisão)
+
+Espelha `.decisions[]`. IDs `dec-NNN` (`printf 'dec-%03d'`).
+
+| Coluna | Tipo | Constraint | Origem (flag do `state-decisions.sh register`) |
+|---|---|---|---|
+| `id` | TEXT | PK | `.decisions[].id` |
+| `execution_id` | TEXT | FK → execution(id), NOT NULL | — |
+| `wave_id` | TEXT | FK → wave(id), NULL p/ `"init"` | `.wave_id` |
+| `timestamp` | TEXT | NOT NULL | `.timestamp` |
+| `agent` | TEXT | NOT NULL, len > 0 | `.agent` (`--agente`) |
+| `stage` | TEXT | NOT NULL, len > 0 | `.stage` (`--etapa`) |
+| `context` | TEXT | NOT NULL, len >= 20 | `.context` (`--contexto`) |
+| `options_considered` | TEXT | NOT NULL, JSON array len >= 1 | `.options_considered` (`--opcoes`) |
+| `choice` | TEXT | NOT NULL, len > 0 | `.choice` (`--escolha`) |
+| `rationale` | TEXT | NOT NULL, len >= 20 | `.rationale` (`--justificativa`) |
+| `justification_score` | INTEGER | NULL ou 0..3 | `.justification_score` (`--score`) |
+| `evidence` | TEXT | NULL | `.evidence` (`--evidencia`) |
+| `references` | TEXT | NULL (JSON array) | `.references` (`--referencias`) |
+| `originating_artifact` | TEXT | NULL | `.originating_artifact` |
+
+> `--score` mapeia para a coluna `justification_score` — confirmado no
+> fonte de `state-decisions.sh`. O nome da flag e o do campo **não**
+> coincidem; preservar o nome do campo é requisito de compatibilidade do
+> export (FR-007) e da ingestão do recall, que lê
+> `.score // .justification_score // .score_justificativa`.
+
+### Constraints que materializam FR-002 (os 5 campos obrigatórios, Princípio I)
+
+```sql
+CHECK (length(agent)   > 0)
+CHECK (length(stage)   > 0)
+CHECK (length(choice)  > 0)
+CHECK (length(context)   >= 20)   -- paridade com a regra de state-decisions.sh
+CHECK (length(rationale) >= 20)   -- idem
+CHECK (json_valid(options_considered)
+       AND json_array_length(options_considered) >= 1)
+CHECK (justification_score IS NULL
+       OR justification_score BETWEEN 0 AND 3)
+
+-- Trava empírica do score 3: exige evidência >= 20 chars
+CHECK (justification_score IS NULL OR justification_score < 3
+       OR (evidence IS NOT NULL AND length(evidence) >= 20))
+```
+
+Esta última constraint é o exemplo mais direto do ganho da feature: hoje a
+regra "score 3 exige evidência" vive **apenas** dentro de
+`state-decisions.sh register`. Qualquer escrita que não passe por esse
+script — inclusive um agente autônomo editando estado por outro caminho —
+contorna a trava silenciosamente. Como `CHECK`, ela passa a valer para todo
+escritor.
+
+> `json_valid` / `json_array_length` exigem o SQLite compilado com JSON1.
+> Presente por padrão desde 3.38 (2022); ambiente local verificado em 3.51.0.
+> **A verificar na task de schema**: confirmar JSON1 no `sqlite3` alvo antes
+> de depender dessas funções em `CHECK`; sem JSON1, degradar para
+> `CHECK (length(options_considered) > 2)` + validação no script.
+
+---
+
+## Entity: human_block (Bloqueio Humano)
+
+Espelha `.human_blocks[]`. IDs `block-NNN`.
+
+| Coluna | Tipo | Constraint | Origem |
+|---|---|---|---|
+| `id` | TEXT | PK | `.human_blocks[].id` |
+| `execution_id` | TEXT | FK → execution(id), NOT NULL | — |
+| `decision_id` | TEXT | **FK → decision(id), NOT NULL** | `.decision_id` |
+| `question` | TEXT | NOT NULL, len >= 20 | `.question` |
+| `context_for_answer` | TEXT | NOT NULL, len > 0 | `.context_for_answer` |
+| `recommended_options` | TEXT | NULL (JSON array) | `.recommended_options` |
+| `status` | TEXT | NOT NULL, CHECK enum | `.status` |
+| `human_answer` | TEXT | NULL | `.human_answer` |
+| `triggered_at` | TEXT | NOT NULL | `.triggered_at` |
+| `answered_at` | TEXT | NULL | `.answered_at` |
+
+```sql
+CHECK (status IN ('aguardando','respondido'))
+CHECK ((status = 'aguardando'  AND answered_at IS NULL)
+    OR (status = 'respondido' AND answered_at IS NOT NULL))
+CHECK (length(question) >= 20)
+FOREIGN KEY (decision_id) REFERENCES decision(id)
+```
+
+A FK cobre o FR-002 ("bloqueio humano referenciando decisão inexistente") e
+o cenário US1-AS4. Hoje isso é uma checagem imperativa
+(`_bl_decisao_exists` em `bloqueios.sh`) mais uma revalidação *a posteriori*
+em `state-validate.sh`. **Requer `PRAGMA foreign_keys=ON` por conexão** —
+sem isso a FK é decorativa (ver research.md Decision 5).
+
+---
+
+## Entity: task_outcome (Resultado de Task)
+
+Espelha `.tasks[]` (camada B). Chave natural documentada:
+`(project, feature, execution_id, task_id)`.
+
+| Coluna | Tipo | Constraint | Origem |
+|---|---|---|---|
+| `execution_id` | TEXT | FK → execution(id), NOT NULL | — |
+| `task_id` | TEXT | NOT NULL, PK(execution_id, task_id) | `.task_id` |
+| `title` | TEXT | NOT NULL (pode ser `''`) | `.title` |
+| `wave_id` | TEXT | FK → wave(id), NOT NULL | `.wave_id` |
+| `outcome` | TEXT | NOT NULL, CHECK enum | `.outcome` |
+| `tests_run` | INTEGER | NOT NULL, >= 0 | `.tests_run` |
+| `tests_passed` | INTEGER | NOT NULL, >= 0 | `.tests_passed` |
+| `lint_ok` | INTEGER | NULL (0/1) | `.lint_ok` |
+| `touched_files` | TEXT | NOT NULL, JSON array | `.touched_files` |
+| `recorded_at` | TEXT | NOT NULL | `.recorded_at` |
+| `source` | TEXT | NULL | `.source` |
+
+```sql
+CHECK (outcome IN ('pass','fail'))
+CHECK (tests_run >= 0 AND tests_passed >= 0 AND tests_passed <= tests_run)
+CHECK (lint_ok IS NULL OR lint_ok IN (0,1))
+```
+
+A PK composta `(execution_id, task_id)` dá de graça o upsert idempotente que
+`state-ondas.sh record-task` implementa hoje em jq — e elimina a
+possibilidade de duas linhas para a mesma task.
+
+---
+
+## Entity: event (Evento)
+
+Espelha `.events[]`. Timeline cronológica; sem enum fechado (o `event_type`
+é texto livre restrito por convenção — a ingestão do recall **não** valida
+allowlist, conforme o contrato da camada B).
+
+| Coluna | Tipo | Constraint | Origem |
+|---|---|---|---|
+| `id` | INTEGER | PK AUTOINCREMENT (ordem de append) | — |
+| `execution_id` | TEXT | FK → execution(id), NOT NULL | — |
+| `event_type` | TEXT | NOT NULL, len > 0 | `.event_type` |
+| `timestamp` | TEXT | NOT NULL | `.timestamp` |
+| `description` | TEXT | NULL | `.description` |
+
+Tipos em uso hoje: `lock_contention`, `validation_failed`, `wave_retry`,
+`schedule_wait`, `recall_consulted`. A PK autoincremental preserva a ordem
+de append, que hoje é implícita na ordem do array JSON.
+
+---
+
+## Entity: skill_invocation (Invocação de Skill/Gate)
+
+Espelha `.waves[].skills_invoked[]` — deixa de ser array aninhado e vira
+tabela própria com FK para a onda.
+
+| Coluna | Tipo | Constraint | Origem |
+|---|---|---|---|
+| `id` | INTEGER | PK AUTOINCREMENT | — |
+| `wave_id` | TEXT | FK → wave(id), NOT NULL | onda que contém |
+| `skill` | TEXT | NOT NULL, len > 0 | `.skill` |
+| `timestamp` | TEXT | NOT NULL | `.timestamp` |
+| `decision_id` | TEXT | FK → decision(id), NULL | `.decision_id` |
+| `kind` | TEXT | NOT NULL DEFAULT `'skill'`, CHECK | `.kind` |
+
+```sql
+CHECK (kind IN ('skill','gate'))
+```
+
+A distinção `skill`/`gate` é consumida pela ingestão do recall, que **exclui**
+`kind = 'gate'` da tabela `skills` e do cálculo de `n_skills`. Preservá-la
+como coluna com CHECK mantém essa semântica intacta (FR-008/FR-009).
+
+---
+
+## Entity: migration_run (Execução de Migração)
+
+Registro de auditoria de cada tentativa de migração (FR-005/FR-006/
+FR-014-INFRA-IDEMP). **[PROPOSTA]** — entidade nova, sem contrapartida no
+`state.json` atual.
+
+| Coluna | Tipo | Constraint | Semântica |
+|---|---|---|---|
+| `id` | INTEGER | PK AUTOINCREMENT | — |
+| `execution_id` | TEXT | NOT NULL | identidade de origem (chave de idempotência) |
+| `source_path` | TEXT | NOT NULL | caminho do `state.json` de origem |
+| `source_sha256` | TEXT | NOT NULL | hash da origem no momento da migração |
+| `started_at` | TEXT | NOT NULL | — |
+| `finished_at` | TEXT | NULL | — |
+| `result` | TEXT | NOT NULL, CHECK enum | `success` \| `refused` \| `failed` |
+| `diagnostic` | TEXT | NULL | motivo da recusa (SC-006) |
+| `counts_source` | TEXT | NULL (JSON) | contagem por entidade na origem |
+| `counts_target` | TEXT | NULL (JSON) | contagem por entidade no destino |
+
+```sql
+CHECK (result IN ('success','refused','failed'))
+```
+
+`counts_source`/`counts_target` são a evidência auditável de FR-006 e SC-001:
+tornam verificável *depois* que nenhum registro se perdeu, sem depender de
+reexecutar a comparação.
+
+---
+
+## Entity: ExportSnapshot — deliberadamente NÃO é tabela
+
+`ExportSnapshot` é entidade da spec, mas **não** ganha tabela: é o artefato
+`state.json` derivado, materializado em disco pelo export (FR-007) e usado
+como snapshot por onda em `state-history/` (FR-013-INFRA-BACKUP). Persistir
+o export dentro do próprio banco duplicaria a fonte de verdade — exatamente
+o que a feature existe para eliminar.
+
+---
+
+## State transitions
+
+**execution.status** — enum já validado hoje por `state-validate.sh`:
+
+```
+em_andamento ──> aguardando_humano ──> em_andamento
+      │                                      │
+      ├──────────> concluida (finished_at != NULL)
+      └──────────> abortada  (finished_at != NULL)
+```
+
+`aguardando_humano` é setado por `bloqueios.sh register` e revertido por
+`respond` quando nenhum bloqueio permanece em `aguardando`. Terminais
+(`concluida`/`abortada`) exigem `finished_at` não-nulo — a constraint #2 de
+`execution` torna isso inviolável.
+
+**wave.termination_reason**:
+
+```
+aberta (NULL) ──> fechada (um dos 5 valores do enum)   [transição única]
+```
+
+Irreversível por `trg_wave_close_once`. No máximo uma onda em `aberta` por
+execução, por `ux_wave_single_open`.
+
+**human_block.status**: `aguardando ──> respondido` (une-direcional; hoje
+`bloqueios.sh respond` já recusa responder um bloqueio fora de
+`aguardando`).
+
+---
+
+## Rastreabilidade FR-002 → constraint
+
+| Invariante (FR-002) | Mecanismo | Hoje |
+|---|---|---|
+| Duas ondas abertas simultaneamente | `ux_wave_single_open` (UNIQUE parcial) | prosa no orquestrador + `wave-status` |
+| Onda fechada mais de uma vez | `trg_wave_close_once` (TRIGGER) | nada impede |
+| Decisão sem os 5 campos obrigatórios | 6 `CHECK` em `decision` | `state-decisions.sh` + `state-validate.sh` |
+| Bloqueio referenciando decisão inexistente | `FOREIGN KEY` + `PRAGMA foreign_keys=ON` | `_bl_decisao_exists` + `state-validate.sh` |
+| Profundidade de subagente acima do teto | `CHECK (subagent_depth <= max_recursion)` | `_ST_MAX` em `spawn-tracker.sh` (exit 3) |

--- a/docs/specs/state-db-foundation/plan.md
+++ b/docs/specs/state-db-foundation/plan.md
@@ -121,7 +121,7 @@ amendment — não substituto dele, e não autoriza prosseguir sem ele.
 docs/specs/state-db-foundation/
 ├── spec.md
 ├── plan.md              # This file
-├── research.md          # Phase 0 — 9 decisões + 2 em aberto (D4-a, D7-a)
+├── research.md          # Phase 0 — 9 decisões + 1 em aberto (D7-a; D4-a fechada por dec-025)
 ├── data-model.md        # Phase 1 — schema + constraints do FR-002
 ├── quickstart.md        # Phase 1 — 7 cenários cobrindo SC-001..SC-006
 └── contracts/
@@ -218,7 +218,7 @@ para `/create-tasks`, não substituto dele.
 | 3 | Seleção de backend (`state.db` vs `state.json`) | FR-012, SC-003 | 2 |
 | 4 | Export derivado | FR-007, FR-013-INFRA-BACKUP | 2 |
 | 5 | Migração + verificação | FR-005, FR-006, FR-014 | 3, 4 |
-| 6 | Verificação de integridade | FR-010 | 1, **D4-a fechada** |
+| 6 | Verificação de integridade | FR-010 | 1, D4-a (**fechada** — dec-025, opção 1) |
 | 7 | Ingestão SQL→SQL | FR-008, FR-009 | 5, **D7-a fechada** |
 
 O passo 4 antes do 5 é deliberado: a verificação campo-a-campo da migração
@@ -229,13 +229,13 @@ comparador novo.
 
 ## Decisões em aberto a fechar antes das tasks correspondentes
 
-| # | Decisão | Bloqueia | Onde |
-|---|---|---|---|
-| D4-a | Cobertura de adulteração deliberada (`integrity_check` não detecta edição bem-formada, `sha256-verify` detecta) | FR-010 | research.md Decision 4 |
-| D7-a | Forma do acesso na ingestão SQL→SQL (`ATTACH … mode=ro` vs. processo separado) | FR-008 | research.md Decision 7 |
-| E5-a | Gatilho do export (sob demanda / ao fim da onda / ambos) | FR-007 | export.md §E5 |
-| M1-a | `aguardando_humano` é migrável ou recusado? | FR-005 | migration.md §M1 |
-| C8-a | Parâmetros nomeados (`.param set`) disponíveis na versão mínima de `sqlite3`? Se não, `strip_nul`+`sql_escape` é o piso | FR-003, FR-004 | primitives.md §C8 |
+| # | Decisão | Bloqueia | Onde | Status |
+|---|---|---|---|---|
+| D4-a | Cobertura de adulteração deliberada (`integrity_check` não detecta edição bem-formada, `sha256-verify` detecta) | FR-010 | research.md Decision 4 | **Fechada** — dec-025 (resposta ao block-002): opção 1, `integrity_check` apenas, regresso aceito |
+| D7-a | Forma do acesso na ingestão SQL→SQL (`ATTACH … mode=ro` vs. processo separado) | FR-008 | research.md Decision 7 | Em aberto — fechar em `/create-tasks` |
+| E5-a | Gatilho do export (sob demanda / ao fim da onda / ambos) | FR-007 | export.md §E5 | Em aberto — fechar em `/create-tasks` |
+| M1-a | `aguardando_humano` é migrável ou recusado? | FR-005 | migration.md §M1 | Em aberto — fechar em `/create-tasks` |
+| C8-a | Parâmetros nomeados (`.param set`) disponíveis na versão mínima de `sqlite3`? Se não, `strip_nul`+`sql_escape` é o piso | FR-003, FR-004 | primitives.md §C8 | Em aberto — fechar em `/create-tasks` |
 
 ### Achados do gate de segurança (onda-004)
 
@@ -246,7 +246,7 @@ escalada ao operador; um é informativo.
 | # | Finding | Sev. | Tratamento |
 |---|---|---|---|
 | S1 | Contratos especificavam SQL sem exigir escape de texto livre de origem LLM (A05/CWE-89; `sqlite3` CLI executa múltiplos statements) | **high** | **Remediado** — primitives.md §C8 (MUST `strip_nul`+`sql_escape`, reusando os helpers de `recall.sh`) + teste obrigatório |
-| S2 | Troca de `sha256-verify` por `PRAGMA integrity_check` remove detecção de adulteração bem-formada do rastro de auditoria (A08/A09, ASVS L2 "tamper-evident") | **high** | **Escalado ao operador** — bloqueio humano; é D4-a |
+| S2 | Troca de `sha256-verify` por `PRAGMA integrity_check` remove detecção de adulteração bem-formada do rastro de auditoria (A08/A09, ASVS L2 "tamper-evident") | **high** | **Escalado ao operador e respondido** — bloqueio `block-002`, resolvido via `dec-025`: opção 1 (`integrity_check` apenas, regresso aceito, operador local confiável). D4-a fechada. |
 | S3 | Permissão de arquivo é ambiente (umask), não imposta; WAL triplica os arquivos e o `-wal` contém transações recentes em claro | **medium** | **Remediado** — primitives.md §C9 (`chmod 600` explícito) |
 | S4 | Temporário da migração com nome derivado de PID (symlink/TOCTOU) | **medium** | **Remediado** — primitives.md §C10 + migration.md §M2 (`mktemp`) |
 | S5 | Cadeia de propagação: `state.db` adulterado → export → ingestão → `knowledge.db` → read-back loop realimenta prompts futuros (ASI06 memory poisoning) | **medium** | **Informativo** — amplifica o impacto de S2; mitigado se S2 for resolvido. O scrub de segredos na ingestão permanece inalterado. |
@@ -266,7 +266,7 @@ Reavaliação após o design (data-model + contratos + quickstart):
 | O design introduziu complexidade não justificada? | **Não.** Nenhum serviço, camada ou processo novo. Uma tabela por entidade **já existente** na spec; a única entidade nova (`migration_run`) é exigida pela auditabilidade do FR-006. `ExportSnapshot` foi deliberadamente **não** modelada como tabela para não duplicar a fonte de verdade. |
 | Princípios MUST continuam respeitados? | I, IV, V, VI: PASS, sem alteração. **II: continua CONDICIONAL** — o design não removeu a necessidade do amendment 1.3.0; ao contrário, confirmou-a (o `state.db` é inviável sem `sqlite3`). |
 | Superfície pública mudou? | Não — §C1 de primitives.md fixa paridade de subcomandos/flags/exit codes. Uma mudança de comportamento observável foi identificada e declarada: `state-ondas.sh start` com onda aberta passa a **falhar** em vez de duplicar (§C3) — é a correção de um bug, mas precisa constar. |
-| Novo risco identificado no design? | Sim, um: trocar `sha256-verify` por `PRAGMA integrity_check` **reduz** a cobertura contra adulteração deliberada. Não silenciado — virou D4-a e o cenário 7.a do quickstart fica sem *expected* até ser fechado. |
+| Novo risco identificado no design? | Sim, um: trocar `sha256-verify` por `PRAGMA integrity_check` **reduz** a cobertura contra adulteração deliberada. Não silenciado — virou D4-a, escalada como bloqueio humano (`block-002`) e **fechada** via `dec-025` (opção 1, regresso aceito e documentado); o cenário 7.a do quickstart já tem *expected* definido. |
 
 **Veredito**: PASS em todos os princípios exceto o II, que permanece
 **CONDICIONAL ao amendment 1.3.0** — pré-requisito externo, bloqueante para

--- a/docs/specs/state-db-foundation/plan.md
+++ b/docs/specs/state-db-foundation/plan.md
@@ -1,0 +1,301 @@
+# Implementation Plan: Fundação state.db
+
+**Feature**: `state-db-foundation` | **Date**: 2026-07-30 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Substituir o `state.json` por um banco SQLite (`state.db`) por projeto como
+fonte de verdade transacional das execuções 00c, movendo para a camada de
+armazenamento as invariantes que hoje vivem em prosa e em validação
+imperativa espalhada por scripts.
+
+**Abordagem técnica** (research.md): CLI `sqlite3` invocado de POSIX sh —
+mesmo padrão já em produção em `cli/lib/recall.sh` para o `knowledge.db`;
+`PRAGMA journal_mode=WAL` como mecanismo primário de concorrência
+(pré-decidido pelo operador em `dec-014`); uma transação `BEGIN IMMEDIATE`
+por mutação; invariantes do FR-002 como `CHECK`/`UNIQUE` parcial/`FOREIGN
+KEY`/`TRIGGER`; migração em quatro tempos (recusar → construir fora →
+verificar → publicar por rename atômico); export derivado `state.json`
+(FR-007) protegendo ~24 consumidores existentes sem reescrita.
+
+**A superfície de CLI dos scripts de runtime não muda** — só o backend por
+trás dela. Ver [contracts/primitives.md](./contracts/primitives.md) §C1.
+
+---
+
+## Technical Context
+
+**Language/Version**: POSIX sh (`#!/bin/sh`, `set -eu`, sem Bash-isms) —
+Princípio II da constitution.
+**Primary Dependencies**: `sqlite3` (verificado local: `/usr/bin/sqlite3`
+3.51.0) — **ver ressalva no Constitution Check**; `jq` (já dependência de
+fato: 23 scripts do runtime gateiam nele).
+**Storage**: SQLite por projeto, em
+`<projeto-alvo>/.claude/{agente-00c-state,feature-00c-state/<short-name>}/state.db`.
+WAL ⇒ sidecars `state.db-wal` / `state.db-shm`.
+**Testing**: harness POSIX do repo (`tests/run.sh`, ~1100+ cenários);
+convenção `tests/test_<nome>.sh` p/ `global/skills/*/scripts/`,
+`tests/cstk/test_<nome>.sh` p/ `cli/lib/`; `--check-coverage` falha em
+script órfão.
+**Target Platform**: macOS/Linux, filesystem local (WAL não é confiável
+sobre NFS — aceito: o estado vive dentro do repo de trabalho).
+**Project Type**: CLI / biblioteca de scripts — single-layer.
+**Performance Goals**: SC-004 — export reflete mutação em <= 5s. Escrita de
+estado é da ordem de dezenas de mutações por onda, não throughput sustentado.
+**Constraints**: SC-002 (0% de atualização perdida sob escrita concorrente);
+SC-003 (0 regressões na suíte para projeto não migrado).
+**Scale/Scope**: um banco por projeto; ordem de dezenas a centenas de ondas
+e decisões por execução (esta própria execução: 4 ondas, 20 decisões).
+
+---
+
+## Constitution Check
+
+*GATE: deve passar antes do Phase 0. Re-checado após Phase 1 — ver §Re-check.*
+
+Constitution `docs/constitution.md`, **versão 1.2.0** (rodapé: `**Version**:
+1.2.0 | **Ratified**: 2026-04-20 | **Last Amended**: 2026-06-18`).
+
+| Princípio | Status | Notas |
+|---|---|---|
+| I. SDD recursivo (NON-NEGOTIABLE) | PASS | Feature conduzida pela pipeline SDD; spec ratificada, clarify concluído, decisões auditadas em `state.json`. O FR-002 **reforça** o Princípio I ao tornar os 5 campos obrigatórios da decisão uma constraint inviolável. |
+| II. POSIX sh puro, zero dep externa (NON-NEGOTIABLE) | **CONDICIONAL — ver ressalva** | Scripts seguem POSIX sh; a dependência `sqlite3` é obrigatória e **sem fallback**. |
+| III. Formato canônico de skill | N/A | A feature não cria nem altera skill; mexe no runtime interno (`agente-00c-runtime`) e possivelmente no CLI `cstk`. |
+| IV. Zero coleta remota (NON-NEGOTIABLE) | PASS | Tudo local: `state.db` no projeto, `knowledge.db` em `~/.claude/cstk/`. Nenhuma rede introduzida. |
+| V. Profundidade > métricas de adoção | PASS | A feature existe para reduzir retrabalho (corrigir a fragilidade do RMW e das invariantes por convenção), não para ampliar adoção. |
+| VI. Veracidade de dados (NON-NEGOTIABLE) | PASS | Todo identificador nos artefatos foi extraído por leitura direta das fontes reais, com arquivo/linha; propostas estão marcadas `[PROPOSTA]` e decisões não fechadas como **DECISÃO EM ABERTO**. |
+
+### RESSALVA BLOQUEANTE — Princípio II e a dependência `sqlite3`
+
+**Situação de direito.** O Princípio II é NON-NEGOTIABLE e diz, literalmente
+(`docs/constitution.md` L109-110):
+
+> *"Dependencias obrigatorias (sem fallback) permanecem proibidas sob o
+> bloco MUST do Principio II."*
+
+O carve-out `#### Optional dependencies with graceful fallback (amendment
+1.1.0)` **não cobre** este caso: exige três condições cumulativas, e a (a) é
+*"Uso genuinamente opcional com fallback graceful documentado E verificável
+— a feature MUST funcionar sem a ferramenta"*. O `state.db` **não pode**
+funcionar sem `sqlite3`; não há fallback possível para a fonte de verdade
+transacional.
+
+**Portanto**: assumir `sqlite3` como dependência obrigatória exige um
+**amendment MINOR dedicado da constitution (1.2.0 → 1.3.0)** que reconheça a
+camada de estado transacional como exceção disciplinada.
+
+**Esse amendment NÃO EXISTE hoje.** É **pré-requisito de implementação** e
+é conduzido **fora** desta feature: o pipeline `feature-00c`
+(`specify → clarify → plan → checklist → create-tasks → execute-task →
+review-task`) **não inclui a etapa `constitution`**. Registrado na spec
+(§Clarifications, Session 2026-07-30, Q1) e na decisão `dec-020` desta
+execução.
+
+**Consequência operacional (MUST):** nenhuma task que implemente escrita ou
+leitura do `state.db` pode ser considerada pronta para execução antes do
+amendment 1.3.0 ser ratificado. `/create-tasks` MUST materializar isso como
+dependência explícita — não como nota de rodapé.
+
+**Fato que reduz — mas não elimina — o risco do amendment**: o runtime de
+estado **já** carrega uma dependência obrigatória sem fallback hoje.
+`state-rw.sh` L116-118 encerra com exit 1 e mensagem de instalação quando
+`jq` está ausente, e 23 scripts do runtime têm o mesmo gate. Ou seja, a
+tensão com a leitura literal do Princípio II **pré-existe** a esta feature;
+o amendment 1.3.0 regularizaria uma condição já vigente e a estenderia a
+`sqlite3`, em vez de abrir precedente inédito. Isso é argumento **para** o
+amendment — não substituto dele, e não autoriza prosseguir sem ele.
+
+> Nota de método: a alternativa "documentar a violação em Complexity
+> Tracking e seguir" é explicitamente vedada para princípio MUST. O caminho
+> adotado é o único disponível: prosseguir com o **plano** (que é
+> documentação técnica), carregando a ressalva, e travar a **implementação**
+> até a ratificação.
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+docs/specs/state-db-foundation/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Phase 0 — 9 decisões + 2 em aberto (D4-a, D7-a)
+├── data-model.md        # Phase 1 — schema + constraints do FR-002
+├── quickstart.md        # Phase 1 — 7 cenários cobrindo SC-001..SC-006
+└── contracts/
+    ├── primitives.md    # FR-004 — superfície atual + contrato do backend
+    ├── export.md        # FR-007 — export derivado state.json
+    └── migration.md     # FR-005 / FR-006 / FR-014 — migração
+```
+
+### Source Code (repository root — árvore real, verificada)
+
+```
+cstk/
+├── cli/
+│   ├── cstk                       # binário (dispatch de subcomandos)
+│   └── lib/
+│       ├── recall.sh              # ingestão knowledge.db (FR-008) — 2702 L
+│       ├── 00c-bootstrap.sh       # lê state.json
+│       └── …
+├── global/
+│   ├── agents/
+│   │   ├── agente-00c-orchestrator.md
+│   │   └── agente-00c-feature-orchestrator.md
+│   ├── commands/                  # 6 slash commands 00c
+│   └── skills/
+│       └── agente-00c-runtime/
+│           ├── hooks/             # pretooluse-bash-guard, posttooluse-*
+│           └── scripts/           # 35 scripts POSIX (alvo principal)
+│               ├── state-rw.sh          # 831 L
+│               ├── state-ondas.sh       # 1379 L
+│               ├── state-decisions.sh   # 362 L
+│               ├── bloqueios.sh         # 370 L
+│               ├── spawn-tracker.sh     # 240 L
+│               ├── state-validate.sh    # 404 L
+│               ├── state-lock.sh        # 172 L
+│               └── …
+├── docs/
+│   ├── constitution.md            # v1.2.0 — amendment 1.3.0 pendente
+│   └── specs/
+└── tests/
+    ├── run.sh                     # harness (~1100+ cenários)
+    ├── lib/harness.sh
+    ├── test_state-rw.sh           # … um por script
+    └── cstk/                      # testes de cli/lib/
+```
+
+**Structure Decision**: a feature vive **dentro da estrutura existente** —
+nenhum diretório novo de topo. O backend SQLite entra nos scripts de
+`global/skills/agente-00c-runtime/scripts/` que já detêm o estado; a
+migração ganha script próprio (`state-db-migrate.sh` ou equivalente, ver
+[migration.md](./contracts/migration.md) §Nomeação) por causa da colisão com
+o subcomando `migrate` **já existente** em `state-rw.sh`; a ingestão SQL→SQL
+entra em `cli/lib/recall.sh`, único arquivo que já fala SQLite no CLI.
+
+**Confinamento da dependência**: manter as menções a `sqlite3` no menor
+número possível de arquivos identificáveis. Isso não satisfaz o carve-out
+1.1.0 sozinho (falta a condição (a), o fallback), mas preserva a condição
+(b) — *"grep pelo nome do executável localiza todas as menções"* — que o
+amendment 1.3.0 provavelmente vai querer herdar.
+
+---
+
+## Convenções de Borda
+
+**N/A — single-layer.** A feature é biblioteca/CLI POSIX sh local: não há
+fronteira backend↔frontend, DTO, payload de API nem serialização entre
+serviços — logo não há risco da classe snake_case vs camelCase que motiva
+esta seção.
+
+A única fronteira de formato é `state.db` ↔ export `state.json`:
+
+| Camada | Convenção | Validação | Fonte da verdade |
+|---|---|---|---|
+| Colunas do `state.db` | `snake_case` | `CHECK`/`FK`/`UNIQUE` no schema | [data-model.md](./data-model.md) |
+| Chaves do export `state.json` | `snake_case`, **em inglês** | `state-validate.sh` (exit 0) | [contracts/export.md](./contracts/export.md) |
+| IDs | `dec-NNN`, `block-NNN`, `onda-NNN` | preservados literalmente | scripts de runtime atuais |
+
+Não há mapper layer nem ORM: a tradução banco↔JSON é explícita no export.
+A canonicalização pt-BR→EN das chaves **já é vigente** (`_SR_RENAME_MAP` em
+`state-rw.sh`) e o export não a reverte. Consumidor externo (`cstk-panel`)
+lê o `knowledge.db`, não o `state.json`.
+
+---
+
+## Ordem de implementação sugerida
+
+Deriva das prioridades da spec e das dependências entre requisitos. Insumo
+para `/create-tasks`, não substituto dele.
+
+| Ordem | Escopo | Requisitos | Depende de |
+|---|---|---|---|
+| **0** | **Amendment 1.3.0 da constitution** | — | **externo à feature; bloqueia tudo abaixo** |
+| 1 | Schema + PRAGMAs + constraints | FR-001, FR-002 | 0 |
+| 2 | Primitivas de escrita/leitura (paridade de superfície) | FR-003, FR-004, FR-011 | 1 |
+| 3 | Seleção de backend (`state.db` vs `state.json`) | FR-012, SC-003 | 2 |
+| 4 | Export derivado | FR-007, FR-013-INFRA-BACKUP | 2 |
+| 5 | Migração + verificação | FR-005, FR-006, FR-014 | 3, 4 |
+| 6 | Verificação de integridade | FR-010 | 1, **D4-a fechada** |
+| 7 | Ingestão SQL→SQL | FR-008, FR-009 | 5, **D7-a fechada** |
+
+O passo 4 antes do 5 é deliberado: a verificação campo-a-campo da migração
+(M3.2) **usa** o export como comparador, fechando SC-001 sem escrever um
+comparador novo.
+
+---
+
+## Decisões em aberto a fechar antes das tasks correspondentes
+
+| # | Decisão | Bloqueia | Onde |
+|---|---|---|---|
+| D4-a | Cobertura de adulteração deliberada (`integrity_check` não detecta edição bem-formada, `sha256-verify` detecta) | FR-010 | research.md Decision 4 |
+| D7-a | Forma do acesso na ingestão SQL→SQL (`ATTACH … mode=ro` vs. processo separado) | FR-008 | research.md Decision 7 |
+| E5-a | Gatilho do export (sob demanda / ao fim da onda / ambos) | FR-007 | export.md §E5 |
+| M1-a | `aguardando_humano` é migrável ou recusado? | FR-005 | migration.md §M1 |
+| C8-a | Parâmetros nomeados (`.param set`) disponíveis na versão mínima de `sqlite3`? Se não, `strip_nul`+`sql_escape` é o piso | FR-003, FR-004 | primitives.md §C8 |
+
+### Achados do gate de segurança (onda-004)
+
+O gate `owasp-security` sobre o desenho produziu 5 findings. Três foram
+**remediados no próprio contrato** nesta onda; um é decisão de threat model
+escalada ao operador; um é informativo.
+
+| # | Finding | Sev. | Tratamento |
+|---|---|---|---|
+| S1 | Contratos especificavam SQL sem exigir escape de texto livre de origem LLM (A05/CWE-89; `sqlite3` CLI executa múltiplos statements) | **high** | **Remediado** — primitives.md §C8 (MUST `strip_nul`+`sql_escape`, reusando os helpers de `recall.sh`) + teste obrigatório |
+| S2 | Troca de `sha256-verify` por `PRAGMA integrity_check` remove detecção de adulteração bem-formada do rastro de auditoria (A08/A09, ASVS L2 "tamper-evident") | **high** | **Escalado ao operador** — bloqueio humano; é D4-a |
+| S3 | Permissão de arquivo é ambiente (umask), não imposta; WAL triplica os arquivos e o `-wal` contém transações recentes em claro | **medium** | **Remediado** — primitives.md §C9 (`chmod 600` explícito) |
+| S4 | Temporário da migração com nome derivado de PID (symlink/TOCTOU) | **medium** | **Remediado** — primitives.md §C10 + migration.md §M2 (`mktemp`) |
+| S5 | Cadeia de propagação: `state.db` adulterado → export → ingestão → `knowledge.db` → read-back loop realimenta prompts futuros (ASI06 memory poisoning) | **medium** | **Informativo** — amplifica o impacto de S2; mitigado se S2 for resolvido. O scrub de segredos na ingestão permanece inalterado. |
+
+Nenhuma delas é `NEEDS CLARIFICATION` de contexto técnico: são escolhas de
+design delimitadas, com opções enumeradas e ponto de decisão atribuído.
+Registradas para **não** serem decididas silenciosamente na implementação.
+
+---
+
+## Re-check pós-Phase 1
+
+Reavaliação após o design (data-model + contratos + quickstart):
+
+| Verificação | Resultado |
+|---|---|
+| O design introduziu complexidade não justificada? | **Não.** Nenhum serviço, camada ou processo novo. Uma tabela por entidade **já existente** na spec; a única entidade nova (`migration_run`) é exigida pela auditabilidade do FR-006. `ExportSnapshot` foi deliberadamente **não** modelada como tabela para não duplicar a fonte de verdade. |
+| Princípios MUST continuam respeitados? | I, IV, V, VI: PASS, sem alteração. **II: continua CONDICIONAL** — o design não removeu a necessidade do amendment 1.3.0; ao contrário, confirmou-a (o `state.db` é inviável sem `sqlite3`). |
+| Superfície pública mudou? | Não — §C1 de primitives.md fixa paridade de subcomandos/flags/exit codes. Uma mudança de comportamento observável foi identificada e declarada: `state-ondas.sh start` com onda aberta passa a **falhar** em vez de duplicar (§C3) — é a correção de um bug, mas precisa constar. |
+| Novo risco identificado no design? | Sim, um: trocar `sha256-verify` por `PRAGMA integrity_check` **reduz** a cobertura contra adulteração deliberada. Não silenciado — virou D4-a e o cenário 7.a do quickstart fica sem *expected* até ser fechado. |
+
+**Veredito**: PASS em todos os princípios exceto o II, que permanece
+**CONDICIONAL ao amendment 1.3.0** — pré-requisito externo, bloqueante para
+implementação, não para planejamento.
+
+---
+
+## Complexity Tracking
+
+| Violação | Por que necessário | Alternativa simples rejeitada porque |
+|---|---|---|
+| **Dependência obrigatória em `sqlite3`, sem fallback** (Princípio II, L109-110) — **pendente de amendment 1.2.0 → 1.3.0** | A feature inteira é "usar um banco relacional como fonte de verdade" (FR-001) e "impor invariantes na camada de armazenamento" (FR-002). Não existe fallback: um modo degradado sem `sqlite3` seria o `state.json` de hoje — isto é, a ausência da feature. | *Manter JSON com lock mais rigoroso*: não atende FR-002 (invariantes declarativas) nem FR-011 (leitores concorrentes não-bloqueados); só endurece o mecanismo que a spec identifica como frágil. *Implementar um motor de constraints em sh sobre JSON*: reescreveria mal um banco de dados, com muito mais código e menos garantia. *Tratar `sqlite3` como dep opcional sob o carve-out 1.1.0*: impossível — a condição (a) exige que a feature funcione sem a ferramenta. |
+| `sqlite3` fora de um único arquivo (tensão com a condição (b) do carve-out 1.1.0) | O estado é mutado por múltiplos scripts especializados (`state-rw`, `state-ondas`, `state-decisions`, `bloqueios`, `spawn-tracker`). Concentrar todo acesso a banco num só arquivo criaria uma camada de indireção nova entre cada script e seu próprio estado. | *Camada única de acesso*: reduziria menções a `sqlite3` a um arquivo, mas ao custo de um indireção artificial. **Não descartada** — é decisão de granularidade a revisitar em `/create-tasks`, e o amendment 1.3.0 pode torná-la desnecessária ao dispensar a condição (b) para esta camada. |
+
+> Nenhuma outra violação. Esta tabela existe **exclusivamente** por causa da
+> ressalva do Princípio II documentada no Constitution Check — e ela **não**
+> autoriza prosseguir: o amendment é pré-requisito, não justificativa
+> *post-hoc*.
+
+---
+
+## Artefatos
+
+| Arquivo | Status |
+|---|---|
+| `docs/specs/state-db-foundation/plan.md` | Criado |
+| `docs/specs/state-db-foundation/research.md` | Criado |
+| `docs/specs/state-db-foundation/data-model.md` | Criado |
+| `docs/specs/state-db-foundation/contracts/primitives.md` | Criado |
+| `docs/specs/state-db-foundation/contracts/export.md` | Criado |
+| `docs/specs/state-db-foundation/contracts/migration.md` | Criado |
+| `docs/specs/state-db-foundation/quickstart.md` | Criado |

--- a/docs/specs/state-db-foundation/quickstart.md
+++ b/docs/specs/state-db-foundation/quickstart.md
@@ -249,16 +249,19 @@ feature — a seleção de backend (§C2) é o ponto único de falha.
 
 **Expected**: (1) exit 0. (2) exit != 0, corrupção reportada.
 
-### 7.a — Adulteração bem-formada `[DECISÃO EM ABERTO D4-a]`
+### 7.a — Adulteração bem-formada `[D4-a FECHADA — dec-025]`
 
 1. `UPDATE decision SET choice='outra' WHERE id='dec-001';` via `sqlite3`.
 2. Rodar a verificação.
 
-**Expected**: **depende de D4-a** (research.md Decision 4).
-`PRAGMA integrity_check` sozinho retorna `ok` — não detecta edição
-bem-formada, enquanto o `sha256-verify` de hoje detectaria. Este cenário
-**não tem expected definido** até D4-a ser fechada; deixá-lo passar por
-inércia mascararia um regresso de cobertura. Fechar antes da task de FR-010.
+**Expected**: exit 0 (`ok`) — comportamento **aceito e documentado**, não um
+bug. D4-a (research.md Decision 4) foi fechada pelo operador (bloqueio
+`block-002`, resposta `dec-025`) na opção 1: `PRAGMA integrity_check`
+sozinho, sem cobertura de adulteração bem-formada, assumindo operador local
+confiável. Este cenário existe para **documentar o regresso**, não para
+reprová-lo — se um teste automatizado cobrir 7.a, o assert correto é "exit
+0 mesmo após edição bem-formada", registrando o limite conhecido do
+mecanismo.
 
 ---
 

--- a/docs/specs/state-db-foundation/quickstart.md
+++ b/docs/specs/state-db-foundation/quickstart.md
@@ -1,0 +1,272 @@
+# Quickstart / Cenários de Teste: state.db
+
+**Feature**: `state-db-foundation` | **Phase**: 1
+**Spec**: [spec.md](./spec.md)
+
+Cenários executáveis que fecham os Success Criteria. Convenção do harness
+POSIX do repo (`tests/README.md`): script em `tests/test_<nome>.sh` para
+`global/skills/*/scripts/<nome>.sh`, e `tests/cstk/test_<nome>.sh` para
+`cli/lib/<nome>.sh`. `./tests/run.sh --check-coverage` falha (exit 1) se um
+script novo não tiver teste correspondente.
+
+---
+
+## Ambiente
+
+```sh
+sqlite3 --version   # >= 3.38 recomendado (JSON1 para os CHECK do data-model)
+jq --version        # já é dep de fato do runtime (23 scripts gateiam nele)
+./tests/run.sh --list | head    # confere o harness
+```
+
+---
+
+## Cenário 1 — Persistência íntegra e atômica (US1, P1)
+
+**Objetivo**: exercitar cada primitiva de escrita num projeto novo e provar
+que as invariantes são impostas pela camada de armazenamento.
+
+1. Criar state dir temporário e inicializar execução (`state-rw.sh init`).
+2. Abrir onda → `state-ondas.sh start`.
+3. Registrar decisão → `state-decisions.sh register` (7 flags obrigatórias).
+4. Registrar bloqueio referenciando a decisão → `bloqueios.sh register`.
+5. Registrar task → `state-ondas.sh record-task --outcome pass`.
+6. Registrar skill → `state-ondas.sh record-skill --skill X --kind gate`.
+7. `spawn-tracker.sh enter` / `leave`.
+8. Fechar onda → `state-ondas.sh end --motivo-termino etapa_concluida_avancando`.
+
+**Expected**: cada comando sai 0; `state-validate.sh` sai 0 ao final;
+`wave-status` imprime `closed`; `current-id` imprime `onda-001`.
+
+### 1.a — Onda duplicada é rejeitada (US1 AS-1)
+
+1. `state-ondas.sh start` (onda aberta).
+2. `state-ondas.sh start` de novo, **sem** fechar a primeira.
+
+**Expected**: a segunda chamada **falha** (exit != 0, stderr explicando
+onda já aberta) — `ux_wave_single_open`. Contagem de ondas permanece 1.
+**Nunca** duas ondas abertas.
+
+> Regressão que este cenário trava: hoje `start` faz append cego e cria uma
+> segunda onda; a proteção existe só como prosa no orquestrador (passo
+> 3.bis). Ver [contracts/primitives.md](./contracts/primitives.md) §C3.
+
+### 1.b — Onda fechada uma única vez (FR-002)
+
+1. Fechar a onda (`end --motivo-termino concluido`).
+2. Tentar fechar a mesma onda de novo.
+
+**Expected**: segunda chamada falha (`trg_wave_close_once`);
+`termination_reason` e `finished_at` permanecem os da primeira.
+
+### 1.c — Decisão sem campo obrigatório é rejeitada (US1 AS-2)
+
+1. `state-decisions.sh register` omitindo `--justificativa`.
+2. Escrita direta no banco (`INSERT INTO decision …`) com `rationale` vazio.
+
+**Expected**: (1) exit 1 — paridade com hoje. (2) **também falha**, por
+`CHECK (length(rationale) >= 20)`. É o ponto do FR-002: a garantia não
+depende de quem chama.
+
+### 1.d — Score 3 sem evidência é rejeitado
+
+1. `INSERT` direto com `justification_score = 3` e `evidence = NULL`.
+
+**Expected**: falha por CHECK. Hoje essa trava existe **apenas** dentro de
+`state-decisions.sh register` e é contornável por qualquer outro caminho.
+
+### 1.e — Bloqueio órfão é rejeitado (US1 AS-4)
+
+1. `bloqueios.sh register --decisao-id dec-999` (inexistente).
+2. `INSERT INTO human_block` com `decision_id` inexistente, com
+   `PRAGMA foreign_keys=ON`.
+
+**Expected**: ambos falham. Sem `foreign_keys=ON` o (2) passaria — por isso
+o PRAGMA é MUST por conexão ([primitives.md](./contracts/primitives.md) §C5).
+
+### 1.f — Teto de profundidade (FR-002)
+
+1. `spawn-tracker.sh enter` até depth 3; mais um `enter`.
+
+**Expected**: exit **3** no que excederia o teto, sem gravar — paridade com
+`_ST_MAX=3` de hoje, agora com `CHECK` no banco como rede.
+
+---
+
+## Cenário 2 — Escrita concorrente sem atualização perdida (US1 AS-3, SC-002)
+
+1. Inicializar execução e abrir onda.
+2. Disparar **em paralelo**: `state-decisions.sh register` (decisão A) e
+   `state-ondas.sh record-task` (task B).
+3. Aguardar ambos; conferir exit codes.
+4. Contar decisões e tasks.
+
+**Expected**: ambos saem 0; a decisão A **e** a task B estão presentes.
+Taxa de atualização perdida = **0%** (SC-002). Nenhum estado parcial.
+
+**Variante — dois escritores na mesma entidade**: dois `register`
+simultâneos ⇒ duas decisões com IDs distintos (`dec-001`, `dec-002`),
+nenhuma sobrescrita.
+
+> Este é o cenário que o mecanismo atual não sustenta: o RMW do
+> `state.json` faz read-modify-write do arquivo inteiro; duas escritas
+> concorrentes fora do lock perdem uma das duas.
+
+### 2.a — Leitor durante escrita (FR-011)
+
+1. Iniciar uma escrita longa (transação com `sleep` interno).
+2. Durante ela, rodar `state-rw.sh get --field '.current_stage'` e
+   `bloqueios.sh count --pending-only`.
+
+**Expected**: leituras retornam **imediatamente**, com o último estado
+consistente (pré-transação), exit 0. Não bloqueiam nem são bloqueadas — WAL.
+Nenhuma leitura parcial.
+
+---
+
+## Cenário 3 — Migração preserva 100% da auditoria (US2, SC-001)
+
+1. Tomar um `state.json` real com N decisões, M ondas, K tasks, J eventos,
+   L bloqueios (ex.: o desta própria execução, já com 4 ondas).
+2. Rodar a migração.
+3. Comparar contagens e conteúdo (round-trip do export vs. origem
+   canonicalizada com `jq -S .`).
+
+**Expected**: contagens idênticas; IDs (`dec-NNN`, `block-NNN`, `onda-NNN`),
+timestamps e conteúdo preservados; diff canonicalizado vazio. `state.json`
+original **intacto**.
+
+### 3.a — Idempotência (US2 AS-2)
+
+1. Rodar a migração de novo sobre o mesmo projeto.
+
+**Expected**: sem duplicação nem corrupção; contagens iguais às de (3).
+Registro em `migration_run`.
+
+### 3.b — Dados inconsistentes ⇒ recusa (US2 AS-3, SC-006)
+
+1. Forjar `state.json` com bloqueio humano apontando decisão inexistente.
+2. Tentar migrar.
+
+**Expected**: recusa com diagnóstico apontando o registro problemático;
+**nenhum** `state.db` produzido. 100% dos casos (SC-006).
+
+### 3.c — Execução ativa ⇒ recusa (FR-005)
+
+1. `state.json` com `.execution.status == "em_andamento"`; migrar.
+
+**Expected**: recusa; mensagem instruindo concluir/abortar/pausar antes.
+
+### 3.d — Interrupção no meio (US2 AS-4)
+
+1. Matar o processo entre a construção e a publicação.
+2. Inspecionar o projeto.
+
+**Expected**: `state.json` intacto e operável; nenhum `state.db` **visível**
+(só, no pior caso, um temporário `.state.db.tmp.*`). O projeto nunca fica
+sem fonte de verdade válida.
+
+---
+
+## Cenário 4 — Export aceito pelos consumidores atuais (US3, SC-004)
+
+1. Gerar o export de um projeto em `state.db`.
+2. `state-validate.sh --state-dir <dir>`.
+
+**Expected**: **exit 0** (US3 AS-1). O validador de hoje é o oráculo.
+
+### 4.a — Export reflete mutação nova (US3 AS-2, SC-004)
+
+1. Registrar decisão nova no `state.db`.
+2. Regenerar o export; ler `.decisions[-1].id`.
+
+**Expected**: a decisão nova aparece, em **até 5 segundos** (SC-004).
+
+### 4.b — Consumidor legado não percebe diferença (US3 AS-3)
+
+1. Rodar consumidores reais contra o export: `cycles.sh`, `circular.sh`,
+   `retro.sh`, `pipeline.sh`, `report.sh` e o hook
+   `posttooluse-tool-call-tick.sh`.
+
+**Expected**: comportamento idêntico ao de um `state.json` nativo. Atenção a
+E3 de [export.md](./contracts/export.md): chaves **ausentes** (não `null`)
+para `canonical_project`/`session_name` quando não fornecidas.
+
+### 4.c — Falha de export não bloqueia o fechamento da onda (Edge Case)
+
+1. Tornar o destino do export não-gravável.
+2. Fechar uma onda (`state-ondas.sh end`).
+
+**Expected**: a onda **fecha** no `state.db` (transação commitada); a falha
+de export vai para stderr. Degrada, não bloqueia.
+
+---
+
+## Cenário 5 — Ingestão SQL→SQL equivalente (US4, SC-005)
+
+1. Projeto com `state.db` populado; rodar ingestão SQL→SQL.
+2. Mesmo projeto: gerar export e rodar a ingestão JQ atual num
+   `knowledge.db` separado.
+3. Comparar as tabelas resultantes.
+
+**Expected**: mesmas entidades (`decisions`, `waves`, `blocks`, `tasks`,
+`events`, `skills`), mesma proveniência (`project`/`feature`/`wave`/data) —
+100% de equivalência (SC-005). Atenção: `skills` **exclui** `kind = 'gate'`.
+
+### 5.a — Projeto não migrado segue pelo caminho JSON (US4 AS-2, FR-012)
+
+1. Projeto só com `state.json`; rodar `cstk recall --ingest --state-dir …`.
+
+**Expected**: funciona **sem alteração**. A rota SQL é aditiva.
+
+### 5.b — knowledge.db continua único e derivado (US4 AS-3, FR-009)
+
+**Expected**: nenhum projeto grava no `knowledge.db`; ele permanece global,
+derivado e reconstruível por `cstk recall --reindex`.
+
+---
+
+## Cenário 6 — Projeto não migrado inalterado (FR-012, SC-003)
+
+1. Projeto com `state.json` e **sem** `state.db`.
+2. Rodar uma onda completa (init → start → decisão → end).
+3. `./tests/run.sh` (suíte inteira, ~1100+ cenários).
+
+**Expected**: comportamento observável idêntico ao de hoje; **0 regressões**
+atribuíveis a esta feature (SC-003). Este é o cenário de maior risco da
+feature — a seleção de backend (§C2) é o ponto único de falha.
+
+> Nota de execução (memória do repo): a suíte completa leva ~12 min; rodar
+> em background preso ao processo pai. `--fast` é atalho de dev-loop e não
+> substitui o gate de release.
+
+---
+
+## Cenário 7 — Verificação de integridade (FR-010)
+
+1. `state.db` íntegro ⇒ rodar a verificação.
+2. Corromper bytes do arquivo ⇒ verificar de novo.
+
+**Expected**: (1) exit 0. (2) exit != 0, corrupção reportada.
+
+### 7.a — Adulteração bem-formada `[DECISÃO EM ABERTO D4-a]`
+
+1. `UPDATE decision SET choice='outra' WHERE id='dec-001';` via `sqlite3`.
+2. Rodar a verificação.
+
+**Expected**: **depende de D4-a** (research.md Decision 4).
+`PRAGMA integrity_check` sozinho retorna `ok` — não detecta edição
+bem-formada, enquanto o `sha256-verify` de hoje detectaria. Este cenário
+**não tem expected definido** até D4-a ser fechada; deixá-lo passar por
+inércia mascararia um regresso de cobertura. Fechar antes da task de FR-010.
+
+---
+
+## Convenções de borda
+
+**N/A — single-layer.** A feature é biblioteca/CLI POSIX sh local: não há
+fronteira backend↔frontend, nem DTO, nem payload de API, nem serialização
+entre serviços. A única fronteira de formato é `state.db` ↔ export
+`state.json`, cujo contrato é [contracts/export.md](./contracts/export.md) e
+cujo oráculo é `state-validate.sh`. O consumidor externo (`cstk-panel`) lê o
+`knowledge.db`, não o `state.json` — protegido indiretamente por FR-008/009.

--- a/docs/specs/state-db-foundation/research.md
+++ b/docs/specs/state-db-foundation/research.md
@@ -315,14 +315,64 @@ migração jamais escreva no nome final antes de verificar.
 
 ---
 
+## Decision 10 — Versão mínima de `sqlite3` suportada (task 1.2)
+
+**Decision**: piso de `sqlite3` **3.45.1**, definido pelo ambiente mais
+restritivo entre os dois já documentados como reais (não hipotéticos):
+macOS local (`3.51.0`) e o runner `ubuntu-latest` do CI (`3.45.1`, imagem
+`Ubuntu 24.04`).
+
+**Evidência (fonte rastreável, não suposição)**:
+
+- macOS local: `sqlite3 --version` → `3.51.0 2025-06-12 ... f0ca7bba1c5e...`
+  (Decision 1, já documentado).
+- CI (`ubuntu-latest`, `.github/workflows/*.yml` — `release.yml`,
+  `shellcheck.yml`, `publish-site.yml` usam `runs-on: ubuntu-latest`):
+  consultado via GitHub API
+  (`api.github.com/repos/actions/runner-images/contents/images/ubuntu/Ubuntu2404-Readme.md`,
+  README oficial da imagem Ubuntu 24.04 usada pelos runners hospedados),
+  seção "Databases" lista `sqlite3 3.45.1` e a tabela de pacotes lista
+  `sqlite3 | 3.45.1-1ubuntu2.6`.
+- Menor das duas versões reais = **3.45.1** → piso adotado.
+
+**C8-b (JSON1 / `json_valid` / `json_array_length`)**: suportado no piso.
+Confirmado por duas fontes: (1) execução local —
+`SELECT json_valid('{"a":1}'), json_array_length('[1,2,3]');` → `1|3`,
+sem PRAGMA nem extensão carregada; (2) árvore de fontes do tag
+`version-3.45.1` no repositório oficial (`github.com/sqlite/sqlite`,
+consultado via `api.github.com/repos/sqlite/sqlite/contents/src?ref=version-3.45.1`)
+já contém `src/json.c` **dentro do core** (não em `ext/misc/`), confirmando
+que as funções JSON são compiladas por padrão desde antes do piso — não é
+preciso o degrade documentado em `data-model.md` para `CHECK
+(length(options_considered) > 2)`.
+
+**C8-a (parâmetros nomeados / `.param set`)**: suportado no piso.
+Confirmado via árvore de fontes do mesmo tag (`src/shell.c.in` em
+`version-3.45.1`): a função `bind_table_init` cria a tabela
+`temp.sqlite_parameters` e o dispatcher de comandos-ponto implementa
+`.parameter set NAME VALUE` (`.param` casa por prefixo, forma abreviada
+usual do shell `sqlite3`). Veredito: **adotar `.param set` como
+otimização** sobre o piso já obrigatório (`strip_nul` + `sql_escape`,
+`contracts/primitives.md` §C8) — ambos os mecanismos convivem; primitivas
+usam parâmetros nomeados quando disponíveis e mantêm o escape manual como
+caminho compatível caso uma instalação divergente não suporte `.param`.
+
+**Consequência**: nenhum degrade de JSON1 é necessário; `research.md`/
+`data-model.md` documentam piso `3.45.1` (não mais "assumir >= 3.38, a
+verificar"). Decisão registrada como `dec-046` (score 3, evidência =
+outputs literais acima).
+
+---
+
 ## Riscos e não-decisões
 
 | # | Item | Estado |
 |---|---|---|
-| R1 | Amendment 1.3.0 da constitution (sqlite3 obrigatório) | **Pré-requisito externo não ratificado** — ver [plan.md](./plan.md) §Constitution Check |
+| R1 | Amendment 1.3.0 da constitution (sqlite3 obrigatório) | **Fechada** — ratificado (commit `c5b2d65`, rodapé `docs/constitution.md` = `1.3.0`); gate task 1.1 liberado (dec-045) |
 | R2 | Cobertura de adulteração (D4-a) | **Fechada** (dec-025, resposta ao block-002) — opção 1, `integrity_check` apenas, regresso aceito e documentado |
 | R3 | Forma do acesso na ingestão SQL→SQL (D7-a) | Decisão em aberto — fechar antes da task de FR-008 |
 | R4 | ~24 scripts leem `state.json` hoje | Mitigado por FR-007 (export); nenhum precisa ser reescrito nesta fase |
+| R5 | Versão mínima de `sqlite3` (task 1.2) | **Fechada** (Decision 10, dec-046) — piso `3.45.1`, JSON1 e `.param set` confirmados no piso |
 
 **Nenhum `NEEDS CLARIFICATION` do Technical Context permanece aberto.** D4-a
 e D7-a não são unknowns de contexto técnico: são escolhas de design

--- a/docs/specs/state-db-foundation/research.md
+++ b/docs/specs/state-db-foundation/research.md
@@ -141,20 +141,29 @@ Nota: o sha256 de hoje já é uma defesa parcial — quem adultera o
 `state.json` pode recomputar o sidecar `.sha256`, já que a chave não é
 secreta. Ele detecta adulteração *descuidada*, não adulteração informada.
 
-**DECISÃO EM ABERTO (D4-a)** — como cobrir a parte de adulteração. Opções
-levantadas, nenhuma escolhida nesta fase:
+**DECISÃO FECHADA (D4-a)** — opção **1: `integrity_check` apenas**, aceitando
+o regresso documentado acima. Resolvida pelo operador humano em resposta ao
+bloqueio `block-002` (finding S2 do gate `owasp-security`, onda-004),
+registrada como `dec-025`. Opções que estavam em avaliação:
 
-1. `integrity_check` apenas, aceitando o regresso e documentando-o
-   (registra que o modelo de ameaça do toolkit é operador local confiável).
+1. **[ESCOLHIDA]** `integrity_check` apenas, aceitando o regresso e
+   documentando-o (registra que o modelo de ameaça do toolkit é operador
+   local confiável).
 2. `integrity_check` + hash-chain append-only sobre a tabela de decisões
    (cada linha carrega o hash da anterior) — detecta remoção/reescrita de
    rastro de auditoria, que é o ativo que o Princípio I protege.
 3. `integrity_check` + sha256 do **export** `state.json` (FR-007),
    preservando literalmente o mecanismo atual sobre o artefato derivado.
 
-Recomendação para `/checklist` e `/create-tasks`: tratar D4-a como item que
-precisa de decisão explícita antes da task que implementa FR-010 —
-não deixar o implementador escolher por conta própria.
+**Justificativa do operador**: o sha256 atual já é defesa parcial — quem
+adultera o `state.json` pode recomputar o sidecar `.sha256`, já que a chave
+não é secreta; ele detecta adulteração *descuidada*, não *informada*. O
+modelo de ameaça assumido para esta feature é operador local confiável, o
+que torna as opções 2/3 (custo adicional de hash-chain ou de manter dois
+mecanismos de verificação) desproporcionais ao ativo protegido nesta fase.
+`FR-010` passa a ser implementado apenas com `PRAGMA integrity_check` (ou
+`quick_check`), sem cobertura adicional de adulteração bem-formada — o
+regresso é aceito e documentado, não silenciado.
 
 ---
 
@@ -311,11 +320,12 @@ migração jamais escreva no nome final antes de verificar.
 | # | Item | Estado |
 |---|---|---|
 | R1 | Amendment 1.3.0 da constitution (sqlite3 obrigatório) | **Pré-requisito externo não ratificado** — ver [plan.md](./plan.md) §Constitution Check |
-| R2 | Cobertura de adulteração (D4-a) | Decisão em aberto — fechar antes da task de FR-010 |
+| R2 | Cobertura de adulteração (D4-a) | **Fechada** (dec-025, resposta ao block-002) — opção 1, `integrity_check` apenas, regresso aceito e documentado |
 | R3 | Forma do acesso na ingestão SQL→SQL (D7-a) | Decisão em aberto — fechar antes da task de FR-008 |
 | R4 | ~24 scripts leem `state.json` hoje | Mitigado por FR-007 (export); nenhum precisa ser reescrito nesta fase |
 
 **Nenhum `NEEDS CLARIFICATION` do Technical Context permanece aberto.** D4-a
 e D7-a não são unknowns de contexto técnico: são escolhas de design
 delimitadas, com opções enumeradas e ponto de decisão atribuído — registradas
-aqui para não serem decididas silenciosamente na implementação.
+aqui para não serem decididas silenciosamente na implementação. D4-a **já
+está fechada** (dec-025); D7-a permanece em aberto para `/create-tasks`.

--- a/docs/specs/state-db-foundation/research.md
+++ b/docs/specs/state-db-foundation/research.md
@@ -1,0 +1,321 @@
+# Research: Fundação state.db
+
+**Feature**: `state-db-foundation` | **Date**: 2026-07-30 | **Phase**: 0
+**Spec**: [spec.md](./spec.md)
+
+> Todo identificador (subcomando, flag, campo, tabela, coluna, exit code)
+> citado abaixo foi extraído por leitura direta das fontes reais do repo e
+> tem o arquivo/linha indicado. Onde a decisão ainda não está fechada, o
+> item aparece explicitamente como **DECISÃO EM ABERTO**, nunca como fato.
+> (Constitution VI — Veracidade de Dados.)
+
+---
+
+## Decision 1 — Mecanismo de acesso ao SQLite: CLI `sqlite3` via POSIX sh
+
+**Decision**: A camada de estado acessa o `state.db` invocando o binário
+`sqlite3` a partir de scripts POSIX sh, alimentando-o com SQL por heredoc/
+stdin — sem driver nativo, sem binding de linguagem, sem ORM.
+
+**Rationale**:
+
+- O toolkit não tem runtime de linguagem próprio: todo o runtime de estado
+  é POSIX sh (`global/skills/agente-00c-runtime/scripts/*.sh`). Introduzir
+  um driver exigiria introduzir uma linguagem hospedeira — mudança de
+  ordem de grandeza maior que esta feature.
+- **Precedente real e verificável no próprio repo**: `cli/lib/recall.sh`
+  já opera um banco SQLite (`~/.claude/cstk/knowledge.db`, 12 tabelas +
+  FTS5) inteiramente por CLI `sqlite3` a partir de POSIX sh, incluindo
+  transações (`BEGIN; … COMMIT;` por arquivo ingerido) e retry sob lock
+  (`recall_apply_sql_with_retry`, até 4 tentativas com backoff
+  PID-jitterado sobre `database is locked`/`database is busy`).
+- Ambiente de desenvolvimento confirmado: `sqlite3` presente em
+  `/usr/bin/sqlite3`, versão `3.51.0` (macOS). WAL exige SQLite >= 3.7.0
+  (2010), logo não há risco de versão nesse aspecto.
+
+**Alternatives considered**:
+
+- *Driver nativo (better-sqlite3 / node:sqlite / python sqlite3)*:
+  rejeitado — introduz runtime de linguagem no caminho crítico do estado,
+  contra a arquitetura POSIX sh do runtime. (O read-back loop recuperou uma
+  decisão análoga de outro projeto — `gamedev-training/onda-012`, escolha
+  `better-sqlite3` — mas aquele projeto **já era** Node; o critério que a
+  motivou não transfere para cá.)
+- *Manter JSON + lock mais rigoroso*: rejeitado — não resolve FR-002
+  (invariantes na camada de armazenamento) nem FR-011 (leitores
+  concorrentes não-bloqueados); apenas endurece o mecanismo que a spec
+  identifica como frágil.
+
+---
+
+## Decision 2 — Concorrência: WAL como mecanismo primário
+
+**Decision**: `PRAGMA journal_mode=WAL` no `state.db`, aplicado uma vez na
+criação do banco. Leitores não bloqueiam o escritor e o escritor não
+bloqueia leitores. Complementos obrigatórios: `PRAGMA busy_timeout` (espera
+o escritor concorrente em vez de falhar imediatamente com `SQLITE_BUSY`) e
+`PRAGMA foreign_keys=ON` (ver Decision 5).
+
+**Rationale**: pré-decidido pelo operador no clarify — `dec-014`, resposta
+ao `block-001`, registrada em [spec.md](./spec.md) §Clarifications Session
+2026-07-30. O `journal_mode` é persistente no header do arquivo do banco:
+setar uma vez na criação basta, não precisa ser reaplicado a cada conexão
+(diferente de `busy_timeout` e `foreign_keys`, que são **por conexão** e
+portanto precisam ser emitidos em toda invocação de `sqlite3`).
+
+**Consequências assumidas**:
+
+- O lock de diretório atual (`state-lock.sh`, `mkdir` de `<state-dir>/.lock`,
+  exit 3 em contenção) **deixa de ser requisito** para serialização de
+  escritores e para leitores. Permanece disponível como camada extra
+  opcional (spec FR-011).
+- WAL cria arquivos sidecar `state.db-wal` e `state.db-shm` junto ao banco.
+  Consequência operacional: cópia de arquivo do `state.db` isolado **não é**
+  um backup válido — daí o backup ser feito por export serializado
+  (Decision 6 / FR-013-INFRA-BACKUP), não por `cp`.
+- WAL pressupõe filesystem local com shared-memory funcional; não é
+  confiável sobre NFS. **Aceito**: o estado 00c já vive em
+  `<projeto-alvo>/.claude/`, isto é, dentro do repositório de trabalho local.
+
+---
+
+## Decision 3 — Atomicidade: uma transação `BEGIN IMMEDIATE` por mutação
+
+**Decision**: cada mutação de estado (as do FR-004) é uma única invocação
+de `sqlite3` contendo `BEGIN IMMEDIATE; …; COMMIT;`. A mutação inteira
+aplica ou não deixa rastro (FR-003).
+
+**Rationale**:
+
+- `BEGIN IMMEDIATE` adquire o write-lock na abertura da transação, em vez
+  de tentar promover um lock de leitura para escrita no meio dela. Isso
+  elimina a classe de falha em que duas transações deferred leem, tentam
+  escrever e uma recebe `SQLITE_BUSY` sem possibilidade de retry seguro —
+  exatamente o modo de falha que o RMW do `state.json` sofre hoje.
+- Uma invocação por mutação = um processo `sqlite3` por mutação. O custo é
+  aceitável: a frequência de mutação de estado é de ordem dezenas por onda,
+  não milhares por segundo.
+- Combinado com `busy_timeout`, o segundo escritor espera em vez de falhar.
+
+**Retry**: reaproveitar o padrão já implementado e testado em
+`cli/lib/recall.sh` (`recall_apply_sql_with_retry`) em vez de inventar um
+novo — mesma classe de erro (`database is locked` / `database is busy` /
+`locking protocol`), mesmo backoff jitterado.
+
+**Diferença de contrato face ao recall**: no `recall.sh` a degradação sob
+lock persistente é **pular a ingestão e sair 0** (o índice é derivado e
+reconstruível). No `state.db` isso é **inaceitável** — é a fonte de verdade;
+lock persistente após retries MUST falhar com exit não-zero, nunca degradar
+silenciosamente.
+
+---
+
+## Decision 4 — Verificação de integridade (FR-010): o que muda face ao sha256
+
+**Decision**: a operação de verificação passa a ser
+`PRAGMA integrity_check` (ou `quick_check` no caminho quente) sobre o
+`state.db`, substituindo a comparação de hash do arquivo.
+
+**Como funciona hoje** (fonte: `state-rw.sh`, subcomandos `sha256-update` /
+`sha256-verify`): calcula-se o SHA-256 do arquivo `<state-dir>/state.json`
+inteiro via `sha256sum` com fallback para `shasum -a 256`, e guarda-se o
+hex puro num arquivo sidecar `<state-dir>/state.json.sha256` (**não** é um
+campo dentro do JSON). `sha256-verify` compara e sai 1 em divergência.
+
+**Limitação que precisa ser dita com honestidade**: `integrity_check` e
+`sha256-verify` **não detectam a mesma coisa**.
+
+| Ameaça | `sha256-verify` (hoje) | `PRAGMA integrity_check` |
+|---|---|---|
+| Corrupção estrutural (disco, escrita parcial) | detecta | detecta |
+| Edição externa bem-formada (adulteração deliberada) | **detecta** | **NÃO detecta** |
+
+Um `UPDATE` manual via `sqlite3` num `state.db` produz um banco
+estruturalmente perfeito — `integrity_check` retorna `ok`. O sha256 do
+arquivo JSON, ao contrário, muda com qualquer edição. Ou seja: trocar sha256
+por `integrity_check` **fecha** o requisito de corrupção e **abre um
+regresso** no requisito de adulteração, que o FR-010 menciona
+explicitamente ("corrupção/adulteração silenciosa").
+
+Nota: o sha256 de hoje já é uma defesa parcial — quem adultera o
+`state.json` pode recomputar o sidecar `.sha256`, já que a chave não é
+secreta. Ele detecta adulteração *descuidada*, não adulteração informada.
+
+**DECISÃO EM ABERTO (D4-a)** — como cobrir a parte de adulteração. Opções
+levantadas, nenhuma escolhida nesta fase:
+
+1. `integrity_check` apenas, aceitando o regresso e documentando-o
+   (registra que o modelo de ameaça do toolkit é operador local confiável).
+2. `integrity_check` + hash-chain append-only sobre a tabela de decisões
+   (cada linha carrega o hash da anterior) — detecta remoção/reescrita de
+   rastro de auditoria, que é o ativo que o Princípio I protege.
+3. `integrity_check` + sha256 do **export** `state.json` (FR-007),
+   preservando literalmente o mecanismo atual sobre o artefato derivado.
+
+Recomendação para `/checklist` e `/create-tasks`: tratar D4-a como item que
+precisa de decisão explícita antes da task que implementa FR-010 —
+não deixar o implementador escolher por conta própria.
+
+---
+
+## Decision 5 — Invariantes do FR-002 dentro do banco, não na prosa
+
+**Decision**: as cinco invariantes citadas no FR-002 são expressas como
+constraints declarativas (`CHECK`, `UNIQUE` parcial, `FOREIGN KEY`,
+`TRIGGER` onde constraint não alcança) — detalhadas em
+[data-model.md](./data-model.md).
+
+**Rationale**: hoje essas regras existem em dois lugares, ambos
+não-declarativos e verificáveis só *a posteriori*:
+
+- `state-validate.sh` — script de checagem única (sem subcomandos) que
+  reprova depois do fato: valida `.schema_version == "1.0.0"`, tipos dos
+  campos obrigatórios, consistência `status` × `finished_at`,
+  `.budgets.current_subagent_depth <= 3`,
+  `.budgets.cycles_consumed_current_stage <= 5`,
+  `.budgets.retro_executions_consumed <= 2`, os 5 campos não-vazios de cada
+  decisão (`context`, `options_considered`, `choice`, `rationale`, `agent`)
+  e a referência de cada bloqueio humano a uma decisão existente.
+- Validação imperativa espalhada nos scripts de escrita — ex.:
+  `state-decisions.sh register` exige `--contexto` e `--justificativa` com
+  >= 20 bytes e rejeita `--score 3` sem `--evidencia` de >= 20 chars;
+  `bloqueios.sh register` checa a existência do `--decisao-id` via
+  `_bl_decisao_exists` antes de gravar.
+
+O ponto do FR-002 é que essas garantias passem a ser **impossíveis de
+contornar** por um chamador que esqueça a checagem — inclusive um agente
+autônomo escrevendo direto. `PRAGMA foreign_keys=ON` é obrigatório por
+conexão (SQLite desliga FK por default) — se esquecido, a FK de bloqueio→
+decisão vira decorativa.
+
+**Alternative rejeitada**: manter as invariantes só em script e usar o banco
+como armazenamento burro — anula a justificativa central da feature.
+
+---
+
+## Decision 6 — Backup por onda: export serializado, sem mecanismo novo
+
+**Decision**: o snapshot por onda fechada continua sendo gerado em
+`state-history/`, agora serializado a partir do `state.db` reaproveitando o
+export do FR-007. Nenhum mecanismo de backup nativo do SQLite
+(`VACUUM INTO`, `.backup`) é introduzido nesta fase.
+
+**Rationale**: pré-decidido no clarify (spec §Clarifications, Session
+2026-07-30) e reforçado por Decision 2 — como o WAL mantém dados em sidecars
+`-wal`/`-shm`, um snapshot por cópia de arquivo seria sutilmente incorreto,
+enquanto o export serializado é auto-contido por construção. Diretório
+`state-history/` já existe no state dir real desta própria execução.
+
+---
+
+## Decision 7 — Ingestão do knowledge.db a partir do state.db (FR-008)
+
+**Decision**: adicionar ao `cli/lib/recall.sh` um caminho de ingestão que lê
+o `state.db` por SQL, mantendo o caminho JSON atual intacto e funcionando
+(FR-012 e spec US4 AS-2: a rota SQL é **aditiva**, não substitui).
+
+**Fatos verificados do mecanismo atual** (fonte: `cli/lib/recall.sh`):
+
+- Modos existentes: busca (default), `--ingest`, `--reindex`, `--context`,
+  `--list-memories`.
+- `--ingest` **não descobre** arquivo: exige `--state-dir` e lê literalmente
+  `"$state_dir/state.json"`. Ausente/ilegível ⇒ warning + exit 0.
+- Schema em `schema_meta` (linha `key='schema_version'`), **não** em
+  `PRAGMA user_version`; versão corrente `RECALL_SCHEMA_VERSION=12`.
+- Entidades ingeridas e suas origens em JSON: `executions` (de
+  `.execution` + `.accumulated_metrics`), `waves` (`.waves[]`), `decisions`
+  (`.decisions[]`), `blocks` (`.human_blocks[]`), `tasks` (`.tasks[]`),
+  `events` (`.events[]`), `skills` (`.waves[].skills_invoked[]`, filtrando
+  `kind == "gate"`), `suggestions`, `retros`, `alert_signals`,
+  `wave_model_usage`, `memories`.
+- Idempotência por `UNIQUE(project, feature, wave, source_id)` +
+  `ON CONFLICT … DO UPDATE`.
+- Proveniência: `project` via `recall_derive_canonical` (campo congelado
+  `.execution.canonical_project` > git worktree > basename do
+  `target_project_path`); `feature` via `.short_name` com fallback por
+  layout de diretório.
+- Degradação: ausência de `sqlite3`, `jq` ou `secrets-filter.sh` ⇒
+  `log_warn` + exit 0, nunca aborta a onda.
+
+**Consequência de projeto**: como a ingestão SQL→SQL passa a ler de um banco
+e escrever noutro, o caminho natural é `ATTACH DATABASE` do `state.db` (o
+`knowledge.db` continua sendo o único destino de escrita — FR-009).
+**DECISÃO EM ABERTO (D7-a)**: `ATTACH` do `state.db` como `read-only`
+(`file:…?mode=ro` via URI) versus leitura em processo `sqlite3` separado
+com pipe do resultado. A primeira é mais direta; a segunda evita qualquer
+possibilidade de o processo de ingestão escrever no `state.db` por engano.
+Decidir antes da task de FR-008.
+
+**Invariante preservada (FR-009)**: nenhum projeto grava no `knowledge.db`
+diretamente; ele continua único, global, derivado e reconstruível por
+`--reindex`.
+
+---
+
+## Decision 8 — Migração idempotente (FR-005 / FR-006 / FR-014-INFRA-IDEMP)
+
+**Decision**: migração em quatro tempos — **recusar → construir fora →
+verificar → publicar atomicamente**:
+
+1. **Recusar cedo**: aborta se `.execution.status` for `em_andamento`
+   (FR-005) ou se a validação atual reprovar. Reaproveitar os verificadores
+   que já existem em vez de reimplementar: `state-validate.sh` (invariantes)
+   e `state-rw.sh sha256-verify` (integridade do arquivo de origem). Um
+   bloqueio humano órfão, por exemplo, já é detectado por
+   `state-validate.sh` — atende SC-006 sem código novo de checagem.
+2. **Construir fora do lugar**: escrever num arquivo temporário no mesmo
+   diretório (mesmo filesystem, requisito para o rename atômico).
+3. **Verificar** (FR-006): contagem por entidade e comparação campo-a-campo
+   entre origem e destino. Falhou ⇒ descarta o temporário; o projeto
+   continua operando pelo `state.json` original, intacto (spec US2 AS-4).
+4. **Publicar**: `mv` do temporário para `state.db` — atômico dentro do
+   mesmo filesystem.
+
+**Idempotência**: chave natural = identidade da execução (`.execution.id`,
+o campo que `state-rw.sh init` grava e que a ingestão do recall já usa como
+`execution_id`). Reexecutar sobre projeto já migrado não duplica nem
+corrompe: a migração é sempre reconstrução completa a partir da origem,
+seguida de publicação atômica — não é append incremental sobre um banco
+existente. Registrar cada tentativa em `MigrationRun` (entidade da spec).
+
+**Verificação campo-a-campo — como fechar SC-001 sem escrever um comparador
+novo**: gerar o export FR-007 a partir do `state.db` recém-construído e
+compará-lo com o `state.json` de origem. É exatamente o que SC-001 pede
+("comparação campo-a-campo entre o export pós-migração e o `state.json`
+original") e reduz a superfície de código de verificação a uma comparação de
+JSON canonicalizado.
+
+**Ordem de inserção**: a FK bloqueio→decisão obriga inserir decisões antes
+de bloqueios. Como os IDs originais (`dec-NNN`, `block-NNN`, `onda-NNN`) são
+preservados (FR-005), não há reescrita de identificador.
+
+---
+
+## Decision 9 — Coexistência e precedência de fonte de verdade
+
+**Decision**: presença de `state.db` **com migração verificada** vence;
+`state.json` remanescente vira export/legado. Pré-decidido no clarify.
+
+**Consequência de implementação**: precisa existir um sinal legível de
+"migração verificada" — não basta o arquivo existir, porque um `state.db`
+parcial de uma migração interrompida não deve ganhar precedência. Como a
+Decision 8 publica por rename atômico, um `state.db` **visível** é sempre
+um banco completo e verificado; o temporário nunca ocupa o nome final. A
+precedência pode então ser decidida por presença do arquivo — desde que a
+migração jamais escreva no nome final antes de verificar.
+
+---
+
+## Riscos e não-decisões
+
+| # | Item | Estado |
+|---|---|---|
+| R1 | Amendment 1.3.0 da constitution (sqlite3 obrigatório) | **Pré-requisito externo não ratificado** — ver [plan.md](./plan.md) §Constitution Check |
+| R2 | Cobertura de adulteração (D4-a) | Decisão em aberto — fechar antes da task de FR-010 |
+| R3 | Forma do acesso na ingestão SQL→SQL (D7-a) | Decisão em aberto — fechar antes da task de FR-008 |
+| R4 | ~24 scripts leem `state.json` hoje | Mitigado por FR-007 (export); nenhum precisa ser reescrito nesta fase |
+
+**Nenhum `NEEDS CLARIFICATION` do Technical Context permanece aberto.** D4-a
+e D7-a não são unknowns de contexto técnico: são escolhas de design
+delimitadas, com opções enumeradas e ponto de decisão atribuído — registradas
+aqui para não serem decididas silenciosamente na implementação.

--- a/docs/specs/state-db-foundation/spec.md
+++ b/docs/specs/state-db-foundation/spec.md
@@ -52,14 +52,17 @@ deste documento.
   nunca como fonte independente.
 - Q: Qual mecanismo de concorrência do `state.db` substitui/complementa o
   lock de diretório atual para serializar escritores e permitir leitores
-  concorrentes sem bloqueio (FR-011)? → **BLOQUEADO aguardando decisão
-  humana** (bloqueio `block-001`): o próprio spec.md tem sinais
-  conflitantes entre FR-011 (leitor concorrente sem bloqueio, sugerindo
-  WAL mode nativo do SQLite) e a nota de infraestrutura "Mutex
-  multi-réplica" (serialização entre orquestradores via lock de diretório
-  hoje vigente, declarada fora do escopo desta feature). Nenhuma das duas
-  opções viola a constitution — resolução requer decisão humana antes de
-  `plan`.
+  concorrentes sem bloqueio (FR-011)? → **A: WAL mode nativo do SQLite**
+  (`PRAGMA journal_mode=WAL`) resolve FR-011 diretamente — passa a ser o
+  mecanismo primário de concorrência do `state.db`, liberando leitores
+  durante uma escrita em andamento sem bloqueio nem leitura parcial. O
+  lock de diretório hoje vigente deixa de ser o único serializador entre
+  orquestradores; é **mantido apenas como camada extra opcional**,
+  acionável quando se justificar por melhoria de robustez/segurança
+  adicional (ex.: coordenação cross-processo além do que o WAL cobre
+  sozinho), nunca como requisito para leitores nem como mecanismo
+  primário de FR-011. Resolução do bloqueio `block-001` — decisão
+  registrada em `dec-014` (respondida pelo operador em 2026-07-30).
 
 ## User Scenarios & Testing
 
@@ -248,13 +251,14 @@ skills) devem ser equivalentes.
   tratado como export/legado, nunca como fonte independente (ver
   Clarifications, Session 2026-07-30).
 - O que acontece quando duas instâncias de orquestrador (ex.: agente-00c
-  e feature-00c) tentam escrever no mesmo `state.db` ao mesmo tempo? O
-  comportamento de serialização de escrita concorrente hoje garantido
-  pelo lock de diretório não pode regredir. **Mecanismo exato ainda em
-  aberto** — bloqueado aguardando decisão humana (`block-001`, ver
-  Clarifications, Session 2026-07-30) sobre se WAL mode nativo do SQLite
-  substitui o lock de diretório ou se o lock é mantido como camada de
-  serialização entre orquestradores.
+  e feature-00c) tentam escrever no mesmo `state.db` ao mesmo tempo? WAL
+  mode nativo do SQLite (`PRAGMA journal_mode=WAL`) serializa escritores
+  automaticamente e libera leitores concorrentes sem bloqueio — resolvido
+  via `block-001` (ver Clarifications, Session 2026-07-30). O lock de
+  diretório hoje vigente deixa de ser o serializador exigido; pode ser
+  mantido como camada extra opcional se uma necessidade concreta de
+  robustez/segurança adicional justificar, mas não é requisito desta
+  feature.
 - O que acontece quando a geração do export falha (ex.: disco cheio,
   processo interrompido) no meio do fechamento de uma onda? O
   fechamento da onda no `state.db` não pode ficar condicionado ao
@@ -335,7 +339,11 @@ skills) devem ser equivalentes.
 - **FR-011**: System MUST permitir que leitores (ex.: painel, comando de
   inspeção) acessem os dados do `state.db` enquanto uma escrita está em
   andamento, sem bloquear a escrita nem produzir leitura corrompida ou
-  parcial.
+  parcial. O mecanismo primário é WAL mode nativo do SQLite (`PRAGMA
+  journal_mode=WAL`); o lock de diretório hoje vigente deixa de ser
+  exigido para este fim e pode ser mantido apenas como camada extra
+  opcional quando justificar melhoria de robustez/segurança (ver
+  Clarifications, Session 2026-07-30 — `block-001`).
 - **FR-012**: Um projeto que ainda não foi migrado MUST continuar
   operando exatamente como hoje (lendo/escrevendo `state.json`) até que a
   migração seja executada — a introdução do `state.db` não pode quebrar
@@ -362,8 +370,12 @@ skills) devem ser equivalentes.
 > de token externo — não há integração com IdP/OAuth nesta feature.
 > Mutex multi-réplica — o toolkit roda como processo local
 > single-instance por projeto; a serialização entre orquestradores
-> concorrentes continua sendo resolvida pelo mecanismo de lock hoje
-> vigente (fora do escopo desta feature alterar).
+> concorrentes passa a ser resolvida primariamente pelo WAL mode nativo
+> do `state.db` (ver `block-001`, Clarifications Session 2026-07-30); o
+> lock de diretório hoje vigente deixa de ser o único mecanismo e é
+> mantido apenas como camada extra opcional, quando justificar melhoria
+> de robustez/segurança — não é reintroduzido como requisito desta
+> feature.
 
 ### Key Entities
 

--- a/docs/specs/state-db-foundation/spec.md
+++ b/docs/specs/state-db-foundation/spec.md
@@ -100,7 +100,7 @@ duplicada é rejeitada ou idempotente, nunca corrompe o registro existente.
    **Then** exatamente uma onda fica registrada como aberta e uma
    segunda tentativa de abrir onda antes de fechar a primeira é
    rejeitada ou tratada como no-op, nunca cria uma segunda onda aberta.
-2. **Given** uma decisão sendo registrada sem um dos cinco campos
+2. **Given** uma decisão sendo registrada sem um dos seis campos
    obrigatórios (agente, etapa, contexto, opções consideradas, escolha,
    justificativa),
    **Then** o registro é rejeitado antes de ser persistido — a
@@ -288,7 +288,7 @@ skills) devem ser equivalentes.
 - **FR-002**: System MUST impedir, na própria camada de armazenamento,
   os estados inválidos que hoje dependem só de convenção de script — no
   mínimo: duas ondas abertas simultaneamente, uma onda fechada mais de
-  uma vez, uma decisão sem os cinco campos obrigatórios de auditoria
+  uma vez, uma decisão sem os seis campos obrigatórios de auditoria
   (agente, etapa, contexto, opções consideradas, escolha, justificativa),
   um bloqueio humano referenciando uma decisão inexistente, e
   profundidade de subagente excedendo o teto configurado.
@@ -385,7 +385,7 @@ skills) devem ser equivalentes.
   etapas executadas, motivo de término e as invocações de skill/gate
   ocorridas dentro dela.
 - **Decision (Decisão)**: um registro auditável de uma escolha tomada
-  durante uma onda, com os cinco campos obrigatórios de auditoria mais
+  durante uma onda, com os seis campos obrigatórios de auditoria mais
   score/evidência opcionais.
 - **HumanBlock (Bloqueio Humano)**: uma pausa da execução aguardando
   resposta humana, sempre vinculada a uma Decision existente.

--- a/docs/specs/state-db-foundation/spec.md
+++ b/docs/specs/state-db-foundation/spec.md
@@ -1,0 +1,438 @@
+# Feature Specification: Fundação state.db
+
+**Feature**: `state-db-foundation`
+**Created**: 2026-07-30
+**Status**: Draft
+
+## Contexto
+
+Hoje o estado transacional de uma execução autônoma 00c (agente-00c ou
+feature-00c) vive inteiro num único arquivo `state.json` por projeto,
+escrito por uma família de scripts POSIX via leitura-modificação-escrita
+(RMW) protegida por um lock de diretório não-reentrante. Esse mecanismo é
+rigoroso onde há regra determinística de script, mas frágil exatamente na
+fronteira em que um agente autônomo *declara* um resultado (ex.: "task
+concluída", "onda fechada") que o script então persiste como fato, sem
+verificação estrutural equivalente a uma constraint de banco de dados.
+
+Esta feature é a **Fase 1 (fundação)** de uma linha de evolução maior: um
+banco `state.db` (SQLite) por projeto substitui o `state.json` como fonte
+de verdade transacional. Fases futuras (servidor de acesso tipado,
+inversão de verificação, telemetria ao vivo) estão **fora de escopo**
+deste documento.
+
+## Clarifications
+
+### Session 2026-07-30
+
+- Q: Como reconciliar o uso obrigatório de `sqlite3` pelo `state.db` com o
+  Princípio II (POSIX puro) da constitution? → A: `sqlite3` passa a ser
+  reconhecido como dependência obrigatória da camada de estado
+  transacional via **amendment dedicado da constitution** (MINOR bump),
+  distinto do carve-out opcional 1.1.0 — sem exigência de fallback
+  POSIX-puro para esta camada específica. **Dependência externa a esta
+  feature**: o amendment da constitution está fora do escopo do pipeline
+  `feature-00c` (que não inclui a etapa `constitution`) e precisa ser
+  conduzido separadamente antes de `plan` assumir `sqlite3` como
+  mandatório sem ressalva.
+- Q: A migração de um projeto existente para `state.db` deve ser
+  automática/transparente na próxima invocação do orquestrador, ou exigir
+  comando explícito do operador? → A: **Explícita via comando dedicado do
+  operador**, executada apenas fora de uma execução ativa (nunca sobre um
+  projeto com `status=em_andamento`).
+- Q: O backup por onda fechada deve continuar sendo um snapshot
+  serializado ou usar mecanismo nativo do SQLite? → A: **Continuar
+  gerando snapshot em `state-history/` por onda fechada**, agora
+  serializado a partir do `state.db` reaproveitando o export já exigido
+  por FR-007 — sem introduzir mecanismo de backup novo.
+- Q: Quando `state.json` e `state.db` coexistem no mesmo projeto, o que
+  determina qual é a fonte de verdade corrente? → A: **A presença de
+  `state.db` com migração verificada (FR-006 concluída) sempre vence** —
+  um `state.json` remanescente passa a ser tratado como export/legado,
+  nunca como fonte independente.
+- Q: Qual mecanismo de concorrência do `state.db` substitui/complementa o
+  lock de diretório atual para serializar escritores e permitir leitores
+  concorrentes sem bloqueio (FR-011)? → **BLOQUEADO aguardando decisão
+  humana** (bloqueio `block-001`): o próprio spec.md tem sinais
+  conflitantes entre FR-011 (leitor concorrente sem bloqueio, sugerindo
+  WAL mode nativo do SQLite) e a nota de infraestrutura "Mutex
+  multi-réplica" (serialização entre orquestradores via lock de diretório
+  hoje vigente, declarada fora do escopo desta feature). Nenhuma das duas
+  opções viola a constitution — resolução requer decisão humana antes de
+  `plan`.
+
+## User Scenarios & Testing
+
+### User Story 1 - Persistência íntegra e atômica das mutações de estado (Priority: P1)
+
+Como orquestrador autônomo (agente-00c ou feature-00c) executando uma
+onda, preciso que cada mutação de estado — abrir/fechar uma onda,
+registrar uma decisão, registrar um bloqueio humano, registrar o
+resultado de uma task, registrar a invocação de uma skill/gate, entrar ou
+sair de um nível de subagente — seja aplicada de forma atômica e com as
+mesmas invariantes de integridade hoje garantidas por convenção nos
+scripts (nunca duas ondas abertas simultaneamente, todo bloqueio humano
+referenciando uma decisão existente, profundidade de subagente nunca
+excedendo o teto configurado), mesmo que uma mutação seja interrompida no
+meio (crash, timeout, sinal).
+
+**Why this priority**: é o núcleo da fundação — sem persistência íntegra
+e atômica, nenhuma das fases seguintes (migração, export, ingestão) tem
+uma base confiável para se apoiar. Resolve a fragilidade central
+identificada no runtime atual (race de leitura-modificação-escrita,
+`start` de onda não-idempotente, invariantes checadas só por prosa).
+
+**Independent Test**: criar um projeto novo (sem `state.json` prévio),
+inicializar uma execução, e exercitar cada primitiva de escrita (abrir
+onda, registrar decisão, registrar bloqueio, registrar task, registrar
+skill, entrar/sair de spawn) — inclusive disparando duas tentativas
+concorrentes da mesma mutação (ex.: duas tentativas de abrir a mesma
+onda) — e verificar que o estado final é íntegro e que a mutação
+duplicada é rejeitada ou idempotente, nunca corrompe o registro existente.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma execução recém-iniciada sem nenhuma onda aberta,
+   **When** o orquestrador abre uma onda,
+   **Then** exatamente uma onda fica registrada como aberta e uma
+   segunda tentativa de abrir onda antes de fechar a primeira é
+   rejeitada ou tratada como no-op, nunca cria uma segunda onda aberta.
+2. **Given** uma decisão sendo registrada sem um dos cinco campos
+   obrigatórios (agente, etapa, contexto, opções consideradas, escolha,
+   justificativa),
+   **Then** o registro é rejeitado antes de ser persistido — a
+   invariante de auditabilidade é garantida pela própria camada de
+   armazenamento, não apenas pelo script chamador.
+3. **Given** duas mutações concorrentes tentando escrever no mesmo
+   projeto ao mesmo tempo (ex.: registrar decisão e fechar onda em
+   paralelo),
+   **When** ambas são submetidas,
+   **Then** nenhuma atualização é perdida — cada mutação aplica
+   integralmente ou não aplica nada, e o estado final reflete as duas
+   mudanças.
+4. **Given** um bloqueio humano sendo registrado referenciando um ID de
+   decisão que não existe,
+   **Then** o registro é rejeitado (a referência é validada na
+   persistência, não só na convenção de quem chama).
+
+---
+
+### User Story 2 - Migração de execuções existentes sem perda de auditoria (Priority: P2)
+
+Como operador do toolkit, preciso converter uma execução existente
+(`state.json` no formato atual) para `state.db`, preservando **100%**
+dos registros de auditoria — cada decisão, onda, task, evento, bloqueio
+humano e invocação de skill/gate, com seus identificadores e timestamps
+originais intactos — para que nenhuma execução em andamento ou já
+concluída perca histórico ao adotar o novo mecanismo.
+
+**Why this priority**: sem uma rota de migração, a fundação fica
+inutilizável em qualquer projeto que já tenha execuções — que é o caso
+comum. Depende da User Story 1 (o destino da migração precisa já
+existir e ser íntegro).
+
+**Independent Test**: pegar um `state.json` real (de uma execução
+concluída ou em andamento), rodar a migração, e comparar campo-a-campo
+cada registro do resultado contra o original — sem depender de nenhuma
+outra capacidade da feature (export ou ingestão).
+
+**Acceptance Scenarios**:
+
+1. **Given** um `state.json` existente com N decisões, M ondas, K tasks,
+   J eventos e L bloqueios humanos,
+   **When** a migração é executada,
+   **Then** o `state.db` resultante contém exatamente N decisões, M
+   ondas, K tasks, J eventos e L bloqueios humanos, cada um com os
+   mesmos identificadores, timestamps e conteúdo do original.
+2. **Given** uma migração concluída com sucesso,
+   **When** a mesma migração é executada novamente sobre o mesmo
+   projeto,
+   **Then** nenhum dado é duplicado ou corrompido (a operação é
+   idempotente).
+3. **Given** um `state.json` que falha na validação de schema/invariantes
+   hoje aplicada (ex.: bloqueio humano referenciando decisão
+   inexistente),
+   **When** a migração é tentada,
+   **Then** a migração é recusada com diagnóstico claro apontando o
+   registro problemático, em vez de migrar dados inconsistentes.
+4. **Given** uma migração interrompida no meio (processo morto,
+   máquina reiniciada),
+   **When** o operador inspeciona o projeto,
+   **Then** o projeto continua operável com o `state.json` original
+   intacto (a migração não deixa o projeto num estado sem fonte de
+   verdade válida).
+
+---
+
+### User Story 3 - Compatibilidade retroativa via export derivado (Priority: P3)
+
+Como consumidor já existente do `state.json` (o painel cstk-panel e o
+hook de ingestão do knowledge.db), preciso continuar lendo um
+`state.json` estruturalmente equivalente ao de hoje, gerado a partir do
+`state.db`, para continuar funcionando sem precisar ser reescrito durante
+o período de transição.
+
+**Why this priority**: protege os consumidores existentes contra ruptura
+imediata, mas só faz sentido depois que existe uma fonte (`state.db`,
+User Story 1) e dados migrados (User Story 2) para exportar.
+
+**Independent Test**: gerar o export de um projeto já em `state.db` e
+verificar que um consumidor existente (ex.: o próprio `state-validate.sh`
+usado hoje para validar `state.json`) aceita o resultado sem alterações.
+
+**Acceptance Scenarios**:
+
+1. **Given** um projeto operando em `state.db`,
+   **When** o export é gerado,
+   **Then** o `state.json` resultante passa na validação de schema e
+   invariantes hoje aplicada a um `state.json` nativo.
+2. **Given** uma nova mutação de estado aplicada ao `state.db` (ex.:
+   nova decisão registrada),
+   **When** o export é regenerado,
+   **Then** o `state.json` exportado reflete a nova mutação.
+3. **Given** um consumidor que só sabe ler `state.json` (ex.: um script
+   de auditoria de terceiros ainda não adaptado),
+   **When** ele lê o export derivado,
+   **Then** ele não percebe diferença estrutural em relação a um
+   `state.json` escrito diretamente pelo mecanismo atual.
+
+---
+
+### User Story 4 - Ingestão do knowledge.db direto do state.db (Priority: P4)
+
+Como mantenedor da memória cross-feature (`knowledge.db` global), preciso
+que a ingestão leia diretamente do `state.db` de cada projeto via SQL, em
+vez de reconstruir os mesmos dados a partir do `state.json` exportado
+usando `jq` e `sqlite3` em shell script, para eliminar uma camada de
+serialização/desserialização redundante e reduzir a superfície de
+divergência entre os dois formatos.
+
+**Why this priority**: é uma otimização/simplificação do mecanismo de
+ingestão que só faz sentido depois que `state.db` é a fonte de verdade
+confiável (User Story 1) — é a story de menor risco/urgência, adiável sem
+bloquear a adoção da fundação.
+
+**Independent Test**: rodar a ingestão de um projeto em `state.db` e
+comparar o resultado no `knowledge.db` contra o resultado da ingestão do
+mecanismo atual (via `state.json` exportado do mesmo projeto) — as
+entidades resultantes (decisões, ondas, tasks, eventos, bloqueios,
+skills) devem ser equivalentes.
+
+**Acceptance Scenarios**:
+
+1. **Given** um projeto com `state.db` populado,
+   **When** a ingestão do knowledge.db é executada para esse projeto,
+   **Then** as mesmas entidades (decisões, ondas, tasks, eventos,
+   bloqueios, skills invocadas) aparecem no knowledge.db, com a mesma
+   proveniência (projeto/feature/onda/data) que a ingestão via
+   `state.json` produziria.
+2. **Given** um projeto ainda não migrado (só `state.json`),
+   **When** a ingestão é executada,
+   **Then** o mecanismo atual (via JSON) continua funcionando sem
+   alteração — a ingestão SQL-para-SQL é aditiva, não substitui o
+   caminho legado enquanto ele for necessário.
+3. **Given** a ingestão SQL-para-SQL de um projeto,
+   **When** ela é executada,
+   **Then** o `knowledge.db` global permanece o único banco agregado,
+   derivado e somente-leitura do ponto de vista dos projetos — nenhum
+   projeto grava diretamente nele.
+
+---
+
+### Edge Cases
+
+- O que acontece quando um projeto tem `state.json` **e** `state.db`
+  presentes simultaneamente (migração interrompida ou reexecutada)? A
+  presença de `state.db` com migração verificada (FR-006 concluída)
+  sempre vence como fonte de verdade; um `state.json` remanescente é
+  tratado como export/legado, nunca como fonte independente (ver
+  Clarifications, Session 2026-07-30).
+- O que acontece quando duas instâncias de orquestrador (ex.: agente-00c
+  e feature-00c) tentam escrever no mesmo `state.db` ao mesmo tempo? O
+  comportamento de serialização de escrita concorrente hoje garantido
+  pelo lock de diretório não pode regredir. **Mecanismo exato ainda em
+  aberto** — bloqueado aguardando decisão humana (`block-001`, ver
+  Clarifications, Session 2026-07-30) sobre se WAL mode nativo do SQLite
+  substitui o lock de diretório ou se o lock é mantido como camada de
+  serialização entre orquestradores.
+- O que acontece quando a geração do export falha (ex.: disco cheio,
+  processo interrompido) no meio do fechamento de uma onda? O
+  fechamento da onda no `state.db` não pode ficar condicionado ao
+  sucesso do export — a falha de export degrada, não bloqueia a fonte
+  de verdade.
+- O que acontece quando a migração é tentada sobre um `state.json` que já
+  está corrompido ou com hash de integridade divergente? A migração deve
+  recusar e reportar, nunca "consertar" silenciosamente dados suspeitos.
+- O que acontece com os backups por onda que hoje existem
+  (`state-history/`) depois da migração — eles continuam sendo gerados,
+  agora a partir do `state.db`, ou são substituídos por um mecanismo de
+  backup nativo do banco?
+- O que acontece quando a ingestão do knowledge.db roda enquanto o
+  `state.db` do projeto está no meio de uma transação de escrita? A
+  ingestão deve enxergar um estado consistente (a última transação
+  concluída), nunca uma leitura parcial de uma transação em andamento.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST persistir todo o estado transacional de uma
+  execução 00c (ondas, decisões, tasks, eventos, bloqueios humanos,
+  invocações de skill/gate, uso de spawn de subagente) num banco de
+  dados relacional por projeto (`state.db`), em vez de um único arquivo
+  JSON.
+- **FR-002**: System MUST impedir, na própria camada de armazenamento,
+  os estados inválidos que hoje dependem só de convenção de script — no
+  mínimo: duas ondas abertas simultaneamente, uma onda fechada mais de
+  uma vez, uma decisão sem os cinco campos obrigatórios de auditoria
+  (agente, etapa, contexto, opções consideradas, escolha, justificativa),
+  um bloqueio humano referenciando uma decisão inexistente, e
+  profundidade de subagente excedendo o teto configurado.
+- **FR-003**: System MUST aplicar cada mutação individual de estado
+  (abrir/fechar onda, registrar decisão, registrar bloqueio, registrar
+  resultado de task, registrar invocação de skill/gate, entrar/sair de
+  spawn) de forma atômica — a mutação aplica integralmente ou não deixa
+  rastro parcial, mesmo sob acesso concorrente ou interrupção no meio.
+- **FR-004**: System MUST expor primitivas de acesso cobrindo os mesmos
+  verbos que os orquestradores usam hoje em todo caminho de escrita:
+  inicializar execução (projeto ou feature), ler um campo, atualizar um
+  campo, registrar decisão, abrir/fechar onda, registrar invocação de
+  skill/gate, registrar resultado de task, registrar/listar/contar/
+  responder bloqueio humano, entrar/checar/sair de profundidade de
+  spawn.
+- **FR-005**: System MUST prover uma operação de migração que converte um
+  `state.json` existente (formato atual) para `state.db`, preservando
+  cada registro (decisões, ondas, tasks, eventos, bloqueios humanos,
+  invocações de skill) com seus identificadores e timestamps originais,
+  sem perda nem reordenação do rastro de auditoria. A migração MUST ser
+  disparada apenas por comando explícito do operador, nunca automática
+  ou transparente numa invocação do orquestrador — e MUST recusar rodar
+  sobre um projeto com execução ativa (`status=em_andamento`), exigindo
+  que a execução seja concluída, abortada ou pausada antes da conversão
+  (ver Clarifications, Session 2026-07-30).
+- **FR-006**: System MUST verificar, imediatamente após a migração, que
+  nenhum dado foi perdido ou alterado (contagem de registros e
+  correspondência campo-a-campo entre origem e destino) e MUST recusar
+  considerar a migração concluída se essa verificação falhar.
+- **FR-007**: System MUST gerar, a partir do `state.db`, um export
+  equivalente ao `state.json` de hoje, estruturalmente compatível com os
+  consumidores atuais (painel, ingestão do knowledge.db), para que esses
+  consumidores continuem funcionando sem reescrita durante a transição.
+- **FR-008**: System MUST permitir que o processo de ingestão do
+  knowledge.db leia diretamente do `state.db` de um projeto (não do JSON
+  exportado) para popular as mesmas entidades de conhecimento que popula
+  hoje.
+- **FR-009**: System MUST preservar a separação de responsabilidade já
+  vigente do knowledge.db global — ele continua único, independente de
+  projeto, derivado e somente-leitura; esta feature muda apenas o
+  mecanismo pelo qual ele é populado (SQL a partir do `state.db`), nunca
+  seu escopo, propriedade ou modelo de acesso de escrita.
+- **FR-010**: System MUST continuar oferecendo uma operação de
+  verificação de integridade equivalente à checagem de hash usada hoje
+  antes de confiar numa leitura — expressa, para `state.db`, como uma
+  operação executável antes de cada uso que detecta corrupção/adulteração
+  silenciosa.
+- **FR-011**: System MUST permitir que leitores (ex.: painel, comando de
+  inspeção) acessem os dados do `state.db` enquanto uma escrita está em
+  andamento, sem bloquear a escrita nem produzir leitura corrompida ou
+  parcial.
+- **FR-012**: Um projeto que ainda não foi migrado MUST continuar
+  operando exatamente como hoje (lendo/escrevendo `state.json`) até que a
+  migração seja executada — a introdução do `state.db` não pode quebrar
+  nem exigir migração forçada de projetos ainda não convertidos.
+
+**Decisões de infraestrutura auditáveis:**
+
+- **FR-013-INFRA-BACKUP**: System MUST suportar backup/restauração do
+  `state.db` com granularidade pelo menos equivalente à disponível hoje
+  (um snapshot recuperável por onda fechada), reaproveitando o export
+  `state.json` já exigido por FR-007 como mecanismo de snapshot — sem
+  introduzir um mecanismo de backup nativo do SQLite separado nesta fase
+  (ver Clarifications, Session 2026-07-30) — com a restauração validada
+  por teste antes de ser considerada disponível.
+- **FR-014-INFRA-IDEMP**: A operação de migração MUST ser idempotente —
+  reexecutá-la contra um projeto já migrado não pode duplicar nem
+  corromper dados (chave de idempotência: identidade do projeto/execução
+  de origem).
+
+> Demais categorias do checklist de infraestrutura: N/A explícito.
+> Scheduling — feature não introduz job periódico novo (execução
+> continua disparada pelos mesmos gatilhos de onda de hoje). Rotação de
+> chave — nenhum dado novo passa a ser criptografado nesta fase. Refresh
+> de token externo — não há integração com IdP/OAuth nesta feature.
+> Mutex multi-réplica — o toolkit roda como processo local
+> single-instance por projeto; a serialização entre orquestradores
+> concorrentes continua sendo resolvida pelo mecanismo de lock hoje
+> vigente (fora do escopo desta feature alterar).
+
+### Key Entities
+
+- **StateDatabase**: o banco `state.db` por projeto — a nova fonte de
+  verdade transacional de uma execução 00c, substituindo o `state.json`.
+- **Wave (Onda)**: um ciclo de execução do orquestrador; tem início, fim,
+  etapas executadas, motivo de término e as invocações de skill/gate
+  ocorridas dentro dela.
+- **Decision (Decisão)**: um registro auditável de uma escolha tomada
+  durante uma onda, com os cinco campos obrigatórios de auditoria mais
+  score/evidência opcionais.
+- **HumanBlock (Bloqueio Humano)**: uma pausa da execução aguardando
+  resposta humana, sempre vinculada a uma Decision existente.
+- **TaskOutcome (Resultado de Task)**: o resultado (sucesso/falha) da
+  execução de uma task do backlog dentro de uma onda, com métricas de
+  teste/lint associadas.
+- **Event (Evento)**: um marco cronológico da execução (ex.: consulta ao
+  histórico, contenção de lock, validação falha) usado para reconstruir
+  a linha do tempo de uma execução.
+- **SkillInvocation (Invocação de Skill/Gate)**: o registro de que uma
+  skill ou gate determinístico rodou dentro de uma onda, associado
+  opcionalmente à decisão que motivou sua invocação.
+- **SpawnUsage (Uso de Spawn)**: o registro de profundidade de subagente
+  consumida/liberada dentro de uma execução, usado para impedir
+  recursão além do teto configurado.
+- **MigrationRun (Execução de Migração)**: o registro de uma tentativa de
+  converter um `state.json` existente em `state.db`, com seu resultado de
+  verificação (sucesso/recusa) e diagnóstico.
+- **ExportSnapshot (Export Derivado)**: a representação `state.json`
+  gerada a partir do `state.db`, consumida por quem ainda não lê o banco
+  diretamente.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 100% dos registros de auditoria (decisões, ondas, tasks,
+  eventos, bloqueios humanos, invocações de skill/gate) de uma execução
+  existente são preservados após a migração, verificado por comparação
+  campo-a-campo entre o export pós-migração e o `state.json` original.
+- **SC-002**: Sob escrita concorrente (duas mutações de estado
+  simultâneas no mesmo projeto), a taxa de atualização perdida é 0% —
+  nenhuma mutação aplicada com sucesso desaparece do estado final,
+  medido em teste de carga concorrente.
+- **SC-003**: Um projeto que já operava com `state.json` continua
+  funcionando (leitura e escrita) sem qualquer alteração de
+  comportamento observável, até o momento em que é migrado — 0
+  regressões na suíte de testes existente do toolkit atribuíveis a esta
+  feature.
+- **SC-004**: O export do `state.json` a partir do `state.db` reflete uma
+  mutação de estado em até 5 segundos após ela ser aplicada, medido em
+  teste automatizado.
+- **SC-005**: A ingestão do knowledge.db a partir do `state.db` produz o
+  mesmo conjunto de entidades (mesma proveniência projeto/feature/onda)
+  que a ingestão a partir do `state.json` exportado do mesmo projeto, com
+  100% de equivalência num conjunto de projetos de amostra.
+- **SC-006**: Uma tentativa de migração sobre um projeto com dados
+  inconsistentes (ex.: bloqueio humano órfão) é recusada em 100% dos
+  casos, nunca produzindo um `state.db` com a mesma inconsistência.
+
+## Delta Requirements
+
+**Skip**: nenhuma capability documentada em `docs/specs/current/`
+(`atomic-commit-staging`, `bash-guard-enforcement`, `delta-archive-gate`,
+`guards-defense-in-depth`, `serve-integrity`, `spec-corpus`,
+`spec-delta-requirements`, `trusted-release-hosts`) descreve o mecanismo
+de persistência transacional do `state.json`/scripts de runtime — esse
+comportamento hoje vive nos scripts de runtime e nos arquivos de agente,
+não no corpus de specs vivas. Nada a alterar no corpus nesta fase; uma
+capability nova (`state-db-foundation` ou equivalente) poderá ser
+declarada quando esta feature for arquivada, seguindo o processo padrão
+de `delta-merge`. — agente-00c-feature-orchestrator, 2026-07-30

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -860,39 +860,81 @@ dec-037); dec-035 (CHK015, critério de amostra)
 
 ### 8.1 Caminho de ingestão SQL→SQL em `cli/lib/recall.sh` `[M]`
 
-- [ ] 8.1.1 Implementar `ATTACH DATABASE 'file:<path do state.db>?mode=ro'
+- [x] 8.1.1 Implementar `ATTACH DATABASE 'file:<path do state.db>?mode=ro'
   AS src;` seguido de `INSERT ... SELECT` para cada entidade (executions,
   waves, decisions, blocks, tasks, events, skills), preservando a mesma
   proveniência (`project`/`feature`/`onda`/data) e a mesma idempotência
   (`UNIQUE(project, feature, wave, source_id)` + `ON CONFLICT DO UPDATE`)
   do caminho JSON atual
-- [ ] 8.1.2 Aplicar o mesmo filtro `kind == 'gate'` na exclusão da tabela
+  — onda-018: `recall_ingest_state_db()` (`cli/lib/recall.sh`). Duas
+  passagens: PASS 1 bulk `ATTACH+INSERT...SELECT` (json_extract/json_each
+  para os blobs de onda — piso sqlite3 3.45.1, dec-046 — sem shell/jq);
+  PASS 2 fixup de scrub (secrets-filter.sh é processo externo, sem
+  equivalente em SQL puro) + reconstrução de `knowledge_fts` escopada por
+  execution_id. Ver dec-086 (mecanismo `mode=ro` sozinho falha sem
+  `-shm`/`-wal` presentes; `immutable=1` é obrigatório junto) e dec-087
+  (`INSERT...SELECT...ON CONFLICT` exige `WHERE` explícito antes do
+  `ON CONFLICT` para o parser SQLite não confundir com join-`ON`)
+- [x] 8.1.2 Aplicar o mesmo filtro `kind == 'gate'` na exclusão da tabela
   `skills` (paridade com o caminho JSON)
-- [ ] 8.1.3 Preservar FR-009: nenhuma escrita direta no `knowledge.db` por
+  — onda-018: `WHERE si.kind != 'gate'` na SELECT de `skill_invocation`,
+  com `ROW_NUMBER() OVER (PARTITION BY wave_id ORDER BY id)` (window
+  function, piso 3.25 — bem abaixo do piso 3.45.1) replicando o índice
+  posicional por onda que o caminho JSON deriva de `to_entries[]`
+- [x] 8.1.3 Preservar FR-009: nenhuma escrita direta no `knowledge.db` por
   outro caminho; `ATTACH ... mode=ro` garante que o processo de ingestão
   não pode escrever acidentalmente no `state.db` de origem
+  — onda-018: verificado empiricamente (dec-086) que `mode=ro&immutable=1`
+  rejeita QUALQUER escrita em `src` com exit 8 ("attempt to write a
+  readonly database"), inclusive quando não há `-shm`/`-wal` no disco
 
 ### 8.2 Preservar o caminho JSON legado intacto (FR-012, US4 AS-2) `[M]`
 
-- [ ] 8.2.1 Detectar presença de `state.db` para escolher o caminho
+- [x] 8.2.1 Detectar presença de `state.db` para escolher o caminho
   SQL→SQL; ausência mantém o caminho JSON atual sem alteração
-- [ ] 8.2.2 Teste: projeto ainda não migrado (`state.json` apenas) ingere
+  — onda-018: `recall_mode_ingest()` checa `[ -r "$_ing_state_dir/state.db" ]`
+  antes de despachar para `recall_ingest_state_db` vs `recall_ingest_state_json`
+- [x] 8.2.2 Teste: projeto ainda não migrado (`state.json` apenas) ingere
   exatamente como hoje, sem regressão
+  — onda-018: `scenario_sqldb_json_path_preservado_sem_migracao`
+  (`tests/cstk/test_recall.sh`)
 
 ### 8.3 Testes de equivalência SQL vs JSON (SC-005) `[M]`
 
 Ref: dec-035 (critério de amostra)
 
-- [ ] 8.3.1 Fixtures sintéticas cobrindo os 3 casos de dec-035 (vazio/
+- [x] 8.3.1 Fixtures sintéticas cobrindo os 3 casos de dec-035 (vazio/
   mínimo: 0 decisões e 1 onda; médio: ~10 decisões/3 ondas; grande: ~50+
   decisões/10+ ondas) — ingerir via os dois caminhos (JSON exportado vs
   SQL direto) e comparar as entidades resultantes no `knowledge.db`
-- [ ] 8.3.2 Incluir, quando disponíveis no ambiente de teste local, os
+  — onda-018: `_seed_sql_equiv_state` + `_assert_sql_json_equivalent` +
+  `scenario_sqldb_equiv_vazio/medio/grande` (`tests/cstk/test_recall.sh`).
+  Bug pre-existente achado ao construir as fixtures (FASE 3/6, fora do
+  escopo de 8.x mas bloqueava `state-db-migrate.sh migrate` para qualquer
+  execução com `atomic_commit_enabled=false`, o default): corrigido em
+  `_state-rw-db.sh` — dec-085
+- [~] 8.3.2 Incluir, quando disponíveis no ambiente de teste local, os
   state-dirs reais já existentes (ex.: este próprio
   `.claude/feature-00c-state/state-db-foundation` após migrado) como
   amostra adicional, sem depender exclusivamente deles
-- [ ] 8.3.3 Confirmar 100% de equivalência de entidades entre os dois
+  — onda-018: **deliberadamente NÃO migrado** o state-dir desta própria
+  execução em andamento (`.claude/feature-00c-state/state-db-foundation`)
+  — migrar o state.json ATIVO de uma orquestração em curso é destrutivo
+  (M2/M6 do contrato de migração assumem execução parada) e violaria o
+  blast radius desta onda. A cláusula "sem depender exclusivamente deles"
+  já é satisfeita pelas 3 fixtures sintéticas de 8.3.1 (ver dec-035); a
+  amostra de state-dir real fica como extensão futura opcional, não
+  bloqueante para SC-005 — dec-088
+- [x] 8.3.3 Confirmar 100% de equivalência de entidades entre os dois
   caminhos de ingestão na amostra (SC-005)
+  — onda-018: `_assert_sql_json_equivalent` compara as 7 tabelas linha-a-
+  linha (`ORDER BY source_id`) para as 3 fixtures; 100% de equivalência nas
+  colunas comparáveis. 2 classes de divergência ACEITA e documentada (não
+  são falha de SC-005): `ingested_at` (wall-clock, propositalmente fora do
+  escopo de comparação) e `executions.subagents_spawned/
+  skill_suggestions_total/toolkit_issues_opened` (sem coluna em state.db —
+  mesmo gap já aceito em dec-079/M3.2; NULL em vez do 0 fabricado que o
+  export JSON produz, por Princípio VI)
 
 ---
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -220,16 +220,55 @@ Ref: contracts/primitives.md §C1 (paridade), §C2 (seleção de backend)
 
 Ref: contracts/primitives.md tabela de subcomandos `state-ondas.sh`
 
-- [ ] 3.3.1 Adaptar `start`/`end`/`wave-status`/`current-id` — declarar
+- [x] 3.3.1 Adaptar `start`/`end`/`wave-status`/`current-id` — declarar
   explicitamente a mudança de comportamento autorizada por C3: `start` com
   onda já aberta passa a **falhar** (hoje duplica silenciosamente)
-- [ ] 3.3.2 Adaptar `record-skill`/`record-task`/`reconcile-tasks` — PK
+  — onda-009: novo `_state-ondas-db.sh` (`_so_db_start`/`_so_db_end`/
+  `_so_db_wave_status`/`_so_db_current_id`), dispatch por backend em
+  `state-ondas.sh`; `start` sobre onda aberta falha via `ux_wave_single_open`
+  (INSERT rejeitado, exit 1 + stderr); `end` fecha a onda aberta numa unica
+  transacao (C4) incl. `next_instruction` quando fornecido;
+  `accumulated_metrics` passa a ser DERIVADO por agregação SQL
+  (`_sr_db_read`), sem campo separado a manter em sincronia. Fix lateral:
+  `_so_start_snapshot_baseline` lia `.execution.target_project_path` via
+  `jq` direto no `state.json` (quebrava sob SQLite) — migrado para
+  `state-rw.sh get` (backend-safe nos dois backends)
+- [x] 3.3.2 Adaptar `record-skill`/`record-task`/`reconcile-tasks` — PK
   composta de `task_outcome` substitui o upsert em `jq` por
   `INSERT ... ON CONFLICT DO UPDATE`
-- [ ] 3.3.3 Adaptar `tool-call-tick`/`git-commit`
-- [ ] 3.3.4 Teste: guarda `wave-status` do orquestrador continua válida
+  — onda-009: `_so_db_record_skill` (INSERT...SELECT...WHERE NOT EXISTS,
+  check-then-insert atomico, mesma idempotência skill+decisão do path
+  JSON, alvo = última onda por seq como `.waves[-1]`, não exige onda
+  aberta); `_so_db_record_task` (dispatcher DO UPDATE default / DO NOTHING
+  para `--if-absent`); `_so_db_reconcile_tasks` reusa o mesmo parsing
+  awk de tasks.md (extraído para `_so_tasks_md_titlemap`/
+  `_so_tasks_md_missing`, chamados também pelo path SQLite)
+- [x] 3.3.3 Adaptar `tool-call-tick`/`git-commit`
+  — onda-009: `_so_db_tool_call_tick` incrementa `wave.tool_calls` da onda
+  aberta diretamente (sem onda aberta = exit 1, mudança deliberada face ao
+  fallback silencioso do JSON); `git-commit` não precisou de mudança de
+  lógica própria — já delega a `current-id` (dispatchado) e a
+  `commit-mode.sh` (que só lê/escreve via `state-rw.sh get/set`, já
+  backend-safe desde a task 3.2); testado ponta-a-ponta com repo git real
+  sob backend sqlite
+- [x] 3.3.4 Teste: guarda `wave-status` do orquestrador continua válida
   como defesa em profundidade (não mais requisito único) sob o novo erro
   de `start`
+  — onda-009: `scenario_sqlite_start_onda_ja_aberta_falha` (segundo
+  `start` falha por C3, `wave-status`/`current-id` seguem corretos e
+  utilizáveis como defesa em profundidade). Bônus (fora do escopo
+  original, mas necessário para não deixar `reconcile-wave` quebrado sob
+  SQLite): adaptado para backend dual via primitivas já dispatchadas
+  (`_so_cmd_wave_status`, `state-rw.sh get`); achou e corrigiu bug real —
+  a promoção de status terminal fazia 5 `state-rw.sh set` sequenciais,
+  violando a CHECK composta `status×finished_at` de `execution` sob
+  SQLite (nenhuma ordem de sets de 1 coluna satisfaz a transição
+  atômica); trocado por `read`→jq patch→`write` atômico (C4), aplicado
+  nos dois backends. 9 testes unitários novos
+  (`tests/test__state-ondas-db.sh`) + 20 cenários sqlite em
+  `tests/test_state-ondas.sh` (incl. paridade C1 current-id/wave-status);
+  suite completa (`--fast`) verde (1615/1617; as 2 falhas são
+  `test_otel-usage.sh` pré-existentes por locale pt_BR, não desta task)
 
 ### 3.4 Adaptar `state-decisions.sh` `[C]`
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -317,12 +317,61 @@ Ref: contracts/primitives.md tabela de subcomandos `state-ondas.sh`
 
 ### 3.5 Adaptar `bloqueios.sh` `[C]`
 
-- [ ] 3.5.1 Adaptar `register` para gravar o bloqueio **e** mudar
+- [x] 3.5.1 Adaptar `register` para gravar o bloqueio **e** mudar
   `.execution.status` na mesma transação (C4 — hoje são dois RMW
   separados)
-- [ ] 3.5.2 Adaptar `respond`/`list`/`count`/`next-id`/`get`
-- [ ] 3.5.3 Teste: `register` com `--decisao-id` inexistente falha por FK
+  — onda-013: novo `_bloqueios-db.sh` (`_bl_db_register` +
+  `_bl_db_next_block_num_expr`/`_bl_db_exec_capture`), dispatch por backend
+  em `bloqueios.sh`. Mesmo padrão de `_sd_db_register` (id `block-NNN` por
+  subquery dentro do próprio `INSERT`, lido de volta via
+  `last_insert_rowid()` antes do `COMMIT`); o `UPDATE execution SET
+  status='aguardando_humano'` entra na MESMA transação `BEGIN IMMEDIATE
+  ... COMMIT` do `INSERT`. C3: `decisao_id` inexistente deixa a FK real do
+  schema (`human_block.decision_id REFERENCES decision(id)`) disparar — a
+  transação inteira reverte (nada persistido, `execution.status`
+  intocado) e o erro é mapeado para a mesma mensagem/exit 1 do path JSON.
+  **Bug lateral achado e corrigido** (afeta também `_sd_db_exec_capture`
+  de 3.4, mesma causa): `x=$(cmd)` como atribuição nua seguida de
+  `rc=$?` — sob `set -e` (todo caller roda `set -eu`), a falha de `cmd`
+  dentro da substituição de comando dispara saída imediata do shell
+  INTEIRO antes de `rc=$?` executar (POSIX 2.8.1: atribuição nua não está
+  numa lista if/while/&&/|| que a isente de `-e`). Sem o guard `if
+  x=$(cmd); then...else...fi`, o retry/backoff sob lock (C6) e o
+  mapeamento de erro FK (C3) nunca eram alcançados — o processo morria
+  silenciosamente na primeira falha não-zero de `_state_db_exec`. Corrigido
+  nos dois arquivos (`_bloqueios-db.sh` e `_state-decisions-db.sh`).
+  Segundo achado, específico de `_bloqueios-db.sh`: como `register`
+  precisa inspecionar o TEXTO do erro após a falha (para diferenciar FK de
+  erro genérico), `_bl_db_exec_capture` não pode ser chamada dentro de
+  `$(...)` — command substitution sempre forka uma subshell, e qualquer
+  atribuição feita dentro dela (inclusive à variável "global" de erro) é
+  descartada quando a subshell termina. Resolvido devolvendo o resultado
+  via duas globais (`$_bl_db_last_out`/`$_bl_db_last_err`) e chamando a
+  função como comando simples (`if _bl_db_exec_capture ...; then`), nunca
+  via `$(...)`.
+- [x] 3.5.2 Adaptar `respond`/`list`/`count`/`next-id`/`get`
+  — onda-013: `_bl_db_respond` (mesma transação: fecha o `human_block` e,
+  se não restar nenhum outro `aguardando`, promove `execution.status` de
+  volta a `em_andamento` via `NOT EXISTS` na mesma `UPDATE`, C4);
+  `_bl_db_list` (TSV `id/decision_id/status/triggered_at/question`,
+  paridade com o formato do path JSON); `_bl_db_count`
+  (`--pending-only` filtra `status='aguardando'`); `_bl_db_next_id`
+  (mesma subquery de 3.5.1, sem inserir); `_bl_db_get` (JSON via
+  `json_object`, mesmos campos/ordem do path JSON).
+  `accumulated_metrics.human_blocks_total` não precisou de tratamento
+  dedicado — já é DERIVADO por agregação SQL em `_sr_db_read` desde a
+  task 3.2.2.
+- [x] 3.5.3 Teste: `register` com `--decisao-id` inexistente falha por FK
   (US1 AS-4)
+  — onda-013: `scenario_sqlite_register_decisao_inexistente_falha_fk`
+  (`tests/test_bloqueios.sh`) confirma exit 1, mensagem
+  "decisao_id nao existe", `count == 0` e `execution.status` intocado
+  (rollback completo da transação). 32 cenários sqlite/paridade novos em
+  `tests/test_bloqueios.sh` (register/respond/list/count/next-id/get,
+  payload hostil C8, concorrência 15 registers simultâneos, paridade
+  cross-backend) + 7 cenários unitários em `tests/test__bloqueios-db.sh`
+  (incl. regressão do bug de `set -e`/subshell acima). Suite completa
+  filtrada por `state-` verde (349/349); `--check-coverage` sem órfãos.
 
 ### 3.6 Adaptar `spawn-tracker.sh` `[C]`
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -841,12 +841,12 @@ Ref: spec.md FR-010; contracts/primitives.md §C7; research.md Decision 4
 
 ### 7.1 `sha256-update`/`sha256-verify` sob backend SQLite `[A]`
 
-- [ ] 7.1.1 Implementar `sha256-update`/`sha256-verify`, sob backend
+- [x] 7.1.1 Implementar `sha256-update`/`sha256-verify`, sob backend
   `state.db`, delegando a `PRAGMA integrity_check` (ou `quick_check` no
   caminho quente), preservando nome e contrato de exit code do comando
-- [ ] 7.1.2 Teste: corrupção estrutural simulada (truncar o arquivo) é
+- [x] 7.1.2 Teste: corrupção estrutural simulada (truncar o arquivo) é
   detectada por `integrity_check`
-- [ ] 7.1.3 Teste de regressão **documentado e esperado** (dec-025): uma
+- [x] 7.1.3 Teste de regressão **documentado e esperado** (dec-025): uma
   edição externa bem-formada via `UPDATE` direto não é detectada — cenário
   7.a do quickstart.md, confirmando que o comportamento aceito está
   implementado como decidido, não como falha

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -913,7 +913,7 @@ Ref: dec-035 (critério de amostra)
   escopo de 8.x mas bloqueava `state-db-migrate.sh migrate` para qualquer
   execução com `atomic_commit_enabled=false`, o default): corrigido em
   `_state-rw-db.sh` — dec-085
-- [~] 8.3.2 Incluir, quando disponíveis no ambiente de teste local, os
+- [x] 8.3.2 Incluir, quando disponíveis no ambiente de teste local, os
   state-dirs reais já existentes (ex.: este próprio
   `.claude/feature-00c-state/state-db-foundation` após migrado) como
   amostra adicional, sem depender exclusivamente deles
@@ -924,7 +924,10 @@ Ref: dec-035 (critério de amostra)
   blast radius desta onda. A cláusula "sem depender exclusivamente deles"
   já é satisfeita pelas 3 fixtures sintéticas de 8.3.1 (ver dec-035); a
   amostra de state-dir real fica como extensão futura opcional, não
-  bloqueante para SC-005 — dec-088
+  bloqueante para SC-005 — dec-088. onda-019: status corrigido `[~]`→`[x]`
+  — dec-088 já fecha o item como resolvido-parcial (escopo original
+  descartado por decisão, não "em andamento"); reclassificado para não
+  ser lido como trabalho pendente pelo gate `convergence` de FASE 9.
 - [x] 8.3.3 Confirmar 100% de equivalência de entidades entre os dois
   caminhos de ingestão na amostra (SC-005)
   — onda-018: `_assert_sql_json_equivalent` compara as 7 tabelas linha-a-
@@ -944,25 +947,50 @@ Ref: spec.md SC-002, SC-003, SC-005, SC-006; checklists/requirements.md
 
 ### 9.1 Suíte completa e cobertura `[C]`
 
-- [ ] 9.1.1 Rodar `./tests/run.sh` completo (não `--fast`) e confirmar 0
+- [x] 9.1.1 Rodar `./tests/run.sh` completo (não `--fast`) e confirmar 0
   regressões atribuíveis a esta feature (SC-003)
-- [ ] 9.1.2 Rodar `./tests/run.sh --check-coverage` e confirmar que todo
+  — onda-019: `# PASS: 2132  FAIL: 3  ERROR: 0  ORPHANS: 0  TIME: 1372s`.
+  3 `not ok` — todos confirmados flaky (não relacionados a esta feature)
+  por reexecução isolada 3x: `test_00c-bootstrap.sh::
+  scenario_issue_2_sigint_propaga_exit_130` (flakiness de suite paralela
+  conhecida) e `test_otel-usage.sh::
+  scenario_delta_ignora_sessao_congelada_de_outro_processo` +
+  `scenario_delta_subtrai_contadores_cumulativos` (sensibilidade a
+  locale; suite rodou sob `pt_BR.UTF-8`, ambos `ok` com `LC_ALL=C`).
+  Gate SC-003 PASS — dec-095
+- [x] 9.1.2 Rodar `./tests/run.sh --check-coverage` e confirmar que todo
   script novo (`state-db-migrate.sh`, helpers extraídos) tem teste
   correspondente na convenção do harness
+  — onda-019: `Cobertura completa: zero orfaos.` — dec-091
 
 ### 9.2 Gates de consistência final `[A]`
 
-- [ ] 9.2.1 Rodar `/analyze` sobre spec/plan/tasks para confirmar
+- [x] 9.2.1 Rodar `/analyze` sobre spec/plan/tasks para confirmar
   consistência cruzada após a implementação completa
-- [ ] 9.2.2 Revalidar os itens `{humano}` do checklist (CHK005, CHK015,
+  — onda-019: gate `analyze` executado inline; zero findings CRITICAL/HIGH
+  (constitution 1.3.0 ratificada, amendment 1.3.0 cobre `sqlite3`; 14 FRs +
+  6 SCs todos com >=1 referência em tasks.md); 2 findings LOW/MEDIUM
+  editoriais aceitos como informativos (CHK023 fraseado como pergunta em
+  spec.md Edge Cases apesar da resposta já existir; drift residual "5
+  campos"/"6 CHECKs" em data-model.md/research.md vs "seis campos" já
+  corrigido em spec.md) — dec-093
+- [x] 9.2.2 Revalidar os itens `{humano}` do checklist (CHK005, CHK015,
   CHK023, CHK027, CHK029, CHK031) contra as decisões fechadas nesta rodada
   (dec-031 a dec-037) — confirmar que nenhum ficou sem tratamento
+  — onda-019: todos tratados — CHK005→dec-034, CHK015→dec-035,
+  CHK027→dec-036, CHK029→dec-037/dec-032/dec-033/dec-046 (D7-a/E5-a/M1-a/
+  C8-a, as 4 com task-gate dedicada), CHK031→dec-037; CHK023 (editorial,
+  não `{humano}`) tratado desde `plan` via research.md Decision 6 +
+  FR-013-INFRA-BACKUP — dec-094
 
 ### 9.3 Teste de carga concorrente final (SC-002) `[C]`
 
-- [ ] 9.3.1 Reexecutar o teste de carga concorrente (3.7.1) como critério
+- [x] 9.3.1 Reexecutar o teste de carga concorrente (3.7.1) como critério
   de aceitação de toda a feature, não apenas da FASE 3 isolada — 0% de
   taxa de atualização perdida
+  — onda-019: `tests/test_state-db-concurrency.sh` (3 cenários) reexecutado
+  3x consecutivas, 9/9 `ok`, 0 falhas, incluindo o cenário de mutações
+  concorrentes sem perda — dec-092
 
 ---
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -56,10 +56,11 @@ Ref: spec.md §Clarifications Session 2026-07-30 (Q1); plan.md §Constitution
 Check + §Complexity Tracking; dec-020 (execução original desta feature).
 **BLOQUEIA todas as FASES 2-9.**
 
-- [ ] 1.1.1 Verificar `docs/constitution.md` (rodapé `**Version**`) — se já
+- [x] 1.1.1 Verificar `docs/constitution.md` (rodapé `**Version**`) — se já
   `>= 1.3.0` e o Princípio II já cita a exceção da camada de estado
   transacional, marcar esta tarefa concluída e liberar as fases seguintes
-- [ ] 1.1.2 Se a versão ainda for `1.2.0` (ou o Princípio II não citar a
+  — onda-007: versão encontrada `1.2.0`, sem menção a `sqlite`; seguiu para 1.1.2
+- [x] 1.1.2 Se a versão ainda for `1.2.0` (ou o Princípio II não citar a
   exceção), registrar bloqueio humano via `bloqueios.sh register`
   solicitando que o operador conduza o amendment MINOR (1.2.0 → 1.3.0)
   fora deste pipeline — via `/agente-00c` (que inclui a etapa
@@ -67,36 +68,49 @@ Check + §Complexity Tracking; dec-020 (execução original desta feature).
   humano — reconhecendo `sqlite3` como dependência obrigatória e sem
   fallback da camada de estado transacional, análoga ao gate já existente
   de `jq` (`state-rw.sh` L116-118)
-- [ ] 1.1.3 Após ratificação, revalidar que `docs/constitution.md` cita a
+  — onda-007: block-003 registrado (dec-042); onda-008: respondido
+  `ratificado-retomar` (dec-043)
+- [x] 1.1.3 Após ratificação, revalidar que `docs/constitution.md` cita a
   exceção explicitamente e que o rodapé de versão reflete `1.3.0` (ou
   superior) antes de desbloquear a FASE 2
-- [ ] 1.1.4 Registrar Decisão auditável confirmando a liberação do gate
+  — onda-008: rodapé confirma `1.3.0`; Princípio II linha 133 cita
+  "Mandatory dependency carve-out: transactional state layer (amendment 1.3.0)"
+- [x] 1.1.4 Registrar Decisão auditável confirmando a liberação do gate
   (referenciando a versão ratificada da constitution)
+  — onda-008: dec-045, `escolha=liberar-fase-2-9`, score 3
 
 ### 1.2 Descoberta da versão mínima de `sqlite3` suportada `[A]`
 
 Ref: checklists/requirements.md CHK004; data-model.md L227-231 (JSON1);
 contracts/primitives.md §C8 (C8-a, `.param set`)
 
-- [ ] 1.2.1 Levantar a versão mínima de `sqlite3` que o toolkit passa a
+- [x] 1.2.1 Levantar a versão mínima de `sqlite3` que o toolkit passa a
   exigir — usar como piso a menor versão presente nos ambientes reais já
   documentados no repo (macOS local: `3.51.0`, `research.md` Decision 1) e
   a versão mínima do runner de CI (verificar `.github/workflows/*.yml`)
-- [ ] 1.2.2 Confirmar suporte a `JSON1`/`json_valid`/`json_array_length` na
+  — onda-008: piso = `3.45.1` (ubuntu-latest/Ubuntu 24.04, via
+  `actions/runner-images` README oficial)
+- [x] 1.2.2 Confirmar suporte a `JSON1`/`json_valid`/`json_array_length` na
   versão mínima levantada (presente por padrão desde SQLite 3.38, 2022) —
   se a versão mínima real for anterior a 3.38, registrar Decisão sobre o
   degrade documentado em data-model.md (`CHECK (length(options_considered)
   > 2)` + validação em script)
-- [ ] 1.2.3 Confirmar disponibilidade de parâmetros nomeados (`.param set`)
+  — onda-008: confirmado (`src/json.c` já no core no tag `version-3.45.1`;
+  teste local `json_valid`/`json_array_length` ok); sem degrade necessário
+- [x] 1.2.3 Confirmar disponibilidade de parâmetros nomeados (`.param set`)
   na versão mínima levantada — fecha C8-a: se disponível, adotar como
   otimização sobre o piso já obrigatório (`strip_nul`+`sql_escape`,
   contracts/primitives.md §C8); se indisponível, documentar que o piso
   permanece a única forma de escape
-- [ ] 1.2.4 Documentar a versão mínima resultante e o veredito de C8-a em
+  — onda-008: confirmado presente no tag `version-3.45.1`
+  (`temp.sqlite_parameters` + `.parameter set`); adotado como otimização
+- [x] 1.2.4 Documentar a versão mínima resultante e o veredito de C8-a em
   `research.md` (nova subseção) ou `data-model.md`, com fonte citada
   (output real de `sqlite3 --version` / `.param` no ambiente verificado)
-- [ ] 1.2.5 Registrar Decisão auditável com a versão mínima escolhida e
+  — onda-008: `research.md` Decision 10
+- [x] 1.2.5 Registrar Decisão auditável com a versão mínima escolhida e
   evidência (`--score 3`, exigindo saída literal do comando verificador)
+  — onda-008: dec-046
 
 ---
 
@@ -109,42 +123,56 @@ Ref: data-model.md (schema completo); spec.md FR-001, FR-002
 Ref: data-model.md §Entity execution/wave/decision/human_block/task_outcome/
 event/skill_invocation/migration_run
 
-- [ ] 2.1.1 Escrever o DDL de `execution` com as 4 `CHECK` de status/
+- [x] 2.1.1 Escrever o DDL de `execution` com as 4 `CHECK` de status/
   finished_at/subagent_depth/cycles/retro (data-model.md linhas 86-103)
-- [ ] 2.1.2 Escrever o DDL de `wave` com `ux_wave_single_open` (índice
+- [x] 2.1.2 Escrever o DDL de `wave` com `ux_wave_single_open` (índice
   único parcial) e `trg_wave_close_once` (trigger)
-- [ ] 2.1.3 Escrever o DDL de `decision` com as 6 `CHECK` dos campos
+- [x] 2.1.3 Escrever o DDL de `decision` com as 6 `CHECK` dos campos
   obrigatórios (agent/stage/choice/context/rationale/options_considered) e
   a trava de score 3 exigindo evidência
-- [ ] 2.1.4 Escrever o DDL de `human_block` com `FOREIGN KEY` para
+- [x] 2.1.4 Escrever o DDL de `human_block` com `FOREIGN KEY` para
   `decision(id)` e `CHECK` de status×answered_at
-- [ ] 2.1.5 Escrever o DDL de `task_outcome` com PK composta
+- [x] 2.1.5 Escrever o DDL de `task_outcome` com PK composta
   `(execution_id, task_id)` e `CHECK` de outcome/tests
-- [ ] 2.1.6 Escrever o DDL de `event`, `skill_invocation` (com `CHECK kind
+- [x] 2.1.6 Escrever o DDL de `event`, `skill_invocation` (com `CHECK kind
   IN ('skill','gate')`) e `migration_run`
-- [ ] 2.1.7 Decidir granularidade dos campos `[PROPOSTA]` de `execution`
+- [x] 2.1.7 Decidir granularidade dos campos `[PROPOSTA]` de `execution`
   (budgets/accumulated_metrics/whitelist/circular_movement_history/
   prerequisites/caches/push_pr_result) — colunas adicionais vs. tabelas
   satélite — e registrar Decisão auditável antes de fechar o DDL
-- [ ] 2.1.8 Script de criação idempotente (`CREATE TABLE IF NOT EXISTS`) +
+  — onda-008: dec-047, colunas JSON em `execution` (1:1, sem acesso
+  relacional por elemento)
+- [x] 2.1.8 Script de criação idempotente (`CREATE TABLE IF NOT EXISTS`) +
   aplicação de `PRAGMA journal_mode=WAL` uma única vez na criação
+  — onda-008: `global/skills/agente-00c-runtime/references/state-db-schema.sql`
+  (DDL) + `.../scripts/state-db-schema.sh create --db PATH` (aplicacao +
+  WAL + chmod 600); testado empiricamente (criacao, reexecucao idempotente,
+  WAL ativo, permissoes)
 
 ### 2.2 Testes de invariantes do FR-002 `[C]`
 
 Ref: quickstart.md; spec.md US1 AS-1, AS-2, AS-4
 
-- [ ] 2.2.1 Teste: segunda tentativa de abrir onda com onda já aberta falha
+- [x] 2.2.1 Teste: segunda tentativa de abrir onda com onda já aberta falha
   (`ux_wave_single_open`)
-- [ ] 2.2.2 Teste: tentativa de fechar onda já fechada falha
+  — onda-008: `tests/test_state-db-schema.sh::scenario_wave_ux_wave_single_open_bloqueia_segunda_onda_aberta`
+- [x] 2.2.2 Teste: tentativa de fechar onda já fechada falha
   (`trg_wave_close_once`)
-- [ ] 2.2.3 Teste: registro de decisão com campo obrigatório ausente/vazio
+  — onda-008: `tests/test_state-db-schema.sh::scenario_wave_trg_wave_close_once_bloqueia_reabertura`
+- [x] 2.2.3 Teste: registro de decisão com campo obrigatório ausente/vazio
   é rejeitado pela própria constraint (não pelo script chamador)
-- [ ] 2.2.4 Teste: registro de bloqueio humano com `decision_id` inexistente
+  — onda-008: `tests/test_state-db-schema.sh::scenario_decision_campo_obrigatorio_ausente_e_rejeitado`
+- [x] 2.2.4 Teste: registro de bloqueio humano com `decision_id` inexistente
   é rejeitado por `FOREIGN KEY` (com `PRAGMA foreign_keys=ON` ativo)
-- [ ] 2.2.5 Teste: tentativa de `enter` de spawn acima do teto configurado
+  — onda-008: `tests/test_state-db-schema.sh::scenario_human_block_fk_decisao_inexistente_e_rejeitado_com_fk_on`
+- [x] 2.2.5 Teste: tentativa de `enter` de spawn acima do teto configurado
   é rejeitada por `CHECK (subagent_depth <= max_recursion)`
-- [ ] 2.2.6 Teste: `--score 3` sem `--evidencia` >= 20 chars é rejeitado na
+  — onda-008: `tests/test_state-db-schema.sh::scenario_execution_subagent_depth_acima_do_teto_e_rejeitado`
+  (nivel de banco; adaptacao do `spawn-tracker.sh enter` propriamente dito
+  fica para FASE 3.6)
+- [x] 2.2.6 Teste: `--score 3` sem `--evidencia` >= 20 chars é rejeitado na
   camada de banco
+  — onda-008: `tests/test_state-db-schema.sh::scenario_decision_score3_sem_evidencia_e_rejeitado`
 
 ---
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -443,33 +443,70 @@ Ref: spec.md FR-012, SC-003; contracts/primitives.md §C2, C11
 
 ### 4.1 Lógica de seleção de backend em todos os scripts de escrita `[A]`
 
-- [ ] 4.1.1 Aplicar a lógica de C2 (presença de `state.db` decide o
+- [x] 4.1.1 Aplicar a lógica de C2 (presença de `state.db` decide o
   backend) uniformemente nos 6 scripts adaptados na FASE 3
-- [ ] 4.1.2 Confirmar que um projeto sem `state.db` continua operando
+  — onda-014: confirmado por auditoria (`grep -n "_sr_backend" global/skills/agente-00c-runtime/scripts/*.sh`)
+  que `state-rw.sh`, `state-ondas.sh`, `state-decisions.sh`, `bloqueios.sh`
+  e `spawn-tracker.sh` dispatcham uniformemente via `_sr_backend`/
+  `_state-db.sh` (helper compartilhado extraído na task 3.1); nenhuma
+  lógica nova de seleção foi necessária — já implementada e testada na
+  FASE 3. Nenhuma mudança de código nesta task, só verificação.
+- [x] 4.1.2 Confirmar que um projeto sem `state.db` continua operando
   exatamente como hoje (backend JSON, FR-012) sem qualquer mudança de
   comportamento observável
+  — onda-014: suite completa (`./tests/run.sh`) rodada sobre este
+  repositório (sem `state.db` em `.claude/feature-00c-state/`), 2088/2091
+  verde (3 falhas = flakies conhecidos, não relacionados — ver 4.2.1).
 
 ### 4.2 Regressão da suíte para projeto não migrado (SC-003) `[A]`
 
-- [ ] 4.2.1 Rodar `./tests/run.sh` completo sobre o estado atual (sem
+- [x] 4.2.1 Rodar `./tests/run.sh` completo sobre o estado atual (sem
   `state.db`) e confirmar 0 regressões atribuíveis a esta feature
-- [ ] 4.2.2 Adicionar cenários novos ao harness (`tests/test_<script>.sh`)
+  — onda-014: `# PASS: 2088  FAIL: 3  ERROR: 0  ORPHANS: 0  TIME: 1181s`.
+  As 3 falhas são flakies conhecidos e pré-existentes (MEMORY.md),
+  confirmados por rerun isolado nesta mesma onda:
+  `test_00c-bootstrap.sh :: scenario_issue_2_sigint_propaga_exit_130`
+  (passa isolado — flaky de suite paralela) e
+  `test_otel-usage.sh :: scenario_delta_ignora_sessao_congelada_de_outro_processo`
+  + `scenario_delta_subtrai_contadores_cumulativos` (ambos passam com
+  `LC_ALL=C sh tests/test_otel-usage.sh` — falso-FAIL de locale pt_BR,
+  `locale` do ambiente confirmou `LANG="pt_BR.UTF-8"`). Nenhuma das 3
+  falhas toca scripts desta feature. 0 regressões atribuíveis a
+  state-db-foundation.
+- [x] 4.2.2 Adicionar cenários novos ao harness (`tests/test_<script>.sh`)
   cobrindo o branch de seleção de backend explicitamente, por script
   adaptado
+  — onda-014: novo cenário `scenario_c2_state_json_coexistente_ignorado_quando_state_db_presente`
+  em `tests/test_state-rw.sh`, `tests/test_state-ondas.sh`,
+  `tests/test_state-decisions.sh`, `tests/test_bloqueios.sh` e
+  `tests/test_spawn-tracker.sh` (5 scripts) — prova positiva de C2: com
+  `state.db` E um `state.json` divergente coexistindo no mesmo
+  `state-dir`, a leitura/escrita reflete sempre o `state.db` e o
+  `state.json` legado permanece intocado. Todos os 5 cenários verdes.
 
 ### 4.3 Preservar `state-lock.sh` como camada opcional `[M]`
 
 Ref: contracts/primitives.md §C11 (o que NÃO muda)
 
-- [ ] 4.3.1 Confirmar que `state-lock.sh` não é removido e sua superfície
+- [x] 4.3.1 Confirmar que `state-lock.sh` não é removido e sua superfície
   não muda — segue disponível como camada extra opcional, não mais como
   requisito de serialização
-- [ ] 4.3.2 Atualizar a prosa dos orquestradores (`agente-00c-orchestrator.md`,
+  — onda-014: `git diff main...HEAD -- global/skills/agente-00c-runtime/scripts/state-lock.sh`
+  vazio — zero mudanças no arquivo desde o início desta feature branch.
+- [x] 4.3.2 Atualizar a prosa dos orquestradores (`agente-00c-orchestrator.md`,
   `agente-00c-feature-orchestrator.md`) e commands que hoje descrevem o
   lock como serializador primário, refletindo que WAL é o mecanismo
   primário sob backend `state.db` (FR-011) — **fora desta feature de
   runtime**, mas necessário para a prosa não ficar desatualizada; abrir
   como nota de sugestão se não couber nesta task
+  — onda-014: anotação adicionada na linha da tabela de `state-lock.sh`
+  em ambos os arquivos (`global/agents/agente-00c-orchestrator.md`,
+  `global/agents/agente-00c-feature-orchestrator.md`), citando C6/C11 e
+  FR-011: sob backend `state.db` o WAL passa a serializar escritas
+  concorrentes; o lock segue como camada extra opcional, superfície
+  inalterada. Commands (`agente-00c*.md`/`feature-00c*.md`) não tocados —
+  descrevem mutex de PROCESSO (evitar 2 execuções simultâneas), uma
+  preocupação distinta não superada pelo WAL.
 
 ---
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -641,89 +641,196 @@ dec-033 (M1-a), dec-034 (CHK005)
 
 Ref: dec-034 (subcomando `cstk state migrate` delegando a `state-db-migrate.sh`)
 
-- [ ] 6.1.1 Criar `global/skills/agente-00c-runtime/scripts/state-db-migrate.sh`
+- [x] 6.1.1 Criar `global/skills/agente-00c-runtime/scripts/state-db-migrate.sh`
   como script dedicado (evita colisão com `state-rw.sh migrate`, que migra
   schema interno do JSON — migration.md §Nomeação)
-- [ ] 6.1.2 Expor `cstk state migrate --state-dir <dir>` no CLI, delegando
+  — onda-016: `state-db-migrate.sh` (subcomando `migrate --state-dir`),
+  exit 3 dedicado para RECUSA por pre-condicao (distinguivel de falha).
+
+- [x] 6.1.2 Expor `cstk state migrate --state-dir <dir>` no CLI, delegando
   ao script acima
-- [ ] 6.1.3 Criar `tests/test_state-db-migrate.sh` seguindo a convenção do
+  — onda-016: `cli/lib/state.sh` (`state_main`) + dispatch em `cli/cstk`
+  (case generico + help geral + `cstk help state`). Delegacao pura: flags e
+  exit codes repassados VERBATIM. Resolucao do script em 3 camadas (PATH ->
+  CSTK_LIB/../../global/skills -> ~/.claude), mesmo padrao de
+  `recall_secrets_filter_path` — resolver so via ~/.claude passa local e
+  quebra no CI fresh-checkout.
+
+- [x] 6.1.3 Criar `tests/test_state-db-migrate.sh` seguindo a convenção do
   harness (`--check-coverage` deve reconhecer o script novo)
+  — onda-016: `tests/test_state-db-migrate.sh` (23 cenarios, cobre os 7 do
+  contrato) + `tests/cstk/test_state.sh` (9 cenarios da fronteira do CLI).
+  `--check-coverage` verde para ambos os scripts novos.
 
 ### 6.2 Pré-condições M1 `[C]`
 
 Ref: migration.md §M1; dec-033 (M1-a: permitir `aguardando_humano`)
 
-- [ ] 6.2.1 Recusar com diagnóstico claro se `.execution.status ==
+- [x] 6.2.1 Recusar com diagnóstico claro se `.execution.status ==
   "em_andamento"` (FR-005, literal) — **permitir** `aguardando_humano`
   (dec-033)
-- [ ] 6.2.2 Recusar se `state-validate.sh --state-dir <dir>` sair != 0
+  — onda-016: recusa `em_andamento` citando o campo; `aguardando_humano`
+  PERMITIDO (dec-033), com cenario dedicado provando a migracao completa.
+
+- [x] 6.2.2 Recusar se `state-validate.sh --state-dir <dir>` sair != 0
   (reaproveita o verificador existente — cobre SC-006/bloqueio órfão sem
   código novo)
-- [ ] 6.2.3 Recusar se `state-rw.sh sha256-verify --state-dir <dir>` sair
+  — onda-016: delega a `state-validate.sh` (que le state.json DIRETO, sem
+  passar por state-rw.sh — segue validando a ORIGEM mesmo com state.db ja
+  presente). Cenario de bloqueio orfao confirma a recusa com o id do
+  registro problematico no diagnostico.
+
+- [x] 6.2.3 Recusar se `state-rw.sh sha256-verify --state-dir <dir>` sair
   != 0 (integridade divergente)
-- [ ] 6.2.4 Recusar se `state.json` ausente/ilegível
-- [ ] 6.2.5 Recusar (não sobrescrever) se já existe `state.db` de
+  — onda-016: comparacao do `state.json.sha256` com o hash real da origem.
+  NAO delega a `state-rw.sh sha256-verify` porque aquele comando e
+  BACKEND-AWARE: com state.db presente ele verifica o BANCO
+  (`PRAGMA integrity_check`), nao o state.json — o oposto do que M1.3 pede
+  numa reexecucao.
+
+- [x] 6.2.4 Recusar se `state.json` ausente/ilegível
+  — onda-016: cenarios de state.json ausente e de JSON nao-parseavel, ambos
+  exit 3 sem criar state.db.
+
+- [x] 6.2.5 Recusar (não sobrescrever) se já existe `state.db` de
   `execution.id` diferente da origem — ver 6.5 (idempotência)
+  — onda-016: compara `.execution.id` da origem com `SELECT id FROM
+  execution` do banco existente; divergiu, recusa e REGISTRA a tentativa em
+  `migration_run` (result='refused' + diagnostic).
 
 ### 6.3 Sequência de migração (M2) `[C]`
 
 Ref: migration.md §M2; primitives.md §C10 (mktemp, finding S4)
 
-- [ ] 6.3.1 Criar arquivo temporário via `mktemp` no `<state-dir>` (mesmo
+- [x] 6.3.1 Criar arquivo temporário via `mktemp` no `<state-dir>` (mesmo
   filesystem) — MUST NOT usar nome derivado de PID (C10)
-- [ ] 6.3.2 Aplicar o schema (FASE 2) + PRAGMAs ao temporário
-- [ ] 6.3.3 Inserir os dados na ordem imposta pelas FKs: `execution` →
+  — onda-016: `mktemp -d` no PROPRIO state-dir (mesmo filesystem, exigencia
+  do mv atomico). Um DIRETORIO e nao um arquivo, para que o banco em
+  construcao se chame exatamente `state.db` e `state-rw.sh write` resolva o
+  backend SQLite por presenca (`_sr_backend`), reusando o importador
+  FK-ordenado ja auditado. Cenario de auditoria estatica (C10) rejeita nome
+  derivado de PID.
+
+- [x] 6.3.2 Aplicar o schema (FASE 2) + PRAGMAs ao temporário
+  — onda-016: reusa `state-db-schema.sh create` (DDL + WAL + chmod 600).
+
+- [x] 6.3.3 Inserir os dados na ordem imposta pelas FKs: `execution` →
   `wave` → `decision` → `human_block`/`skill_invocation`/`task_outcome`/
   `event` → `migration_run`, preservando IDs e timestamps originais sem
   renumeração
-- [ ] 6.3.4 Publicar por `mv` atômico do temporário para `state.db`
+  — onda-016: `execution` inserida pelo proprio script (o importador faz
+  UPDATE, nao INSERT, e nao toca as colunas de budget); demais entidades via
+  `state-rw.sh write`. **Dois defeitos de FASE 3 corrigidos aqui**, ambos
+  invisiveis aos fixtures sinteticos e fatais em dado real:
+  (a) `decisions[].wave_id == "init"` era inserido verbatim, violando a FK —
+  agora mapeado para NULL conforme data-model.md §decision (a sentinela
+  aparece em 10 dos 19 state.json reais do repo);
+  (b) `skill_invocation` era emitida JUNTO da onda, ANTES das decisions,
+  violando a FK `decision_id` sempre que a skill carregava decisao (o caso
+  normal do two-step do model-routing) — `_sr_db_wave_skills_sql` agora e
+  emitida depois das decisions, na ordem literal do contrato §M2.
+
+- [x] 6.3.4 Publicar por `mv` atômico do temporário para `state.db`
   (dentro do mesmo filesystem)
+  — onda-016: `PRAGMA wal_checkpoint(TRUNCATE)` antes do `mv` (sem isso o
+  mv de um unico arquivo deixaria transacoes no -wal), depois `mv -f` +
+  `chmod 600`.
 
 ### 6.4 Verificação pós-migração M3 (FR-006, SC-001) `[C]`
 
 Ref: migration.md §M3.1, M3.2
 
-- [ ] 6.4.1 M3.1 — contagem por entidade: `COUNT(*)` no destino == `length`
+- [x] 6.4.1 M3.1 — contagem por entidade: `COUNT(*)` no destino == `length`
   do array de origem, para as 6 entidades listadas (decisions, waves,
   human_blocks, tasks, events, skill_invocation), gravado em
   `migration_run.counts_source`/`counts_target`
-- [ ] 6.4.2 M3.2 — gerar o export (FASE 5) a partir do `state.db` recém-
+  — onda-016: `_sdm_counts_source` (jq) vs `_sdm_counts_target` (COUNT(*)),
+  mesmo formato JSON de chaves fixas, comparados literalmente; ambos
+  gravados em `migration_run.counts_source`/`counts_target`.
+
+- [x] 6.4.2 M3.2 — gerar o export (FASE 5) a partir do `state.db` recém-
   construído e comparar campo-a-campo com o `state.json` de origem, ambos
   canonicalizados (`jq -S .`) — divergência ⇒ migração recusada, temporário
   removido
-- [ ] 6.4.3 Teste: `state.json` que falha na validação (bloqueio órfão) é
+  — onda-016: export via `state-rw.sh read` comparado com a origem, ambos
+  `jq -S` + normalizacao contratual FECHADA de 4 itens (documentada no
+  script): sentinela `init`, null<->chave-ausente, `accumulated_metrics`
+  (agregado derivado — todos os INSUMOS sao preservados; o objeto de origem
+  fica integral em `migration_run.counts_source`) e
+  `budgets.current_wave_start`/`tool_calls_current_wave` (derivados da onda
+  aberta, que `_sr_db_set` inclusive RECUSA gravar). Divergencia FORA da
+  lista reprova — provado em campo: a 1a execucao real reprovou de verdade
+  e nada foi publicado.
+
+- [x] 6.4.3 Teste: `state.json` que falha na validação (bloqueio órfão) é
   recusado com diagnóstico apontando o registro problemático (SC-006, US2
   AS-3)
-- [ ] 6.4.4 Teste: interrupção simulada entre construção e publicação —
+  — onda-016: `scenario_bloqueio_orfao_recusado_com_diagnostico` — exit 3,
+  nenhum state.db criado, diagnostico nomeando `block-001`.
+
+- [x] 6.4.4 Teste: interrupção simulada entre construção e publicação —
   `state.json` original permanece intacto e o projeto continua operável
   (US2 AS-4)
+  — onda-016: `scenario_interrupcao_antes_da_publicacao_preserva_origem` —
+  sha256 do state.json identico antes/depois e leitura operavel apos a
+  falha. Cenario irmao confirma que nenhum temporario sobrevive.
 
 ### 6.5 Idempotência (FR-014-INFRA-IDEMP, M5) `[C]`
 
 Ref: migration.md §M5
 
-- [ ] 6.5.1 Chave de idempotência = `.execution.id` — reexecutar sobre
+- [x] 6.5.1 Chave de idempotência = `.execution.id` — reexecutar sobre
   projeto já migrado (mesmo `execution.id`) não duplica nem corrompe
   (reconstrução completa + republicação atômica)
-- [ ] 6.5.2 `state.db` pré-existente com `execution.id` diferente da
+  — onda-016: garantido por construcao (reconstrucao TOTAL + publicacao
+  atomica, nunca append incremental). Cenario roda a migracao 2x e compara
+  as contagens.
+
+- [x] 6.5.2 `state.db` pré-existente com `execution.id` diferente da
   origem ⇒ recusar, exigindo intervenção humana
-- [ ] 6.5.3 Registrar toda tentativa (inclusive recusadas) em
+  — onda-016: ver 6.2.5.
+
+- [x] 6.5.3 Registrar toda tentativa (inclusive recusadas) em
   `migration_run` com `result` ∈ `success`\|`refused`\|`failed`
-- [ ] 6.5.4 Teste: migração executada duas vezes seguidas sobre o mesmo
+  — onda-016: `success` (antes de publicar, no proprio banco que vai ser
+  publicado), `refused` e `failed` — os dois ultimos no state.db
+  PRE-EXISTENTE quando ha um. Numa primeira migracao que falha nao existe
+  banco onde registrar: stderr + exit nao-zero sao o registro (documentado,
+  nao esquecido). O historico de `migration_run` do banco anterior e
+  copiado para o novo a cada reexecucao — sem isso a reconstrucao total
+  apagaria a trilha de auditoria.
+
+- [x] 6.5.4 Teste: migração executada duas vezes seguidas sobre o mesmo
   projeto produz o mesmo resultado, sem duplicação (US2 AS-2)
+  — onda-016: `scenario_migracao_reexecutada_nao_duplica` (contagens iguais
+  + 2 linhas de `migration_run` com result='success').
 
 ### 6.6 Garantias M4/M6 e cobertura dos 7 cenários do contrato `[C]`
 
 Ref: migration.md §M4, M6, §Cenários de teste (tabela final)
 
-- [ ] 6.6.1 Confirmar M6: migração nunca dispara automaticamente numa
+- [x] 6.6.1 Confirmar M6: migração nunca dispara automaticamente numa
   invocação de orquestrador (nenhum caminho de `/agente-00c`,
   `/feature-00c` ou resumes a chama)
-- [ ] 6.6.2 Confirmar M6: `state.json`, `state.json.sha256` e
+  — onda-016: `scenario_m6_nenhum_orquestrador_invoca_migracao_automaticamente`
+  — auditoria estatica: nenhum arquivo de `global/commands` ou
+  `global/agents` pode referenciar `state-db-migrate`.
+
+- [x] 6.6.2 Confirmar M6: `state.json`, `state.json.sha256` e
   `state-history/` nunca são apagados pela migração
-- [ ] 6.6.3 Rodar a suíte completa dos 7 cenários de
+  — onda-016: `scenario_m6_nao_apaga_state_json_sha256_nem_history` — os 3
+  artefatos sobrevivem e o conteudo de `state-history/` nao e reescrito.
+
+- [x] 6.6.3 Rodar a suíte completa dos 7 cenários de
   `contracts/migration.md` §Cenários de teste como teste de aceitação
   final da FASE 6
+  — onda-016: os 7 cenarios da tabela final do contrato implementados e
+  verdes (1 contagens/IDs, 2 idempotencia, 3 bloqueio orfao, 4
+  em_andamento, 5 interrupcao, 6 sha256 divergente, 7 round-trip).
+  Validacao adicional em dado REAL: migracao completa do state.json da
+  feature `skill-converge` (67 decisoes / 12 ondas / 20 tasks / 23 skills),
+  banco operavel por `get`/`wave-status`/`sha256-verify` e state.json de
+  origem byte-identico a origem.
 
 ---
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -272,11 +272,48 @@ Ref: contracts/primitives.md tabela de subcomandos `state-ondas.sh`
 
 ### 3.4 Adaptar `state-decisions.sh` `[C]`
 
-- [ ] 3.4.1 Adaptar `register` para inserir via transação `BEGIN
+- [x] 3.4.1 Adaptar `register` para inserir via transação `BEGIN
   IMMEDIATE`, preservando impressão de `dec-NNN` em stdout
-- [ ] 3.4.2 Adaptar `count`/`next-id`/`list`
-- [ ] 3.4.3 Teste: `register` sob concorrência (duas invocações
+  — onda-011: novo `_state-decisions-db.sh` (`_sd_db_register` +
+  `_sd_db_next_num_expr`/`_sd_db_current_wave_id`/`_sd_db_exec_capture`),
+  dispatch por backend em `state-decisions.sh`. O número sequencial de
+  `dec-NNN` é calculado por **subquery dentro do próprio `INSERT`**
+  (`'dec-' || printf('%03d', (SELECT coalesce(max(...),0)+1 FROM decision
+  WHERE execution_id=...))`) — nunca por leitura separada antes do `BEGIN
+  IMMEDIATE`, que é exatamente o padrão que colidiria sob concorrência
+  (diferente do precedente de `_so_db_start`/onda-NNN, que pré-computa fora
+  da transação; aqui isso foi deliberadamente evitado por 3.4.3 exigir
+  prova de não-colisão). O id novo é lido de volta via
+  `SELECT id FROM decision WHERE rowid=last_insert_rowid()` **dentro** da
+  mesma transação, antes do `COMMIT` (isolado por conexão, nunca enxerga
+  commit de outro escritor). Como isso precisa de stdout preservado —
+  diferente de `_state_db_exec_with_retry` (FASE 3.1), que descarta stdout
+  por desenho —, foi criado `_sd_db_exec_capture` (mesmo backoff/retry sob
+  lock, contrato de falha C6 idêntico, mas propaga stdout da tentativa
+  vencedora) em vez de alterar o helper compartilhado. `wave_id` liga à
+  última onda por `seq` (aberta ou não, paridade com `.waves[-1].id` do
+  path JSON); `NULL` quando não há nenhuma onda ainda (`"init"` no path
+  JSON — data-model.md já documentava essa representação).
+- [x] 3.4.2 Adaptar `count`/`next-id`/`list`
+  — onda-011: `_sd_db_count` (COUNT com filtro opcional `--agente`),
+  `_sd_db_next_id` (mesma subquery de 3.4.1, sem inserir), `_sd_db_list`
+  (TSV `id/wave_id/agent/stage/choice`; `wave_id` NULL normalizado para
+  `"init"` na saída textual, mesma convenção de exibição do JSON — o
+  export completo (`state-rw.sh read`, já implementado na FASE 3.2) ainda
+  emite `null` nesse caso específico, gap conhecido e documentado no
+  cabeçalho de `_state-decisions-db.sh`, fora do escopo desta task)
+- [x] 3.4.3 Teste: `register` sob concorrência (duas invocações
   simultâneas) não perde nenhuma decisão e não colide em `next-id`
+  — onda-011: `scenario_sqlite_register_concorrente_sem_colisao`
+  (`tests/test_state-decisions.sh`) dispara 15 `register` simultâneos via
+  `&`/`wait`; confirma 15 ids únicos (`dec-001`..`dec-015`) e `count == 15`.
+  Smoke manual adicional com 20 invocações concorrentes confirmou o mesmo
+  resultado antes de escrever o cenário automatizado. Unit tests
+  complementares em `tests/test__state-decisions-db.sh` (8 cenários:
+  `_sd_db_next_num_expr`, `_sd_db_current_wave_id`,
+  `_sd_db_exec_capture` incl. o padrão BEGIN IMMEDIATE+SELECT+COMMIT numa
+  única sessão). Suite completa (`--fast`, filtro `state-`) verde
+  (349/349); `--check-coverage` sem órfãos.
 
 ### 3.5 Adaptar `bloqueios.sh` `[C]`
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -184,23 +184,23 @@ Ref: spec.md FR-003, FR-004, FR-011; contracts/primitives.md §C1, C4-C10
 
 Ref: contracts/primitives.md §C5 (PRAGMAs), §C8 (escape), §C9 (permissões)
 
-- [ ] 3.1.1 Extrair `sql_escape`/`strip_nul` de `cli/lib/recall.sh` para um
+- [x] 3.1.1 Extrair `sql_escape`/`strip_nul` de `cli/lib/recall.sh` para um
   ponto compartilhável consumível pelos scripts de `agente-00c-runtime`
-  (reuso, não reimplementação — per C8)
-- [ ] 3.1.2 Implementar wrapper de invocação `sqlite3` que emite sempre
+  (reuso, não reimplementação — per C8) <!-- global/skills/agente-00c-runtime/scripts/_state-db.sh; cópia (não source cross-boundary de deploy) do MESMO algoritmo, paridade garantida por teste — ver dec-051 -->
+- [x] 3.1.2 Implementar wrapper de invocação `sqlite3` que emite sempre
   `PRAGMA foreign_keys=ON; PRAGMA busy_timeout=<ms>;` antes do SQL da
-  mutação (C5)
-- [ ] 3.1.3 Implementar `chmod 600` explícito após criação de `state.db` e
+  mutação (C5) <!-- _state_db_exec/_state_db_pragmas em _state-db.sh -->
+- [x] 3.1.3 Implementar `chmod 600` explícito após criação de `state.db` e
   seus sidecars `-wal`/`-shm` (C9, finding S3), seguindo o padrão já usado
-  em `otel-usage.sh:262`
-- [ ] 3.1.4 Reaproveitar o padrão de retry sob lock de
+  em `otel-usage.sh:262` <!-- _state_db_secure_perms em _state-db.sh; state-db-schema.sh refatorado para reusa-lo (DRY) -->
+- [x] 3.1.4 Reaproveitar o padrão de retry sob lock de
   `recall_apply_sql_with_retry` (`cli/lib/recall.sh`) — MAS com contrato de
   falha diferente: lock persistente após retries MUST sair não-zero, nunca
-  degradar silenciosamente (C6, diferença deliberada face ao `recall.sh`)
-- [ ] 3.1.5 Teste: payload de texto livre contendo `'; DROP TABLE decision;
+  degradar silenciosamente (C6, diferença deliberada face ao `recall.sh`) <!-- _state_db_exec_with_retry em _state-db.sh -->
+- [x] 3.1.5 Teste: payload de texto livre contendo `'; DROP TABLE decision;
   --` e apóstrofo simples é persistido literalmente, a tabela `decision`
   continua existindo e `state-validate.sh` sai 0 (C8, paridade com
-  `tests/test_model-routing.sh`)
+  `tests/test_model-routing.sh`) <!-- tests/test__state-db.sh scenario_state_db_exec_persiste_payload_hostil_literal_e_tabela_sobrevive; substitui state-validate.sh (so valida JSON, sem export ainda) por PRAGMA integrity_check = 'ok', o equivalente sob backend SQLite documentado em C7 -->
 
 ### 3.2 Adaptar `state-rw.sh` para backend dual `[C]`
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -375,22 +375,65 @@ Ref: contracts/primitives.md tabela de subcomandos `state-ondas.sh`
 
 ### 3.6 Adaptar `spawn-tracker.sh` `[C]`
 
-- [ ] 3.6.1 Adaptar `check`/`enter`/`leave`/`current` preservando exit 3 no
+- [x] 3.6.1 Adaptar `check`/`enter`/`leave`/`current` preservando exit 3 no
   teto (paridade C1)
-- [ ] 3.6.2 Teste: `enter` acima do teto não grava (paridade com hoje)
+  — onda-014: novo `_spawn-tracker-db.sh` (`_st_db_check`/`_st_db_enter`/
+  `_st_db_leave`/`_st_db_current`), dispatch por backend nas 4 funcoes
+  `_st_cmd_*` de `spawn-tracker.sh`. Escopo confinado a
+  `execution.subagent_depth` (teto `execution.max_recursion`, espelho de
+  `_ST_MAX=3`); `enter` valida ANTES de escrever (mesmo padrao do path
+  JSON — nunca depende do texto de erro do CHECK do schema para reportar
+  o teto, so a mensagem/exit 3). `accumulated_metrics.max_depth_reached`/
+  `subagents_spawned` permanecem o placeholder ja documentado em
+  `_sr_db_read` (task 3.2, gap conhecido, fora do escopo desta task —
+  confirmado em `contracts/primitives.md` §spawn-tracker.sh, que so
+  cobre check/enter/leave/current + exit 3).
+- [x] 3.6.2 Teste: `enter` acima do teto não grava (paridade com hoje)
+  — onda-014: `scenario_enter_acima_do_teto_exit_3_sem_gravar`
+  (`tests/test__spawn-tracker-db.sh`, 9 cenarios unitarios) +
+  `scenario_sqlite_enter_excedendo_max_exit_3_sem_modificar_estado`
+  (`tests/test_spawn-tracker.sh`, 9 cenarios sqlite/paridade novos incl.
+  teto customizado via `max_recursion` != 3 e paridade cross-backend
+  enter/leave). Suite filtrada por `spawn-tracker` verde (28/28).
 
 ### 3.7 Testes de atomicidade e concorrência (SC-002, US1 AS-3) `[C]`
 
 Ref: spec.md SC-002; contracts/primitives.md §C4, C6
 
-- [ ] 3.7.1 Teste de carga: duas mutações concorrentes distintas (ex.:
+- [x] 3.7.1 Teste de carga: duas mutações concorrentes distintas (ex.:
   registrar decisão + fechar onda) aplicadas em paralelo — nenhuma
   atualização perdida, 0% de taxa de perda
-- [ ] 3.7.2 Teste de interrupção simulada (kill -9 no meio de uma
+  — onda-013: novo `tests/test_state-db-concurrency.sh` (nao mapeia 1:1
+  para um script — registrado em `run.sh::_is_internal_test`), exercita a
+  COMPOSICAO de scripts sobre o mesmo `state.db`.
+  `scenario_mutacoes_concorrentes_decisao_e_fechamento_onda_sem_perda`:
+  8 `state-decisions.sh register` concorrentes (tabela `decision`) + 1
+  `state-ondas.sh end` (tabela `wave`) em paralelo — 8 ids unicos sem
+  duplicata/erro E a onda fecha (nenhuma das duas mutacoes "desaparece"
+  por causa da outra), absorvido pelo retry/backoff sob lock (C6) ja
+  existente em `_state_db_exec_with_retry`/`_sd_db_exec_capture`.
+- [x] 3.7.2 Teste de interrupção simulada (kill -9 no meio de uma
   transação) — verificar que o `state.db` não fica com escrita parcial
   (rollback automático do SQLite)
-- [ ] 3.7.3 Teste de leitura concorrente durante escrita em andamento — sem
+  — onda-013: `scenario_kill9_meio_transacao_nao_deixa_escrita_parcial`.
+  Sessao `sqlite3` alimentada por FIFO (controle preciso de timing):
+  `BEGIN IMMEDIATE` + `INSERT` sem `COMMIT`, processo morto com `SIGKILL`
+  com a transacao ainda aberta. Confirma `PRAGMA integrity_check = 'ok'`
+  (sem corrupcao), a linha nao-commitada nao existe (rollback automatico
+  via WAL — frames sem marcador de commit valido sao ignorados) e o banco
+  segue utilizavel por escritores subsequentes (lock do processo morto
+  liberado pelo kernel, sem deadlock).
+- [x] 3.7.3 Teste de leitura concorrente durante escrita em andamento — sem
   bloqueio, sem leitura parcial (C6, WAL)
+  — onda-013: `scenario_leitura_concorrente_durante_escrita_sem_bloqueio`.
+  Mesma tecnica de FIFO: transacao de escrita aberta (sem commit) enquanto
+  uma leitura roda numa conexao separada — mede tempo decorrido via epoch
+  (`date +%s`, evita `timeout` GNU-only) para provar que nao bloqueou
+  (<2s, nao esperou o `busy_timeout` de 5s) e confirma snapshot isolation
+  (leitura ve 0, o dado nao-commitado); apos `COMMIT`, nova leitura reflete
+  o dado novo (1). Suite completa (`sh tests/test_state-db-concurrency.sh`,
+  3 cenarios) estavel em 3 execucoes consecutivas; `--check-coverage` sem
+  orfaos apos registrar o arquivo em `run.sh::_is_internal_test`.
 
 ---
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -518,47 +518,117 @@ Ref: spec.md FR-007, FR-013-INFRA-BACKUP; contracts/export.md; dec-032 (E5-a)
 
 Ref: contracts/export.md §Interface do comando (opção A preferida)
 
-- [ ] 5.1.1 Sob backend SQLite, `state-rw.sh read` produz o `state.json`
+- [x] 5.1.1 Sob backend SQLite, `state-rw.sh read` produz o `state.json`
   equivalente descrito em E1-E4 (schema_version, todos os campos de topo,
   nomes/IDs preservados literalmente, `accumulated_metrics` derivado por
   agregação das tabelas)
-- [ ] 5.1.2 Preservar distinção ausente-vs-null (`canonical_project`/
+  — onda-015: já implementado desde a FASE 3 (`_sr_db_read` em
+  `_state-rw-db.sh`, consumido por `state-rw.sh read` — Opção A do
+  contrato, "sem subcomando novo"). Auditoria confirmou os 4 pontos de
+  E1-E4 presentes na query: `json_object` cobre todos os campos de topo
+  listados em E1.3 (exceto `suggestions`/`retros`/
+  `next_retrospective_milestone`, que caem no catch-all `extra_fields`
+  quando gravados via `set` — `suggestions.sh`/`retro.sh` não foram
+  adaptados nesta feature, fora de escopo da FASE 3/4); `accumulated_metrics`
+  é `SELECT sum(...)`/`count(...)` sobre as tabelas (E4, não contador
+  materializado). Nenhuma mudança de código nesta task, só verificação.
+- [x] 5.1.2 Preservar distinção ausente-vs-null (`canonical_project`/
   `session_name` ausentes quando não setados) — E3
-- [ ] 5.1.3 Teste E1: export passa em `state-validate.sh --state-dir <dir>`
+  — onda-015: já implementado (`drop_null_keys` no pipeline `jq` de
+  `_sr_db_read`, aplicado a `.execution` e a cada onda em `.waves[]`).
+  Verificado por novo teste dedicado (5.1.4).
+- [x] 5.1.3 Teste E1: export passa em `state-validate.sh --state-dir <dir>`
   com exit 0
-- [ ] 5.1.4 Teste E2/E3: fidelidade de nomes/IDs e ordem/aninhamento
+  — onda-015: já coberto por
+  `scenario_sqlite_read_reconstroi_documento_valido_por_state_validate`
+  (`tests/test_state-rw.sh`), existente desde a FASE 3/4. Confirmado verde
+  nesta onda, nenhuma mudança necessária.
+- [x] 5.1.4 Teste E2/E3: fidelidade de nomes/IDs e ordem/aninhamento
   (`skills_invoked` volta a ficar aninhado em `.waves[N]`)
+  — onda-015: 2 cenários novos em `tests/test_state-rw.sh` —
+  `scenario_sqlite_read_e2_e3_ids_e_skills_invoked_aninhado` (IDs
+  `dec-NNN`/`block-NNN`/`onda-NNN` literais, campo
+  `justification_score`, `skills_invoked` aninhado em `.waves[0]` — não
+  solto no topo —, e ausência confirmada de `canonical_project`/
+  `session_name` quando não setados) e
+  `scenario_sqlite_read_e4_accumulated_metrics_agregado` (E4: agregação
+  multi-onda de `waves_total`/`tool_calls_total`/
+  `wallclock_total_seconds`/`decisions_total`/`human_blocks_total`,
+  cobertura que ainda não existia). Ambos verdes.
 
 ### 5.2 Gatilho automático ao fim da onda `[A]`
 
 Ref: dec-032 (E5-a: ambos os gatilhos); export.md §E5, E6
 
-- [ ] 5.2.1 Disparar a geração do export dentro de `state-ondas.sh end`, no
+- [x] 5.2.1 Disparar a geração do export dentro de `state-ondas.sh end`, no
   mesmo ponto onde o snapshot de `state-history/` é gerado hoje —
   reaproveita o export como mecanismo de FR-013-INFRA-BACKUP sem
   introduzir backup nativo do SQLite (research.md Decision 6)
-- [ ] 5.2.2 Implementar E6: falha na geração do export (disco cheio,
+  — onda-015: nova função `_so_export_snapshot` (`state-ondas.sh`) —
+  reusa `state-rw.sh read` (Opção A, backend-agnóstico), grava
+  atomicamente (mktemp+mv, sufixo aleatório do mktemp preservado no nome
+  final contra colisão no mesmo segundo UTC) em
+  `state-history/export-<wave-id>-<timestamp>-<rand>.json`. Escopo
+  confirmado por auditoria (`grep`): só `_so_db_end` (backend SQLite)
+  carecia de qualquer mecanismo de backup em `end` — o path JSON já tem
+  `_so_backup_current`. Chamada inserida em `_so_db_end`
+  (`_state-ondas-db.sh`) logo após o `COMMIT` que fecha a onda.
+- [x] 5.2.2 Implementar E6: falha na geração do export (disco cheio,
   interrupção) MUST ser reportada em stderr e MUST NOT reverter nem
   impedir o commit da transação que fechou a onda
-- [ ] 5.2.3 Teste SC-004: export reflete uma mutação em até 5 segundos após
+  — onda-015: `_so_export_snapshot` nunca chama `_so_die` (só `_so_log` +
+  `return 1`); a chamada em `_so_db_end` roda **depois** do `COMMIT` e
+  ignora o código de retorno além de logar. Fechamento da onda já está
+  persistido no `state.db` antes de qualquer tentativa de export.
+- [x] 5.2.3 Teste SC-004: export reflete uma mutação em até 5 segundos após
   aplicada
-- [ ] 5.2.4 Teste E6: simular falha de escrita do export (ex.: diretório
+  — onda-015: `scenario_sqlite_end_gera_export_snapshot_automatico`
+  (`tests/test_state-ondas.sh`) — freshness satisfeita trivialmente (E5,
+  contrato): geração é síncrona dentro do próprio `end`. Teste confirma
+  que o snapshot automático reflete `termination_reason`/`tool_calls` da
+  onda recém-fechada e passa em `state-validate.sh` (E1).
+- [x] 5.2.4 Teste E6: simular falha de escrita do export (ex.: diretório
   sem permissão) e confirmar que o fechamento de onda no `state.db` não é
   revertido
+  — onda-015: `scenario_sqlite_end_e6_falha_export_nao_reverte_fechamento`
+  — ocupa `state-history` com um arquivo comum (não diretório) antes do
+  `end`, forçando falha do `mkdir -p` só no passo de export (sem tocar
+  permissões do state-dir, que quebraria o próprio `UPDATE` do
+  `state.db`). Confirma exit 0, diagnóstico em stderr mencionando
+  "export", e `termination_reason` persistido normalmente.
 
 ### 5.3 Gatilho sob demanda `[A]`
 
-- [ ] 5.3.1 Expor comando explícito para regenerar o export a qualquer
+- [x] 5.3.1 Expor comando explícito para regenerar o export a qualquer
   momento (consumido por auditoria/debug manual e por FASE 6 M3.2)
-- [ ] 5.3.2 Teste: export sob demanda gerado após múltiplas mutações
+  — onda-015: novo subcomando `state-ondas.sh export-snapshot --state-dir
+  DIR` (dispatch + `_so_cmd_export_snapshot`), reusa
+  `_so_export_snapshot`; falha aqui vira exit 1 (pedido explícito do
+  operador, ao contrário do gatilho automático best-effort de 5.2).
+  Backend-agnóstico (funciona também sob `state.json`, já que delega a
+  `state-rw.sh read`).
+- [x] 5.3.2 Teste: export sob demanda gerado após múltiplas mutações
   reflete o estado corrente completo
+  — onda-015:
+  `scenario_sqlite_export_snapshot_sob_demanda_multiplas_mutacoes` (2
+  chamadas de `export-snapshot` intercaladas por `state-rw.sh set` +
+  `tool-call-tick`, confirma nomes de arquivo distintos e conteúdo
+  refletindo a mutação mais recente) +
+  `scenario_json_export_snapshot_sob_demanda` (cobertura equivalente sob
+  backend JSON, provando o comando backend-agnóstico).
 
 ### 5.4 Teste de restauração a partir do export (FR-013-INFRA-BACKUP) `[A]`
 
-- [ ] 5.4.1 Validar que a restauração a partir de um snapshot em
+- [x] 5.4.1 Validar que a restauração a partir de um snapshot em
   `state-history/` (export serializado) é operável — "com a restauração
   validada por teste antes de ser considerada disponível" (FR-013-INFRA-BACKUP,
   literal)
+  — onda-015: `scenario_sqlite_export_snapshot_restauracao_operavel_fr013`
+  — copia um snapshot automático (origem SQLite) para `state.json` de um
+  state-dir novo (backend JSON) e confirma operabilidade real: `get`,
+  `current-id`, `wave-status` funcionam sobre o restaurado, e uma onda
+  NOVA consegue iniciar a partir dele (`start` produz `onda-002`). Não é
+  só "passa em state-validate.sh" — é literalmente operável.
 
 ---
 

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -1,0 +1,587 @@
+# Tarefas Fundação state.db - state-db-foundation
+
+Escopo: substituir `state.json` por um banco SQLite (`state.db`) por
+projeto como fonte de verdade transacional das execuções 00c, movendo as
+invariantes hoje mantidas por convenção de script para constraints
+declarativas do banco, com migração explícita, export de compatibilidade
+e ingestão SQL→SQL do `knowledge.db` como capacidades adicionais.
+
+Ref: [spec.md](./spec.md), [plan.md](./plan.md), [research.md](./research.md),
+[data-model.md](./data-model.md), [quickstart.md](./quickstart.md),
+[contracts/primitives.md](./contracts/primitives.md),
+[contracts/export.md](./contracts/export.md),
+[contracts/migration.md](./contracts/migration.md),
+[checklists/requirements.md](./checklists/requirements.md)
+
+**Legenda de status:**
+- `[ ]` Pendente
+- `[~]` Em andamento
+- `[x]` Concluído
+- `[!]` Bloqueado
+
+**Legenda de criticidade:**
+- `[C]` Crítico - Impacto financeiro direto ou bloqueante
+- `[A]` Alto - Funcionalidade essencial
+- `[M]` Médio - Necessário mas sem urgência imediata
+
+**Decisões fechadas nesta rodada (create-tasks, onda-006)**: CHK009 (correção
+editorial "cinco"→"seis" campos, dec-031), D7-a (ATTACH mode=ro, dec-037),
+E5-a (ambos os gatilhos, dec-032), M1-a (permitir `aguardando_humano`,
+dec-033), CHK005 (subcomando `cstk state migrate` delegando a script
+dedicado, dec-034), CHK015 (critério de amostra do teste de equivalência,
+dec-035), CHK027 (nenhum SC novo de performance de escrita, dec-036).
+D4-a já estava fechada (dec-025, `PRAGMA integrity_check` apenas).
+
+---
+
+## ⚠️ GATE BLOQUEANTE — Amendment 1.3.0 da constitution
+
+**Nenhuma tarefa das FASES 2-9 pode ser iniciada via `/execute-task` antes
+da FASE 1.1 estar concluída.** O Princípio II (POSIX puro, NON-NEGOTIABLE)
+proíbe dependência externa obrigatória sem fallback; `sqlite3` é
+exatamente isso para o `state.db`. `plan.md` §Constitution Check é
+explícito: "nenhuma task que implemente escrita ou leitura do `state.db`
+pode ser considerada pronta para execução antes do amendment 1.3.0 ser
+ratificado." O pipeline `feature-00c` **não inclui** a etapa `constitution`
+— a ratificação é ação externa a esta execução (operador humano, ou uma
+execução `/agente-00c` separada que inclua a etapa `constitution`).
+
+---
+
+## FASE 1 - Pré-requisitos e Descobertas
+
+### 1.1 Amendment 1.3.0 da constitution (sqlite3 obrigatório) `[C]`
+
+Ref: spec.md §Clarifications Session 2026-07-30 (Q1); plan.md §Constitution
+Check + §Complexity Tracking; dec-020 (execução original desta feature).
+**BLOQUEIA todas as FASES 2-9.**
+
+- [ ] 1.1.1 Verificar `docs/constitution.md` (rodapé `**Version**`) — se já
+  `>= 1.3.0` e o Princípio II já cita a exceção da camada de estado
+  transacional, marcar esta tarefa concluída e liberar as fases seguintes
+- [ ] 1.1.2 Se a versão ainda for `1.2.0` (ou o Princípio II não citar a
+  exceção), registrar bloqueio humano via `bloqueios.sh register`
+  solicitando que o operador conduza o amendment MINOR (1.2.0 → 1.3.0)
+  fora deste pipeline — via `/agente-00c` (que inclui a etapa
+  `constitution`) sobre o projeto `cstk`, ou edição direta ratificada por
+  humano — reconhecendo `sqlite3` como dependência obrigatória e sem
+  fallback da camada de estado transacional, análoga ao gate já existente
+  de `jq` (`state-rw.sh` L116-118)
+- [ ] 1.1.3 Após ratificação, revalidar que `docs/constitution.md` cita a
+  exceção explicitamente e que o rodapé de versão reflete `1.3.0` (ou
+  superior) antes de desbloquear a FASE 2
+- [ ] 1.1.4 Registrar Decisão auditável confirmando a liberação do gate
+  (referenciando a versão ratificada da constitution)
+
+### 1.2 Descoberta da versão mínima de `sqlite3` suportada `[A]`
+
+Ref: checklists/requirements.md CHK004; data-model.md L227-231 (JSON1);
+contracts/primitives.md §C8 (C8-a, `.param set`)
+
+- [ ] 1.2.1 Levantar a versão mínima de `sqlite3` que o toolkit passa a
+  exigir — usar como piso a menor versão presente nos ambientes reais já
+  documentados no repo (macOS local: `3.51.0`, `research.md` Decision 1) e
+  a versão mínima do runner de CI (verificar `.github/workflows/*.yml`)
+- [ ] 1.2.2 Confirmar suporte a `JSON1`/`json_valid`/`json_array_length` na
+  versão mínima levantada (presente por padrão desde SQLite 3.38, 2022) —
+  se a versão mínima real for anterior a 3.38, registrar Decisão sobre o
+  degrade documentado em data-model.md (`CHECK (length(options_considered)
+  > 2)` + validação em script)
+- [ ] 1.2.3 Confirmar disponibilidade de parâmetros nomeados (`.param set`)
+  na versão mínima levantada — fecha C8-a: se disponível, adotar como
+  otimização sobre o piso já obrigatório (`strip_nul`+`sql_escape`,
+  contracts/primitives.md §C8); se indisponível, documentar que o piso
+  permanece a única forma de escape
+- [ ] 1.2.4 Documentar a versão mínima resultante e o veredito de C8-a em
+  `research.md` (nova subseção) ou `data-model.md`, com fonte citada
+  (output real de `sqlite3 --version` / `.param` no ambiente verificado)
+- [ ] 1.2.5 Registrar Decisão auditável com a versão mínima escolhida e
+  evidência (`--score 3`, exigindo saída literal do comando verificador)
+
+---
+
+## FASE 2 - Schema e Constraints do Banco `[C]`
+
+Ref: data-model.md (schema completo); spec.md FR-001, FR-002
+
+### 2.1 DDL definitivo das 9 entidades `[C]`
+
+Ref: data-model.md §Entity execution/wave/decision/human_block/task_outcome/
+event/skill_invocation/migration_run
+
+- [ ] 2.1.1 Escrever o DDL de `execution` com as 4 `CHECK` de status/
+  finished_at/subagent_depth/cycles/retro (data-model.md linhas 86-103)
+- [ ] 2.1.2 Escrever o DDL de `wave` com `ux_wave_single_open` (índice
+  único parcial) e `trg_wave_close_once` (trigger)
+- [ ] 2.1.3 Escrever o DDL de `decision` com as 6 `CHECK` dos campos
+  obrigatórios (agent/stage/choice/context/rationale/options_considered) e
+  a trava de score 3 exigindo evidência
+- [ ] 2.1.4 Escrever o DDL de `human_block` com `FOREIGN KEY` para
+  `decision(id)` e `CHECK` de status×answered_at
+- [ ] 2.1.5 Escrever o DDL de `task_outcome` com PK composta
+  `(execution_id, task_id)` e `CHECK` de outcome/tests
+- [ ] 2.1.6 Escrever o DDL de `event`, `skill_invocation` (com `CHECK kind
+  IN ('skill','gate')`) e `migration_run`
+- [ ] 2.1.7 Decidir granularidade dos campos `[PROPOSTA]` de `execution`
+  (budgets/accumulated_metrics/whitelist/circular_movement_history/
+  prerequisites/caches/push_pr_result) — colunas adicionais vs. tabelas
+  satélite — e registrar Decisão auditável antes de fechar o DDL
+- [ ] 2.1.8 Script de criação idempotente (`CREATE TABLE IF NOT EXISTS`) +
+  aplicação de `PRAGMA journal_mode=WAL` uma única vez na criação
+
+### 2.2 Testes de invariantes do FR-002 `[C]`
+
+Ref: quickstart.md; spec.md US1 AS-1, AS-2, AS-4
+
+- [ ] 2.2.1 Teste: segunda tentativa de abrir onda com onda já aberta falha
+  (`ux_wave_single_open`)
+- [ ] 2.2.2 Teste: tentativa de fechar onda já fechada falha
+  (`trg_wave_close_once`)
+- [ ] 2.2.3 Teste: registro de decisão com campo obrigatório ausente/vazio
+  é rejeitado pela própria constraint (não pelo script chamador)
+- [ ] 2.2.4 Teste: registro de bloqueio humano com `decision_id` inexistente
+  é rejeitado por `FOREIGN KEY` (com `PRAGMA foreign_keys=ON` ativo)
+- [ ] 2.2.5 Teste: tentativa de `enter` de spawn acima do teto configurado
+  é rejeitada por `CHECK (subagent_depth <= max_recursion)`
+- [ ] 2.2.6 Teste: `--score 3` sem `--evidencia` >= 20 chars é rejeitado na
+  camada de banco
+
+---
+
+## FASE 3 - Primitivas de Acesso `[C]`
+
+Ref: spec.md FR-003, FR-004, FR-011; contracts/primitives.md §C1, C4-C10
+
+### 3.1 Helpers compartilhados de conexão e escape `[C]`
+
+Ref: contracts/primitives.md §C5 (PRAGMAs), §C8 (escape), §C9 (permissões)
+
+- [ ] 3.1.1 Extrair `sql_escape`/`strip_nul` de `cli/lib/recall.sh` para um
+  ponto compartilhável consumível pelos scripts de `agente-00c-runtime`
+  (reuso, não reimplementação — per C8)
+- [ ] 3.1.2 Implementar wrapper de invocação `sqlite3` que emite sempre
+  `PRAGMA foreign_keys=ON; PRAGMA busy_timeout=<ms>;` antes do SQL da
+  mutação (C5)
+- [ ] 3.1.3 Implementar `chmod 600` explícito após criação de `state.db` e
+  seus sidecars `-wal`/`-shm` (C9, finding S3), seguindo o padrão já usado
+  em `otel-usage.sh:262`
+- [ ] 3.1.4 Reaproveitar o padrão de retry sob lock de
+  `recall_apply_sql_with_retry` (`cli/lib/recall.sh`) — MAS com contrato de
+  falha diferente: lock persistente após retries MUST sair não-zero, nunca
+  degradar silenciosamente (C6, diferença deliberada face ao `recall.sh`)
+- [ ] 3.1.5 Teste: payload de texto livre contendo `'; DROP TABLE decision;
+  --` e apóstrofo simples é persistido literalmente, a tabela `decision`
+  continua existindo e `state-validate.sh` sai 0 (C8, paridade com
+  `tests/test_model-routing.sh`)
+
+### 3.2 Adaptar `state-rw.sh` para backend dual `[C]`
+
+Ref: contracts/primitives.md §C1 (paridade), §C2 (seleção de backend)
+
+- [ ] 3.2.1 Implementar seleção de backend por presença de arquivo (existe
+  `<state-dir>/state.db` ⇒ SQLite; senão ⇒ JSON atual) em `init`
+- [ ] 3.2.2 Adaptar `read`/`get`/`set`/`write` preservando stdout/exit code
+  idênticos ao comportamento JSON atual (C1)
+- [ ] 3.2.3 Adaptar `sha256-update`/`sha256-verify` para, sob backend
+  SQLite, delegar à FASE 7 (`PRAGMA integrity_check`) mantendo nome e
+  contrato de exit code
+- [ ] 3.2.4 Teste de paridade: cada subcomando de `state-rw.sh` produz o
+  mesmo stdout/exit code sob os dois backends, para os mesmos dados
+
+### 3.3 Adaptar `state-ondas.sh` `[C]`
+
+Ref: contracts/primitives.md tabela de subcomandos `state-ondas.sh`
+
+- [ ] 3.3.1 Adaptar `start`/`end`/`wave-status`/`current-id` — declarar
+  explicitamente a mudança de comportamento autorizada por C3: `start` com
+  onda já aberta passa a **falhar** (hoje duplica silenciosamente)
+- [ ] 3.3.2 Adaptar `record-skill`/`record-task`/`reconcile-tasks` — PK
+  composta de `task_outcome` substitui o upsert em `jq` por
+  `INSERT ... ON CONFLICT DO UPDATE`
+- [ ] 3.3.3 Adaptar `tool-call-tick`/`git-commit`
+- [ ] 3.3.4 Teste: guarda `wave-status` do orquestrador continua válida
+  como defesa em profundidade (não mais requisito único) sob o novo erro
+  de `start`
+
+### 3.4 Adaptar `state-decisions.sh` `[C]`
+
+- [ ] 3.4.1 Adaptar `register` para inserir via transação `BEGIN
+  IMMEDIATE`, preservando impressão de `dec-NNN` em stdout
+- [ ] 3.4.2 Adaptar `count`/`next-id`/`list`
+- [ ] 3.4.3 Teste: `register` sob concorrência (duas invocações
+  simultâneas) não perde nenhuma decisão e não colide em `next-id`
+
+### 3.5 Adaptar `bloqueios.sh` `[C]`
+
+- [ ] 3.5.1 Adaptar `register` para gravar o bloqueio **e** mudar
+  `.execution.status` na mesma transação (C4 — hoje são dois RMW
+  separados)
+- [ ] 3.5.2 Adaptar `respond`/`list`/`count`/`next-id`/`get`
+- [ ] 3.5.3 Teste: `register` com `--decisao-id` inexistente falha por FK
+  (US1 AS-4)
+
+### 3.6 Adaptar `spawn-tracker.sh` `[C]`
+
+- [ ] 3.6.1 Adaptar `check`/`enter`/`leave`/`current` preservando exit 3 no
+  teto (paridade C1)
+- [ ] 3.6.2 Teste: `enter` acima do teto não grava (paridade com hoje)
+
+### 3.7 Testes de atomicidade e concorrência (SC-002, US1 AS-3) `[C]`
+
+Ref: spec.md SC-002; contracts/primitives.md §C4, C6
+
+- [ ] 3.7.1 Teste de carga: duas mutações concorrentes distintas (ex.:
+  registrar decisão + fechar onda) aplicadas em paralelo — nenhuma
+  atualização perdida, 0% de taxa de perda
+- [ ] 3.7.2 Teste de interrupção simulada (kill -9 no meio de uma
+  transação) — verificar que o `state.db` não fica com escrita parcial
+  (rollback automático do SQLite)
+- [ ] 3.7.3 Teste de leitura concorrente durante escrita em andamento — sem
+  bloqueio, sem leitura parcial (C6, WAL)
+
+---
+
+## FASE 4 - Seleção de Backend e Compatibilidade `[A]`
+
+Ref: spec.md FR-012, SC-003; contracts/primitives.md §C2, C11
+
+### 4.1 Lógica de seleção de backend em todos os scripts de escrita `[A]`
+
+- [ ] 4.1.1 Aplicar a lógica de C2 (presença de `state.db` decide o
+  backend) uniformemente nos 6 scripts adaptados na FASE 3
+- [ ] 4.1.2 Confirmar que um projeto sem `state.db` continua operando
+  exatamente como hoje (backend JSON, FR-012) sem qualquer mudança de
+  comportamento observável
+
+### 4.2 Regressão da suíte para projeto não migrado (SC-003) `[A]`
+
+- [ ] 4.2.1 Rodar `./tests/run.sh` completo sobre o estado atual (sem
+  `state.db`) e confirmar 0 regressões atribuíveis a esta feature
+- [ ] 4.2.2 Adicionar cenários novos ao harness (`tests/test_<script>.sh`)
+  cobrindo o branch de seleção de backend explicitamente, por script
+  adaptado
+
+### 4.3 Preservar `state-lock.sh` como camada opcional `[M]`
+
+Ref: contracts/primitives.md §C11 (o que NÃO muda)
+
+- [ ] 4.3.1 Confirmar que `state-lock.sh` não é removido e sua superfície
+  não muda — segue disponível como camada extra opcional, não mais como
+  requisito de serialização
+- [ ] 4.3.2 Atualizar a prosa dos orquestradores (`agente-00c-orchestrator.md`,
+  `agente-00c-feature-orchestrator.md`) e commands que hoje descrevem o
+  lock como serializador primário, refletindo que WAL é o mecanismo
+  primário sob backend `state.db` (FR-011) — **fora desta feature de
+  runtime**, mas necessário para a prosa não ficar desatualizada; abrir
+  como nota de sugestão se não couber nesta task
+
+---
+
+## FASE 5 - Export Derivado `[A]`
+
+Ref: spec.md FR-007, FR-013-INFRA-BACKUP; contracts/export.md; dec-032 (E5-a)
+
+### 5.1 Implementar o export (opção A — reusar `state-rw.sh read`) `[A]`
+
+Ref: contracts/export.md §Interface do comando (opção A preferida)
+
+- [ ] 5.1.1 Sob backend SQLite, `state-rw.sh read` produz o `state.json`
+  equivalente descrito em E1-E4 (schema_version, todos os campos de topo,
+  nomes/IDs preservados literalmente, `accumulated_metrics` derivado por
+  agregação das tabelas)
+- [ ] 5.1.2 Preservar distinção ausente-vs-null (`canonical_project`/
+  `session_name` ausentes quando não setados) — E3
+- [ ] 5.1.3 Teste E1: export passa em `state-validate.sh --state-dir <dir>`
+  com exit 0
+- [ ] 5.1.4 Teste E2/E3: fidelidade de nomes/IDs e ordem/aninhamento
+  (`skills_invoked` volta a ficar aninhado em `.waves[N]`)
+
+### 5.2 Gatilho automático ao fim da onda `[A]`
+
+Ref: dec-032 (E5-a: ambos os gatilhos); export.md §E5, E6
+
+- [ ] 5.2.1 Disparar a geração do export dentro de `state-ondas.sh end`, no
+  mesmo ponto onde o snapshot de `state-history/` é gerado hoje —
+  reaproveita o export como mecanismo de FR-013-INFRA-BACKUP sem
+  introduzir backup nativo do SQLite (research.md Decision 6)
+- [ ] 5.2.2 Implementar E6: falha na geração do export (disco cheio,
+  interrupção) MUST ser reportada em stderr e MUST NOT reverter nem
+  impedir o commit da transação que fechou a onda
+- [ ] 5.2.3 Teste SC-004: export reflete uma mutação em até 5 segundos após
+  aplicada
+- [ ] 5.2.4 Teste E6: simular falha de escrita do export (ex.: diretório
+  sem permissão) e confirmar que o fechamento de onda no `state.db` não é
+  revertido
+
+### 5.3 Gatilho sob demanda `[A]`
+
+- [ ] 5.3.1 Expor comando explícito para regenerar o export a qualquer
+  momento (consumido por auditoria/debug manual e por FASE 6 M3.2)
+- [ ] 5.3.2 Teste: export sob demanda gerado após múltiplas mutações
+  reflete o estado corrente completo
+
+### 5.4 Teste de restauração a partir do export (FR-013-INFRA-BACKUP) `[A]`
+
+- [ ] 5.4.1 Validar que a restauração a partir de um snapshot em
+  `state-history/` (export serializado) é operável — "com a restauração
+  validada por teste antes de ser considerada disponível" (FR-013-INFRA-BACKUP,
+  literal)
+
+---
+
+## FASE 6 - Migração state.json → state.db `[C]`
+
+Ref: spec.md FR-005, FR-006, FR-014-INFRA-IDEMP; contracts/migration.md;
+dec-033 (M1-a), dec-034 (CHK005)
+
+### 6.1 Interface do comando de migração `[C]`
+
+Ref: dec-034 (subcomando `cstk state migrate` delegando a `state-db-migrate.sh`)
+
+- [ ] 6.1.1 Criar `global/skills/agente-00c-runtime/scripts/state-db-migrate.sh`
+  como script dedicado (evita colisão com `state-rw.sh migrate`, que migra
+  schema interno do JSON — migration.md §Nomeação)
+- [ ] 6.1.2 Expor `cstk state migrate --state-dir <dir>` no CLI, delegando
+  ao script acima
+- [ ] 6.1.3 Criar `tests/test_state-db-migrate.sh` seguindo a convenção do
+  harness (`--check-coverage` deve reconhecer o script novo)
+
+### 6.2 Pré-condições M1 `[C]`
+
+Ref: migration.md §M1; dec-033 (M1-a: permitir `aguardando_humano`)
+
+- [ ] 6.2.1 Recusar com diagnóstico claro se `.execution.status ==
+  "em_andamento"` (FR-005, literal) — **permitir** `aguardando_humano`
+  (dec-033)
+- [ ] 6.2.2 Recusar se `state-validate.sh --state-dir <dir>` sair != 0
+  (reaproveita o verificador existente — cobre SC-006/bloqueio órfão sem
+  código novo)
+- [ ] 6.2.3 Recusar se `state-rw.sh sha256-verify --state-dir <dir>` sair
+  != 0 (integridade divergente)
+- [ ] 6.2.4 Recusar se `state.json` ausente/ilegível
+- [ ] 6.2.5 Recusar (não sobrescrever) se já existe `state.db` de
+  `execution.id` diferente da origem — ver 6.5 (idempotência)
+
+### 6.3 Sequência de migração (M2) `[C]`
+
+Ref: migration.md §M2; primitives.md §C10 (mktemp, finding S4)
+
+- [ ] 6.3.1 Criar arquivo temporário via `mktemp` no `<state-dir>` (mesmo
+  filesystem) — MUST NOT usar nome derivado de PID (C10)
+- [ ] 6.3.2 Aplicar o schema (FASE 2) + PRAGMAs ao temporário
+- [ ] 6.3.3 Inserir os dados na ordem imposta pelas FKs: `execution` →
+  `wave` → `decision` → `human_block`/`skill_invocation`/`task_outcome`/
+  `event` → `migration_run`, preservando IDs e timestamps originais sem
+  renumeração
+- [ ] 6.3.4 Publicar por `mv` atômico do temporário para `state.db`
+  (dentro do mesmo filesystem)
+
+### 6.4 Verificação pós-migração M3 (FR-006, SC-001) `[C]`
+
+Ref: migration.md §M3.1, M3.2
+
+- [ ] 6.4.1 M3.1 — contagem por entidade: `COUNT(*)` no destino == `length`
+  do array de origem, para as 6 entidades listadas (decisions, waves,
+  human_blocks, tasks, events, skill_invocation), gravado em
+  `migration_run.counts_source`/`counts_target`
+- [ ] 6.4.2 M3.2 — gerar o export (FASE 5) a partir do `state.db` recém-
+  construído e comparar campo-a-campo com o `state.json` de origem, ambos
+  canonicalizados (`jq -S .`) — divergência ⇒ migração recusada, temporário
+  removido
+- [ ] 6.4.3 Teste: `state.json` que falha na validação (bloqueio órfão) é
+  recusado com diagnóstico apontando o registro problemático (SC-006, US2
+  AS-3)
+- [ ] 6.4.4 Teste: interrupção simulada entre construção e publicação —
+  `state.json` original permanece intacto e o projeto continua operável
+  (US2 AS-4)
+
+### 6.5 Idempotência (FR-014-INFRA-IDEMP, M5) `[C]`
+
+Ref: migration.md §M5
+
+- [ ] 6.5.1 Chave de idempotência = `.execution.id` — reexecutar sobre
+  projeto já migrado (mesmo `execution.id`) não duplica nem corrompe
+  (reconstrução completa + republicação atômica)
+- [ ] 6.5.2 `state.db` pré-existente com `execution.id` diferente da
+  origem ⇒ recusar, exigindo intervenção humana
+- [ ] 6.5.3 Registrar toda tentativa (inclusive recusadas) em
+  `migration_run` com `result` ∈ `success`\|`refused`\|`failed`
+- [ ] 6.5.4 Teste: migração executada duas vezes seguidas sobre o mesmo
+  projeto produz o mesmo resultado, sem duplicação (US2 AS-2)
+
+### 6.6 Garantias M4/M6 e cobertura dos 7 cenários do contrato `[C]`
+
+Ref: migration.md §M4, M6, §Cenários de teste (tabela final)
+
+- [ ] 6.6.1 Confirmar M6: migração nunca dispara automaticamente numa
+  invocação de orquestrador (nenhum caminho de `/agente-00c`,
+  `/feature-00c` ou resumes a chama)
+- [ ] 6.6.2 Confirmar M6: `state.json`, `state.json.sha256` e
+  `state-history/` nunca são apagados pela migração
+- [ ] 6.6.3 Rodar a suíte completa dos 7 cenários de
+  `contracts/migration.md` §Cenários de teste como teste de aceitação
+  final da FASE 6
+
+---
+
+## FASE 7 - Verificação de Integridade `[A]`
+
+Ref: spec.md FR-010; contracts/primitives.md §C7; research.md Decision 4
+(D4-a fechada, dec-025)
+
+### 7.1 `sha256-update`/`sha256-verify` sob backend SQLite `[A]`
+
+- [ ] 7.1.1 Implementar `sha256-update`/`sha256-verify`, sob backend
+  `state.db`, delegando a `PRAGMA integrity_check` (ou `quick_check` no
+  caminho quente), preservando nome e contrato de exit code do comando
+- [ ] 7.1.2 Teste: corrupção estrutural simulada (truncar o arquivo) é
+  detectada por `integrity_check`
+- [ ] 7.1.3 Teste de regressão **documentado e esperado** (dec-025): uma
+  edição externa bem-formada via `UPDATE` direto não é detectada — cenário
+  7.a do quickstart.md, confirmando que o comportamento aceito está
+  implementado como decidido, não como falha
+
+---
+
+## FASE 8 - Ingestão SQL→SQL no knowledge.db `[M]`
+
+Ref: spec.md FR-008, FR-009; research.md Decision 7 (D7-a fechada,
+dec-037); dec-035 (CHK015, critério de amostra)
+
+### 8.1 Caminho de ingestão SQL→SQL em `cli/lib/recall.sh` `[M]`
+
+- [ ] 8.1.1 Implementar `ATTACH DATABASE 'file:<path do state.db>?mode=ro'
+  AS src;` seguido de `INSERT ... SELECT` para cada entidade (executions,
+  waves, decisions, blocks, tasks, events, skills), preservando a mesma
+  proveniência (`project`/`feature`/`onda`/data) e a mesma idempotência
+  (`UNIQUE(project, feature, wave, source_id)` + `ON CONFLICT DO UPDATE`)
+  do caminho JSON atual
+- [ ] 8.1.2 Aplicar o mesmo filtro `kind == 'gate'` na exclusão da tabela
+  `skills` (paridade com o caminho JSON)
+- [ ] 8.1.3 Preservar FR-009: nenhuma escrita direta no `knowledge.db` por
+  outro caminho; `ATTACH ... mode=ro` garante que o processo de ingestão
+  não pode escrever acidentalmente no `state.db` de origem
+
+### 8.2 Preservar o caminho JSON legado intacto (FR-012, US4 AS-2) `[M]`
+
+- [ ] 8.2.1 Detectar presença de `state.db` para escolher o caminho
+  SQL→SQL; ausência mantém o caminho JSON atual sem alteração
+- [ ] 8.2.2 Teste: projeto ainda não migrado (`state.json` apenas) ingere
+  exatamente como hoje, sem regressão
+
+### 8.3 Testes de equivalência SQL vs JSON (SC-005) `[M]`
+
+Ref: dec-035 (critério de amostra)
+
+- [ ] 8.3.1 Fixtures sintéticas cobrindo os 3 casos de dec-035 (vazio/
+  mínimo: 0 decisões e 1 onda; médio: ~10 decisões/3 ondas; grande: ~50+
+  decisões/10+ ondas) — ingerir via os dois caminhos (JSON exportado vs
+  SQL direto) e comparar as entidades resultantes no `knowledge.db`
+- [ ] 8.3.2 Incluir, quando disponíveis no ambiente de teste local, os
+  state-dirs reais já existentes (ex.: este próprio
+  `.claude/feature-00c-state/state-db-foundation` após migrado) como
+  amostra adicional, sem depender exclusivamente deles
+- [ ] 8.3.3 Confirmar 100% de equivalência de entidades entre os dois
+  caminhos de ingestão na amostra (SC-005)
+
+---
+
+## FASE 9 - Validação Final e Regressão `[C]`
+
+Ref: spec.md SC-002, SC-003, SC-005, SC-006; checklists/requirements.md
+
+### 9.1 Suíte completa e cobertura `[C]`
+
+- [ ] 9.1.1 Rodar `./tests/run.sh` completo (não `--fast`) e confirmar 0
+  regressões atribuíveis a esta feature (SC-003)
+- [ ] 9.1.2 Rodar `./tests/run.sh --check-coverage` e confirmar que todo
+  script novo (`state-db-migrate.sh`, helpers extraídos) tem teste
+  correspondente na convenção do harness
+
+### 9.2 Gates de consistência final `[A]`
+
+- [ ] 9.2.1 Rodar `/analyze` sobre spec/plan/tasks para confirmar
+  consistência cruzada após a implementação completa
+- [ ] 9.2.2 Revalidar os itens `{humano}` do checklist (CHK005, CHK015,
+  CHK023, CHK027, CHK029, CHK031) contra as decisões fechadas nesta rodada
+  (dec-031 a dec-037) — confirmar que nenhum ficou sem tratamento
+
+### 9.3 Teste de carga concorrente final (SC-002) `[C]`
+
+- [ ] 9.3.1 Reexecutar o teste de carga concorrente (3.7.1) como critério
+  de aceitação de toda a feature, não apenas da FASE 3 isolada — 0% de
+  taxa de atualização perdida
+
+---
+
+## Matriz de Dependências
+
+```mermaid
+flowchart TD
+    F1[FASE 1 - Pre-requisitos e Descobertas]
+    F2[FASE 2 - Schema e Constraints]
+    F3[FASE 3 - Primitivas de Acesso]
+    F4[FASE 4 - Selecao de Backend]
+    F5[FASE 5 - Export Derivado]
+    F6[FASE 6 - Migracao]
+    F7[FASE 7 - Verificacao de Integridade]
+    F8[FASE 8 - Ingestao SQL para SQL]
+    F9[FASE 9 - Validacao Final]
+
+    F1 --> F2
+    F2 --> F3
+    F3 --> F4
+    F3 --> F5
+    F4 --> F6
+    F5 --> F6
+    F2 --> F7
+    F6 --> F8
+    F4 --> F9
+    F5 --> F9
+    F6 --> F9
+    F7 --> F9
+    F8 --> F9
+```
+
+## Resumo Quantitativo
+
+| Fase | Tarefas | Subtarefas | Criticidade |
+|------|---------|------------|-------------|
+| 1 - Pré-requisitos e Descobertas | 2 | 9 | C/A |
+| 2 - Schema e Constraints | 2 | 14 | C |
+| 3 - Primitivas de Acesso | 7 | 24 | C |
+| 4 - Seleção de Backend | 3 | 6 | A/M |
+| 5 - Export Derivado | 4 | 12 | A |
+| 6 - Migração | 6 | 21 | C |
+| 7 - Verificação de Integridade | 1 | 3 | A |
+| 8 - Ingestão SQL→SQL | 3 | 8 | M |
+| 9 - Validação Final | 3 | 5 | C/A |
+| **Total** | **31** | **102** | - |
+
+## Escopo Coberto
+
+| Item | Descrição | Fase |
+|------|-----------|------|
+| FR-001, FR-002 | Persistência relacional + invariantes na camada de armazenamento | 2 |
+| FR-003, FR-004, FR-011 | Atomicidade + primitivas de acesso + concorrência WAL | 3 |
+| FR-012, SC-003 | Compatibilidade com projeto não migrado | 4 |
+| FR-007, FR-013-INFRA-BACKUP | Export derivado + backup por onda | 5 |
+| FR-005, FR-006, FR-014-INFRA-IDEMP | Migração idempotente com verificação | 6 |
+| FR-010 | Verificação de integridade (`integrity_check`) | 7 |
+| FR-008, FR-009 | Ingestão SQL→SQL aditiva ao knowledge.db | 8 |
+| SC-002, SC-005, SC-006 | Validação de carga, equivalência e recusa | 9 |
+| CHK004, CHK009, CHK005, CHK015, CHK027, CHK029 | Gaps do checklist consumidos | 1, 6, 8, 9 |
+| Amendment 1.3.0 da constitution | Gate bloqueante externo materializado como tarefa | 1 |
+
+## Escopo Excluído
+
+| Item | Descrição | Motivo |
+|------|-----------|--------|
+| Servidor de acesso tipado | API/servidor dedicado sobre o `state.db` | spec.md §Contexto — fase futura explícita, fora desta "Fase 1 (fundação)" |
+| Inversão de verificação | Mover verificação de invariantes para fora do banco (ou vice-versa em outro sentido arquitetural) | spec.md §Contexto — fase futura |
+| Telemetria ao vivo | Streaming de eventos do `state.db` para consumidores externos em tempo real | spec.md §Contexto — fase futura |
+| Driver nativo SQLite (better-sqlite3/node:sqlite/python) | Acesso ao banco via binding de linguagem em vez de CLI `sqlite3` | research.md Decision 1 — introduziria runtime de linguagem hospedeira, contra a arquitetura POSIX sh |
+| Mecanismo de backup nativo do SQLite (`VACUUM INTO`, `.backup`) | Backup binário do arquivo `.db` | research.md Decision 6 — export serializado já cobre FR-013-INFRA-BACKUP sem mecanismo novo |
+| Hash-chain de auditoria / sha256 do export como camada extra de integridade | Opções 2/3 de D4-a | dec-025 — regresso de detecção de adulteração aceito e documentado; desproporcional ao modelo de ameaça (operador local confiável) |
+| Reescrita dos ~24 consumidores atuais de `state.json` | Adaptar cada consumidor para ler `state.db`/`knowledge.db` diretamente | contracts/export.md — o export FR-007 os protege sem reescrita nesta fase |
+| SC novo de performance de escrita por mutação | Meta formal de latência do `BEGIN IMMEDIATE`/`COMMIT` | dec-036 (CHK027) — sem sinal de que overhead de I/O local é gargalo frente ao tempo dominado por chamadas de LLM por onda |

--- a/docs/specs/state-db-foundation/tasks.md
+++ b/docs/specs/state-db-foundation/tasks.md
@@ -206,15 +206,15 @@ Ref: contracts/primitives.md §C5 (PRAGMAs), §C8 (escape), §C9 (permissões)
 
 Ref: contracts/primitives.md §C1 (paridade), §C2 (seleção de backend)
 
-- [ ] 3.2.1 Implementar seleção de backend por presença de arquivo (existe
-  `<state-dir>/state.db` ⇒ SQLite; senão ⇒ JSON atual) em `init`
-- [ ] 3.2.2 Adaptar `read`/`get`/`set`/`write` preservando stdout/exit code
-  idênticos ao comportamento JSON atual (C1)
-- [ ] 3.2.3 Adaptar `sha256-update`/`sha256-verify` para, sob backend
+- [x] 3.2.1 Implementar seleção de backend por presença de arquivo (existe
+  `<state-dir>/state.db` ⇒ SQLite; senão ⇒ JSON atual) em `init` <!-- _sr_backend/_sr_db_file em _state-rw-db.sh; init recusa se state.db ja existe (migracao e FASE 6, nao init) -->
+- [x] 3.2.2 Adaptar `read`/`get`/`set`/`write` preservando stdout/exit code
+  idênticos ao comportamento JSON atual (C1) <!-- _sr_db_read (reconstrucao completa via json_object/json_group_array + catch-all execution.extra_fields/wave.extra_fields para campos de topo/por-onda ainda nao modelados como coluna — gap documentado entre export.md e data-model.md, dec pendente de registro); _sr_db_set (dispatcher: arrays completos via upsert, .waves[-1|N].campo, colunas conhecidas, fallback extra_fields para campo de topo simples — path aninhado nao modelado falha alto, nunca perde dado silenciosamente); _sr_db_write_document (import completo). Bug lateral corrigido em _state-db.sh: PRAGMA busy_timeout ecoava o valor como linha de resultado, corrompendo stdout de toda SELECT via _state_db_exec -->
+- [x] 3.2.3 Adaptar `sha256-update`/`sha256-verify` para, sob backend
   SQLite, delegar à FASE 7 (`PRAGMA integrity_check`) mantendo nome e
-  contrato de exit code
-- [ ] 3.2.4 Teste de paridade: cada subcomando de `state-rw.sh` produz o
-  mesmo stdout/exit code sob os dois backends, para os mesmos dados
+  contrato de exit code <!-- _sr_db_integrity_check; sha256-update vira no-op (exit 0, sem hash derivado a manter) -->
+- [x] 3.2.4 Teste de paridade: cada subcomando de `state-rw.sh` produz o
+  mesmo stdout/exit code sob os dois backends, para os mesmos dados <!-- tests/test_state-rw.sh (16 cenarios sqlite novos, incl. 2 paridade cross-backend get/set/sha256-verify) + tests/test__state-rw-db.sh (17 cenarios unitarios); read reconstruido passa em state-validate.sh (E1) -->
 
 ### 3.3 Adaptar `state-ondas.sh` `[C]`
 

--- a/global/agents/agente-00c-feature-orchestrator.md
+++ b/global/agents/agente-00c-feature-orchestrator.md
@@ -92,7 +92,7 @@ cada chamada).
 | Script | Uso principal |
 |--------|---------------|
 | `state-rw.sh init\|read\|write\|get\|set\|sha256-update\|sha256-verify` | CRUD do state.json |
-| `state-lock.sh acquire\|release\|check` | mutex anti-concorrencia (FR-028). **acquire/release sao do command PAI** (ver "Fronteira command↔orquestrador") — o orquestrador NAO os chama |
+| `state-lock.sh acquire\|release\|check` | mutex anti-concorrencia (FR-028). **acquire/release sao do command PAI** (ver "Fronteira command↔orquestrador") — o orquestrador NAO os chama. Sob backend `state.db` (feature `state-db-foundation`), o lock deixa de ser o serializador primario — quem serializa escritas concorrentes e o modo WAL do SQLite (PRAGMAs + retry/backoff em `_state-db.sh`, contracts/primitives.md §C6, FR-011); o lock segue disponivel como camada extra opcional, superficie inalterada (contracts/primitives.md §C11) |
 | `state-validate.sh` | schema check (FR-013) |
 | `state-ondas.sh start\|end\|record-skill` | ciclo de vida da onda + skills_invoked (FR-012, FR-020) |
 | `state-decisions.sh register --score N --evidencia "..."` | Decisao auditavel (FR-017) |

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -102,7 +102,7 @@ infraestrutura interna deste agente.
 |--------|------------------------|-----------|
 | `state-rw.sh` | init/read/write/get/set/sha256-update/sha256-verify/path-check | I/O atomico do state.json com backup automatico em `state-history/` |
 | `state-validate.sh` | (sem subcmds) `--state-dir DIR` | Validador FR-008 read-only (10 checagens, sem auto-correcao) |
-| `state-lock.sh` | acquire/release/check/check-execution-busy | Lock anti-concorrencia via mkdir atomico. **acquire/release sao do command PAI** (ver "Fronteira command↔orquestrador") — o orquestrador NAO os chama |
+| `state-lock.sh` | acquire/release/check/check-execution-busy | Lock anti-concorrencia via mkdir atomico. **acquire/release sao do command PAI** (ver "Fronteira command↔orquestrador") — o orquestrador NAO os chama. Sob backend `state.db` (feature `state-db-foundation`), o lock deixa de ser o serializador primario — quem serializa escritas concorrentes e o modo WAL do SQLite (PRAGMAs + retry/backoff em `_state-db.sh`, contracts/primitives.md §C6, FR-011); o lock segue disponivel como camada extra opcional, superficie inalterada (contracts/primitives.md §C11) |
 | `pipeline.sh` | stages/next-stage/prev-stage/detect-completion/skill-conflict | State machine canonica das 10 etapas SDD |
 | `state-decisions.sh` | register/count/next-id/list | Registro auditavel (Principio I — 5 campos obrigatorios) |
 | `spawn-tracker.sh` | check/enter/leave/current | Tracker de profundidade de subagentes (FR-013, MAX 3) |

--- a/global/skills/agente-00c-runtime/references/state-db-schema.sql
+++ b/global/skills/agente-00c-runtime/references/state-db-schema.sql
@@ -54,6 +54,16 @@ CREATE TABLE IF NOT EXISTS execution (
   constitution_cache                  TEXT,   -- JSON
   push_pr_result                      TEXT,   -- JSON
 
+  -- Catch-all [PROPOSTA state-rw dual-backend, task 3.2]: campos de topo do
+  -- state.json que esta feature ainda NAO modela como coluna/tabela dedicada
+  -- (ex.: next_retrospective_milestone, suggestions[], retros[] — gap entre
+  -- contracts/export.md e as 9 entidades fechadas em data-model.md, ver
+  -- Decisao da task 3.2). Guarda um objeto JSON de nivel 1 (chave -> valor)
+  -- preservando fidelidade de round-trip de state-rw.sh set/write generico
+  -- (C1) sem exigir schema apriori de todo campo futuro. Precedencia no
+  -- export: colunas/tabelas modeladas SEMPRE vencem em caso de colisao.
+  extra_fields                        TEXT,   -- JSON object
+
   -- Constraint 1: enum de status
   CHECK (status IN ('em_andamento','aguardando_humano','abortada','concluida')),
 
@@ -89,6 +99,9 @@ CREATE TABLE IF NOT EXISTS wave (
   agent_usage              TEXT,   -- JSON
   agent_spawns             TEXT,   -- JSON
   otel_usage                TEXT,  -- JSON
+  extra_fields             TEXT,   -- JSON object; catch-all por-onda (mesmo
+                                    -- racional de execution.extra_fields
+                                    -- acima — ex.: touched_key_aspects)
 
   UNIQUE (execution_id, seq),
 

--- a/global/skills/agente-00c-runtime/references/state-db-schema.sql
+++ b/global/skills/agente-00c-runtime/references/state-db-schema.sql
@@ -1,0 +1,255 @@
+-- state-db-schema.sql — DDL definitivo do state.db (feature state-db-foundation).
+--
+-- Fonte de contrato: docs/specs/state-db-foundation/data-model.md (9 entidades).
+-- Idempotente: toda CREATE usa IF NOT EXISTS; aplicavel repetidas vezes sem
+-- efeito colateral sobre um banco ja criado (task 2.1.8).
+--
+-- Consumido por: global/skills/agente-00c-runtime/scripts/state-db-schema.sh
+-- (subcomando `create`), que aplica PRAGMA journal_mode=WAL uma unica vez na
+-- criacao (dec-014 — WAL nativo) e chama este arquivo via `sqlite3 <db> < schema`.
+--
+-- NAO editar constraints aqui sem atualizar data-model.md correspondente —
+-- este arquivo E a materializacao de contrato, nao uma copia solta.
+
+PRAGMA foreign_keys = ON;
+
+-- ============================================================
+-- Entity: execution
+-- ============================================================
+CREATE TABLE IF NOT EXISTS execution (
+  id                                  TEXT PRIMARY KEY,
+  schema_version                      TEXT NOT NULL,
+  short_name                          TEXT,
+  target_project_path                 TEXT NOT NULL,
+  target_project_description          TEXT NOT NULL,
+  suggested_stack                     TEXT,
+  status                              TEXT NOT NULL,
+  termination_reason                  TEXT,
+  started_at                          TEXT NOT NULL,
+  finished_at                         TEXT,
+  canonical_project                   TEXT,
+  session_name                        TEXT,
+  current_stage                       TEXT NOT NULL,
+  next_instruction                    TEXT NOT NULL,
+  atomic_commit_enabled               INTEGER,
+  initial_key_aspects                 TEXT,
+  subagent_depth                      INTEGER NOT NULL DEFAULT 1,
+  max_recursion                       INTEGER NOT NULL DEFAULT 3,
+  cycles_consumed_current_stage       INTEGER NOT NULL DEFAULT 0,
+  max_cycles_per_stage                INTEGER NOT NULL DEFAULT 5,
+  retro_executions_consumed           INTEGER NOT NULL DEFAULT 0,
+  max_retro_executions_per_feature    INTEGER NOT NULL DEFAULT 2,
+
+  -- Colunas [PROPOSTA] — decisao de granularidade dec-047 (task 2.1.7):
+  -- cardinalidade 1:1 com execution, sem consumidor que precise de acesso
+  -- relacional por elemento; persistidas como blob JSON, tal qual
+  -- suggested_stack/initial_key_aspects acima.
+  tool_calls_threshold_wave           INTEGER NOT NULL DEFAULT 80,
+  wallclock_threshold_seconds         INTEGER NOT NULL DEFAULT 5400,
+  state_size_threshold_bytes          INTEGER NOT NULL DEFAULT 1048576,
+  external_urls_whitelist             TEXT,   -- JSON array
+  circular_movement_history           TEXT,   -- JSON array (FIFO 6)
+  prerequisites                       TEXT,   -- JSON object (briefing/constitution)
+  briefing_cache                      TEXT,   -- JSON
+  constitution_cache                  TEXT,   -- JSON
+  push_pr_result                      TEXT,   -- JSON
+
+  -- Constraint 1: enum de status
+  CHECK (status IN ('em_andamento','aguardando_humano','abortada','concluida')),
+
+  -- Constraint 2: consistencia status x finished_at
+  CHECK (
+    (status IN ('abortada','concluida') AND finished_at IS NOT NULL)
+    OR
+    (status IN ('em_andamento','aguardando_humano') AND finished_at IS NULL)
+  ),
+
+  -- Constraint 3: teto de profundidade de subagente (_ST_MAX=3 em spawn-tracker.sh)
+  CHECK (subagent_depth >= 1 AND subagent_depth <= max_recursion),
+
+  -- Constraint 4: tetos de ciclo e retro
+  CHECK (cycles_consumed_current_stage <= max_cycles_per_stage),
+  CHECK (retro_executions_consumed <= max_retro_executions_per_feature)
+);
+
+-- ============================================================
+-- Entity: wave (Onda)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS wave (
+  id                       TEXT PRIMARY KEY,
+  execution_id             TEXT NOT NULL REFERENCES execution(id),
+  seq                      INTEGER NOT NULL,
+  started_at               TEXT NOT NULL,
+  finished_at              TEXT,
+  wallclock_seconds        INTEGER,
+  tool_calls               INTEGER NOT NULL DEFAULT 0,
+  termination_reason       TEXT,
+  next_wave_scheduled_for  TEXT,
+  executed_stages          TEXT,   -- JSON array
+  agent_usage              TEXT,   -- JSON
+  agent_spawns             TEXT,   -- JSON
+  otel_usage                TEXT,  -- JSON
+
+  UNIQUE (execution_id, seq),
+
+  CHECK (termination_reason IS NULL OR termination_reason IN (
+    'etapa_concluida_avancando','threshold_proxy_atingido',
+    'bloqueio_humano','aborto','concluido')),
+
+  -- Coerencia: onda fechada tem os dois campos de fechamento preenchidos
+  CHECK ((termination_reason IS NULL AND finished_at IS NULL)
+      OR (termination_reason IS NOT NULL AND finished_at IS NOT NULL))
+);
+
+-- INVARIANTE CENTRAL (FR-002): no maximo UMA onda aberta por execucao.
+-- Indice UNICO parcial: so indexa linhas com termination_reason IS NULL.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_wave_single_open
+  ON wave(execution_id) WHERE termination_reason IS NULL;
+
+-- "Uma onda fechada uma unica vez" (FR-002) — nao expressavel por CHECK
+-- (que so enxerga a linha final, nao a transicao). Requer TRIGGER.
+DROP TRIGGER IF EXISTS trg_wave_close_once;
+CREATE TRIGGER trg_wave_close_once BEFORE UPDATE ON wave
+WHEN OLD.termination_reason IS NOT NULL
+     AND NEW.termination_reason IS NOT OLD.termination_reason
+BEGIN
+  SELECT RAISE(ABORT, 'wave already closed');
+END;
+
+-- ============================================================
+-- Entity: decision (Decisao)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS decision (
+  id                    TEXT PRIMARY KEY,
+  execution_id          TEXT NOT NULL REFERENCES execution(id),
+  wave_id               TEXT REFERENCES wave(id),
+  timestamp             TEXT NOT NULL,
+  agent                 TEXT NOT NULL,
+  stage                 TEXT NOT NULL,
+  context                TEXT NOT NULL,
+  options_considered    TEXT NOT NULL,   -- JSON array
+  choice                TEXT NOT NULL,
+  rationale             TEXT NOT NULL,
+  justification_score   INTEGER,
+  evidence              TEXT,
+  "references"          TEXT,   -- JSON array
+  originating_artifact  TEXT,
+
+  -- Os 5 campos obrigatorios (Principio I)
+  CHECK (length(agent)   > 0),
+  CHECK (length(stage)   > 0),
+  CHECK (length(choice)  > 0),
+  CHECK (length(context)   >= 20),
+  CHECK (length(rationale) >= 20),
+  CHECK (json_valid(options_considered)
+         AND json_array_length(options_considered) >= 1),
+  CHECK (justification_score IS NULL
+         OR justification_score BETWEEN 0 AND 3),
+
+  -- Trava empirica do score 3: exige evidencia >= 20 chars
+  CHECK (justification_score IS NULL OR justification_score < 3
+         OR (evidence IS NOT NULL AND length(evidence) >= 20))
+);
+
+-- ============================================================
+-- Entity: human_block (Bloqueio Humano)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS human_block (
+  id                    TEXT PRIMARY KEY,
+  execution_id          TEXT NOT NULL REFERENCES execution(id),
+  decision_id           TEXT NOT NULL REFERENCES decision(id),
+  question              TEXT NOT NULL,
+  context_for_answer    TEXT NOT NULL,
+  recommended_options   TEXT,   -- JSON array
+  status                TEXT NOT NULL,
+  human_answer          TEXT,
+  triggered_at          TEXT NOT NULL,
+  answered_at           TEXT,
+
+  CHECK (status IN ('aguardando','respondido')),
+  CHECK ((status = 'aguardando'  AND answered_at IS NULL)
+      OR (status = 'respondido' AND answered_at IS NOT NULL)),
+  CHECK (length(question) >= 20),
+  CHECK (length(context_for_answer) > 0)
+);
+
+-- ============================================================
+-- Entity: task_outcome (Resultado de Task — camada B)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS task_outcome (
+  execution_id     TEXT NOT NULL REFERENCES execution(id),
+  task_id          TEXT NOT NULL,
+  title            TEXT NOT NULL,
+  wave_id          TEXT NOT NULL REFERENCES wave(id),
+  outcome          TEXT NOT NULL,
+  tests_run        INTEGER NOT NULL,
+  tests_passed     INTEGER NOT NULL,
+  lint_ok          INTEGER,
+  touched_files    TEXT NOT NULL,   -- JSON array
+  recorded_at      TEXT NOT NULL,
+  source           TEXT,
+
+  PRIMARY KEY (execution_id, task_id),
+  CHECK (outcome IN ('pass','fail')),
+  CHECK (tests_run >= 0 AND tests_passed >= 0 AND tests_passed <= tests_run),
+  CHECK (lint_ok IS NULL OR lint_ok IN (0,1))
+);
+
+-- ============================================================
+-- Entity: event (Evento — timeline cronologica)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS event (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  execution_id   TEXT NOT NULL REFERENCES execution(id),
+  event_type     TEXT NOT NULL,
+  timestamp      TEXT NOT NULL,
+  description    TEXT,
+
+  CHECK (length(event_type) > 0)
+);
+
+-- ============================================================
+-- Entity: skill_invocation (Invocacao de Skill/Gate)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS skill_invocation (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  wave_id       TEXT NOT NULL REFERENCES wave(id),
+  skill         TEXT NOT NULL,
+  timestamp     TEXT NOT NULL,
+  decision_id   TEXT REFERENCES decision(id),
+  kind          TEXT NOT NULL DEFAULT 'skill',
+
+  CHECK (length(skill) > 0),
+  CHECK (kind IN ('skill','gate'))
+);
+
+-- ============================================================
+-- Entity: migration_run (Execucao de Migracao) — [PROPOSTA], sem
+-- contrapartida no state.json atual (FR-005/FR-006/FR-014-INFRA-IDEMP)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS migration_run (
+  id               INTEGER PRIMARY KEY AUTOINCREMENT,
+  execution_id     TEXT NOT NULL,
+  source_path      TEXT NOT NULL,
+  source_sha256    TEXT NOT NULL,
+  started_at       TEXT NOT NULL,
+  finished_at      TEXT,
+  result           TEXT NOT NULL,
+  diagnostic       TEXT,
+  counts_source    TEXT,   -- JSON
+  counts_target    TEXT,   -- JSON
+
+  CHECK (result IN ('success','refused','failed'))
+);
+
+-- ============================================================
+-- Indices de apoio (consultas frequentes dos scripts de runtime)
+-- ============================================================
+CREATE INDEX IF NOT EXISTS ix_decision_execution   ON decision(execution_id);
+CREATE INDEX IF NOT EXISTS ix_decision_wave         ON decision(wave_id);
+CREATE INDEX IF NOT EXISTS ix_human_block_execution ON human_block(execution_id);
+CREATE INDEX IF NOT EXISTS ix_human_block_status    ON human_block(status);
+CREATE INDEX IF NOT EXISTS ix_task_outcome_wave     ON task_outcome(wave_id);
+CREATE INDEX IF NOT EXISTS ix_event_execution       ON event(execution_id);
+CREATE INDEX IF NOT EXISTS ix_skill_invocation_wave ON skill_invocation(wave_id);
+CREATE INDEX IF NOT EXISTS ix_wave_execution        ON wave(execution_id);

--- a/global/skills/agente-00c-runtime/scripts/_bloqueios-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_bloqueios-db.sh
@@ -1,0 +1,267 @@
+#!/bin/sh
+# _bloqueios-db.sh — implementacao do backend SQLite para bloqueios.sh
+# (feature state-db-foundation, FASE 3 task 3.5).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.5
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C3 C4 C5 C6 C8
+#      docs/specs/state-db-foundation/data-model.md §Entity BloqueioHumano (human_block)
+#
+# NAO e executavel diretamente. Sourced por bloqueios.sh, que ja fez
+# `. _state-db.sh` e `. _state-rw-db.sh` antes — depende de sql_escape/
+# strip_nul/_state_db_*/_sr_db_file/_sr_backend/_sr_exec_id/_sr_sql_quote
+# (reuso dos primitivos ja testados das tasks 3.1/3.2, mesmo racional de C8
+# documentado em _state-db.sh e replicado em _state-decisions-db.sh).
+#
+# Funcoes expostas (todas exigem STATE_DIR ja resolvido para backend sqlite
+# pelo caller via _sr_backend, e state.db existente):
+#   _bl_db_register DIR DEC_ID PERGUNTA CONTEXTO OPCOES_JSON
+#                                              -> C4: grava o bloqueio E muda
+#                                                 .execution.status para
+#                                                 "aguardando_humano" na
+#                                                 MESMA transacao BEGIN
+#                                                 IMMEDIATE ... COMMIT. O
+#                                                 numero sequencial de
+#                                                 block-NNN e calculado por
+#                                                 subquery DENTRO do proprio
+#                                                 INSERT (mesmo padrao de
+#                                                 _sd_db_register/dec-NNN —
+#                                                 nunca por leitura separada
+#                                                 antes do BEGIN IMMEDIATE).
+#                                                 C3: decisao_id inexistente
+#                                                 dispara a FK real
+#                                                 (human_block.decision_id
+#                                                 REFERENCES decision(id)) —
+#                                                 o INSERT falha, a transacao
+#                                                 inteira reverte (nenhuma
+#                                                 mudanca de status), e o
+#                                                 erro e mapeado para a mesma
+#                                                 mensagem/exit 1 do path
+#                                                 JSON. Imprime "block-NNN"
+#                                                 em stdout (paridade C1).
+#   _bl_db_respond DIR BLOCK_ID RESPOSTA      -> C4: UPDATE do human_block
+#                                                 (status/human_answer/
+#                                                 answered_at) e, se nao
+#                                                 restar nenhum bloqueio
+#                                                 aguardando, UPDATE de
+#                                                 execution.status para
+#                                                 "em_andamento" — mesma
+#                                                 transacao.
+#   _bl_db_list DIR [STATUS]                  -> TSV id/decision_id/status/
+#                                                 triggered_at/question
+#                                                 (paridade com o formato do
+#                                                 path JSON)
+#   _bl_db_count DIR [PENDING]                -> imprime o total (inteiro);
+#                                                 PENDING="1" filtra
+#                                                 status='aguardando'
+#   _bl_db_next_id DIR                        -> imprime o proximo
+#                                                 "block-NNN" SEM registrar
+#                                                 (leitura pura)
+#   _bl_db_get DIR BLOCK_ID                   -> imprime o JSON do bloqueio
+#                                                 (mesmos campos/ordem do
+#                                                 path JSON)
+
+# _bl_db_next_block_num_expr EXEC_ID_SQL_QUOTED -> imprime a subquery escalar
+# que calcula o proximo numero sequencial de block-NNN para a execution
+# dada. Mesma logica de _sd_db_next_num_expr (state-decisions), adaptada ao
+# prefixo "block-" (6 chars, substr a partir da posicao 7, 1-indexed).
+_bl_db_next_block_num_expr() {
+  printf '(SELECT coalesce(max(cast(substr(id,7) as integer)),0)+1 FROM human_block WHERE execution_id=%s)' "$1"
+}
+
+# _bl_db_exec_capture DB SQL [BUSY_MS] -> mesmo backoff/retry sob lock (C6)
+# de _sd_db_exec_capture (state-decisions), MAS com uma diferenca de
+# invocacao deliberada: este helper e chamado DIRETAMENTE como comando
+# simples — `if _bl_db_exec_capture DB SQL; then ...; fi` — NUNCA dentro de
+# `$(...)`. Motivo: o caller (register/respond) precisa inspecionar o TEXTO
+# do erro apos a falha para diferenciar FK (C3, mensagem amigavel dedicada)
+# de qualquer outra causa; `$(...)` sempre forka uma subshell (POSIX), e
+# qualquer atribuicao feita DENTRO dela — inclusive a uma variavel "global"
+# como $_bl_db_last_err — e descartada quando a subshell termina e nunca
+# chega ao shell chamador. Por isso o resultado e devolvido via duas
+# globais (não pelo stdout de um `$(...)`): $_bl_db_last_out (sucesso) e
+# $_bl_db_last_err (falha); o exit code sinaliza qual delas ler.
+_bl_db_last_out=""
+_bl_db_last_err=""
+_bl_db_exec_capture() {
+  _blc_db="$1"; _blc_sql="$2"; _blc_ms="${3:-5000}"
+  _blc_try=1
+  _bl_db_last_out=""
+  _bl_db_last_err=""
+  while [ "$_blc_try" -le 4 ]; do
+    _blc_errfile=$(mktemp) || return 1
+    # `if x=$(cmd); then ... else ...; fi`, NAO uma atribuicao nua seguida
+    # de `rc=$?`: sob `set -e` (bloqueios.sh sempre roda com `set -eu`),
+    # `x=$(cmd)` cujo `cmd` falha dispara saida imediata do shell inteiro —
+    # a atribuicao nua nao esta numa lista if/while/&&/|| que a isente de
+    # -e (POSIX 2.8.1). Mesmo bug corrigido em _sd_db_exec_capture
+    # (_state-decisions-db.sh, task 3.4) — sem este guard, o retry/lock
+    # (C6) e o mapeamento de erro FK (C3) abaixo nunca eram alcancados: o
+    # processo morria silenciosamente na primeira falha nao-zero de
+    # _state_db_exec.
+    if _blc_out=$(_state_db_exec "$_blc_db" "$_blc_sql" "$_blc_ms" 2>"$_blc_errfile"); then
+      _blc_rc=0
+    else
+      _blc_rc=$?
+    fi
+    _blc_err=$(cat -- "$_blc_errfile" 2>/dev/null)
+    rm -f -- "$_blc_errfile"
+    if [ "$_blc_rc" -eq 0 ]; then
+      _bl_db_last_out="$_blc_out"
+      return 0
+    fi
+    case "$_blc_err" in
+      *"database is locked"*|*"database is busy"*|*"locking protocol"*)
+        _state_db_backoff_sleep "$_blc_try"
+        _blc_try=$((_blc_try + 1))
+        ;;
+      *)
+        _bl_db_last_err="$_blc_err"
+        return 1
+        ;;
+    esac
+  done
+  _bl_db_last_err="$_blc_err"
+  return 1
+}
+
+# ---------- register ----------
+
+_bl_db_register() {
+  _bdr_sdir="$1"; _bdr_dec="$2"; _bdr_perg="$3"; _bdr_ctx="$4"; _bdr_opcoes="$5"
+
+  _bdr_db=$(_sr_db_file "$_bdr_sdir")
+  [ -f "$_bdr_db" ] || _bl_die "register: state.db ausente em $_bdr_sdir" 1
+  _bdr_exec_id=$(_sr_exec_id "$_bdr_db")
+  [ -n "$_bdr_exec_id" ] || _bl_die "register: execution ausente em $_bdr_db" 1
+
+  _bdr_now=$(_bl_iso_now)
+
+  _bdr_opts_sql="NULL"
+  if [ "$_bdr_opcoes" != "null" ]; then
+    _bdr_opts_c=$(printf '%s' "$_bdr_opcoes" | jq -c '.' 2>/dev/null) || _bdr_opts_c="$_bdr_opcoes"
+    _bdr_opts_sql=$(_sr_sql_quote "$_bdr_opts_c")
+  fi
+
+  _bdr_exec_id_sql=$(_sr_sql_quote "$_bdr_exec_id")
+  _bdr_dec_sql=$(_sr_sql_quote "$_bdr_dec")
+  _bdr_id_expr=$(_bl_db_next_block_num_expr "$_bdr_exec_id_sql")
+
+  # C4: INSERT do human_block + UPDATE de execution.status, numa unica
+  # transacao. O id novo e lido de volta via last_insert_rowid() ANTES do
+  # COMMIT (isolado por conexao, nunca enxerga commit de outro escritor) —
+  # mesmo padrao de _sd_db_register para evitar colisao sob concorrencia.
+  _bdr_sql="BEGIN IMMEDIATE; INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,recommended_options,status,human_answer,triggered_at,answered_at) VALUES ('block-' || printf('%03d',$_bdr_id_expr),$_bdr_exec_id_sql,$_bdr_dec_sql,$(_sr_sql_quote "$_bdr_perg"),$(_sr_sql_quote "$_bdr_ctx"),$_bdr_opts_sql,'aguardando',NULL,$(_sr_sql_quote "$_bdr_now"),NULL); UPDATE execution SET status='aguardando_humano' WHERE id=$_bdr_exec_id_sql; SELECT id FROM human_block WHERE rowid=last_insert_rowid(); COMMIT;"
+
+  # Chamada DIRETA (nunca dentro de $(...)) — ver nota de cabecalho de
+  # _bl_db_exec_capture: e so assim que $_bl_db_last_err sobrevive a
+  # chamada para o `case` abaixo poder diferenciar FK (C3) de erro generico.
+  if _bl_db_exec_capture "$_bdr_db" "$_bdr_sql"; then
+    _bdr_id="$_bl_db_last_out"
+  else
+    case "$_bl_db_last_err" in
+      *"FOREIGN KEY constraint failed"*)
+        _bl_die "register: decisao_id nao existe: $_bdr_dec (use state-decisions.sh register antes)" 1
+        ;;
+      *)
+        [ -n "$_bl_db_last_err" ] && printf '%s\n' "$_bl_db_last_err" >&2
+        _bl_die "register: INSERT falhou (backend sqlite) — ver stderr acima" 1
+        ;;
+    esac
+  fi
+  [ -n "$_bdr_id" ] || _bl_die "register: INSERT nao retornou id (backend sqlite)" 1
+  printf '%s\n' "$_bdr_id"
+}
+
+# ---------- respond ----------
+
+_bl_db_respond() {
+  _bdrp_sdir="$1"; _bdrp_bid="$2"; _bdrp_resp="$3"
+
+  _bdrp_db=$(_sr_db_file "$_bdrp_sdir")
+  [ -f "$_bdrp_db" ] || _bl_die "respond: state.db ausente em $_bdrp_sdir" 1
+  _bdrp_exec_id=$(_sr_exec_id "$_bdrp_db")
+  [ -n "$_bdrp_exec_id" ] || _bl_die "respond: execution ausente em $_bdrp_db" 1
+  _bdrp_exec_id_sql=$(_sr_sql_quote "$_bdrp_exec_id")
+
+  _bdrp_status=$(_state_db_exec "$_bdrp_db" \
+    "SELECT status FROM human_block WHERE id=$(_sr_sql_quote "$_bdrp_bid") AND execution_id=$_bdrp_exec_id_sql;")
+  case "$_bdrp_status" in
+    aguardando) ;;
+    "")
+      diag_emit error bloqueio-not-found "respond: bloqueio nao encontrado: $_bdrp_bid" \
+        "confira o id com bloqueios.sh list --state-dir $_bdrp_sdir (block-id invalido ou ja respondido)" || :
+      _bl_die "respond: bloqueio nao encontrado: $_bdrp_bid" 1
+      ;;
+    *) _bl_die "respond: bloqueio $_bdrp_bid nao esta em status aguardando (status=$_bdrp_status)" 1 ;;
+  esac
+
+  _bdrp_now=$(_bl_iso_now)
+
+  # C4: fecha o bloqueio e, se nao restar nenhum outro aguardando, promove
+  # execution.status de volta a "em_andamento" — numa unica transacao.
+  _bdrp_sql="BEGIN IMMEDIATE; UPDATE human_block SET status='respondido', human_answer=$(_sr_sql_quote "$_bdrp_resp"), answered_at=$(_sr_sql_quote "$_bdrp_now") WHERE id=$(_sr_sql_quote "$_bdrp_bid") AND execution_id=$_bdrp_exec_id_sql; UPDATE execution SET status='em_andamento' WHERE id=$_bdrp_exec_id_sql AND NOT EXISTS (SELECT 1 FROM human_block WHERE execution_id=$_bdrp_exec_id_sql AND status='aguardando'); COMMIT;"
+
+  if ! _bl_db_exec_capture "$_bdrp_db" "$_bdrp_sql"; then
+    [ -n "$_bl_db_last_err" ] && printf '%s\n' "$_bl_db_last_err" >&2
+    _bl_die "respond: UPDATE falhou (backend sqlite) — ver stderr acima" 1
+  fi
+}
+
+# ---------- list ----------
+
+_bl_db_list() {
+  _bdl_sdir="$1"; _bdl_status="$2"
+  _bdl_db=$(_sr_db_file "$_bdl_sdir")
+  [ -f "$_bdl_db" ] || _bl_die "list: state.db ausente em $_bdl_sdir" 1
+  _bdl_exec_id=$(_sr_exec_id "$_bdl_db")
+  [ -n "$_bdl_exec_id" ] || _bl_die "list: execution ausente em $_bdl_db" 1
+
+  _bdl_where="execution_id=$(_sr_sql_quote "$_bdl_exec_id")"
+  [ -n "$_bdl_status" ] && _bdl_where="$_bdl_where AND status=$(_sr_sql_quote "$_bdl_status")"
+
+  _state_db_exec "$_bdl_db" \
+    "SELECT id || char(9) || decision_id || char(9) || status || char(9) || triggered_at || char(9) || question FROM human_block WHERE $_bdl_where ORDER BY rowid;"
+}
+
+# ---------- count ----------
+
+_bl_db_count() {
+  _bdc_sdir="$1"; _bdc_pending="$2"
+  _bdc_db=$(_sr_db_file "$_bdc_sdir")
+  [ -f "$_bdc_db" ] || _bl_die "count: state.db ausente em $_bdc_sdir" 1
+  _bdc_exec_id=$(_sr_exec_id "$_bdc_db")
+  [ -n "$_bdc_exec_id" ] || _bl_die "count: execution ausente em $_bdc_db" 1
+  if [ "$_bdc_pending" = "1" ]; then
+    _state_db_exec "$_bdc_db" \
+      "SELECT count(*) FROM human_block WHERE execution_id=$(_sr_sql_quote "$_bdc_exec_id") AND status='aguardando';"
+  else
+    _state_db_exec "$_bdc_db" \
+      "SELECT count(*) FROM human_block WHERE execution_id=$(_sr_sql_quote "$_bdc_exec_id");"
+  fi
+}
+
+# ---------- next-id ----------
+
+_bl_db_next_id() {
+  _bdn_sdir="$1"
+  _bdn_db=$(_sr_db_file "$_bdn_sdir")
+  [ -f "$_bdn_db" ] || _bl_die "next-id: state.db ausente em $_bdn_sdir" 1
+  _bdn_exec_id=$(_sr_exec_id "$_bdn_db")
+  [ -n "$_bdn_exec_id" ] || _bl_die "next-id: execution ausente em $_bdn_db" 1
+  _bdn_expr=$(_bl_db_next_block_num_expr "$(_sr_sql_quote "$_bdn_exec_id")")
+  _state_db_exec "$_bdn_db" "SELECT 'block-' || printf('%03d',$_bdn_expr);"
+}
+
+# ---------- get ----------
+
+_bl_db_get() {
+  _bdg_sdir="$1"; _bdg_bid="$2"
+  _bdg_db=$(_sr_db_file "$_bdg_sdir")
+  [ -f "$_bdg_db" ] || _bl_die "get: state.db ausente em $_bdg_sdir" 1
+  _bdg_exec_id=$(_sr_exec_id "$_bdg_db")
+  [ -n "$_bdg_exec_id" ] || _bl_die "get: execution ausente em $_bdg_db" 1
+
+  _bdg_out=$(_state_db_exec "$_bdg_db" "SELECT json_object('id',id,'decision_id',decision_id,'question',question,'context_for_answer',context_for_answer,'recommended_options',json(coalesce(recommended_options,'null')),'status',status,'human_answer',human_answer,'triggered_at',triggered_at,'answered_at',answered_at) FROM human_block WHERE id=$(_sr_sql_quote "$_bdg_bid") AND execution_id=$(_sr_sql_quote "$_bdg_exec_id");")
+  [ -n "$_bdg_out" ] || _bl_die "get: bloqueio nao encontrado: $_bdg_bid" 1
+  printf '%s\n' "$_bdg_out"
+}

--- a/global/skills/agente-00c-runtime/scripts/_spawn-tracker-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_spawn-tracker-db.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# _spawn-tracker-db.sh — implementacao do backend SQLite para
+# spawn-tracker.sh (feature state-db-foundation, FASE 3 task 3.6).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.6
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C3 C5 C6
+#      docs/specs/state-db-foundation/data-model.md (execution.subagent_depth,
+#      execution.max_recursion, CHECK 3 — teto de profundidade)
+#
+# NAO e executavel diretamente. Sourced por spawn-tracker.sh, que ja fez
+# `. _state-db.sh` e `. _state-rw-db.sh` antes — depende de sql_escape/
+# strip_nul/_state_db_*/_sr_db_file/_sr_backend/_sr_exec_id/_sr_sql_quote
+# (reuso dos primitivos ja testados de state-rw.sh, mesmo racional de C8
+# documentado em _state-db.sh e replicado em _bloqueios-db.sh/
+# _state-decisions-db.sh).
+#
+# Escopo desta task (C1/C3): apenas a coluna execution.subagent_depth (teto
+# execution.max_recursion, espelho de _ST_MAX=3). O campo
+# accumulated_metrics.max_depth_reached/subagents_spawned permanece o
+# placeholder ja documentado no cabecalho de _sr_db_read (task 3.2 —
+# 'max_depth_reached' = subagent_depth corrente, 'subagents_spawned' = 0):
+# gap conhecido entre export.md e data-model.md (schema fechado em 9
+# entidades sem coluna dedicada para contador cumulativo de spawns), fora
+# do escopo desta task — spawn-tracker.sh nao inventa uma coluna nova aqui.
+#
+# Funcoes expostas (todas exigem STATE_DIR ja resolvido para backend sqlite
+# pelo caller via _sr_backend, e state.db existente):
+#   _st_db_get_current STATE_DIR  -> imprime subagent_depth corrente (leitura pura)
+#   _st_db_get_max STATE_DIR      -> imprime max_recursion (leitura pura)
+#   _st_db_check STATE_DIR        -> exit 0 (pode spawnar +1) | exit 3 (teto,
+#                                     paridade C1/C3 com spawn-tracker.sh check)
+#   _st_db_enter STATE_DIR        -> valida ANTES de escrever (mesmo padrao do
+#                                     path JSON — nunca depende do CHECK do
+#                                     schema para reportar o teto); exit 3 SEM
+#                                     gravar se excederia MAX; senao UPDATE
+#                                     (via _state_db_exec_with_retry, C6) +
+#                                     stdout com a nova profundidade
+#   _st_db_leave STATE_DIR        -> idempotente em depth<=1 (nao grava,
+#                                     stdout=depth atual); senao UPDATE +
+#                                     stdout com a nova profundidade
+#   _st_db_current STATE_DIR      -> imprime subagent_depth corrente
+
+_st_db_get_current() {
+  _stdbc_db=$(_sr_db_file "$1")
+  _state_db_exec "$_stdbc_db" "SELECT subagent_depth FROM execution LIMIT 1;"
+}
+
+_st_db_get_max() {
+  _stdbm_db=$(_sr_db_file "$1")
+  _state_db_exec "$_stdbm_db" "SELECT max_recursion FROM execution LIMIT 1;"
+}
+
+_st_db_check() {
+  _stdck_sdir="$1"
+  _stdck_db=$(_sr_db_file "$_stdck_sdir")
+  [ -f "$_stdck_db" ] || _st_die "check: state.db ausente em $_stdck_sdir" 1
+  _stdck_curr=$(_st_db_get_current "$_stdck_sdir")
+  _stdck_max=$(_st_db_get_max "$_stdck_sdir")
+  [ -n "$_stdck_curr" ] || _st_die "check: execution ausente em $_stdck_db" 1
+  _stdck_next=$((_stdck_curr + 1))
+  if [ "$_stdck_next" -gt "$_stdck_max" ]; then
+    printf '%s: profundidade no limite (corrente=%s, MAX=%s) — spawn negado\n' \
+      "$_ST_NAME" "$_stdck_curr" "$_stdck_max" >&2
+    exit 3
+  fi
+  exit 0
+}
+
+_st_db_enter() {
+  _stden_sdir="$1"
+  _stden_db=$(_sr_db_file "$_stden_sdir")
+  [ -f "$_stden_db" ] || _st_die "enter: state.db ausente em $_stden_sdir" 1
+  _stden_exec_id=$(_sr_exec_id "$_stden_db")
+  [ -n "$_stden_exec_id" ] || _st_die "enter: execution ausente em $_stden_db" 1
+
+  _stden_curr=$(_st_db_get_current "$_stden_sdir")
+  _stden_max=$(_st_db_get_max "$_stden_sdir")
+  _stden_next=$((_stden_curr + 1))
+  # Validacao ANTES de qualquer escrita (mesmo padrao do path JSON) —
+  # deliberadamente NAO delegado ao CHECK do schema: precisamos da mensagem
+  # + exit 3 SEM depender do texto de erro do SQLite (paridade C1 exata com
+  # spawn-tracker.sh check/enter hoje).
+  if [ "$_stden_next" -gt "$_stden_max" ]; then
+    printf '%s: enter negado — profundidade %s -> %s excederia MAX %s\n' \
+      "$_ST_NAME" "$_stden_curr" "$_stden_next" "$_stden_max" >&2
+    exit 3
+  fi
+
+  _stden_exec_id_sql=$(_sr_sql_quote "$_stden_exec_id")
+  _stden_sql="UPDATE execution SET subagent_depth=$_stden_next WHERE id=$_stden_exec_id_sql;"
+  _state_db_exec_with_retry "$_stden_db" "$_stden_sql" \
+    || _st_die "enter: UPDATE falhou (backend sqlite) — ver stderr acima" 1
+
+  printf '%s\n' "$_stden_next"
+}
+
+_st_db_leave() {
+  _stdlv_sdir="$1"
+  _stdlv_db=$(_sr_db_file "$_stdlv_sdir")
+  [ -f "$_stdlv_db" ] || _st_die "leave: state.db ausente em $_stdlv_sdir" 1
+  _stdlv_exec_id=$(_sr_exec_id "$_stdlv_db")
+  [ -n "$_stdlv_exec_id" ] || _st_die "leave: execution ausente em $_stdlv_db" 1
+
+  _stdlv_curr=$(_st_db_get_current "$_stdlv_sdir")
+  if [ "$_stdlv_curr" -le 1 ]; then
+    # Idempotente: orquestrador raiz tem profundidade 1; nao baixa abaixo.
+    printf '%s\n' "$_stdlv_curr"
+    return 0
+  fi
+  _stdlv_next=$((_stdlv_curr - 1))
+
+  _stdlv_exec_id_sql=$(_sr_sql_quote "$_stdlv_exec_id")
+  _stdlv_sql="UPDATE execution SET subagent_depth=$_stdlv_next WHERE id=$_stdlv_exec_id_sql;"
+  _state_db_exec_with_retry "$_stdlv_db" "$_stdlv_sql" \
+    || _st_die "leave: UPDATE falhou (backend sqlite) — ver stderr acima" 1
+
+  printf '%s\n' "$_stdlv_next"
+}
+
+_st_db_current() {
+  _stdcu_sdir="$1"
+  _stdcu_db=$(_sr_db_file "$_stdcu_sdir")
+  [ -f "$_stdcu_db" ] || _st_die "current: state.db ausente em $_stdcu_sdir" 1
+  _st_db_get_current "$_stdcu_sdir"
+}

--- a/global/skills/agente-00c-runtime/scripts/_state-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_state-db.sh
@@ -72,10 +72,22 @@ strip_nul() {
 # Diferente de recall_pragmas (cli/lib/recall.sh): aqui foreign_keys=ON
 # (state.db e fonte de verdade transacional com FKs reais entre as 9
 # entidades) em vez de OFF (recall.sh e um indice derivado sem FK).
+#
+# `.output /dev/null` ... `.output stdout` em volta dos PRAGMAs suprime o
+# eco de `PRAGMA busy_timeout=N` — achado em campo na task 3.2 (state-rw.sh
+# dual-backend): o sqlite3 CLI trata `busy_timeout` como "pragma de
+# consulta" e IMPRIME o novo valor como uma linha de resultado
+# (`PRAGMA foreign_keys=ON` nao tem esse efeito colateral). Sem a supressao,
+# todo caller que capture stdout de _state_db_exec para uma SELECT recebia
+# "N\n<resultado real>", corrompendo silenciosamente qualquer leitura —
+# so nao havia sido percebido porque as chamadas ate aqui (task 3.1) eram
+# todas de mutacao (INSERT), cujo stdout ninguem inspecionava.
 _state_db_pragmas() {
   _sdb_ms="${1:-5000}"
+  printf '.output /dev/null\n'
   printf 'PRAGMA foreign_keys=ON;\n'
   printf 'PRAGMA busy_timeout=%s;\n' "$_sdb_ms"
+  printf '.output stdout\n'
 }
 
 # _state_db_exec DB SQL [BUSY_MS] -> aplica SQL sobre DB com os PRAGMAs de

--- a/global/skills/agente-00c-runtime/scripts/_state-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_state-db.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+# _state-db.sh — helpers sourceaveis compartilhados do backend SQLite do
+# state.db (FASE 3 task 3.1).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.1
+#      docs/specs/state-db-foundation/contracts/primitives.md §C5 (PRAGMAs),
+#      §C6 (concorrencia), §C8 (escape de texto livre), §C9 (permissoes)
+#
+# NAO e executavel diretamente. Use:
+#   . "$(dirname -- "$0")/_state-db.sh"
+#
+# Funcoes expostas:
+#   sql_escape VALUE                    -> imprime VALUE com ' duplicado
+#   strip_nul                           -> le stdin, imprime sem bytes NUL
+#   _state_db_pragmas [BUSY_MS]         -> imprime "PRAGMA foreign_keys=ON;"
+#                                          + "PRAGMA busy_timeout=<BUSY_MS>;"
+#                                          (default 5000)
+#   _state_db_exec DB SQL [BUSY_MS]     -> invoca sqlite3 com os PRAGMAs de
+#                                          C5 SEMPRE prefixados ao SQL da
+#                                          mutacao (stdin -> sqlite3 -- DB)
+#   _state_db_exec_with_retry DB SQL [BUSY_MS]
+#                                        -> _state_db_exec com retry/backoff
+#                                          sob "database is locked"/"is
+#                                          busy"/"locking protocol" (ate 4
+#                                          tentativas, backoff com jitter
+#                                          por-PID). CONTRATO DE FALHA
+#                                          DIFERENTE de
+#                                          recall_apply_sql_with_retry
+#                                          (cli/lib/recall.sh): lock
+#                                          persistente apos as 4 tentativas
+#                                          MUST sair nao-zero — callers desta
+#                                          funcao NUNCA devem engolir esse
+#                                          retorno (C6). recall.sh degrada
+#                                          silenciosamente porque seu indice
+#                                          e derivado/best-effort; o state.db
+#                                          e fonte de verdade transacional e
+#                                          NAO pode.
+#   _state_db_secure_perms DB           -> chmod 600 em DB + sidecars WAL
+#                                          (-wal/-shm), best-effort (C9)
+#
+# Nota de deploy (por que sql_escape/strip_nul sao uma copia, nao um source
+# cross-boundary de cli/lib/recall.sh): cli/lib/ (runtime `cstk`, atualizado
+# via `cstk self-update`, instalado em ~/.local) e global/skills/ (catalogo
+# de skills, atualizado via `cstk install`/`cstk update`, instalado em
+# ~/.claude) sao duas unidades de deploy INDEPENDENTES — ver CLAUDE.md "cstk
+# install vs self-update". `source`-ar um arquivo do catalogo de skills a
+# partir de cli/lib (ou vice-versa) acopla runtimes que podem estar em
+# versoes diferentes num dado momento (um `self-update` sem `update`
+# correspondente, ou vice-versa), quebrando silenciosamente se o outro lado
+# nao existir no ambiente (ex.: `cstk` standalone sem catalogo de skills
+# instalado). recall.sh ja segue este principio: consome secrets-filter.sh
+# (agente-00c-runtime/scripts) como SUBPROCESSO resolvido em runtime, nunca
+# via `source`. Por isso sql_escape/strip_nul permanecem definidas nos dois
+# lados com o MESMO algoritmo (nao uma reimplementacao alternativa) —
+# paridade garantida por tests/test__state-db.sh (compara byte-a-byte a saida
+# das duas copias para o mesmo conjunto de payloads, incluindo o payload
+# hostil de C8) em vez de acoplamento em tempo de execucao.
+
+# sql_escape VALUE -> imprime VALUE com aspas simples duplicadas (' -> '').
+# Copia identica ao algoritmo de cli/lib/recall.sh:215-218 (ver nota acima).
+sql_escape() {
+  printf '%s' "$1" | sed "s/'/''/g"
+}
+
+# strip_nul reads stdin -> imprime stdin sem bytes NUL.
+# Copia identica ao algoritmo de cli/lib/recall.sh:347-349 (ver nota acima).
+strip_nul() {
+  tr -d '\000'
+}
+
+# _state_db_pragmas [BUSY_MS] -> imprime os PRAGMAs obrigatorios de C5.
+# Diferente de recall_pragmas (cli/lib/recall.sh): aqui foreign_keys=ON
+# (state.db e fonte de verdade transacional com FKs reais entre as 9
+# entidades) em vez de OFF (recall.sh e um indice derivado sem FK).
+_state_db_pragmas() {
+  _sdb_ms="${1:-5000}"
+  printf 'PRAGMA foreign_keys=ON;\n'
+  printf 'PRAGMA busy_timeout=%s;\n' "$_sdb_ms"
+}
+
+# _state_db_exec DB SQL [BUSY_MS] -> aplica SQL sobre DB com os PRAGMAs de
+# C5 sempre prefixados. stdin/stdout/stderr do sqlite3 sao preservados
+# (caller decide se quer capturar). Exit: o do sqlite3 (0 sucesso).
+_state_db_exec() {
+  _sde_db="$1"
+  _sde_sql="$2"
+  _sde_ms="${3:-5000}"
+  { _state_db_pragmas "$_sde_ms"; printf '%s\n' "$_sde_sql"; } | sqlite3 -- "$_sde_db"
+}
+
+# _state_db_backoff_sleep TRY -> dorme ~TRY segundos + jitter fracionario
+# [0,1)s derivado do PID (evita thundering herd entre escritores que
+# colidiram no mesmo instante). Mesmo algoritmo de recall_backoff_sleep
+# (cli/lib/recall.sh) — duplicado pela mesma razao de fronteira de deploy
+# documentada no cabecalho deste arquivo.
+_state_db_backoff_sleep() {
+  _sdbo_base="$1"
+  _sdbo_frac=$(awk -v p="$$" -v t="$_sdbo_base" 'BEGIN{srand(p*7+t); printf "%02d", int(rand()*100)}' 2>/dev/null)
+  [ -n "$_sdbo_frac" ] || _sdbo_frac="00"
+  sleep "${_sdbo_base}.${_sdbo_frac}" 2>/dev/null || sleep "$_sdbo_base"
+}
+
+# _state_db_exec_with_retry DB SQL [BUSY_MS] -> _state_db_exec com retry sob
+# lock (ate 4 tentativas). CONTRATO DE FALHA: retorna 1 se esgotar as
+# tentativas (lock persistente) OU se o erro nao for de lock — em AMBOS os
+# casos o stderr da ultima tentativa e ecoado em stderr desta funcao para
+# diagnostico. Callers MUST propagar esse retorno como falha dura (exit
+# nao-zero do script), nunca best-effort/silencioso — diferenca deliberada
+# face a recall_apply_sql_with_retry (ver nota do cabecalho, C6).
+_state_db_exec_with_retry() {
+  _sder_db="$1"
+  _sder_sql="$2"
+  _sder_ms="${3:-5000}"
+  _sder_try=1
+  while [ "$_sder_try" -le 4 ]; do
+    _sder_err=$(_state_db_exec "$_sder_db" "$_sder_sql" "$_sder_ms" 2>&1 >/dev/null) && return 0
+    case "$_sder_err" in
+      *"database is locked"*|*"database is busy"*|*"locking protocol"*)
+        _state_db_backoff_sleep "$_sder_try"
+        _sder_try=$((_sder_try + 1))
+        ;;
+      *)
+        [ -n "$_sder_err" ] && printf '%s\n' "$_sder_err" >&2
+        return 1
+        ;;
+    esac
+  done
+  [ -n "${_sder_err:-}" ] && printf '%s\n' "$_sder_err" >&2
+  return 1
+}
+
+# _state_db_secure_perms DB -> chmod 600 em DB e nos sidecars WAL
+# (-wal/-shm), best-effort (sidecar pode nao existir ainda). Padrao ja usado
+# em otel-usage.sh:262 e state-db-schema.sh — C9, finding S3.
+_state_db_secure_perms() {
+  _sdsp_db="$1"
+  chmod 600 -- "$_sdsp_db" 2>/dev/null || :
+  chmod 600 -- "$_sdsp_db-wal" 2>/dev/null || :
+  chmod 600 -- "$_sdsp_db-shm" 2>/dev/null || :
+}

--- a/global/skills/agente-00c-runtime/scripts/_state-decisions-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_state-decisions-db.sh
@@ -1,0 +1,216 @@
+#!/bin/sh
+# _state-decisions-db.sh — implementacao do backend SQLite para
+# state-decisions.sh (feature state-db-foundation, FASE 3 task 3.4).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.4
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C4 C5 C6 C8
+#      docs/specs/state-db-foundation/data-model.md §Entity Decisao
+#      (wave_id: NULL representa "init" — nao ha wave ainda)
+#
+# NAO e executavel diretamente. Sourced por state-decisions.sh, que ja fez
+# `. _state-db.sh` e `. _state-rw-db.sh` antes — depende de sql_escape/
+# strip_nul/_state_db_*/_sr_db_file/_sr_backend/_sr_exec_id/_sr_sql_quote
+# (reuso dos primitivos ja testados das tasks 3.1/3.2, nao reimplementacao —
+# mesmo racional de C8 documentado em _state-db.sh).
+#
+# Funcoes expostas (todas exigem STATE_DIR ja resolvido para backend sqlite
+# pelo caller via _sr_backend, e state.db existente):
+#   _sd_db_register DIR AGENT STAGE CTX OPTS_JSON CHOICE RATIONALE \
+#                    SCORE EVIDENCE REFS_JSON ORIG_ARTIFACT
+#                                              -> INSERT do dec-NNN novo numa
+#                                                 unica transacao (C4), com o
+#                                                 numero calculado por
+#                                                 subquery DENTRO do proprio
+#                                                 INSERT (nunca por leitura
+#                                                 separada antes do BEGIN
+#                                                 IMMEDIATE — e exatamente
+#                                                 essa leitura separada que
+#                                                 colidiria sob concorrencia,
+#                                                 task 3.4.3). Imprime
+#                                                 "dec-NNN" em stdout
+#                                                 (paridade C1).
+#   _sd_db_count DIR [AGENT]                  -> imprime o total (inteiro)
+#   _sd_db_next_id DIR                        -> imprime o proximo "dec-NNN"
+#                                                 SEM registrar (leitura pura)
+#   _sd_db_list DIR [AGENT] [STAGE]           -> TSV id/wave_id/agent/stage/
+#                                                 choice (paridade com o
+#                                                 formato do path JSON;
+#                                                 wave_id NULL -> "init" na
+#                                                 saida, mesma convencao do
+#                                                 documento JSON)
+#
+# GAP CONHECIDO E DOCUMENTADO (mesmo espirito da nota de _state-rw-db.sh):
+# o export completo (`state-rw.sh read`, FASE 3.2) reconstroi
+# `.decisions[].wave_id` a partir da coluna SQL crua — quando NULL (nenhuma
+# onda existia no momento do register), o export emite JSON `null`, nao a
+# string literal "init" que o path JSON grava. Aqui em `list` a saida
+# textual É normalizada para "init" (parity de leitura pontual); a
+# normalizacao equivalente no export completo fica fora do escopo desta task
+# (pertence a FASE 3.2, ja implementada e testada) — registrado como nota
+# para eventual sugestao futura, nao um bug silencioso: nenhum dado se
+# perde, o campo apenas aparece como null em vez de "init" nesse caminho
+# especifico.
+
+# _sd_db_next_num_expr EXEC_ID_SQL_QUOTED -> imprime a subquery escalar que
+# calcula o proximo numero sequencial de dec-NNN para a execution dada.
+# Mesma logica do lado JSON (_sd_next_dec_id): extrai os 3 digitos apos o
+# prefixo "dec-" (posicao 5 em diante, 1-indexed), converte para inteiro,
+# soma 1 sobre o maximo (0 se nao houver nenhuma decisao ainda).
+_sd_db_next_num_expr() {
+  printf '(SELECT coalesce(max(cast(substr(id,5) as integer)),0)+1 FROM decision WHERE execution_id=%s)' "$1"
+}
+
+# _sd_db_exec_capture DB SQL [BUSY_MS] -> como _state_db_exec_with_retry
+# (mesmo backoff/retry sob lock, mesmo contrato de falha C6: lock
+# persistente apos 4 tentativas MUST sair nao-zero), mas PRESERVA o stdout
+# da tentativa vencedora.
+#
+# Por que nao reusar _state_db_exec_with_retry diretamente: aquela funcao
+# descarta stdout por desenho (`2>&1 >/dev/null`) — nenhum caller de FASE
+# 3.2/3.3 precisava do stdout da transacao (sempre fazem uma leitura
+# SEPARADA depois do COMMIT para reportar). `register` nao pode seguir esse
+# padrao: o id novo PRECISA ser lido de DENTRO da mesma transacao (via
+# `last_insert_rowid()`, antes do COMMIT) para nao colidir sob concorrencia
+# — uma leitura separada apos o COMMIT poderia enxergar o dec-NNN de OUTRO
+# escritor que tenha comitado no meio (task 3.4.3). Duplicar o loop de
+# retry aqui (em vez de generalizar o helper compartilhado) mantem
+# _state-db.sh estavel para os callers ja testados de 3.1/3.2/3.3.
+_sd_db_exec_capture() {
+  _sdc_db="$1"; _sdc_sql="$2"; _sdc_ms="${3:-5000}"
+  _sdc_try=1
+  while [ "$_sdc_try" -le 4 ]; do
+    _sdc_errfile=$(mktemp) || return 1
+    _sdc_out=$(_state_db_exec "$_sdc_db" "$_sdc_sql" "$_sdc_ms" 2>"$_sdc_errfile")
+    _sdc_rc=$?
+    _sdc_err=$(cat -- "$_sdc_errfile" 2>/dev/null)
+    rm -f -- "$_sdc_errfile"
+    if [ "$_sdc_rc" -eq 0 ]; then
+      printf '%s\n' "$_sdc_out"
+      return 0
+    fi
+    case "$_sdc_err" in
+      *"database is locked"*|*"database is busy"*|*"locking protocol"*)
+        _state_db_backoff_sleep "$_sdc_try"
+        _sdc_try=$((_sdc_try + 1))
+        ;;
+      *)
+        [ -n "$_sdc_err" ] && printf '%s\n' "$_sdc_err" >&2
+        return 1
+        ;;
+    esac
+  done
+  [ -n "${_sdc_err:-}" ] && printf '%s\n' "$_sdc_err" >&2
+  return 1
+}
+
+# _sd_db_current_wave_id DB EXEC_ID -> id da ultima onda por seq (NAO
+# necessariamente aberta), ou "" se nenhuma onda existe ainda. Paridade
+# exata com _sd_current_onda_id do path JSON (.waves[-1].id), que tambem
+# nao filtra por onda aberta/fechada — so pelo default "init" quando o
+# array esta vazio.
+_sd_db_current_wave_id() {
+  _sdw_db="$1"; _sdw_exec_id="$2"
+  _state_db_exec "$_sdw_db" \
+    "SELECT id FROM wave WHERE execution_id=$(_sr_sql_quote "$_sdw_exec_id") ORDER BY seq DESC LIMIT 1;"
+}
+
+# ---------- register ----------
+
+_sd_db_register() {
+  _sdb_sdir="$1"; _sdb_agent="$2"; _sdb_stage="$3"; _sdb_ctx="$4"
+  _sdb_opts="$5"; _sdb_choice="$6"; _sdb_rationale="$7"; _sdb_score="$8"
+  _sdb_evi="$9"
+  shift 9
+  _sdb_refs="$1"; _sdb_orig="$2"
+
+  _sdb_db=$(_sr_db_file "$_sdb_sdir")
+  [ -f "$_sdb_db" ] || _sd_die "register: state.db ausente em $_sdb_sdir" 1
+  _sdb_exec_id=$(_sr_exec_id "$_sdb_db")
+  [ -n "$_sdb_exec_id" ] || _sd_die "register: execution ausente em $_sdb_db" 1
+
+  _sdb_wid=$(_sd_db_current_wave_id "$_sdb_db" "$_sdb_exec_id")
+  _sdb_wid_sql="NULL"
+  [ -n "$_sdb_wid" ] && _sdb_wid_sql=$(_sr_sql_quote "$_sdb_wid")
+
+  _sdb_now=$(_sd_iso_now)
+
+  _sdb_score_sql="NULL"
+  [ "$_sdb_score" != "null" ] && _sdb_score_sql="$_sdb_score"
+
+  _sdb_evi_sql="NULL"
+  [ -n "$_sdb_evi" ] && _sdb_evi_sql=$(_sr_sql_quote "$_sdb_evi")
+
+  _sdb_orig_sql="NULL"
+  [ -n "$_sdb_orig" ] && [ "$_sdb_orig" != "null" ] && _sdb_orig_sql=$(_sr_sql_quote "$_sdb_orig")
+
+  # options_considered/references ja foram validados como JSON array pelo
+  # caller (state-decisions.sh, antes do dispatch de backend) — compactamos
+  # aqui so por higiene de armazenamento (paridade com _sr_db_upsert_decision,
+  # que usa `jq -c` no mesmo par de campos).
+  _sdb_opts_c=$(printf '%s' "$_sdb_opts" | jq -c '.' 2>/dev/null) || _sdb_opts_c="$_sdb_opts"
+  _sdb_refs_c=$(printf '%s' "$_sdb_refs" | jq -c '.' 2>/dev/null) || _sdb_refs_c="$_sdb_refs"
+
+  _sdb_exec_id_sql=$(_sr_sql_quote "$_sdb_exec_id")
+  _sdb_id_expr=$(_sd_db_next_num_expr "$_sdb_exec_id_sql")
+
+  # C4: id novo (via subquery), insercao e leitura do proprio id inserido
+  # (last_insert_rowid(), isolado por conexao — nunca enxerga commit de
+  # outro escritor) na MESMA transacao BEGIN IMMEDIATE ... COMMIT. Isso e o
+  # que garante nao colidir sob concorrencia (task 3.4.3): um segundo
+  # escritor so consegue seu proprio BEGIN IMMEDIATE apos o primeiro
+  # COMMITar, e nesse momento seu MAX(...) ja enxerga a linha do primeiro.
+  _sdb_sql="BEGIN IMMEDIATE; INSERT INTO decision (id,execution_id,wave_id,timestamp,agent,stage,context,options_considered,choice,rationale,justification_score,evidence,\"references\",originating_artifact) VALUES ('dec-' || printf('%03d',$_sdb_id_expr),$_sdb_exec_id_sql,$_sdb_wid_sql,$(_sr_sql_quote "$_sdb_now"),$(_sr_sql_quote "$_sdb_agent"),$(_sr_sql_quote "$_sdb_stage"),$(_sr_sql_quote "$_sdb_ctx"),$(_sr_sql_quote "$_sdb_opts_c"),$(_sr_sql_quote "$_sdb_choice"),$(_sr_sql_quote "$_sdb_rationale"),$_sdb_score_sql,$_sdb_evi_sql,$(_sr_sql_quote "$_sdb_refs_c"),$_sdb_orig_sql); SELECT id FROM decision WHERE rowid=last_insert_rowid(); COMMIT;"
+
+  _sdb_id=$(_sd_db_exec_capture "$_sdb_db" "$_sdb_sql") \
+    || _sd_die "register: INSERT falhou (backend sqlite) — ver stderr acima" 1
+  [ -n "$_sdb_id" ] || _sd_die "register: INSERT nao retornou id (backend sqlite)" 1
+  printf '%s\n' "$_sdb_id"
+}
+
+# ---------- count ----------
+
+_sd_db_count() {
+  _sdc_sdir="$1"; _sdc_agent="$2"
+  _sdc_db=$(_sr_db_file "$_sdc_sdir")
+  [ -f "$_sdc_db" ] || _sd_die "count: state.db ausente em $_sdc_sdir" 1
+  _sdc_exec_id=$(_sr_exec_id "$_sdc_db")
+  [ -n "$_sdc_exec_id" ] || _sd_die "count: execution ausente em $_sdc_db" 1
+  if [ -n "$_sdc_agent" ]; then
+    _state_db_exec "$_sdc_db" \
+      "SELECT count(*) FROM decision WHERE execution_id=$(_sr_sql_quote "$_sdc_exec_id") AND agent=$(_sr_sql_quote "$_sdc_agent");"
+  else
+    _state_db_exec "$_sdc_db" \
+      "SELECT count(*) FROM decision WHERE execution_id=$(_sr_sql_quote "$_sdc_exec_id");"
+  fi
+}
+
+# ---------- next-id ----------
+
+_sd_db_next_id() {
+  _sdn_sdir="$1"
+  _sdn_db=$(_sr_db_file "$_sdn_sdir")
+  [ -f "$_sdn_db" ] || _sd_die "next-id: state.db ausente em $_sdn_sdir" 1
+  _sdn_exec_id=$(_sr_exec_id "$_sdn_db")
+  [ -n "$_sdn_exec_id" ] || _sd_die "next-id: execution ausente em $_sdn_db" 1
+  _sdn_expr=$(_sd_db_next_num_expr "$(_sr_sql_quote "$_sdn_exec_id")")
+  _state_db_exec "$_sdn_db" "SELECT 'dec-' || printf('%03d',$_sdn_expr);"
+}
+
+# ---------- list ----------
+
+_sd_db_list() {
+  _sdl_sdir="$1"; _sdl_agent="$2"; _sdl_stage="$3"
+  _sdl_db=$(_sr_db_file "$_sdl_sdir")
+  [ -f "$_sdl_db" ] || _sd_die "list: state.db ausente em $_sdl_sdir" 1
+  _sdl_exec_id=$(_sr_exec_id "$_sdl_db")
+  [ -n "$_sdl_exec_id" ] || _sd_die "list: execution ausente em $_sdl_db" 1
+
+  _sdl_where="execution_id=$(_sr_sql_quote "$_sdl_exec_id")"
+  [ -n "$_sdl_agent" ] && _sdl_where="$_sdl_where AND agent=$(_sr_sql_quote "$_sdl_agent")"
+  [ -n "$_sdl_stage" ] && _sdl_where="$_sdl_where AND stage=$(_sr_sql_quote "$_sdl_stage")"
+
+  # wave_id NULL -> "init" na saida textual (mesma convencao de exibicao do
+  # path JSON; ver nota de GAP CONHECIDO no cabecalho deste arquivo).
+  _state_db_exec "$_sdl_db" \
+    "SELECT id || char(9) || coalesce(wave_id,'init') || char(9) || agent || char(9) || stage || char(9) || choice FROM decision WHERE $_sdl_where ORDER BY rowid;"
+}

--- a/global/skills/agente-00c-runtime/scripts/_state-decisions-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_state-decisions-db.sh
@@ -80,8 +80,21 @@ _sd_db_exec_capture() {
   _sdc_try=1
   while [ "$_sdc_try" -le 4 ]; do
     _sdc_errfile=$(mktemp) || return 1
-    _sdc_out=$(_state_db_exec "$_sdc_db" "$_sdc_sql" "$_sdc_ms" 2>"$_sdc_errfile")
-    _sdc_rc=$?
+    # `if _sdc_out=$(...); then ... else ...; fi` (NAO uma atribuicao nua
+    # seguida de `_sdc_rc=$?`): sob `set -e` (o caller sempre roda com
+    # `set -eu`), uma atribuicao `x=$(cmd)` cujo `cmd` falha DISPARA saida
+    # imediata do shell inteiro — a atribuicao nao esta numa lista
+    # if/while/&&/|| que a isente de -e (POSIX 2.8.1). Bug latente achado
+    # na task 3.5 (bloqueios.sh dual-backend), corrigido aqui por
+    # compartilhar exatamente o mesmo padrao: o `case` de retry/lock (C6)
+    # abaixo nunca era alcancado sob erro nao-lock nem sob lock persistente
+    # — o processo morria silenciosamente na primeira falha de
+    # `_state_db_exec`, pulando o backoff/retry inteiro.
+    if _sdc_out=$(_state_db_exec "$_sdc_db" "$_sdc_sql" "$_sdc_ms" 2>"$_sdc_errfile"); then
+      _sdc_rc=0
+    else
+      _sdc_rc=$?
+    fi
     _sdc_err=$(cat -- "$_sdc_errfile" 2>/dev/null)
     rm -f -- "$_sdc_errfile"
     if [ "$_sdc_rc" -eq 0 ]; then

--- a/global/skills/agente-00c-runtime/scripts/_state-ondas-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_state-ondas-db.sh
@@ -20,7 +20,17 @@
 #                                                 via ux_wave_single_open)
 #   _so_db_end DIR MOTIVO PROXIMA ETAPAS_RAW NEXT_SET NEXT_RAW
 #                                              -> fecha a onda aberta (uma
-#                                                 unica transacao, C4)
+#                                                 unica transacao, C4). Apos
+#                                                 o COMMIT, dispara o export
+#                                                 derivado (FASE 5,
+#                                                 contracts/export.md E5/E6
+#                                                 — _so_export_snapshot,
+#                                                 definida em
+#                                                 state-ondas.sh) como
+#                                                 gatilho automatico de
+#                                                 FR-013-INFRA-BACKUP;
+#                                                 best-effort, nunca reverte
+#                                                 o fechamento ja commitado
 #   _so_db_tool_call_tick DIR                 -> UPDATE wave.tool_calls+=1
 #                                                 na onda aberta
 #   _so_db_record_skill DIR SKILL DEC KIND    -> INSERT idempotente em
@@ -258,6 +268,17 @@ _so_db_end() {
 
   _state_db_exec_with_retry "$_e_db" "$_e_sql" \
     || _so_die "end: UPDATE de onda falhou (backend sqlite)" 1
+
+  # Export derivado (FASE 5, contracts/export.md E5/E6, dec-032 E5-a):
+  # gatilho automatico ao fim da onda — reaproveita o export como mecanismo
+  # de FR-013-INFRA-BACKUP sob backend SQLite sem introduzir backup nativo
+  # do SQLite (research.md Decision 6). Roda DEPOIS do COMMIT acima: a
+  # fonte de verdade (state.db) ja fechou a onda; E6 (MUST) exige que uma
+  # falha aqui NUNCA reverta nem impeca esse fechamento — so degrada,
+  # reportada em stderr por _so_export_snapshot (definida em
+  # state-ondas.sh, disponivel neste escopo por sourcing).
+  _so_export_snapshot "$_e_sdir" >/dev/null \
+    || _so_log "end: export/backup derivado nao gerado nesta onda (E6: fechamento da onda ja commitado, nao afetado) [backend sqlite]"
 
   _so_ticks_reset "$_e_sdir"
   _so_agent_usage_reset "$_e_sdir"

--- a/global/skills/agente-00c-runtime/scripts/_state-ondas-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_state-ondas-db.sh
@@ -1,0 +1,452 @@
+#!/bin/sh
+# _state-ondas-db.sh — implementacao do backend SQLite para state-ondas.sh
+# (feature state-db-foundation, FASE 3 task 3.3).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.3
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C3 C4 C6
+#      docs/specs/state-db-foundation/data-model.md (entities wave/
+#      skill_invocation/task_outcome)
+#
+# NAO e executavel diretamente. Sourced por state-ondas.sh, que ja fez
+# `. _state-db.sh` e `. _state-rw-db.sh` antes — depende de sql_escape/
+# strip_nul/_state_db_*/_sr_db_file/_sr_backend/_sr_exec_id/_sr_sql_quote
+# (reuso deliberado dos primitivos ja testados da task 3.2, nao
+# reimplementacao — mesmo racional de C8 para sql_escape/strip_nul).
+#
+# Funcoes expostas (todas exigem STATE_DIR ja resolvido para backend sqlite
+# pelo caller via _sr_backend, e state.db existente):
+#   _so_db_start DIR                          -> INSERT de nova onda (C3:
+#                                                 onda ja aberta => exit 1,
+#                                                 via ux_wave_single_open)
+#   _so_db_end DIR MOTIVO PROXIMA ETAPAS_RAW NEXT_SET NEXT_RAW
+#                                              -> fecha a onda aberta (uma
+#                                                 unica transacao, C4)
+#   _so_db_tool_call_tick DIR                 -> UPDATE wave.tool_calls+=1
+#                                                 na onda aberta
+#   _so_db_record_skill DIR SKILL DEC KIND    -> INSERT idempotente em
+#                                                 skill_invocation (ultima
+#                                                 onda por seq, igual ao
+#                                                 .waves[-1] do path JSON)
+#   _so_db_record_task DIR TID TTL WID OC TR TP LK AF ORIGEM IFABSENT
+#                                              -> upsert em task_outcome
+#                                                 (ON CONFLICT DO UPDATE, ou
+#                                                 DO NOTHING se IFABSENT=yes)
+#   _so_db_reconcile_tasks DIR TASKS_MD WID DRY
+#                                              -> back-fill deterministico a
+#                                                 partir do tasks.md
+#   _so_db_wave_status DIR                    -> none|open|closed
+#   _so_db_current_id DIR                     -> onda-NNN ou "init"
+#
+# GAP CONHECIDO E DOCUMENTADO (nao um bug silencioso, mesmo padrao da nota
+# de _state-rw-db.sh): o hook marco-aware de retrospectiva proativa
+# (_so_retro_milestone_fire, definido em state-ondas.sh) opera sobre
+# state.json via jq direto no arquivo. Sob backend SQLite isso e um no-op
+# silencioso e SEGURO (arquivo ausente -> jq falha -> _so_retro_milestone_due
+# retorna 1 -> hook nunca dispara), nao uma falha de `end`. Adaptar esse hook
+# para consultar o state.db exigiria tocar Decisao/Bloqueio tambem sob
+# backend dual — fora do escopo de "Adaptar state-ondas.sh" (task 3.3, que
+# cobre apenas start/end/wave-status/current-id, record-skill/record-task/
+# reconcile-tasks, tool-call-tick/git-commit). Rastreado como gap conhecido.
+
+# ---------- Helpers de agregacao (duplicados deliberadamente de
+# _so_cmd_end no path JSON — ver nota de risco no cabecalho: preferimos
+# duplicar ~15 linhas de jq a arriscar regressao no path JSON ja testado
+# refatorando-o para uma funcao compartilhada) ----------
+
+# _so_db_aggregate_agent_usage SPAWNS_JSON -> objeto agent_usage agregado
+# (ou "null"). Mesma semantica de _so_cmd_end (path JSON): so agrega o que
+# foi de fato observado no sidecar, nunca fabrica.
+_so_db_aggregate_agent_usage() {
+  printf '%s' "$1" | jq -c '
+    . as $sp
+    | ($sp | length) as $total
+    | ([$sp[] | select(.status != "indisponivel")] | length) as $with_usage
+    | ($total - $with_usage) as $unavailable
+    | def sum_field(f): ([$sp[] | select(f != null) | f]) as $vals
+        | if ($vals | length) > 0 then ($vals | add) else null end;
+      if $total > 0 then {
+        spawns_total: $total,
+        spawns_with_usage: $with_usage,
+        spawns_unavailable: $unavailable,
+        total_tokens: sum_field(.total_tokens),
+        input_tokens: sum_field(.input_tokens),
+        output_tokens: sum_field(.output_tokens),
+        cache_read_input_tokens: sum_field(.cache_read_input_tokens),
+        cache_creation_input_tokens: sum_field(.cache_creation_input_tokens),
+        tool_use_count: sum_field(.tool_use_count),
+        duration_ms: sum_field(.duration_ms)
+      } else null end
+  ' 2>/dev/null
+}
+
+# ---------- Parsing de tasks.md (duplicado deliberadamente das duas awk
+# inline de _so_cmd_reconcile_tasks — mesmo racional de risco acima) ----------
+
+# _so_tasks_md_titlemap TASKS_MD -> stdout "id<TAB>titulo" por task com
+# titulo resolvivel (heading tem precedencia sobre checkbox).
+_so_tasks_md_titlemap() {
+  awk '
+    { sub(/\r$/, "") }
+    /^### / {
+      line = $0; sub(/^### +/, "", line)
+      split(line, a, /[ \t]+/); id = a[1]
+      if (id ~ /^[0-9]+(\.[0-9]+)+(-bis(\.[0-9]+)*)?$/) {
+        t = line; sub(/^[^ \t]+[ \t]+/, "", t)
+        gsub(/`/, "", t); sub(/[ \t]*\[[CAM]\][ \t]*$/, "", t)
+        gsub(/\t/, " ", t); gsub(/  +/, " ", t)
+        sub(/^ +/, "", t); sub(/ +$/, "", t)
+        if (t != "") heading[id] = t
+      }
+      next
+    }
+    /^- \[.\] / {
+      line = $0; sub(/^- \[.\][ \t]+/, "", line)
+      split(line, a, /[ \t]+/); id = a[1]
+      if (id ~ /^[0-9]+(\.[0-9]+)+(-bis(\.[0-9]+)*)?$/) {
+        t = line; sub(/^[^ \t]+[ \t]+/, "", t)
+        gsub(/`/, "", t); gsub(/\t/, " ", t); gsub(/  +/, " ", t)
+        sub(/^ +/, "", t); sub(/ +$/, "", t)
+        if (t != "" && !(id in checkbox)) checkbox[id] = t
+      }
+      next
+    }
+    END {
+      for (k in checkbox) if (!(k in heading)) print k "\t" checkbox[k]
+      for (k in heading) print k "\t" heading[k]
+    }
+  ' "$1"
+}
+
+# _so_tasks_md_missing TASKS_MD EXISTING_IDS_FILE -> stdout "id<TAB>titulo"
+# por task CONCLUIDA (todas as subtarefas-checkbox [x]) ausente de EXISTING.
+_so_tasks_md_missing() {
+  _tmm_md="$1"; _tmm_exf="$2"
+  awk -v exf="$_tmm_exf" '
+    { sub(/\r$/, "") }
+    FILENAME == exf { seen[$0] = 1; next }
+    function flush() {
+      if (cur != "" && nsub > 0 && ndone == nsub && !(cur in seen)) {
+        print cur "\t" titulo
+      }
+      cur = ""; titulo = ""; nsub = 0; ndone = 0
+    }
+    /^#/ {
+      flush()
+      if ($0 ~ /^### /) {
+        line = $0; sub(/^### +/, "", line)
+        split(line, a, /[ \t]+/); id = a[1]
+        if (id ~ /^[0-9]+(\.[0-9]+)+(-bis(\.[0-9]+)*)?$/) {
+          cur = id
+          t = line; sub(/^[^ \t]+[ \t]+/, "", t)
+          gsub(/`/, "", t); sub(/[ \t]*\[[CAM]\][ \t]*$/, "", t)
+          gsub(/\t/, " ", t)
+          titulo = t
+        }
+      }
+      next
+    }
+    /^- \[.\] / {
+      if (cur != "") {
+        st = substr($0, 4, 1)
+        nsub++
+        if (st == "x" || st == "X") ndone++
+      }
+      next
+    }
+    END { flush() }
+  ' "$_tmm_exf" "$_tmm_md"
+}
+
+# ---------- start ----------
+
+_so_db_start() {
+  _sdb_sdir="$1"
+  _sdb_db=$(_sr_db_file "$_sdb_sdir")
+  [ -f "$_sdb_db" ] || _so_die "start: state.db ausente em $_sdb_sdir" 1
+  _sdb_exec_id=$(_sr_exec_id "$_sdb_db")
+  [ -n "$_sdb_exec_id" ] || _so_die "start: execution ausente em $_sdb_db" 1
+
+  _sdb_num=$(_state_db_exec "$_sdb_db" \
+    "SELECT coalesce(max(seq),0)+1 FROM wave WHERE execution_id=$(_sr_sql_quote "$_sdb_exec_id");")
+  case "$_sdb_num" in ''|*[!0-9]*) _so_die "start: falha ao calcular seq da onda (backend sqlite)" 1 ;; esac
+  _sdb_id=$(printf 'onda-%03d' "$_sdb_num")
+  _sdb_now=$(_so_iso_now)
+
+  _sdb_sql="BEGIN IMMEDIATE; INSERT INTO wave (id,execution_id,seq,started_at,finished_at,tool_calls,termination_reason,next_wave_scheduled_for,executed_stages,agent_usage,agent_spawns,otel_usage,extra_fields) VALUES ($(_sr_sql_quote "$_sdb_id"),$(_sr_sql_quote "$_sdb_exec_id"),$_sdb_num,$(_sr_sql_quote "$_sdb_now"),NULL,0,NULL,NULL,$(_sr_sql_quote '[]'),NULL,NULL,NULL,NULL); COMMIT;"
+
+  # C3: onda ja aberta viola ux_wave_single_open — a constraint do banco
+  # falha o INSERT; _state_db_exec_with_retry ja ecoa o erro sqlite3 em
+  # stderr (nunca silenciado).
+  _state_db_exec_with_retry "$_sdb_db" "$_sdb_sql" \
+    || _so_die "start: INSERT de onda falhou (onda ja aberta, ou erro de banco — ver stderr acima) [backend sqlite]" 1
+
+  # Sidecares + baseline + OTel: backend-agnosticos (arquivos no state-dir,
+  # nao no state.db) — mesma sequencia do path JSON.
+  _so_ticks_reset "$_sdb_sdir"
+  _so_agent_usage_reset "$_sdb_sdir"
+  _so_start_snapshot_baseline "$_sdb_sdir"
+  _so_otel_reset "$_sdb_sdir"
+  _so_otel_snapshot "$_sdb_sdir" start
+
+  printf '%s\n' "$_sdb_id"
+}
+
+# ---------- end ----------
+
+_so_db_end() {
+  _e_sdir="$1"; _e_motivo="$2"; _e_proxima="$3"; _e_etapas_raw="$4"
+  _e_next_set="$5"; _e_next_raw="$6"
+
+  _e_db=$(_sr_db_file "$_e_sdir")
+  [ -f "$_e_db" ] || _so_die "end: state.db ausente em $_e_sdir" 1
+  _e_exec_id=$(_sr_exec_id "$_e_db")
+  [ -n "$_e_exec_id" ] || _so_die "end: execution ausente em $_e_db" 1
+
+  _e_wid=$(_state_db_exec "$_e_db" \
+    "SELECT id FROM wave WHERE execution_id=$(_sr_sql_quote "$_e_exec_id") AND termination_reason IS NULL;")
+  if [ -z "$_e_wid" ]; then
+    diag_emit error no-open-wave "end: nao ha onda em andamento" \
+      "rode state-ondas.sh start antes de end, ou confira se .waves ja foi fechado por outra chamada" || :
+    _so_die "end: nao ha onda em andamento" 1
+  fi
+
+  _e_started=$(_state_db_exec "$_e_db" "SELECT started_at FROM wave WHERE id=$(_sr_sql_quote "$_e_wid");")
+  _e_now=$(_so_iso_now)
+  _e_wc=$(_so_wallclock "$_e_started" "$_e_now") || true
+
+  _e_tc_field=$(_state_db_exec "$_e_db" "SELECT tool_calls FROM wave WHERE id=$(_sr_sql_quote "$_e_wid");")
+  case "$_e_tc_field" in ''|*[!0-9]*) _e_tc_field=0 ;; esac
+  _e_tc_side=$(_so_ticks_count "$_e_sdir")
+  _e_tc=$((_e_tc_field + _e_tc_side))
+
+  _e_cur_stages=$(_state_db_exec "$_e_db" "SELECT coalesce(executed_stages,'[]') FROM wave WHERE id=$(_sr_sql_quote "$_e_wid");")
+  _e_etapas_json=$(printf '%s\n' "$_e_etapas_raw" | sed '/^$/d' | jq -R . | jq -s .)
+  _e_stages_merged=$(printf '%s' "$_e_cur_stages" | jq -c --argjson add "$_e_etapas_json" '. + $add') \
+    || _so_die "end: falha ao mesclar executed_stages (backend sqlite)" 1
+
+  _e_proxima_sql="NULL"
+  [ "$_e_proxima" != "null" ] && _e_proxima_sql=$(_sr_sql_quote "$_e_proxima")
+
+  _e_next_instr_sql=""
+  if [ "$_e_next_set" = 1 ]; then
+    [ -n "$_e_next_raw" ] || _so_die "end: --next-instruction nao aceita valor vazio" 1
+    _e_next_instr_sql=$(_sr_sql_quote "$_e_next_raw")
+  fi
+
+  # Agregacao do sidecar de uso de agente — mesma semantica do path JSON
+  # (data-model.md "Entity: Consumo Agregado da Onda"), nunca fabrica.
+  _e_spawns=$(_so_agent_usage_read "$_e_sdir")
+  _e_au=$(_so_db_aggregate_agent_usage "$_e_spawns") || _e_au="null"
+  [ -n "$_e_au" ] || _e_au="null"
+
+  # Consumo OTel — sidecares TSV, backend-agnosticos.
+  _so_otel_snapshot "$_e_sdir" end
+  _e_otel=$(_so_otel_delta "$_e_sdir")
+  case "$_e_otel" in ''|null) _e_otel="null" ;; esac
+
+  _e_spawns_sql="NULL"; [ "$_e_spawns" != "[]" ] && [ -n "$_e_spawns" ] && _e_spawns_sql=$(_sr_sql_quote "$_e_spawns")
+  _e_au_sql="NULL"; [ "$_e_au" != "null" ] && _e_au_sql=$(_sr_sql_quote "$_e_au")
+  _e_otel_sql="NULL"; [ "$_e_otel" != "null" ] && _e_otel_sql=$(_sr_sql_quote "$_e_otel")
+
+  # C4: fechamento da onda + atualizacao de next_instruction na MESMA
+  # transacao (paridade com o write atomico unico do path JSON).
+  _e_sql="BEGIN IMMEDIATE; UPDATE wave SET finished_at=$(_sr_sql_quote "$_e_now"), wallclock_seconds=$_e_wc, tool_calls=$_e_tc, termination_reason=$(_sr_sql_quote "$_e_motivo"), next_wave_scheduled_for=$_e_proxima_sql, executed_stages=$(_sr_sql_quote "$_e_stages_merged"), agent_usage=$_e_au_sql, agent_spawns=$_e_spawns_sql, otel_usage=$_e_otel_sql WHERE id=$(_sr_sql_quote "$_e_wid");"
+  if [ "$_e_next_set" = 1 ]; then
+    _e_sql="$_e_sql UPDATE execution SET next_instruction=$_e_next_instr_sql WHERE id=$(_sr_sql_quote "$_e_exec_id");"
+  fi
+  _e_sql="$_e_sql COMMIT;"
+
+  _state_db_exec_with_retry "$_e_db" "$_e_sql" \
+    || _so_die "end: UPDATE de onda falhou (backend sqlite)" 1
+
+  _so_ticks_reset "$_e_sdir"
+  _so_agent_usage_reset "$_e_sdir"
+  _so_otel_reset "$_e_sdir"
+  _so_log "end: onda finalizada (motivo=$_e_motivo, wallclock=${_e_wc}s, tool_calls=$_e_tc) [backend sqlite]"
+
+  # Hook marco-aware de retrospectiva: ver GAP CONHECIDO no cabecalho deste
+  # arquivo. Deliberadamente NAO chamado aqui sob backend sqlite.
+}
+
+# ---------- tool-call-tick ----------
+
+_so_db_tool_call_tick() {
+  _sdb_sdir="$1"
+  _sdb_db=$(_sr_db_file "$_sdb_sdir")
+  [ -f "$_sdb_db" ] || _so_die "tool-call-tick: state.db ausente" 1
+  _sdb_exec_id=$(_sr_exec_id "$_sdb_db")
+  [ -n "$_sdb_exec_id" ] || _so_die "tool-call-tick: execution ausente" 1
+  _sdb_wid=$(_state_db_exec "$_sdb_db" \
+    "SELECT id FROM wave WHERE execution_id=$(_sr_sql_quote "$_sdb_exec_id") AND termination_reason IS NULL;")
+  [ -n "$_sdb_wid" ] || _so_die "tool-call-tick: nenhuma onda aberta (backend sqlite) — rode state-ondas.sh start primeiro" 1
+  _state_db_exec_with_retry "$_sdb_db" \
+    "BEGIN IMMEDIATE; UPDATE wave SET tool_calls = tool_calls + 1 WHERE id = $(_sr_sql_quote "$_sdb_wid"); COMMIT;" \
+    || _so_die "tool-call-tick: UPDATE falhou (backend sqlite)" 1
+  _state_db_exec "$_sdb_db" "SELECT tool_calls FROM wave WHERE id = $(_sr_sql_quote "$_sdb_wid");"
+}
+
+# ---------- record-skill ----------
+
+_so_db_record_skill() {
+  _sdb_sdir="$1"; _sdb_skill="$2"; _sdb_dec="$3"; _sdb_kind="$4"
+  _sdb_db=$(_sr_db_file "$_sdb_sdir")
+  [ -f "$_sdb_db" ] || _so_die "record-skill: state.db ausente em $_sdb_sdir" 1
+  _sdb_exec_id=$(_sr_exec_id "$_sdb_db")
+  [ -n "$_sdb_exec_id" ] || _so_die "record-skill: execution ausente" 1
+
+  # Ultima onda por seq (nao necessariamente aberta) — paridade exata com
+  # o path JSON, que grava em .waves[-1] independente de estar fechada.
+  _sdb_wid=$(_state_db_exec "$_sdb_db" \
+    "SELECT id FROM wave WHERE execution_id=$(_sr_sql_quote "$_sdb_exec_id") ORDER BY seq DESC LIMIT 1;")
+  if [ -z "$_sdb_wid" ]; then
+    diag_emit error no-open-wave "record-skill: nenhuma onda em andamento (rode state-ondas.sh start primeiro)" \
+      "rode state-ondas.sh start antes de record-skill" || :
+    _so_die "record-skill: nenhuma onda em andamento (rode state-ondas.sh start primeiro)" 1
+  fi
+
+  _sdb_now=$(_so_iso_now)
+  _sdb_dec_cmp="decision_id IS NULL"
+  _sdb_dec_val="NULL"
+  if [ -n "$_sdb_dec" ]; then
+    _sdb_dec_cmp="decision_id = $(_sr_sql_quote "$_sdb_dec")"
+    _sdb_dec_val=$(_sr_sql_quote "$_sdb_dec")
+  fi
+
+  # INSERT ... SELECT ... WHERE NOT EXISTS: check-then-insert atomico numa
+  # unica statement, sem race entre a checagem e a escrita (C4/C6).
+  _sdb_sql="BEGIN IMMEDIATE; INSERT INTO skill_invocation (wave_id,skill,timestamp,decision_id,kind) SELECT $(_sr_sql_quote "$_sdb_wid"),$(_sr_sql_quote "$_sdb_skill"),$(_sr_sql_quote "$_sdb_now"),$_sdb_dec_val,$(_sr_sql_quote "$_sdb_kind") WHERE NOT EXISTS (SELECT 1 FROM skill_invocation WHERE wave_id=$(_sr_sql_quote "$_sdb_wid") AND skill=$(_sr_sql_quote "$_sdb_skill") AND $_sdb_dec_cmp); COMMIT;"
+  _state_db_exec_with_retry "$_sdb_db" "$_sdb_sql" \
+    || _so_die "record-skill: INSERT falhou (backend sqlite)" 1
+  _state_db_exec "$_sdb_db" "SELECT count(*) FROM skill_invocation WHERE wave_id=$(_sr_sql_quote "$_sdb_wid");"
+}
+
+# ---------- record-task ----------
+
+# _so_db_record_task DIR TID TTL WID OC TR TP LK AF ORIGEM IFABSENT
+# LK ja normalizado pelo caller para o literal "true"|"false"|"null".
+_so_db_record_task() {
+  _sdb_sdir="$1"; _sdb_tid="$2"; _sdb_ttl="$3"; _sdb_wid="$4"; _sdb_oc="$5"
+  _sdb_tr="$6"; _sdb_tp="$7"; _sdb_lk="$8"; _sdb_af="$9"
+  _sdb_origem="${10}"; _sdb_ifabsent="${11}"
+
+  _sdb_db=$(_sr_db_file "$_sdb_sdir")
+  [ -f "$_sdb_db" ] || _so_die "record-task: state.db ausente em $_sdb_sdir" 1
+  _sdb_exec_id=$(_sr_exec_id "$_sdb_db")
+  [ -n "$_sdb_exec_id" ] || _so_die "record-task: execution ausente" 1
+
+  if [ -z "$_sdb_wid" ]; then
+    _sdb_wid=$(_state_db_exec "$_sdb_db" \
+      "SELECT id FROM wave WHERE execution_id=$(_sr_sql_quote "$_sdb_exec_id") ORDER BY seq DESC LIMIT 1;")
+  fi
+
+  _sdb_now=$(_so_iso_now)
+  _sdb_lint_sql="NULL"
+  case "$_sdb_lk" in true) _sdb_lint_sql=1 ;; false) _sdb_lint_sql=0 ;; esac
+  _sdb_src_sql="NULL"
+  [ -n "$_sdb_origem" ] && _sdb_src_sql=$(_sr_sql_quote "$_sdb_origem")
+
+  _sdb_conflict="DO UPDATE SET title=excluded.title, wave_id=excluded.wave_id, outcome=excluded.outcome, tests_run=excluded.tests_run, tests_passed=excluded.tests_passed, lint_ok=excluded.lint_ok, touched_files=excluded.touched_files, recorded_at=excluded.recorded_at, source=excluded.source"
+  [ "$_sdb_ifabsent" = "yes" ] && _sdb_conflict="DO NOTHING"
+
+  _sdb_sql="BEGIN IMMEDIATE; INSERT INTO task_outcome (execution_id,task_id,title,wave_id,outcome,tests_run,tests_passed,lint_ok,touched_files,recorded_at,source) VALUES ($(_sr_sql_quote "$_sdb_exec_id"),$(_sr_sql_quote "$_sdb_tid"),$(_sr_sql_quote "$_sdb_ttl"),$(_sr_sql_quote "$_sdb_wid"),$(_sr_sql_quote "$_sdb_oc"),$_sdb_tr,$_sdb_tp,$_sdb_lint_sql,$(_sr_sql_quote "$_sdb_af"),$(_sr_sql_quote "$_sdb_now"),$_sdb_src_sql) ON CONFLICT(execution_id,task_id) $_sdb_conflict; COMMIT;"
+  _state_db_exec_with_retry "$_sdb_db" "$_sdb_sql" \
+    || _so_die "record-task: upsert falhou (backend sqlite)" 1
+  _state_db_exec "$_sdb_db" "SELECT count(*) FROM task_outcome WHERE execution_id=$(_sr_sql_quote "$_sdb_exec_id");"
+}
+
+# ---------- reconcile-tasks ----------
+
+_so_db_reconcile_tasks() {
+  _rc_sdir="$1"; _rc_md="$2"; _rc_wid="$3"; _rc_dry="$4"
+
+  _rc_db=$(_sr_db_file "$_rc_sdir")
+  [ -f "$_rc_db" ] || _so_die "reconcile-tasks: state.db ausente em $_rc_sdir" 1
+  _rc_exec_id=$(_sr_exec_id "$_rc_db")
+  [ -n "$_rc_exec_id" ] || _so_die "reconcile-tasks: execution ausente" 1
+
+  if [ -z "$_rc_wid" ]; then
+    _rc_wid=$(_state_db_exec "$_rc_db" \
+      "SELECT id FROM wave WHERE execution_id=$(_sr_sql_quote "$_rc_exec_id") ORDER BY seq DESC LIMIT 1;")
+  fi
+
+  # Cura de titulos vazios — mesma fonte rastreavel do path JSON (heading/
+  # checkbox do tasks.md), nunca inventada (Principio VI).
+  if [ "$_rc_dry" != "yes" ]; then
+    _rc_titlemap=$(_so_tasks_md_titlemap "$_rc_md")
+    if [ -n "$_rc_titlemap" ]; then
+      while IFS="$(printf '\t')" read -r _rc_hid _rc_httl; do
+        [ -n "$_rc_hid" ] || continue
+        _state_db_exec_with_retry "$_rc_db" \
+          "BEGIN IMMEDIATE; UPDATE task_outcome SET title=$(_sr_sql_quote "$_rc_httl") WHERE execution_id=$(_sr_sql_quote "$_rc_exec_id") AND task_id=$(_sr_sql_quote "$_rc_hid") AND (title IS NULL OR title=''); COMMIT;" \
+          || _so_log "reconcile-tasks: cura de titulo falhou para $_rc_hid (best-effort, ignorado)"
+      done <<EOF
+$_rc_titlemap
+EOF
+    fi
+  fi
+
+  _rc_exfile=$(mktemp) || _so_die "mktemp falhou" 1
+  _state_db_exec "$_rc_db" "SELECT task_id FROM task_outcome WHERE execution_id=$(_sr_sql_quote "$_rc_exec_id");" > "$_rc_exfile"
+
+  _rc_missing=$(_so_tasks_md_missing "$_rc_md" "$_rc_exfile")
+  rm -f -- "$_rc_exfile" 2>/dev/null || :
+
+  if [ -z "$_rc_missing" ]; then
+    [ "$_rc_dry" = "yes" ] || printf '0\n'
+    return 0
+  fi
+  if [ "$_rc_dry" = "yes" ]; then
+    printf '%s\n' "$_rc_missing" | cut -f1
+    return 0
+  fi
+
+  _rc_count=0
+  while IFS="$(printf '\t')" read -r _rc_id _rc_ttl; do
+    [ -n "$_rc_id" ] || continue
+    _so_db_record_task "$_rc_sdir" "$_rc_id" "$_rc_ttl" "$_rc_wid" pass 0 0 null "[]" reconcile yes >/dev/null \
+      || _so_die "reconcile-tasks: record-task falhou para $_rc_id (backend sqlite)" 1
+    _rc_count=$((_rc_count + 1))
+  done <<EOF
+$_rc_missing
+EOF
+  printf '%s\n' "$_rc_count"
+}
+
+# ---------- wave-status ----------
+
+_so_db_wave_status() {
+  _sdb_sdir="$1"
+  _sdb_db=$(_sr_db_file "$_sdb_sdir")
+  [ -f "$_sdb_db" ] || _so_die "wave-status: state.db ausente em $_sdb_sdir" 1
+  _sdb_exec_id=$(_sr_exec_id "$_sdb_db")
+  [ -n "$_sdb_exec_id" ] || _so_die "wave-status: execution ausente" 1
+  _sdb_cnt=$(_state_db_exec "$_sdb_db" "SELECT count(*) FROM wave WHERE execution_id=$(_sr_sql_quote "$_sdb_exec_id");")
+  if [ "$_sdb_cnt" = "0" ]; then
+    printf 'none\n'
+    return 0
+  fi
+  _sdb_term=$(_state_db_exec "$_sdb_db" \
+    "SELECT termination_reason FROM wave WHERE execution_id=$(_sr_sql_quote "$_sdb_exec_id") ORDER BY seq DESC LIMIT 1;")
+  if [ -z "$_sdb_term" ]; then
+    printf 'open\n'
+  else
+    printf 'closed\n'
+  fi
+}
+
+# ---------- current-id ----------
+
+_so_db_current_id() {
+  _sdb_sdir="$1"
+  _sdb_db=$(_sr_db_file "$_sdb_sdir")
+  [ -f "$_sdb_db" ] || _so_die "current-id: state.db ausente" 1
+  _sdb_exec_id=$(_sr_exec_id "$_sdb_db")
+  [ -n "$_sdb_exec_id" ] || _so_die "current-id: execution ausente" 1
+  _sdb_id=$(_state_db_exec "$_sdb_db" \
+    "SELECT id FROM wave WHERE execution_id=$(_sr_sql_quote "$_sdb_exec_id") ORDER BY seq DESC LIMIT 1;")
+  if [ -z "$_sdb_id" ]; then
+    printf 'init\n'
+  else
+    printf '%s\n' "$_sdb_id"
+  fi
+}

--- a/global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
@@ -542,7 +542,10 @@ _sr_db_upsert_task() {
   _ut_outcome=$(printf '%s' "$_ut_row" | jq -r '.outcome')
   _ut_tr=$(printf '%s' "$_ut_row" | jq -r '.tests_run // 0')
   _ut_tp=$(printf '%s' "$_ut_row" | jq -r '.tests_passed // 0')
-  _ut_lint=$(printf '%s' "$_ut_row" | jq -c '.lint_ok // null')
+  # SEM `// null` (mesma classe de bug de .atomic_commit_enabled acima):
+  # jq trata `false` como falsy, entao `.lint_ok // null` perderia um
+  # lint_ok=false real. Chave ausente ja produz `null` sem o `//`.
+  _ut_lint=$(printf '%s' "$_ut_row" | jq -c '.lint_ok')
   _ut_files=$(printf '%s' "$_ut_row" | jq -c '.touched_files // []')
   _ut_rec=$(printf '%s' "$_ut_row" | jq -r '.recorded_at')
   _ut_src=$(printf '%s' "$_ut_row" | jq -r '.source // empty')
@@ -647,7 +650,14 @@ _sr_db_write_document() {
   _wd_short=$(printf '%s' "$_wd_doc" | jq -r '.short_name // empty')
   _wd_stage=$(printf '%s' "$_wd_doc" | jq -r '.current_stage')
   _wd_next=$(printf '%s' "$_wd_doc" | jq -r '.next_instruction')
-  _wd_atomic=$(printf '%s' "$_wd_doc" | jq -c '.atomic_commit_enabled // null')
+  # SEM `// null`: jq trata `false` como falsy, entao `.atomic_commit_enabled
+  # // null` colapsa o valor legitimo `false` (o default do campo — a maioria
+  # das execucoes reais) para `null`, perdendo o dado no UPDATE abaixo
+  # (bug achado empiricamente na FASE 8 desta feature, ao migrar um state.json
+  # de fixture com atomic_commit_enabled=false: M3.2 reprovava toda vez). Sem
+  # o `//`, chave ausente ja produz `null` por padrao do jq — nenhum
+  # comportamento de fallback e perdido.
+  _wd_atomic=$(printf '%s' "$_wd_doc" | jq -c '.atomic_commit_enabled')
   _wd_atomic_sql="NULL"
   case "$_wd_atomic" in true) _wd_atomic_sql=1 ;; false) _wd_atomic_sql=0 ;; esac
   _wd_ika=$(printf '%s' "$_wd_doc" | jq -c '.initial_key_aspects // []')

--- a/global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
@@ -1,0 +1,717 @@
+#!/bin/sh
+# _state-rw-db.sh — implementacao do backend SQLite para state-rw.sh
+# (feature state-db-foundation, FASE 3 task 3.2).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.2
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C7
+#      docs/specs/state-db-foundation/contracts/export.md
+#      docs/specs/state-db-foundation/data-model.md
+#
+# NAO e executavel diretamente. Sourced por state-rw.sh (que ja fez
+# `. _state-db.sh` antes) — depende de sql_escape/strip_nul/_state_db_*.
+#
+# Escopo desta task: reconstrucao completa (read/get) e escrita (set/write)
+# das 9 entidades JA modeladas em data-model.md. O export "oficial" (gatilho
+# automatico ao fim da onda, E5/E6 do contrato) e FASE 5 — aqui o mecanismo
+# de leitura ja fica funcionalmente completo porque FASE 5 o REUSA
+# (contracts/export.md, Opcao A: "state-rw.sh read" vira o export).
+#
+# GAP CONHECIDO E DOCUMENTADO (nao um bug silencioso): contracts/export.md
+# lista `suggestions`, `retros`, `next_retrospective_milestone` entre os
+# campos que os demais scripts acrescentam ao longo da execucao, mas
+# data-model.md fechou o schema em 9 entidades SEM tabela/coluna dedicada
+# para eles. Ate uma FASE futura fechar esse gap (schema amendment), esses
+# campos — e qualquer outro campo de TOPO nao modelado — sao preservados
+# via o catch-all `execution.extra_fields` (JSON object), reconciliado de
+# volta ao documento no `read`. Nenhum dado e perdido; apenas nao ganha
+# tratamento relacional (sem FK/CHECK) enquanto o gap nao fecha.
+#
+# Funcoes expostas (todas exigem STATE_DIR ja resolvido para backend sqlite
+# pelo caller — `_sr_backend` — e state.db existente):
+#   _sr_db_file STATE_DIR                    -> imprime STATE_DIR/state.db
+#   _sr_backend STATE_DIR                    -> imprime "sqlite" ou "json"
+#   _sr_db_read STATE_DIR                    -> imprime o documento JSON completo
+#   _sr_db_set STATE_DIR FIELD VALUE_JSON    -> aplica mutacao pontual
+#   _sr_db_write_document STATE_DIR JSON     -> substitui/upserta a partir de
+#                                                um documento completo
+#   _sr_db_integrity_check STATE_DIR         -> exit 0 se 'ok', 1 senao (C7)
+
+_sr_db_file() { printf '%s/state.db\n' "$1"; }
+
+# _sr_backend STATE_DIR -> "sqlite" se state.db existe, senao "json" (C2).
+_sr_backend() {
+  if [ -f "$(_sr_db_file "$1")" ]; then
+    printf 'sqlite\n'
+  else
+    printf 'json\n'
+  fi
+}
+
+# ---------- Helpers de literal SQL (C8: strip_nul + sql_escape sempre) ----------
+
+# _sr_sql_quote VALUE -> imprime 'valor-escapado' (nunca NULL; caller decide
+# NULL separadamente quando aplicavel).
+_sr_sql_quote() {
+  _sq_v=$(printf '%s' "$1" | strip_nul)
+  printf "'%s'" "$(sql_escape "$_sq_v")"
+}
+
+# _sr_sql_literal TYPE VALUE_JSON -> imprime o literal SQL correto para o
+# TYPE (str|int|bool|json), a partir de um VALUE_JSON (JSON valido — o
+# mesmo formato aceito por `--value`). JSON null -> SQL NULL em todo tipo.
+_sr_sql_literal() {
+  _sl_type="$1"
+  _sl_json="$2"
+  if [ "$(printf '%s' "$_sl_json" | jq -c 'if . == null then "y" else "n" end' 2>/dev/null)" = '"y"' ]; then
+    printf 'NULL'
+    return 0
+  fi
+  case "$_sl_type" in
+    str)
+      _sl_raw=$(printf '%s' "$_sl_json" | jq -r '.' 2>/dev/null) \
+        || _sr_die "set: --value nao e JSON valido para campo texto" 1
+      _sr_sql_quote "$_sl_raw"
+      ;;
+    int)
+      printf '%s' "$_sl_json" | jq -e 'type == "number"' >/dev/null 2>&1 \
+        || _sr_die "set: --value precisa ser numero para este campo" 1
+      printf '%s' "$_sl_json" | jq -c '.'
+      ;;
+    bool)
+      _sl_b=$(printf '%s' "$_sl_json" | jq -c '.' 2>/dev/null)
+      case "$_sl_b" in
+        true)  printf '1' ;;
+        false) printf '0' ;;
+        *) _sr_die "set: --value precisa ser true/false/null para este campo" 1 ;;
+      esac
+      ;;
+    json)
+      _sl_compact=$(printf '%s' "$_sl_json" | jq -c '.' 2>/dev/null) \
+        || _sr_die "set: --value nao e JSON valido" 1
+      _sr_sql_quote "$_sl_compact"
+      ;;
+    *)
+      _sr_die "set: tipo interno desconhecido '$_sl_type'" 1
+      ;;
+  esac
+}
+
+_sr_exec_id() {
+  _state_db_exec "$1" "SELECT id FROM execution LIMIT 1;"
+}
+
+# ---------- C7: sha256-update/sha256-verify sob backend SQLite ----------
+
+# _sr_db_integrity_check STATE_DIR -> exit 0 se PRAGMA integrity_check = 'ok'
+# (dec-025: cobertura de adulteracao deliberada e integrity_check apenas,
+# regresso aceito face ao sha256-verify anterior — operador local confiavel).
+_sr_db_integrity_check() {
+  _dbic_db=$(_sr_db_file "$1")
+  [ -f "$_dbic_db" ] || _sr_die "sha256-verify: state.db ausente em $1" 1
+  _dbic_out=$(_state_db_exec "$_dbic_db" "PRAGMA integrity_check;" 2>&1) \
+    || { printf '%s\n' "$_dbic_out" >&2; return 1; }
+  if [ "$_dbic_out" = "ok" ]; then
+    return 0
+  fi
+  printf '%s: integrity_check divergente:\n%s\n' "$_SR_NAME" "$_dbic_out" >&2
+  diag_emit error hash-mismatch "sha256-verify: PRAGMA integrity_check divergente sob backend SQLite" \
+    "state.db pode estar corrompido — restaure a partir do export mais recente em state-history/" || :
+  return 1
+}
+
+# ============================================================
+# READ — reconstrucao completa do documento JSON (E1-E4 do
+# contracts/export.md, consumido tambem por `get`)
+# ============================================================
+
+_sr_db_read() {
+  _sdbr_sd="$1"
+  _sdbr_db=$(_sr_db_file "$_sdbr_sd")
+  [ -f "$_sdbr_db" ] || _sr_die "read: state.db ausente em $_sdbr_sd" 1
+
+  _sdbr_sql="SELECT json_object(
+    'schema_version', schema_version,
+    'short_name', short_name,
+    'execution', json_object(
+      'id', id,
+      'target_project_path', target_project_path,
+      'target_project_description', target_project_description,
+      'suggested_stack', json(coalesce(suggested_stack,'null')),
+      'status', status,
+      'termination_reason', termination_reason,
+      'started_at', started_at,
+      'finished_at', finished_at,
+      'canonical_project', canonical_project,
+      'session_name', session_name
+    ),
+    'prerequisites', json(coalesce(prerequisites,'null')),
+    'current_stage', current_stage,
+    'next_instruction', next_instruction,
+    'waves', (SELECT coalesce(json_group_array(json_object(
+        'id', w.id,
+        'started_at', w.started_at,
+        'finished_at', w.finished_at,
+        'wallclock_seconds', w.wallclock_seconds,
+        'tool_calls', w.tool_calls,
+        'termination_reason', w.termination_reason,
+        'next_wave_scheduled_for', w.next_wave_scheduled_for,
+        'executed_stages', json(coalesce(w.executed_stages,'[]')),
+        'skills_invoked', (SELECT coalesce(json_group_array(json_object(
+            'skill', si.skill,
+            'timestamp', si.timestamp,
+            'decision_id', si.decision_id,
+            'kind', si.kind
+          )),'[]') FROM (SELECT * FROM skill_invocation WHERE wave_id = w.id ORDER BY id) si),
+        'agent_usage', json(coalesce(w.agent_usage,'null')),
+        'agent_spawns', json(coalesce(w.agent_spawns,'null')),
+        'otel_usage', json(coalesce(w.otel_usage,'null')),
+        'extra_fields', json(coalesce(w.extra_fields,'{}'))
+      )),'[]') FROM (SELECT * FROM wave WHERE execution_id = execution.id ORDER BY seq) w),
+    'decisions', (SELECT coalesce(json_group_array(json_object(
+        'id', d.id,
+        'wave_id', d.wave_id,
+        'timestamp', d.timestamp,
+        'agent', d.agent,
+        'stage', d.stage,
+        'context', d.context,
+        'options_considered', json(d.options_considered),
+        'choice', d.choice,
+        'rationale', d.rationale,
+        'justification_score', d.justification_score,
+        'evidence', d.evidence,
+        'references', json(coalesce(d.\"references\",'null')),
+        'originating_artifact', d.originating_artifact
+      )),'[]') FROM (SELECT * FROM decision WHERE execution_id = execution.id ORDER BY rowid) d),
+    'human_blocks', (SELECT coalesce(json_group_array(json_object(
+        'id', h.id,
+        'decision_id', h.decision_id,
+        'question', h.question,
+        'context_for_answer', h.context_for_answer,
+        'recommended_options', json(coalesce(h.recommended_options,'null')),
+        'status', h.status,
+        'human_answer', h.human_answer,
+        'triggered_at', h.triggered_at,
+        'answered_at', h.answered_at
+      )),'[]') FROM (SELECT * FROM human_block WHERE execution_id = execution.id ORDER BY rowid) h),
+    'budgets', json_object(
+      'max_recursion', max_recursion,
+      'current_subagent_depth', subagent_depth,
+      'max_retro_executions_per_feature', max_retro_executions_per_feature,
+      'retro_executions_consumed', retro_executions_consumed,
+      'max_cycles_per_stage', max_cycles_per_stage,
+      'cycles_consumed_current_stage', cycles_consumed_current_stage,
+      'tool_calls_threshold_wave', tool_calls_threshold_wave,
+      'wallclock_threshold_seconds', wallclock_threshold_seconds,
+      'state_size_threshold_bytes', state_size_threshold_bytes,
+      'tool_calls_current_wave', coalesce((SELECT tool_calls FROM wave WHERE execution_id = execution.id AND termination_reason IS NULL),0),
+      'current_wave_start', (SELECT started_at FROM wave WHERE execution_id = execution.id AND termination_reason IS NULL)
+    ),
+    'accumulated_metrics', json_object(
+      'waves_total', (SELECT count(*) FROM wave WHERE execution_id = execution.id),
+      'tool_calls_total', coalesce((SELECT sum(tool_calls) FROM wave WHERE execution_id = execution.id),0),
+      'wallclock_total_seconds', coalesce((SELECT sum(wallclock_seconds) FROM wave WHERE execution_id = execution.id),0),
+      'max_depth_reached', subagent_depth,
+      'subagents_spawned', 0,
+      'decisions_total', (SELECT count(*) FROM decision WHERE execution_id = execution.id),
+      'human_blocks_total', (SELECT count(*) FROM human_block WHERE execution_id = execution.id),
+      'global_skill_suggestions_total', 0,
+      'toolkit_issues_opened', 0
+    ),
+    'external_urls_whitelist', json(coalesce(external_urls_whitelist,'[]')),
+    'circular_movement_history', json(coalesce(circular_movement_history,'[]')),
+    'initial_key_aspects', json(coalesce(initial_key_aspects,'[]')),
+    'atomic_commit_enabled', json(CASE atomic_commit_enabled WHEN 1 THEN 'true' WHEN 0 THEN 'false' ELSE 'null' END),
+    'tasks', (SELECT coalesce(json_group_array(json_object(
+        'task_id', t.task_id,
+        'title', t.title,
+        'wave_id', t.wave_id,
+        'outcome', t.outcome,
+        'tests_run', t.tests_run,
+        'tests_passed', t.tests_passed,
+        'lint_ok', json(CASE t.lint_ok WHEN 1 THEN 'true' WHEN 0 THEN 'false' ELSE 'null' END),
+        'touched_files', json(t.touched_files),
+        'recorded_at', t.recorded_at,
+        'source', t.source
+      )),'[]') FROM (SELECT * FROM task_outcome WHERE execution_id = execution.id ORDER BY rowid) t),
+    'events', (SELECT coalesce(json_group_array(json_object(
+        'event_type', e.event_type,
+        'timestamp', e.timestamp,
+        'description', e.description
+      )),'[]') FROM (SELECT * FROM event WHERE execution_id = execution.id ORDER BY id) e),
+    'briefing_cache', json(coalesce(briefing_cache,'null')),
+    'constitution_cache', json(coalesce(constitution_cache,'null')),
+    'push_pr_result', json(coalesce(push_pr_result,'null')),
+    'extra_fields', json(coalesce(extra_fields,'{}'))
+  ) FROM execution LIMIT 1;"
+
+  _sdbr_raw=$(_state_db_exec "$_sdbr_db" "$_sdbr_sql") || _sr_die "read: consulta SQLite falhou" 1
+  [ -n "$_sdbr_raw" ] || _sr_die "read: tabela execution vazia em $_sdbr_db (banco corrompido?)" 1
+
+  printf '%s\n' "$_sdbr_raw" | jq '
+    def drop_null_keys(ks):
+      reduce ks[] as $k (.; if (has($k) and .[$k] == null) then del(.[$k]) else . end);
+
+    ((.extra_fields // {}) ) as $ext
+    | (del(.extra_fields)) as $core
+    | ($ext + $core)
+    | drop_null_keys(["short_name"])
+    | (if (has("short_name") | not) then del(.prerequisites) else . end)
+    | .execution |= drop_null_keys(["canonical_project","session_name"])
+    | .waves |= map(
+        ((.extra_fields // {})) as $we
+        | (del(.extra_fields)) as $wc
+        | ($we + $wc)
+        | drop_null_keys(["agent_usage","agent_spawns","otel_usage"])
+      )
+    | .events |= map(drop_null_keys(["description"]))
+  '
+}
+
+# ============================================================
+# SET — mutacao pontual (dispatcher por classe de path)
+# ============================================================
+
+# _sr_exec_col_lookup BARE -> define _sr_lu_col/_sr_lu_type (vazios se
+# BARE nao mapeia para nenhuma coluna conhecida de `execution`).
+_sr_exec_col_lookup() {
+  _lu=$1
+  case "$_lu" in
+    execution.*) _lu=${_lu#execution.} ;;
+  esac
+  _sr_lu_col=""
+  _sr_lu_type=""
+  case "$_lu" in
+    id|schema_version|execution.id|execution.schema_version)
+      _sr_die "set: campo '.$1' e imutavel apos init" 1 ;;
+    short_name)                            _sr_lu_col=short_name; _sr_lu_type=str ;;
+    current_stage)                         _sr_lu_col=current_stage; _sr_lu_type=str ;;
+    next_instruction)                      _sr_lu_col=next_instruction; _sr_lu_type=str ;;
+    atomic_commit_enabled)                 _sr_lu_col=atomic_commit_enabled; _sr_lu_type=bool ;;
+    initial_key_aspects)                   _sr_lu_col=initial_key_aspects; _sr_lu_type=json ;;
+    external_urls_whitelist)               _sr_lu_col=external_urls_whitelist; _sr_lu_type=json ;;
+    circular_movement_history)             _sr_lu_col=circular_movement_history; _sr_lu_type=json ;;
+    prerequisites)                         _sr_lu_col=prerequisites; _sr_lu_type=json ;;
+    briefing_cache)                        _sr_lu_col=briefing_cache; _sr_lu_type=json ;;
+    constitution_cache)                    _sr_lu_col=constitution_cache; _sr_lu_type=json ;;
+    push_pr_result)                        _sr_lu_col=push_pr_result; _sr_lu_type=json ;;
+    target_project_path)                   _sr_lu_col=target_project_path; _sr_lu_type=str ;;
+    target_project_description)            _sr_lu_col=target_project_description; _sr_lu_type=str ;;
+    suggested_stack)                       _sr_lu_col=suggested_stack; _sr_lu_type=json ;;
+    status)                                _sr_lu_col=status; _sr_lu_type=str ;;
+    termination_reason)                    _sr_lu_col=termination_reason; _sr_lu_type=str ;;
+    started_at)                            _sr_lu_col=started_at; _sr_lu_type=str ;;
+    finished_at)                           _sr_lu_col=finished_at; _sr_lu_type=str ;;
+    canonical_project)                     _sr_lu_col=canonical_project; _sr_lu_type=str ;;
+    session_name)                          _sr_lu_col=session_name; _sr_lu_type=str ;;
+    budgets.current_subagent_depth)        _sr_lu_col=subagent_depth; _sr_lu_type=int ;;
+    budgets.max_recursion)                 _sr_lu_col=max_recursion; _sr_lu_type=int ;;
+    budgets.cycles_consumed_current_stage) _sr_lu_col=cycles_consumed_current_stage; _sr_lu_type=int ;;
+    budgets.max_cycles_per_stage)          _sr_lu_col=max_cycles_per_stage; _sr_lu_type=int ;;
+    budgets.retro_executions_consumed)     _sr_lu_col=retro_executions_consumed; _sr_lu_type=int ;;
+    budgets.max_retro_executions_per_feature) _sr_lu_col=max_retro_executions_per_feature; _sr_lu_type=int ;;
+    budgets.tool_calls_threshold_wave)     _sr_lu_col=tool_calls_threshold_wave; _sr_lu_type=int ;;
+    budgets.wallclock_threshold_seconds)   _sr_lu_col=wallclock_threshold_seconds; _sr_lu_type=int ;;
+    budgets.state_size_threshold_bytes)    _sr_lu_col=state_size_threshold_bytes; _sr_lu_type=int ;;
+    budgets.tool_calls_current_wave|budgets.current_wave_start)
+      _sr_die "set: campo '.$1' e derivado da onda aberta — nao gravavel diretamente sob backend SQLite" 1 ;;
+    accumulated_metrics.*)
+      _sr_die "set: campo '.$1' e derivado (accumulated_metrics) — nao gravavel sob backend SQLite" 1 ;;
+    *) : ;;
+  esac
+}
+
+# _sr_db_set_wave_field DB BARE VALUE_JSON -> "waves[-1].NAME" ou "waves[N].NAME"
+_sr_db_set_wave_field() {
+  _wf_db="$1"; _wf_bare="$2"; _wf_value="$3"
+  _wf_sel=${_wf_bare#waves[}
+  [ "$_wf_sel" != "$_wf_bare" ] || _sr_die "set: path de onda malformado: '.$_wf_bare'" 1
+  _wf_idx=${_wf_sel%%]*}
+  _wf_rest=${_wf_sel#*].}
+  [ "$_wf_rest" != "$_wf_sel" ] && [ -n "$_wf_rest" ] \
+    || _sr_die "set: path de onda malformado (esperado 'waves[N].campo'): '.$_wf_bare'" 1
+  # Suporta somente um segmento apos o indice — nesting mais profundo
+  # (ex.: waves[-1].skills_invoked[0].skill) nao e usado hoje e cairia em
+  # fallback ambiguo; falha explicita em vez de mesclar errado (C1/anti-fabricacao).
+  case "$_wf_rest" in
+    *.*|*\[*) _sr_die "set: path de onda com aninhamento nao suportado sob backend SQLite: '.$_wf_bare'" 1 ;;
+  esac
+  _wf_name="$_wf_rest"
+
+  if [ "$_wf_idx" = "-1" ]; then
+    _wf_wave_id=$(_state_db_exec "$_wf_db" "SELECT id FROM wave ORDER BY seq DESC LIMIT 1;")
+  else
+    case "$_wf_idx" in
+      ''|*[!0-9]*) _sr_die "set: indice de onda invalido: '$_wf_idx' (so -1 ou inteiro >= 0 suportado)" 1 ;;
+    esac
+    _wf_seq=$((_wf_idx + 1))
+    _wf_wave_id=$(_state_db_exec "$_wf_db" "SELECT id FROM wave WHERE seq = $_wf_seq;")
+  fi
+  [ -n "$_wf_wave_id" ] || _sr_die "set: onda nao encontrada para '.$_wf_bare'" 1
+
+  _wf_col=""
+  _wf_typ=""
+  case "$_wf_name" in
+    finished_at)               _wf_col=finished_at; _wf_typ=str ;;
+    wallclock_seconds)         _wf_col=wallclock_seconds; _wf_typ=int ;;
+    tool_calls)                _wf_col=tool_calls; _wf_typ=int ;;
+    termination_reason)        _wf_col=termination_reason; _wf_typ=str ;;
+    next_wave_scheduled_for)   _wf_col=next_wave_scheduled_for; _wf_typ=str ;;
+    executed_stages)           _wf_col=executed_stages; _wf_typ=json ;;
+    agent_usage)                _wf_col=agent_usage; _wf_typ=json ;;
+    agent_spawns)               _wf_col=agent_spawns; _wf_typ=json ;;
+    otel_usage)                _wf_col=otel_usage; _wf_typ=json ;;
+    *) : ;;
+  esac
+
+  if [ -n "$_wf_col" ]; then
+    _wf_sqlval=$(_sr_sql_literal "$_wf_typ" "$_wf_value")
+    _wf_sql="UPDATE wave SET $_wf_col = $_wf_sqlval WHERE id = $(_sr_sql_quote "$_wf_wave_id");"
+  else
+    _wf_cur_extra=$(_state_db_exec "$_wf_db" "SELECT coalesce(extra_fields,'{}') FROM wave WHERE id = $(_sr_sql_quote "$_wf_wave_id");")
+    _wf_new_extra=$(printf '%s' "$_wf_cur_extra" | jq -c --argjson v "$_wf_value" --arg n "$_wf_name" '.[$n] = $v') \
+      || _sr_die "set: jq falhou ao mesclar campo de onda '$_wf_name'" 1
+    _wf_sqlval=$(_sr_sql_literal json "$_wf_new_extra")
+    _wf_sql="UPDATE wave SET extra_fields = $_wf_sqlval WHERE id = $(_sr_sql_quote "$_wf_wave_id");"
+  fi
+  _state_db_exec_with_retry "$_wf_db" "BEGIN IMMEDIATE; $_wf_sql COMMIT;" \
+    || _sr_die "set: UPDATE wave.$_wf_name falhou" 1
+}
+
+# _sr_db_replace_events DB EXEC_ID ARRAY_JSON -> DELETE+INSERT (leaf table,
+# sem FK de terceiros; seguro porque `event` nao e referenciada por ninguem).
+_sr_db_replace_events() {
+  _re_db="$1"; _re_exec_id="$2"; _re_arr="$3"
+  _re_tmp=$(mktemp) || _sr_die "set: mktemp falhou" 1
+  printf '%s' "$_re_arr" | jq -c '.[]' > "$_re_tmp" 2>/dev/null \
+    || { rm -f -- "$_re_tmp"; _sr_die "set: --value de '.events' nao e array JSON valido" 1; }
+
+  _re_sql="BEGIN IMMEDIATE; DELETE FROM event WHERE execution_id = $(_sr_sql_quote "$_re_exec_id");"
+  while IFS= read -r _re_row; do
+    _re_type=$(printf '%s' "$_re_row" | jq -r '.event_type')
+    _re_ts=$(printf '%s' "$_re_row" | jq -r '.timestamp')
+    _re_desc=$(printf '%s' "$_re_row" | jq -r '.description // empty')
+    _re_desc_sql="NULL"
+    [ -n "$_re_desc" ] && _re_desc_sql=$(_sr_sql_quote "$_re_desc")
+    _re_sql="$_re_sql INSERT INTO event (execution_id,event_type,timestamp,description) VALUES ($(_sr_sql_quote "$_re_exec_id"),$(_sr_sql_quote "$_re_type"),$(_sr_sql_quote "$_re_ts"),$_re_desc_sql);"
+  done < "$_re_tmp"
+  rm -f -- "$_re_tmp"
+  _re_sql="$_re_sql COMMIT;"
+  _state_db_exec_with_retry "$_re_db" "$_re_sql" || _sr_die "set: resync de '.events' falhou" 1
+}
+
+# _sr_db_upsert_wave DB EXEC_ID WAVE_JSON -> UPSERT de UMA onda + resync do
+# seu skills_invoked (leaf table, seguro DELETE+INSERT por wave_id).
+_sr_db_upsert_wave() {
+  _uw_db="$1"; _uw_exec_id="$2"; _uw_row="$3"
+  _uw_id=$(printf '%s' "$_uw_row" | jq -r '.id')
+  _uw_seq=$(printf '%s' "$_uw_id" | sed -n 's/^onda-0*\([0-9][0-9]*\)$/\1/p')
+  [ -n "$_uw_seq" ] || _sr_die "write: id de onda invalido (esperado 'onda-NNN'): '$_uw_id'" 1
+  _uw_started=$(printf '%s' "$_uw_row" | jq -r '.started_at')
+  _uw_finished=$(printf '%s' "$_uw_row" | jq -r '.finished_at // empty')
+  _uw_wallclock=$(printf '%s' "$_uw_row" | jq -r '.wallclock_seconds // empty')
+  _uw_toolcalls=$(printf '%s' "$_uw_row" | jq -r '.tool_calls // 0')
+  _uw_term=$(printf '%s' "$_uw_row" | jq -r '.termination_reason // empty')
+  _uw_nextsched=$(printf '%s' "$_uw_row" | jq -r '.next_wave_scheduled_for // empty')
+  _uw_stages=$(printf '%s' "$_uw_row" | jq -c '.executed_stages // []')
+  _uw_agent_usage=$(printf '%s' "$_uw_row" | jq -c '.agent_usage // null')
+  _uw_agent_spawns=$(printf '%s' "$_uw_row" | jq -c '.agent_spawns // null')
+  _uw_otel=$(printf '%s' "$_uw_row" | jq -c '.otel_usage // null')
+  _uw_extra=$(printf '%s' "$_uw_row" | jq -c 'del(.id,.started_at,.finished_at,.wallclock_seconds,.tool_calls,.termination_reason,.next_wave_scheduled_for,.executed_stages,.skills_invoked,.agent_usage,.agent_spawns,.otel_usage,.extra_fields)')
+
+  _uw_sql="INSERT INTO wave (id,execution_id,seq,started_at,finished_at,wallclock_seconds,tool_calls,termination_reason,next_wave_scheduled_for,executed_stages,agent_usage,agent_spawns,otel_usage,extra_fields) VALUES ("
+  _uw_sql="$_uw_sql$(_sr_sql_quote "$_uw_id"),$(_sr_sql_quote "$_uw_exec_id"),$_uw_seq,$(_sr_sql_quote "$_uw_started"),"
+  _uw_sql="$_uw_sql$([ -n "$_uw_finished" ] && _sr_sql_quote "$_uw_finished" || printf NULL),"
+  _uw_sql="$_uw_sql$([ -n "$_uw_wallclock" ] && printf '%s' "$_uw_wallclock" || printf NULL),"
+  _uw_sql="$_uw_sql$_uw_toolcalls,"
+  _uw_sql="$_uw_sql$([ -n "$_uw_term" ] && _sr_sql_quote "$_uw_term" || printf NULL),"
+  _uw_sql="$_uw_sql$([ -n "$_uw_nextsched" ] && _sr_sql_quote "$_uw_nextsched" || printf NULL),"
+  _uw_sql="$_uw_sql$(_sr_sql_quote "$_uw_stages"),"
+  _uw_sql="$_uw_sql$([ "$_uw_agent_usage" != "null" ] && _sr_sql_quote "$_uw_agent_usage" || printf NULL),"
+  _uw_sql="$_uw_sql$([ "$_uw_agent_spawns" != "null" ] && _sr_sql_quote "$_uw_agent_spawns" || printf NULL),"
+  _uw_sql="$_uw_sql$([ "$_uw_otel" != "null" ] && _sr_sql_quote "$_uw_otel" || printf NULL),"
+  _uw_sql="$_uw_sql$(_sr_sql_quote "$_uw_extra")"
+  _uw_sql="$_uw_sql) ON CONFLICT(id) DO UPDATE SET seq=excluded.seq, started_at=excluded.started_at, finished_at=excluded.finished_at, wallclock_seconds=excluded.wallclock_seconds, tool_calls=excluded.tool_calls, termination_reason=excluded.termination_reason, next_wave_scheduled_for=excluded.next_wave_scheduled_for, executed_stages=excluded.executed_stages, agent_usage=excluded.agent_usage, agent_spawns=excluded.agent_spawns, otel_usage=excluded.otel_usage, extra_fields=excluded.extra_fields;"
+  printf '%s' "$_uw_sql"
+
+  _uw_skills=$(printf '%s' "$_uw_row" | jq -c '.skills_invoked // []')
+  printf ' DELETE FROM skill_invocation WHERE wave_id = %s;' "$(_sr_sql_quote "$_uw_id")"
+  _uw_stmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
+  printf '%s' "$_uw_skills" | jq -c '.[]' > "$_uw_stmp" 2>/dev/null
+  while IFS= read -r _uw_srow; do
+    _uw_sk=$(printf '%s' "$_uw_srow" | jq -r '.skill')
+    _uw_sts=$(printf '%s' "$_uw_srow" | jq -r '.timestamp')
+    _uw_sdec=$(printf '%s' "$_uw_srow" | jq -r '.decision_id // empty')
+    _uw_skind=$(printf '%s' "$_uw_srow" | jq -r '.kind // "skill"')
+    printf ' INSERT INTO skill_invocation (wave_id,skill,timestamp,decision_id,kind) VALUES (%s,%s,%s,%s,%s);' \
+      "$(_sr_sql_quote "$_uw_id")" "$(_sr_sql_quote "$_uw_sk")" "$(_sr_sql_quote "$_uw_sts")" \
+      "$([ -n "$_uw_sdec" ] && _sr_sql_quote "$_uw_sdec" || printf NULL)" "$(_sr_sql_quote "$_uw_skind")"
+  done < "$_uw_stmp"
+  rm -f -- "$_uw_stmp"
+}
+
+_sr_db_upsert_decision() {
+  _ud_exec_id="$1"; _ud_row="$2"
+  _ud_id=$(printf '%s' "$_ud_row" | jq -r '.id')
+  _ud_wid=$(printf '%s' "$_ud_row" | jq -r '.wave_id // empty')
+  _ud_ts=$(printf '%s' "$_ud_row" | jq -r '.timestamp')
+  _ud_agent=$(printf '%s' "$_ud_row" | jq -r '.agent')
+  _ud_stage=$(printf '%s' "$_ud_row" | jq -r '.stage')
+  _ud_ctx=$(printf '%s' "$_ud_row" | jq -r '.context')
+  _ud_opts=$(printf '%s' "$_ud_row" | jq -c '.options_considered')
+  _ud_choice=$(printf '%s' "$_ud_row" | jq -r '.choice')
+  _ud_rat=$(printf '%s' "$_ud_row" | jq -r '.rationale')
+  _ud_score=$(printf '%s' "$_ud_row" | jq -r '.justification_score // empty')
+  _ud_evid=$(printf '%s' "$_ud_row" | jq -r '.evidence // empty')
+  _ud_refs=$(printf '%s' "$_ud_row" | jq -c '.references // null')
+  _ud_origin=$(printf '%s' "$_ud_row" | jq -r '.originating_artifact // empty')
+
+  printf 'INSERT INTO decision (id,execution_id,wave_id,timestamp,agent,stage,context,options_considered,choice,rationale,justification_score,evidence,"references",originating_artifact) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT(id) DO UPDATE SET wave_id=excluded.wave_id, timestamp=excluded.timestamp, agent=excluded.agent, stage=excluded.stage, context=excluded.context, options_considered=excluded.options_considered, choice=excluded.choice, rationale=excluded.rationale, justification_score=excluded.justification_score, evidence=excluded.evidence, "references"=excluded."references", originating_artifact=excluded.originating_artifact;' \
+    "$(_sr_sql_quote "$_ud_id")" \
+    "$(_sr_sql_quote "$_ud_exec_id")" \
+    "$([ -n "$_ud_wid" ] && _sr_sql_quote "$_ud_wid" || printf NULL)" \
+    "$(_sr_sql_quote "$_ud_ts")" \
+    "$(_sr_sql_quote "$_ud_agent")" \
+    "$(_sr_sql_quote "$_ud_stage")" \
+    "$(_sr_sql_quote "$_ud_ctx")" \
+    "$(_sr_sql_quote "$_ud_opts")" \
+    "$(_sr_sql_quote "$_ud_choice")" \
+    "$(_sr_sql_quote "$_ud_rat")" \
+    "$([ -n "$_ud_score" ] && printf '%s' "$_ud_score" || printf NULL)" \
+    "$([ -n "$_ud_evid" ] && _sr_sql_quote "$_ud_evid" || printf NULL)" \
+    "$(_sr_sql_quote "$_ud_refs")" \
+    "$([ -n "$_ud_origin" ] && _sr_sql_quote "$_ud_origin" || printf NULL)"
+}
+
+_sr_db_upsert_human_block() {
+  _uh_exec_id="$1"; _uh_row="$2"
+  _uh_id=$(printf '%s' "$_uh_row" | jq -r '.id')
+  _uh_decid=$(printf '%s' "$_uh_row" | jq -r '.decision_id')
+  _uh_q=$(printf '%s' "$_uh_row" | jq -r '.question')
+  _uh_ctx=$(printf '%s' "$_uh_row" | jq -r '.context_for_answer')
+  _uh_rec=$(printf '%s' "$_uh_row" | jq -c '.recommended_options // null')
+  _uh_status=$(printf '%s' "$_uh_row" | jq -r '.status')
+  _uh_ans=$(printf '%s' "$_uh_row" | jq -r '.human_answer // empty')
+  _uh_trig=$(printf '%s' "$_uh_row" | jq -r '.triggered_at')
+  _uh_answ_at=$(printf '%s' "$_uh_row" | jq -r '.answered_at // empty')
+
+  printf 'INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,recommended_options,status,human_answer,triggered_at,answered_at) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT(id) DO UPDATE SET decision_id=excluded.decision_id, question=excluded.question, context_for_answer=excluded.context_for_answer, recommended_options=excluded.recommended_options, status=excluded.status, human_answer=excluded.human_answer, triggered_at=excluded.triggered_at, answered_at=excluded.answered_at;' \
+    "$(_sr_sql_quote "$_uh_id")" \
+    "$(_sr_sql_quote "$_uh_exec_id")" \
+    "$(_sr_sql_quote "$_uh_decid")" \
+    "$(_sr_sql_quote "$_uh_q")" \
+    "$(_sr_sql_quote "$_uh_ctx")" \
+    "$(_sr_sql_quote "$_uh_rec")" \
+    "$(_sr_sql_quote "$_uh_status")" \
+    "$([ -n "$_uh_ans" ] && _sr_sql_quote "$_uh_ans" || printf NULL)" \
+    "$(_sr_sql_quote "$_uh_trig")" \
+    "$([ -n "$_uh_answ_at" ] && _sr_sql_quote "$_uh_answ_at" || printf NULL)"
+}
+
+_sr_db_upsert_task() {
+  _ut_exec_id="$1"; _ut_row="$2"
+  _ut_tid=$(printf '%s' "$_ut_row" | jq -r '.task_id')
+  _ut_title=$(printf '%s' "$_ut_row" | jq -r '.title // ""')
+  _ut_wid=$(printf '%s' "$_ut_row" | jq -r '.wave_id')
+  _ut_outcome=$(printf '%s' "$_ut_row" | jq -r '.outcome')
+  _ut_tr=$(printf '%s' "$_ut_row" | jq -r '.tests_run // 0')
+  _ut_tp=$(printf '%s' "$_ut_row" | jq -r '.tests_passed // 0')
+  _ut_lint=$(printf '%s' "$_ut_row" | jq -c '.lint_ok // null')
+  _ut_files=$(printf '%s' "$_ut_row" | jq -c '.touched_files // []')
+  _ut_rec=$(printf '%s' "$_ut_row" | jq -r '.recorded_at')
+  _ut_src=$(printf '%s' "$_ut_row" | jq -r '.source // empty')
+  _ut_lint_sql="NULL"
+  case "$_ut_lint" in true) _ut_lint_sql=1 ;; false) _ut_lint_sql=0 ;; esac
+
+  printf 'INSERT INTO task_outcome (execution_id,task_id,title,wave_id,outcome,tests_run,tests_passed,lint_ok,touched_files,recorded_at,source) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) ON CONFLICT(execution_id,task_id) DO UPDATE SET title=excluded.title, wave_id=excluded.wave_id, outcome=excluded.outcome, tests_run=excluded.tests_run, tests_passed=excluded.tests_passed, lint_ok=excluded.lint_ok, touched_files=excluded.touched_files, recorded_at=excluded.recorded_at, source=excluded.source;' \
+    "$(_sr_sql_quote "$_ut_exec_id")" \
+    "$(_sr_sql_quote "$_ut_tid")" \
+    "$(_sr_sql_quote "$_ut_title")" \
+    "$(_sr_sql_quote "$_ut_wid")" \
+    "$(_sr_sql_quote "$_ut_outcome")" \
+    "$_ut_tr" "$_ut_tp" "$_ut_lint_sql" \
+    "$(_sr_sql_quote "$_ut_files")" \
+    "$(_sr_sql_quote "$_ut_rec")" \
+    "$([ -n "$_ut_src" ] && _sr_sql_quote "$_ut_src" || printf NULL)"
+}
+
+# _sr_db_set STATE_DIR FIELD VALUE_JSON -> dispatcher de `set` sob backend
+# SQLite. FIELD e um path jq (ex.: '.events', '.waves[-1].tool_calls',
+# '.current_stage', '.next_retrospective_milestone').
+_sr_db_set() {
+  _sds_sd="$1"; _sds_field="$2"; _sds_value="$3"
+  _sds_db=$(_sr_db_file "$_sds_sd")
+  [ -f "$_sds_db" ] || _sr_die "set: state.db ausente em $_sds_sd" 1
+  _sds_exec_id=$(_sr_exec_id "$_sds_db")
+  [ -n "$_sds_exec_id" ] || _sr_die "set: execution ausente em $_sds_db" 1
+  _sds_bare=${_sds_field#.}
+
+  case "$_sds_bare" in
+    events)
+      _sr_db_replace_events "$_sds_db" "$_sds_exec_id" "$_sds_value"
+      ;;
+    waves)
+      _sds_tmp=$(mktemp) || _sr_die "set: mktemp falhou" 1
+      printf '%s' "$_sds_value" | jq -c '.[]' > "$_sds_tmp" 2>/dev/null \
+        || { rm -f -- "$_sds_tmp"; _sr_die "set: --value de '.waves' nao e array JSON valido" 1; }
+      _sds_sql="BEGIN IMMEDIATE;"
+      while IFS= read -r _sds_row; do
+        _sds_sql="$_sds_sql $(_sr_db_upsert_wave "$_sds_db" "$_sds_exec_id" "$_sds_row")"
+      done < "$_sds_tmp"
+      rm -f -- "$_sds_tmp"
+      _sds_sql="$_sds_sql COMMIT;"
+      _state_db_exec_with_retry "$_sds_db" "$_sds_sql" || _sr_die "set: resync de '.waves' falhou" 1
+      ;;
+    decisions|human_blocks|tasks)
+      _sds_tmp=$(mktemp) || _sr_die "set: mktemp falhou" 1
+      printf '%s' "$_sds_value" | jq -c '.[]' > "$_sds_tmp" 2>/dev/null \
+        || { rm -f -- "$_sds_tmp"; _sr_die "set: --value de '.$_sds_bare' nao e array JSON valido" 1; }
+      _sds_sql="BEGIN IMMEDIATE;"
+      while IFS= read -r _sds_row; do
+        case "$_sds_bare" in
+          decisions)    _sds_stmt=$(_sr_db_upsert_decision "$_sds_exec_id" "$_sds_row") ;;
+          human_blocks) _sds_stmt=$(_sr_db_upsert_human_block "$_sds_exec_id" "$_sds_row") ;;
+          tasks)        _sds_stmt=$(_sr_db_upsert_task "$_sds_exec_id" "$_sds_row") ;;
+        esac
+        _sds_sql="$_sds_sql $_sds_stmt"
+      done < "$_sds_tmp"
+      rm -f -- "$_sds_tmp"
+      _sds_sql="$_sds_sql COMMIT;"
+      _state_db_exec_with_retry "$_sds_db" "$_sds_sql" || _sr_die "set: resync de '.$_sds_bare' falhou" 1
+      ;;
+    waves\[*)
+      _sr_db_set_wave_field "$_sds_db" "$_sds_bare" "$_sds_value"
+      ;;
+    *)
+      _sr_exec_col_lookup "$_sds_bare"
+      if [ -n "$_sr_lu_col" ]; then
+        _sds_sqlval=$(_sr_sql_literal "$_sr_lu_type" "$_sds_value")
+        _state_db_exec_with_retry "$_sds_db" "BEGIN IMMEDIATE; UPDATE execution SET $_sr_lu_col = $_sds_sqlval; COMMIT;" \
+          || _sr_die "set: UPDATE execution.$_sr_lu_col falhou" 1
+      else
+        case "$_sds_bare" in
+          *.*|*\[*)
+            _sr_die "set: campo nao suportado sob backend SQLite (path aninhado nao modelado): '$_sds_field' — so campos de topo simples tem fallback para extra_fields" 1
+            ;;
+        esac
+        _sds_cur_extra=$(_state_db_exec "$_sds_db" "SELECT coalesce(extra_fields,'{}') FROM execution LIMIT 1;")
+        _sds_new_extra=$(printf '%s' "$_sds_cur_extra" | jq -c --argjson v "$_sds_value" "$_sds_field = \$v") \
+          || _sr_die "set: jq falhou ao aplicar '$_sds_field' em extra_fields" 1
+        _sds_sqlval=$(_sr_sql_literal json "$_sds_new_extra")
+        _state_db_exec_with_retry "$_sds_db" "BEGIN IMMEDIATE; UPDATE execution SET extra_fields = $_sds_sqlval; COMMIT;" \
+          || _sr_die "set: UPDATE execution.extra_fields falhou" 1
+      fi
+      ;;
+  esac
+}
+
+# ============================================================
+# WRITE — importacao de documento completo (substituicao autoritativa)
+# ============================================================
+
+_sr_db_write_document() {
+  _wd_sd="$1"; _wd_doc="$2"
+  _wd_db=$(_sr_db_file "$_wd_sd")
+  [ -f "$_wd_db" ] || _sr_die "write: state.db ausente em $_wd_sd" 1
+  _wd_exec_id=$(_sr_exec_id "$_wd_db")
+  [ -n "$_wd_exec_id" ] || _sr_die "write: execution ausente em $_wd_db" 1
+
+  # --- execution: colunas conhecidas + extra_fields (substituicao total —
+  # write() e "documento completo", diferente do merge pontual do set) ---
+  _wd_short=$(printf '%s' "$_wd_doc" | jq -r '.short_name // empty')
+  _wd_stage=$(printf '%s' "$_wd_doc" | jq -r '.current_stage')
+  _wd_next=$(printf '%s' "$_wd_doc" | jq -r '.next_instruction')
+  _wd_atomic=$(printf '%s' "$_wd_doc" | jq -c '.atomic_commit_enabled // null')
+  _wd_atomic_sql="NULL"
+  case "$_wd_atomic" in true) _wd_atomic_sql=1 ;; false) _wd_atomic_sql=0 ;; esac
+  _wd_ika=$(printf '%s' "$_wd_doc" | jq -c '.initial_key_aspects // []')
+  _wd_urls=$(printf '%s' "$_wd_doc" | jq -c '.external_urls_whitelist // []')
+  _wd_circ=$(printf '%s' "$_wd_doc" | jq -c '.circular_movement_history // []')
+  _wd_prereq=$(printf '%s' "$_wd_doc" | jq -c '.prerequisites // null')
+  _wd_brief=$(printf '%s' "$_wd_doc" | jq -c '.briefing_cache // null')
+  _wd_const=$(printf '%s' "$_wd_doc" | jq -c '.constitution_cache // null')
+  _wd_pr=$(printf '%s' "$_wd_doc" | jq -c '.push_pr_result // null')
+  _wd_stack=$(printf '%s' "$_wd_doc" | jq -c '.execution.suggested_stack // null')
+  _wd_status=$(printf '%s' "$_wd_doc" | jq -r '.execution.status')
+  _wd_term=$(printf '%s' "$_wd_doc" | jq -r '.execution.termination_reason // empty')
+  _wd_started=$(printf '%s' "$_wd_doc" | jq -r '.execution.started_at')
+  _wd_finished=$(printf '%s' "$_wd_doc" | jq -r '.execution.finished_at // empty')
+  _wd_canon=$(printf '%s' "$_wd_doc" | jq -r '.execution.canonical_project // empty')
+  _wd_sess=$(printf '%s' "$_wd_doc" | jq -r '.execution.session_name // empty')
+  _wd_tpp=$(printf '%s' "$_wd_doc" | jq -r '.execution.target_project_path')
+  _wd_tpd=$(printf '%s' "$_wd_doc" | jq -r '.execution.target_project_description')
+  _wd_extra=$(printf '%s' "$_wd_doc" | jq -c 'del(.schema_version,.short_name,.execution,.prerequisites,.current_stage,.next_instruction,.waves,.decisions,.human_blocks,.tasks,.events,.budgets,.accumulated_metrics,.external_urls_whitelist,.circular_movement_history,.initial_key_aspects,.atomic_commit_enabled,.briefing_cache,.constitution_cache,.push_pr_result)')
+
+  _wd_sql="BEGIN IMMEDIATE; UPDATE execution SET "
+  _wd_sql="${_wd_sql}short_name=$([ -n "$_wd_short" ] && _sr_sql_quote "$_wd_short" || printf NULL),"
+  _wd_sql="${_wd_sql}current_stage=$(_sr_sql_quote "$_wd_stage"),"
+  _wd_sql="${_wd_sql}next_instruction=$(_sr_sql_quote "$_wd_next"),"
+  _wd_sql="${_wd_sql}atomic_commit_enabled=$_wd_atomic_sql,"
+  _wd_sql="${_wd_sql}initial_key_aspects=$(_sr_sql_quote "$_wd_ika"),"
+  _wd_sql="${_wd_sql}external_urls_whitelist=$(_sr_sql_quote "$_wd_urls"),"
+  _wd_sql="${_wd_sql}circular_movement_history=$(_sr_sql_quote "$_wd_circ"),"
+  _wd_sql="${_wd_sql}prerequisites=$([ "$_wd_prereq" != "null" ] && _sr_sql_quote "$_wd_prereq" || printf NULL),"
+  _wd_sql="${_wd_sql}briefing_cache=$([ "$_wd_brief" != "null" ] && _sr_sql_quote "$_wd_brief" || printf NULL),"
+  _wd_sql="${_wd_sql}constitution_cache=$([ "$_wd_const" != "null" ] && _sr_sql_quote "$_wd_const" || printf NULL),"
+  _wd_sql="${_wd_sql}push_pr_result=$([ "$_wd_pr" != "null" ] && _sr_sql_quote "$_wd_pr" || printf NULL),"
+  _wd_sql="${_wd_sql}suggested_stack=$([ "$_wd_stack" != "null" ] && _sr_sql_quote "$_wd_stack" || printf NULL),"
+  _wd_sql="${_wd_sql}status=$(_sr_sql_quote "$_wd_status"),"
+  _wd_sql="${_wd_sql}termination_reason=$([ -n "$_wd_term" ] && _sr_sql_quote "$_wd_term" || printf NULL),"
+  _wd_sql="${_wd_sql}started_at=$(_sr_sql_quote "$_wd_started"),"
+  _wd_sql="${_wd_sql}finished_at=$([ -n "$_wd_finished" ] && _sr_sql_quote "$_wd_finished" || printf NULL),"
+  _wd_sql="${_wd_sql}canonical_project=$([ -n "$_wd_canon" ] && _sr_sql_quote "$_wd_canon" || printf NULL),"
+  _wd_sql="${_wd_sql}session_name=$([ -n "$_wd_sess" ] && _sr_sql_quote "$_wd_sess" || printf NULL),"
+  _wd_sql="${_wd_sql}target_project_path=$(_sr_sql_quote "$_wd_tpp"),"
+  _wd_sql="${_wd_sql}target_project_description=$(_sr_sql_quote "$_wd_tpd"),"
+  _wd_sql="${_wd_sql}extra_fields=$(_sr_sql_quote "$_wd_extra")"
+  _wd_sql="${_wd_sql} WHERE id = $(_sr_sql_quote "$_wd_exec_id");"
+
+  # --- waves (+ skills_invoked) — FK-dependente de execution, precede decisions/tasks ---
+  _wd_wtmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
+  printf '%s' "$_wd_doc" | jq -c '.waves[]? // empty' > "$_wd_wtmp" 2>/dev/null
+  while IFS= read -r _wd_wrow; do
+    _wd_sql="$_wd_sql $(_sr_db_upsert_wave "$_wd_db" "$_wd_exec_id" "$_wd_wrow")"
+  done < "$_wd_wtmp"
+  rm -f -- "$_wd_wtmp"
+
+  # --- decisions — FK-dependente de wave ---
+  _wd_dtmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
+  printf '%s' "$_wd_doc" | jq -c '.decisions[]? // empty' > "$_wd_dtmp" 2>/dev/null
+  while IFS= read -r _wd_drow; do
+    _wd_sql="$_wd_sql $(_sr_db_upsert_decision "$_wd_exec_id" "$_wd_drow")"
+  done < "$_wd_dtmp"
+  rm -f -- "$_wd_dtmp"
+
+  # --- human_blocks — FK-dependente de decision ---
+  _wd_htmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
+  printf '%s' "$_wd_doc" | jq -c '.human_blocks[]? // empty' > "$_wd_htmp" 2>/dev/null
+  while IFS= read -r _wd_hrow; do
+    _wd_sql="$_wd_sql $(_sr_db_upsert_human_block "$_wd_exec_id" "$_wd_hrow")"
+  done < "$_wd_htmp"
+  rm -f -- "$_wd_htmp"
+
+  # --- tasks — FK-dependente de wave ---
+  _wd_ttmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
+  printf '%s' "$_wd_doc" | jq -c '.tasks[]? // empty' > "$_wd_ttmp" 2>/dev/null
+  while IFS= read -r _wd_trow; do
+    _wd_sql="$_wd_sql $(_sr_db_upsert_task "$_wd_exec_id" "$_wd_trow")"
+  done < "$_wd_ttmp"
+  rm -f -- "$_wd_ttmp"
+
+  # --- events — leaf, substituicao total ---
+  _wd_events=$(printf '%s' "$_wd_doc" | jq -c '.events // []')
+  _wd_sql="$_wd_sql DELETE FROM event WHERE execution_id = $(_sr_sql_quote "$_wd_exec_id");"
+  _wd_etmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
+  printf '%s' "$_wd_events" | jq -c '.[]' > "$_wd_etmp" 2>/dev/null
+  while IFS= read -r _wd_erow; do
+    _wd_etype=$(printf '%s' "$_wd_erow" | jq -r '.event_type')
+    _wd_ets=$(printf '%s' "$_wd_erow" | jq -r '.timestamp')
+    _wd_edesc=$(printf '%s' "$_wd_erow" | jq -r '.description // empty')
+    _wd_edesc_sql="NULL"
+    [ -n "$_wd_edesc" ] && _wd_edesc_sql=$(_sr_sql_quote "$_wd_edesc")
+    _wd_sql="$_wd_sql INSERT INTO event (execution_id,event_type,timestamp,description) VALUES ($(_sr_sql_quote "$_wd_exec_id"),$(_sr_sql_quote "$_wd_etype"),$(_sr_sql_quote "$_wd_ets"),$_wd_edesc_sql);"
+  done < "$_wd_etmp"
+  rm -f -- "$_wd_etmp"
+
+  _wd_sql="$_wd_sql COMMIT;"
+  _state_db_exec_with_retry "$_wd_db" "$_wd_sql" || _sr_die "write: importacao do documento falhou" 1
+}

--- a/global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+++ b/global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
@@ -399,10 +399,21 @@ _sr_db_replace_events() {
   _state_db_exec_with_retry "$_re_db" "$_re_sql" || _sr_die "set: resync de '.events' falhou" 1
 }
 
-# _sr_db_upsert_wave DB EXEC_ID WAVE_JSON -> UPSERT de UMA onda + resync do
-# seu skills_invoked (leaf table, seguro DELETE+INSERT por wave_id).
+# _sr_db_upsert_wave DB EXEC_ID WAVE_JSON [WITH_SKILLS] -> UPSERT de UMA onda
+# + (por default) resync do seu skills_invoked (leaf table, seguro
+# DELETE+INSERT por wave_id).
+#
+# WITH_SKILLS=no OMITE o bloco de skill_invocation, para o caller emiti-lo
+# DEPOIS das decisions. Necessario porque skill_invocation.decision_id e FK
+# para decision(id): emitir a skill junto da onda (ordem
+# execution -> wave+skills -> decision) viola a FK sempre que a skill carrega
+# decision_id — que e o caso normal do two-step register+record-skill do
+# model-routing. A ordem correta e a do contracts/migration.md §M2:
+# execution -> wave -> decision -> human_block/skill_invocation/task/event.
+# Achado empiricamente na FASE 6 ao migrar state.json reais (os fixtures
+# sinteticos da FASE 3 nao tinham skills_invoked com decision_id).
 _sr_db_upsert_wave() {
-  _uw_db="$1"; _uw_exec_id="$2"; _uw_row="$3"
+  _uw_db="$1"; _uw_exec_id="$2"; _uw_row="$3"; _uw_with_skills="${4:-yes}"
   _uw_id=$(printf '%s' "$_uw_row" | jq -r '.id')
   _uw_seq=$(printf '%s' "$_uw_id" | sed -n 's/^onda-0*\([0-9][0-9]*\)$/\1/p')
   [ -n "$_uw_seq" ] || _sr_die "write: id de onda invalido (esperado 'onda-NNN'): '$_uw_id'" 1
@@ -433,26 +444,42 @@ _sr_db_upsert_wave() {
   _uw_sql="$_uw_sql) ON CONFLICT(id) DO UPDATE SET seq=excluded.seq, started_at=excluded.started_at, finished_at=excluded.finished_at, wallclock_seconds=excluded.wallclock_seconds, tool_calls=excluded.tool_calls, termination_reason=excluded.termination_reason, next_wave_scheduled_for=excluded.next_wave_scheduled_for, executed_stages=excluded.executed_stages, agent_usage=excluded.agent_usage, agent_spawns=excluded.agent_spawns, otel_usage=excluded.otel_usage, extra_fields=excluded.extra_fields;"
   printf '%s' "$_uw_sql"
 
-  _uw_skills=$(printf '%s' "$_uw_row" | jq -c '.skills_invoked // []')
-  printf ' DELETE FROM skill_invocation WHERE wave_id = %s;' "$(_sr_sql_quote "$_uw_id")"
-  _uw_stmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
-  printf '%s' "$_uw_skills" | jq -c '.[]' > "$_uw_stmp" 2>/dev/null
-  while IFS= read -r _uw_srow; do
-    _uw_sk=$(printf '%s' "$_uw_srow" | jq -r '.skill')
-    _uw_sts=$(printf '%s' "$_uw_srow" | jq -r '.timestamp')
-    _uw_sdec=$(printf '%s' "$_uw_srow" | jq -r '.decision_id // empty')
-    _uw_skind=$(printf '%s' "$_uw_srow" | jq -r '.kind // "skill"')
+  [ "$_uw_with_skills" = "no" ] && return 0
+  _sr_db_wave_skills_sql "$_uw_row"
+}
+
+# _sr_db_wave_skills_sql WAVE_JSON -> imprime o resync (DELETE+INSERT) do
+# skills_invoked de UMA onda. Separado de _sr_db_upsert_wave para permitir
+# emissao APOS as decisions (FK skill_invocation.decision_id -> decision.id).
+_sr_db_wave_skills_sql() {
+  _ws_row="$1"
+  _ws_id=$(printf '%s' "$_ws_row" | jq -r '.id')
+  _ws_skills=$(printf '%s' "$_ws_row" | jq -c '.skills_invoked // []')
+  printf ' DELETE FROM skill_invocation WHERE wave_id = %s;' "$(_sr_sql_quote "$_ws_id")"
+  _ws_stmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
+  printf '%s' "$_ws_skills" | jq -c '.[]' > "$_ws_stmp" 2>/dev/null
+  while IFS= read -r _ws_srow; do
+    _ws_sk=$(printf '%s' "$_ws_srow" | jq -r '.skill')
+    _ws_sts=$(printf '%s' "$_ws_srow" | jq -r '.timestamp')
+    _ws_sdec=$(printf '%s' "$_ws_srow" | jq -r '.decision_id // empty')
+    _ws_skind=$(printf '%s' "$_ws_srow" | jq -r '.kind // "skill"')
     printf ' INSERT INTO skill_invocation (wave_id,skill,timestamp,decision_id,kind) VALUES (%s,%s,%s,%s,%s);' \
-      "$(_sr_sql_quote "$_uw_id")" "$(_sr_sql_quote "$_uw_sk")" "$(_sr_sql_quote "$_uw_sts")" \
-      "$([ -n "$_uw_sdec" ] && _sr_sql_quote "$_uw_sdec" || printf NULL)" "$(_sr_sql_quote "$_uw_skind")"
-  done < "$_uw_stmp"
-  rm -f -- "$_uw_stmp"
+      "$(_sr_sql_quote "$_ws_id")" "$(_sr_sql_quote "$_ws_sk")" "$(_sr_sql_quote "$_ws_sts")" \
+      "$([ -n "$_ws_sdec" ] && _sr_sql_quote "$_ws_sdec" || printf NULL)" "$(_sr_sql_quote "$_ws_skind")"
+  done < "$_ws_stmp"
+  rm -f -- "$_ws_stmp"
 }
 
 _sr_db_upsert_decision() {
   _ud_exec_id="$1"; _ud_row="$2"
   _ud_id=$(printf '%s' "$_ud_row" | jq -r '.id')
-  _ud_wid=$(printf '%s' "$_ud_row" | jq -r '.wave_id // empty')
+  # wave_id sentinela "init" -> NULL (data-model.md §decision: `FK -> wave(id),
+  # NULL p/ "init"`). Decisoes registradas pelo command PAI antes da primeira
+  # onda (ex.: wave-select pre-onda) carregam wave_id="init", que nao e uma
+  # onda real — inseri-lo verbatim viola a FK. Achado empiricamente na FASE 6:
+  # 10 dos 19 state.json reais de .claude/feature-00c-state/ tem essa
+  # sentinela.
+  _ud_wid=$(printf '%s' "$_ud_row" | jq -r 'if (.wave_id // "") == "init" then "" else (.wave_id // empty) end')
   _ud_ts=$(printf '%s' "$_ud_row" | jq -r '.timestamp')
   _ud_agent=$(printf '%s' "$_ud_row" | jq -r '.agent')
   _ud_stage=$(printf '%s' "$_ud_row" | jq -r '.stage')
@@ -665,13 +692,15 @@ _sr_db_write_document() {
   _wd_sql="${_wd_sql}extra_fields=$(_sr_sql_quote "$_wd_extra")"
   _wd_sql="${_wd_sql} WHERE id = $(_sr_sql_quote "$_wd_exec_id");"
 
-  # --- waves (+ skills_invoked) — FK-dependente de execution, precede decisions/tasks ---
+  # --- waves (SEM skills_invoked) — FK-dependente de execution, precede
+  # decisions/tasks. As skills_invoked sao emitidas mais abaixo, DEPOIS das
+  # decisions, porque skill_invocation.decision_id e FK para decision(id)
+  # (ordem do contracts/migration.md §M2). ---
   _wd_wtmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
   printf '%s' "$_wd_doc" | jq -c '.waves[]? // empty' > "$_wd_wtmp" 2>/dev/null
   while IFS= read -r _wd_wrow; do
-    _wd_sql="$_wd_sql $(_sr_db_upsert_wave "$_wd_db" "$_wd_exec_id" "$_wd_wrow")"
+    _wd_sql="$_wd_sql $(_sr_db_upsert_wave "$_wd_db" "$_wd_exec_id" "$_wd_wrow" no)"
   done < "$_wd_wtmp"
-  rm -f -- "$_wd_wtmp"
 
   # --- decisions — FK-dependente de wave ---
   _wd_dtmp=$(mktemp) || _sr_die "write: mktemp falhou" 1
@@ -680,6 +709,12 @@ _sr_db_write_document() {
     _wd_sql="$_wd_sql $(_sr_db_upsert_decision "$_wd_exec_id" "$_wd_drow")"
   done < "$_wd_dtmp"
   rm -f -- "$_wd_dtmp"
+
+  # --- skills_invoked — FK-dependente de wave E de decision ---
+  while IFS= read -r _wd_wrow; do
+    _wd_sql="$_wd_sql $(_sr_db_wave_skills_sql "$_wd_wrow")"
+  done < "$_wd_wtmp"
+  rm -f -- "$_wd_wtmp"
 
   # --- human_blocks — FK-dependente de decision ---
   _wd_htmp=$(mktemp) || _sr_die "write: mktemp falhou" 1

--- a/global/skills/agente-00c-runtime/scripts/bloqueios.sh
+++ b/global/skills/agente-00c-runtime/scripts/bloqueios.sh
@@ -48,6 +48,24 @@ _BL_DIR=$(cd "$(dirname -- "$0")" && pwd)
 # shellcheck source=./_diag.sh
 . "$_BL_DIR/_diag.sh"
 
+# Backend dual (feature state-db-foundation, FASE 3 task 3.5): presenca de
+# <state-dir>/state.db seleciona SQLite; senao, backend JSON (comportamento
+# historico, intacto abaixo). Ver contracts/primitives.md §C1/C2. Reusa os
+# primitivos ja testados de _state-rw-db.sh (_sr_backend/_sr_db_file/
+# _sr_exec_id/_sr_sql_quote) em vez de duplica-los — mesmo racional de C8
+# para sql_escape/strip_nul (paridade com state-decisions.sh/state-ondas.sh).
+# shellcheck source=./_state-db.sh
+. "$_BL_DIR/_state-db.sh"
+# shellcheck source=./_state-rw-db.sh
+. "$_BL_DIR/_state-rw-db.sh"
+# shellcheck source=./_bloqueios-db.sh
+. "$_BL_DIR/_bloqueios-db.sh"
+
+# Shim para _state-rw-db.sh (_sr_exec_id/_sr_sql_quote nao chamam _sr_die em
+# seus caminhos normais, mas o shim protege contra qualquer caminho de erro
+# latente sem duplicar a logica de _bl_die).
+_sr_die() { _bl_die "$1" "${2:-1}"; }
+
 _bl_die_usage() { printf '%s: %s\n' "$_BL_NAME" "$1" >&2; exit 2; }
 _bl_die()       { printf '%s: %s\n' "$_BL_NAME" "$1" >&2; exit "${2:-1}"; }
 
@@ -133,15 +151,9 @@ _bl_cmd_register() {
   [ -n "$_ctx" ]  || _bl_die_usage "register: --contexto-para-resposta obrigatorio"
   _bl_require_jq
 
-  _sf=$(_bl_state_file "$_sd")
-  [ -f "$_sf" ] || _bl_die "register: state.json ausente em $_sd" 1
-
-  # FK integrity: decisao referenciada precisa existir
-  if ! _bl_decisao_exists "$_sd" "$_dec"; then
-    _bl_die "register: decisao_id nao existe: $_dec (use state-decisions.sh register antes)" 1
-  fi
-
-  # Validacao de tamanho minimo (data-model: pergunta>=20, contexto>=1)
+  # Validacao de tamanho minimo (data-model: pergunta>=20, contexto>=1) —
+  # comum aos dois backends, roda ANTES do dispatch (paridade de
+  # comportamento, mesmo padrao de state-decisions.sh).
   if [ "$(printf '%s' "$_perg" | wc -c | tr -d ' ')" -lt 20 ]; then
     _bl_die "register: pergunta muito curta (<20 chars). Humano precisa entender sem releitura." 1
   fi
@@ -157,6 +169,20 @@ _bl_cmd_register() {
         || _bl_die "register: --opcoes-recomendadas precisa ser JSON array (ou omitido)" 2
       ;;
   esac
+
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _bl_db_register "$_sd" "$_dec" "$_perg" "$_ctx" "$_opcoes"
+    return 0
+  fi
+
+  _sf=$(_bl_state_file "$_sd")
+  [ -f "$_sf" ] || _bl_die "register: state.json ausente em $_sd" 1
+
+  # FK integrity: decisao referenciada precisa existir (path JSON — sob
+  # SQLite a FK real do schema ja garante isto, ver _bl_db_register/C3).
+  if ! _bl_decisao_exists "$_sd" "$_dec"; then
+    _bl_die "register: decisao_id nao existe: $_dec (use state-decisions.sh register antes)" 1
+  fi
 
   _id=$(_bl_next_block_id "$_sd")
   _now=$(_bl_iso_now)
@@ -210,6 +236,11 @@ _bl_cmd_respond() {
   [ "$_resp_set" = 1 ] || _bl_die_usage "respond: --resposta obrigatorio (use '' para resposta vazia explicita)"
   _bl_require_jq
 
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _bl_db_respond "$_sd" "$_bid" "$_resp"
+    return 0
+  fi
+
   _sf=$(_bl_state_file "$_sd")
   [ -f "$_sf" ] || _bl_die "respond: state.json ausente em $_sd" 1
 
@@ -262,6 +293,10 @@ _bl_cmd_list() {
   done
   [ -n "$_sd" ] || _bl_die_usage "list: --state-dir obrigatorio"
   _bl_require_jq
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _bl_db_list "$_sd" "$_st"
+    return 0
+  fi
   _sf=$(_bl_state_file "$_sd")
   [ -f "$_sf" ] || _bl_die "list: state.json ausente" 1
   jq -r --arg s "$_st" '
@@ -284,6 +319,10 @@ _bl_cmd_count() {
   done
   [ -n "$_sd" ] || _bl_die_usage "count: --state-dir obrigatorio"
   _bl_require_jq
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _bl_db_count "$_sd" "$([ "$_pending" = 1 ] && printf '1' || printf '')"
+    return 0
+  fi
   _sf=$(_bl_state_file "$_sd")
   [ -f "$_sf" ] || _bl_die "count: state.json ausente" 1
   if [ "$_pending" = 1 ]; then
@@ -303,6 +342,10 @@ _bl_cmd_next_id() {
   done
   [ -n "$_sd" ] || _bl_die_usage "next-id: --state-dir obrigatorio"
   _bl_require_jq
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _bl_db_next_id "$_sd"
+    return 0
+  fi
   _sf=$(_bl_state_file "$_sd")
   [ -f "$_sf" ] || _bl_die "next-id: state.json ausente" 1
   _bl_next_block_id "$_sd"
@@ -321,6 +364,10 @@ _bl_cmd_get() {
   [ -n "$_sd" ]  || _bl_die_usage "get: --state-dir obrigatorio"
   [ -n "$_bid" ] || _bl_die_usage "get: --block-id obrigatorio"
   _bl_require_jq
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _bl_db_get "$_sd" "$_bid"
+    return 0
+  fi
   _sf=$(_bl_state_file "$_sd")
   [ -f "$_sf" ] || _bl_die "get: state.json ausente" 1
   _out=$(jq --arg id "$_bid" '

--- a/global/skills/agente-00c-runtime/scripts/spawn-tracker.sh
+++ b/global/skills/agente-00c-runtime/scripts/spawn-tracker.sh
@@ -39,6 +39,25 @@ set -eu
 
 _ST_NAME="spawn-tracker"
 _ST_MAX=3   # FR-013: max 3 niveis (filho, neto, bisneto)
+_ST_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)
+
+# Backend dual (feature state-db-foundation, FASE 3 task 3.6): presenca de
+# <state-dir>/state.db seleciona SQLite; senao, backend JSON (comportamento
+# historico, intacto abaixo). Ver contracts/primitives.md §C1/C2/C3. Reusa
+# os primitivos ja testados de _state-rw-db.sh (_sr_backend/_sr_db_file/
+# _sr_exec_id/_sr_sql_quote) em vez de duplica-los — mesmo racional de C8
+# ja aplicado em bloqueios.sh/state-decisions.sh/state-ondas.sh.
+# shellcheck source=./_state-db.sh
+. "$_ST_DIR/_state-db.sh"
+# shellcheck source=./_state-rw-db.sh
+. "$_ST_DIR/_state-rw-db.sh"
+# shellcheck source=./_spawn-tracker-db.sh
+. "$_ST_DIR/_spawn-tracker-db.sh"
+
+# Shim para _state-rw-db.sh (_sr_exec_id/_sr_sql_quote nao chamam _sr_die em
+# seus caminhos normais, mas o shim protege contra qualquer caminho de erro
+# latente sem duplicar a logica de _st_die — definida logo abaixo).
+_sr_die() { _st_die "$1" "${2:-1}"; }
 
 _st_die_usage() {
   printf '%s: %s\n' "$_ST_NAME" "$1" >&2
@@ -105,6 +124,10 @@ _st_cmd_check() {
   done
   [ -n "$_sdir" ] || _st_die_usage "check: --state-dir obrigatorio"
   _st_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _st_db_check "$_sdir"
+    return 0
+  fi
   _sf=$(_st_state_file "$_sdir")
   [ -f "$_sf" ] || _st_die "check: state.json ausente em $_sdir" 1
   _curr=$(_st_get_current "$_sdir")
@@ -127,6 +150,10 @@ _st_cmd_enter() {
   done
   [ -n "$_sdir" ] || _st_die_usage "enter: --state-dir obrigatorio"
   _st_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _st_db_enter "$_sdir"
+    return 0
+  fi
   _sf=$(_st_state_file "$_sdir")
   [ -f "$_sf" ] || _st_die "enter: state.json ausente em $_sdir" 1
 
@@ -168,6 +195,10 @@ _st_cmd_leave() {
   done
   [ -n "$_sdir" ] || _st_die_usage "leave: --state-dir obrigatorio"
   _st_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _st_db_leave "$_sdir"
+    return 0
+  fi
   _sf=$(_st_state_file "$_sdir")
   [ -f "$_sf" ] || _st_die "leave: state.json ausente em $_sdir" 1
 
@@ -201,6 +232,10 @@ _st_cmd_current() {
   done
   [ -n "$_sdir" ] || _st_die_usage "current: --state-dir obrigatorio"
   _st_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _st_db_current "$_sdir"
+    return 0
+  fi
   _sf=$(_st_state_file "$_sdir")
   [ -f "$_sf" ] || _st_die "current: state.json ausente em $_sdir" 1
   _st_get_current "$_sdir"

--- a/global/skills/agente-00c-runtime/scripts/state-db-migrate.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-db-migrate.sh
@@ -1,0 +1,485 @@
+#!/bin/sh
+# state-db-migrate.sh — migracao EXPLICITA de state.json -> state.db
+# (feature state-db-foundation, FASE 6).
+#
+# Ref: docs/specs/state-db-foundation/spec.md FR-005, FR-006, FR-014-INFRA-IDEMP
+#      docs/specs/state-db-foundation/contracts/migration.md (M1..M6)
+#      docs/specs/state-db-foundation/contracts/primitives.md §C10 (mktemp)
+#      docs/specs/state-db-foundation/data-model.md (9 entidades)
+#
+# NOMEACAO (migration.md §Nomeacao — colisao a evitar): este script NAO e um
+# subcomando de state-rw.sh porque `state-rw.sh migrate` JA EXISTE com outro
+# significado (migracao do schema INTERNO do state.json, pt-BR -> EN). Dois
+# sentidos sob o mesmo verbo, no mesmo script, e armadilha de operador.
+# A UX do operador e `cstk state migrate --state-dir DIR` (cli/lib/state.sh),
+# que DELEGA a este script (dec-034: "B para a UX, delegando a A a
+# implementacao").
+#
+# Subcomandos:
+#   state-db-migrate.sh migrate --state-dir DIR
+#       — Migra <DIR>/state.json para <DIR>/state.db. NUNCA automatica:
+#         so roda por invocacao explicita do operador (M6/FR-005).
+#
+# Exit codes:
+#   0  sucesso (state.db publicado e verificado)
+#   1  falha (erro de IO, sqlite3 ausente, verificacao M3 reprovada)
+#   2  uso incorreto
+#   3  RECUSADO por pre-condicao M1 (execucao ativa, estado invalido,
+#      integridade divergente, state.db conflitante) — distinguivel de 1
+#      para o operador saber que NADA foi tocado
+#
+# GARANTIAS (M4/M6): o state.json de origem, seu .sha256 e state-history/
+# NUNCA sao apagados nem reescritos. Em qualquer ponto de falha o projeto
+# continua operavel pelo state.json original.
+#
+# POSIX sh. Deps: sqlite3, jq (obrigatorias nesta camada — carve-out do
+# amendment 1.3.0 da constitution; fail-fast com diagnostico abaixo).
+
+set -eu
+
+_SDM_NAME="state-db-migrate"
+_SDM_SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)
+
+# shellcheck source=./_state-db.sh
+. "$_SDM_SELF_DIR/_state-db.sh"
+
+_sdm_die_usage() {
+  printf '%s: %s\n' "$_SDM_NAME" "$1" >&2
+  exit 2
+}
+
+# _sdm_die MSG [EXIT] -> diagnostico em stderr + exit (default 1).
+_sdm_die() {
+  printf '%s: %s\n' "$_SDM_NAME" "$1" >&2
+  exit "${2:-1}"
+}
+
+# _sdm_refuse MSG -> recusa por pre-condicao M1 (exit 3, nada foi tocado).
+# Registra a tentativa recusada em migration_run do state.db JA EXISTENTE,
+# quando houver (M5: "toda tentativa — inclusive as recusadas"). Quando nao
+# ha state.db, nao existe onde persistir: o diagnostico em stderr + exit 3
+# e o registro (documentado, nao um esquecimento).
+_sdm_refuse() {
+  _sdm_r_msg="$1"
+  if [ -n "${_SDM_DB:-}" ] && [ -f "${_SDM_DB:-}" ]; then
+    _sdm_record_run "$_SDM_DB" refused "$_sdm_r_msg" '' '' || :
+  fi
+  printf '%s: RECUSADO: %s\n' "$_SDM_NAME" "$_sdm_r_msg" >&2
+  printf '%s: nada foi modificado — state.json de origem intacto\n' "$_SDM_NAME" >&2
+  exit 3
+}
+
+_sdm_require() {
+  command -v "$1" >/dev/null 2>&1 || _sdm_die \
+    "$1 nao encontrado no PATH — dependencia obrigatoria da camada de estado transacional (docs/constitution.md amendment 1.3.0)" 1
+}
+
+_sdm_iso_now() { date -u +%FT%TZ; }
+
+# _sdm_sha256_file FILE -> hash sha256 (mesma logica de state-rw.sh:_sr_sha256_file).
+_sdm_sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  else
+    _sdm_die "sha256sum/shasum ausente — instale coreutils ou perl-shasum" 1
+  fi
+}
+
+# _sdm_record_run DB RESULT DIAG COUNTS_SRC COUNTS_TGT -> INSERT em migration_run.
+# Best-effort: falha de registro NUNCA muda o desfecho da migracao (o registro
+# e evidencia auditavel, nao o resultado em si).
+_sdm_record_run() {
+  _rr_db="$1"; _rr_result="$2"; _rr_diag="$3"; _rr_cs="$4"; _rr_ct="$5"
+  _rr_sql="INSERT INTO migration_run (execution_id,source_path,source_sha256,started_at,finished_at,result,diagnostic,counts_source,counts_target) VALUES ("
+  _rr_sql="$_rr_sql'$(sql_escape "${_SDM_EXEC_ID:-desconhecido}")',"
+  _rr_sql="$_rr_sql'$(sql_escape "${_SDM_SRC:-}")',"
+  _rr_sql="$_rr_sql'$(sql_escape "${_SDM_SRC_SHA:-}")',"
+  _rr_sql="$_rr_sql'$(sql_escape "${_SDM_STARTED_AT:-}")',"
+  _rr_sql="$_rr_sql'$(sql_escape "$(_sdm_iso_now)")',"
+  _rr_sql="$_rr_sql'$(sql_escape "$_rr_result")',"
+  _rr_sql="$_rr_sql$([ -n "$_rr_diag" ] && printf "'%s'" "$(sql_escape "$_rr_diag")" || printf NULL),"
+  _rr_sql="$_rr_sql$([ -n "$_rr_cs" ] && printf "'%s'" "$(sql_escape "$_rr_cs")" || printf NULL),"
+  _rr_sql="$_rr_sql$([ -n "$_rr_ct" ] && printf "'%s'" "$(sql_escape "$_rr_ct")" || printf NULL));"
+  _state_db_exec "$_rr_db" "$_rr_sql" >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# ============================================================
+# M3.2 — normalizacao contratual para a comparacao campo-a-campo
+# ============================================================
+#
+# O export do state.db (state-rw.sh read) NAO e byte-identico ao state.json de
+# origem por tres transformacoes DOCUMENTADAS pelo contrato — nenhuma delas e
+# perda de dado. Aplicamos a MESMA normalizacao aos dois lados; qualquer
+# divergencia FORA desta lista reprova a migracao (M3.2).
+#
+# 1. decisions[].wave_id == "init" -> null
+#    data-model.md §decision: `wave_id | TEXT | FK -> wave(id), NULL p/ "init"`.
+#    Sentinela de decisao registrada antes da primeira onda.
+#
+# 2. chaves de valor null <-> chave ausente
+#    O export emite explicitamente `briefing_cache: null` quando a coluna e
+#    NULL, e OMITE `agent_usage: null` (drop_null_keys do _sr_db_read). Ou
+#    seja: "ausente" e "null" sao o MESMO estado nos dois formatos. A
+#    normalizacao remove recursivamente toda chave de valor null dos dois
+#    lados, tornando a comparacao insensivel a essa escolha de representacao.
+#
+# 3. accumulated_metrics — agregado DERIVADO, recomputado pelo export
+#    Todo campo de accumulated_metrics e um contador sobre entidades que a
+#    migracao preserva integralmente (waves, decisions, human_blocks,
+#    waves[].agent_spawns, waves[].agent_usage, suggestions). Sob state.json
+#    ele e um CACHE mantido por incremento; sob state.db ele e recomputado por
+#    SELECT a cada leitura. Divergir e esperado (o cache podia estar defasado,
+#    e as 9 entidades fechadas em data-model.md nao modelam os agregados
+#    agent_*). Nenhum INSUMO se perde — so o cache do agregado. Para nao
+#    perder nem isso forensicamente, o objeto accumulated_metrics de ORIGEM e
+#    gravado integralmente em migration_run.counts_source.
+#
+# 4. budgets.current_wave_start / budgets.tool_calls_current_wave — derivados
+#    da ONDA ABERTA. Nao ha coluna para eles no schema: o export os calcula
+#    com `SELECT ... FROM wave WHERE termination_reason IS NULL` (e
+#    _sr_db_set RECUSA grava-los: "campo derivado da onda aberta — nao
+#    gravavel diretamente sob backend SQLite"). Com uma onda aberta os dois
+#    lados coincidem; numa execucao concluida (nenhuma onda aberta) o
+#    state.json ainda carrega o valor da ULTIMA onda, ja obsoleto, enquanto o
+#    export corretamente nao produz nenhum. Divergencia de cache defasado, nao
+#    de dado migrado.
+#
+# A lista acima e FECHADA e derivada do contrato — nao um "ajuste ate passar".
+# Qualquer divergencia fora dela reprova a migracao (M3.2).
+_SDM_NORMALIZE_JQ='
+  def drop_nulls:
+    walk(if type == "object" then with_entries(select(.value != null)) else . end);
+  (.decisions // []) as $d
+  | (if ($d | length) > 0
+     then .decisions |= map(if .wave_id == "init" then .wave_id = null else . end)
+     else . end)
+  | del(.accumulated_metrics)
+  | (if has("budgets")
+     then .budgets |= del(.current_wave_start, .tool_calls_current_wave)
+     else . end)
+  | drop_nulls
+'
+
+# ============================================================
+# migrate
+# ============================================================
+
+_sdm_cmd_migrate() {
+  _SDM_SD=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --state-dir) _SDM_SD=$2; shift 2 ;;
+      *) _sdm_die_usage "migrate: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_SDM_SD" ] || _sdm_die_usage "migrate: --state-dir obrigatorio"
+
+  _sdm_require sqlite3
+  _sdm_require jq
+
+  [ -d "$_SDM_SD" ] || _sdm_die "migrate: state-dir nao existe: $_SDM_SD" 1
+  _SDM_SRC="$_SDM_SD/state.json"
+  _SDM_DB="$_SDM_SD/state.db"
+  _SDM_STARTED_AT=$(_sdm_iso_now)
+
+  # ---------- M1: pre-condicoes (recusar antes de tocar em qualquer coisa) ----------
+
+  # M1.4 — state.json ausente/ilegivel
+  [ -f "$_SDM_SRC" ] || _sdm_refuse "state.json ausente em $_SDM_SD (nada a migrar)"
+  jq -e . "$_SDM_SRC" >/dev/null 2>&1 \
+    || _sdm_refuse "state.json nao e JSON parseavel (jq -e . '$_SDM_SRC' para localizar o erro)"
+
+  _SDM_EXEC_ID=$(jq -r '.execution.id // ""' "$_SDM_SRC")
+  [ -n "$_SDM_EXEC_ID" ] \
+    || _sdm_refuse "state.json sem .execution.id — origem nao identificavel (chave de idempotencia, M5)"
+  _SDM_SRC_SHA=$(_sdm_sha256_file "$_SDM_SRC")
+
+  # M1.1 — execucao ativa. `aguardando_humano` E PERMITIDO (dec-033): FR-005
+  # nomeia so `em_andamento` e admite "pausada"; aguardando_humano esta pausada.
+  _sdm_status=$(jq -r '.execution.status // ""' "$_SDM_SRC")
+  [ "$_sdm_status" != "em_andamento" ] || _sdm_refuse \
+    "execucao ativa (.execution.status = em_andamento) — conclua, aborte (/feature-00c-abort) ou aguarde a pausa antes de migrar (FR-005)"
+
+  # M1.2 — estado invalido. state-validate.sh le state.json DIRETO (nao passa
+  # por state-rw.sh), logo continua validando a ORIGEM mesmo quando ja existe
+  # state.db. Cobre SC-006/US2 AS-3 (bloqueio humano orfao) sem codigo novo.
+  if ! _sdm_val=$("$_SDM_SELF_DIR/state-validate.sh" --state-dir "$_SDM_SD" 2>&1); then
+    _sdm_refuse "state.json invalido segundo state-validate.sh: $(printf '%s' "$_sdm_val" | tr '\n' ' ')"
+  fi
+
+  # M1.3 — integridade divergente. NAO delegamos a `state-rw.sh sha256-verify`
+  # incondicionalmente porque ele e backend-aware: com state.db presente ele
+  # verifica o BANCO (PRAGMA integrity_check), nao o state.json de origem —
+  # exatamente o oposto do que M1.3 pede numa reexecucao. Comparamos o
+  # state.json.sha256 com o hash real da origem (mesma semantica do caminho
+  # JSON de sha256-verify).
+  _sdm_shafile="$_SDM_SD/state.json.sha256"
+  if [ -f "$_sdm_shafile" ]; then
+    _sdm_stored=$(head -n 1 -- "$_sdm_shafile" | tr -d '[:space:]')
+    [ "$_sdm_stored" = "$_SDM_SRC_SHA" ] || _sdm_refuse \
+      "integridade divergente do state.json (stored=$_sdm_stored actual=$_SDM_SRC_SHA) — rode state-rw.sh sha256-update se a mudanca foi legitima, senao investigue tampering"
+  fi
+
+  # M1.5 / M5 — state.db pre-existente de OUTRA execucao ⇒ recusar.
+  if [ -f "$_SDM_DB" ]; then
+    _sdm_prev_id=$(_state_db_exec "$_SDM_DB" "SELECT id FROM execution LIMIT 1;" 2>/dev/null) || _sdm_prev_id=""
+    if [ -n "$_sdm_prev_id" ] && [ "$_sdm_prev_id" != "$_SDM_EXEC_ID" ]; then
+      _sdm_refuse "state.db existente e de outra execucao (banco=$_sdm_prev_id origem=$_SDM_EXEC_ID) — intervencao humana necessaria (M5)"
+    fi
+  fi
+
+  # ---------- M2: CONSTRUIR fora (temporario) ----------
+  #
+  # mktemp -d no PROPRIO state-dir: mesmo filesystem (requisito do mv atomico
+  # de M4) e nome aleatorio, NUNCA derivado de PID (primitives.md §C10,
+  # finding S4). Um DIRETORIO (nao um arquivo) porque o banco em construcao
+  # precisa se chamar exatamente `state.db` para que `state-rw.sh write`
+  # resolva o backend SQLite por presenca do arquivo (_sr_backend) e reuse o
+  # importador FK-ordenado ja auditado, em vez de duplicar o mapeamento aqui.
+  _SDM_TMPDIR=$(mktemp -d -- "$_SDM_SD/.state-db-migrate.XXXXXX") \
+    || _sdm_die "migrate: mktemp -d falhou em $_SDM_SD" 1
+  _sdm_tmpdb="$_SDM_TMPDIR/state.db"
+
+  # _sdm_abort_build MSG [EXIT] -> descarta o temporario e aborta (M4: nada
+  # publicado, state.json intacto). Registra `failed` em migration_run do
+  # state.db PRE-EXISTENTE quando houver (M5: "toda tentativa"); numa primeira
+  # migracao que falha nao existe banco algum onde registrar — o diagnostico
+  # em stderr + exit nao-zero e o registro.
+  _sdm_abort_build() {
+    if [ -f "$_SDM_DB" ]; then
+      _sdm_record_run "$_SDM_DB" failed "$1" '' '' || :
+    fi
+    rm -rf -- "$_SDM_TMPDIR" 2>/dev/null || :
+    _sdm_die "$1" "${2:-1}"
+  }
+
+  # M2.2 — schema + PRAGMAs (WAL + chmod 600 aplicados por state-db-schema.sh)
+  "$_SDM_SELF_DIR/state-db-schema.sh" create --db "$_sdm_tmpdb" >/dev/null 2>&1 \
+    || _sdm_abort_build "migrate: falha ao aplicar o schema no temporario"
+
+  # M2.3 — insercao na ordem imposta pelas FKs:
+  #   execution -> wave -> decision -> human_block/skill_invocation/task/event
+  #
+  # A linha de `execution` entra aqui (o importador de documento faz UPDATE,
+  # nao INSERT — ele assume a execucao ja existente). Todas as colunas de
+  # budget entram nesta INSERT porque o importador nao as toca. IDs e
+  # timestamps ORIGINAIS, sem renumeracao (FR-005 literal).
+  _sdm_insert_execution "$_sdm_tmpdb" || _sdm_abort_build "migrate: INSERT da execution falhou"
+
+  # Demais entidades via o importador FK-ordenado ja auditado
+  # (_sr_db_write_document, exercitado por tests/test_state-rw.sh).
+  if ! _sdm_werr=$("$_SDM_SELF_DIR/state-rw.sh" write --state-dir "$_SDM_TMPDIR" < "$_SDM_SRC" 2>&1); then
+    _sdm_abort_build "migrate: importacao das entidades falhou: $(printf '%s' "$_sdm_werr" | tr '\n' ' ')"
+  fi
+
+  # ---------- M3: VERIFICAR (falha ⇒ remove o temporario e aborta) ----------
+
+  _sdm_counts_src=$(_sdm_counts_source "$_SDM_SRC")
+  _sdm_counts_tgt=$(_sdm_counts_target "$_sdm_tmpdb")
+
+  # M3.1 — contagem por entidade
+  if [ "$_sdm_counts_src" != "$_sdm_counts_tgt" ]; then
+    _sdm_abort_build "migrate: M3.1 reprovada — contagem por entidade divergente
+  origem : $_sdm_counts_src
+  destino: $_sdm_counts_tgt"
+  fi
+
+  # M3.2 — comparacao campo-a-campo via round-trip (export do banco recem
+  # construido vs state.json de origem, ambos canonicalizados e normalizados
+  # pelas 3 transformacoes contratuais de _SDM_NORMALIZE_JQ).
+  _sdm_exp="$_SDM_TMPDIR/export.json"
+  if ! "$_SDM_SELF_DIR/state-rw.sh" read --state-dir "$_SDM_TMPDIR" > "$_sdm_exp" 2>/dev/null; then
+    _sdm_abort_build "migrate: M3.2 reprovada — export do banco migrado falhou"
+  fi
+  _sdm_a="$_SDM_TMPDIR/norm-source.json"
+  _sdm_b="$_SDM_TMPDIR/norm-target.json"
+  jq -S "$_SDM_NORMALIZE_JQ" "$_SDM_SRC" > "$_sdm_a" 2>/dev/null \
+    || _sdm_abort_build "migrate: M3.2 reprovada — normalizacao da origem falhou"
+  jq -S "$_SDM_NORMALIZE_JQ" "$_sdm_exp" > "$_sdm_b" 2>/dev/null \
+    || _sdm_abort_build "migrate: M3.2 reprovada — normalizacao do export falhou"
+  if ! _sdm_diff=$(diff -u "$_sdm_a" "$_sdm_b" 2>&1); then
+    _sdm_abort_build "migrate: M3.2 reprovada — export do banco migrado diverge do state.json de origem
+$(printf '%s' "$_sdm_diff" | head -n 40)"
+  fi
+
+  # M5 — preserva o historico de migration_run do banco anterior (a migracao e
+  # reconstrucao TOTAL; sem isso, reexecutar apagaria a trilha de auditoria).
+  if [ -f "$_SDM_DB" ]; then
+    _sdm_carry_migration_runs "$_SDM_DB" "$_sdm_tmpdb" || :
+  fi
+
+  # Registra a tentativa bem-sucedida ANTES de publicar (o banco publicado ja
+  # nasce com sua propria evidencia dentro).
+  _sdm_record_run "$_sdm_tmpdb" success "" "$_sdm_counts_src" "$_sdm_counts_tgt" || :
+
+  # ---------- M4: PUBLICAR (mv atomico, mesmo filesystem) ----------
+  #
+  # O -wal/-shm do temporario sao descartaveis: o checkpoint abaixo integra o
+  # WAL ao arquivo principal, de modo que o `mv` de um unico arquivo publica um
+  # banco completo. Sem isso, mover so o state.db deixaria para tras
+  # transacoes ainda no WAL.
+  _state_db_exec "$_sdm_tmpdb" "PRAGMA wal_checkpoint(TRUNCATE);" >/dev/null 2>&1 || :
+  mv -f -- "$_sdm_tmpdb" "$_SDM_DB" \
+    || _sdm_abort_build "migrate: publicacao (mv) falhou — state.json de origem intacto"
+  _state_db_secure_perms "$_SDM_DB"
+  rm -rf -- "$_SDM_TMPDIR" 2>/dev/null || :
+
+  # M6: state.json, state.json.sha256 e state-history/ permanecem intactos —
+  # nenhuma remocao acontece em ponto algum deste script (grep -n 'rm ' cobre
+  # so o temporario). O state.json passa a ser export/legado (Decision 9).
+  printf '%s: migrate: state.db publicado em %s\n' "$_SDM_NAME" "$_SDM_DB"
+  printf '%s: migrate: contagens verificadas (M3.1) %s\n' "$_SDM_NAME" "$_sdm_counts_src"
+  printf '%s: migrate: round-trip verificado (M3.2) contra %s\n' "$_SDM_NAME" "$_SDM_SRC"
+  printf '%s: migrate: state.json PRESERVADO como export/legado (M6)\n' "$_SDM_NAME"
+}
+
+# _sdm_lit_str VALUE -> literal SQL: NULL se vazio, senao 'escapado'.
+# (String vazia e NULL sao indistinguiveis aqui de proposito: nenhuma coluna
+# de `execution` distingue "ausente" de "vazio" — o export reconstroi ambas
+# como ausencia, e a normalizacao M3.2 trata null == ausente.)
+_sdm_lit_str() {
+  if [ -z "$1" ]; then printf 'NULL'; else printf "'%s'" "$(printf '%s' "$1" | strip_nul | sed "s/'/''/g")"; fi
+}
+
+# _sdm_lit_json JSON -> literal SQL: NULL se vazio/`null`, senao 'json'.
+_sdm_lit_json() {
+  if [ -z "$1" ] || [ "$1" = "null" ]; then printf 'NULL'; else
+    printf "'%s'" "$(printf '%s' "$1" | strip_nul | sed "s/'/''/g")"; fi
+}
+
+# _sdm_jq_raw FILTER -> extrai texto do state.json de origem ("" se null).
+_sdm_jq_raw() { jq -r "$1 // empty" "$_SDM_SRC" 2>/dev/null || printf ''; }
+# _sdm_jq_json FILTER -> extrai JSON compacto do state.json de origem.
+_sdm_jq_json() { jq -c "$1" "$_SDM_SRC" 2>/dev/null || printf 'null'; }
+# _sdm_jq_int FILTER DEFAULT -> extrai inteiro (com default).
+_sdm_jq_int() { jq -r "$1 // $2" "$_SDM_SRC" 2>/dev/null || printf '%s' "$2"; }
+
+# _sdm_insert_execution DB -> INSERT da linha unica de `execution`, com todas
+# as colunas escalares + blobs JSON, a partir do state.json de origem.
+#
+# SQL montado em shell (nao em jq) deliberadamente: gerar SQL DENTRO do
+# programa jq exigiria aspas simples literais no meio de um script jq
+# single-quoted no shell — fonte classica de quebra de quoting. Aqui o jq so
+# EXTRAI valores e todo literal passa por strip_nul + escape de aspas
+# (primitives.md §C8), igual ao resto do runtime.
+_sdm_insert_execution() {
+  _ie_db="$1"
+  _ie_atomic=$(_sdm_jq_json '.atomic_commit_enabled')
+  _ie_atomic_sql="NULL"
+  case "$_ie_atomic" in true) _ie_atomic_sql=1 ;; false) _ie_atomic_sql=0 ;; esac
+
+  _ie_sql="INSERT INTO execution (id,schema_version,short_name,target_project_path,\
+target_project_description,suggested_stack,status,termination_reason,started_at,\
+finished_at,canonical_project,session_name,current_stage,next_instruction,\
+atomic_commit_enabled,initial_key_aspects,subagent_depth,max_recursion,\
+cycles_consumed_current_stage,max_cycles_per_stage,retro_executions_consumed,\
+max_retro_executions_per_feature,tool_calls_threshold_wave,\
+wallclock_threshold_seconds,state_size_threshold_bytes,external_urls_whitelist,\
+circular_movement_history,prerequisites,briefing_cache,constitution_cache,\
+push_pr_result) VALUES ("
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.execution.id')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(jq -r '.schema_version // "1.0.0"' "$_SDM_SRC")"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.short_name')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.execution.target_project_path')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.execution.target_project_description')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_json "$(_sdm_jq_json '.execution.suggested_stack')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.execution.status')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.execution.termination_reason')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.execution.started_at')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.execution.finished_at')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.execution.canonical_project')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.execution.session_name')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.current_stage')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_str "$(_sdm_jq_raw '.next_instruction')"),"
+  _ie_sql="$_ie_sql$_ie_atomic_sql,"
+  _ie_sql="$_ie_sql$(_sdm_lit_json "$(_sdm_jq_json '.initial_key_aspects // []')"),"
+  _ie_sql="$_ie_sql$(_sdm_jq_int '.budgets.current_subagent_depth' 1),"
+  _ie_sql="$_ie_sql$(_sdm_jq_int '.budgets.max_recursion' 3),"
+  _ie_sql="$_ie_sql$(_sdm_jq_int '.budgets.cycles_consumed_current_stage' 0),"
+  _ie_sql="$_ie_sql$(_sdm_jq_int '.budgets.max_cycles_per_stage' 5),"
+  _ie_sql="$_ie_sql$(_sdm_jq_int '.budgets.retro_executions_consumed' 0),"
+  _ie_sql="$_ie_sql$(_sdm_jq_int '.budgets.max_retro_executions_per_feature' 2),"
+  _ie_sql="$_ie_sql$(_sdm_jq_int '.budgets.tool_calls_threshold_wave' 80),"
+  _ie_sql="$_ie_sql$(_sdm_jq_int '.budgets.wallclock_threshold_seconds' 5400),"
+  _ie_sql="$_ie_sql$(_sdm_jq_int '.budgets.state_size_threshold_bytes' 1048576),"
+  _ie_sql="$_ie_sql$(_sdm_lit_json "$(_sdm_jq_json '.external_urls_whitelist // []')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_json "$(_sdm_jq_json '.circular_movement_history // []')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_json "$(_sdm_jq_json '.prerequisites')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_json "$(_sdm_jq_json '.briefing_cache')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_json "$(_sdm_jq_json '.constitution_cache')"),"
+  _ie_sql="$_ie_sql$(_sdm_lit_json "$(_sdm_jq_json '.push_pr_result')"));"
+
+  _state_db_exec_with_retry "$_ie_db" "$_ie_sql" >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# _sdm_counts_source JSON -> JSON compacto com a contagem das 6 entidades
+# listadas em migration.md §M3.1 (chaves em ordem fixa para comparacao literal).
+_sdm_counts_source() {
+  jq -c '{
+    decisions:    (.decisions    // [] | length),
+    waves:        (.waves        // [] | length),
+    human_blocks: (.human_blocks // [] | length),
+    tasks:        (.tasks        // [] | length),
+    events:       (.events       // [] | length),
+    skill_invocation: ([(.waves // [])[].skills_invoked // [] | .[]] | length)
+  }' "$1" 2>/dev/null
+}
+
+# _sdm_counts_target DB -> mesmo formato, via COUNT(*) no banco.
+_sdm_counts_target() {
+  _ct_raw=$(_state_db_exec "$1" "SELECT
+    (SELECT count(*) FROM decision) || '|' ||
+    (SELECT count(*) FROM wave) || '|' ||
+    (SELECT count(*) FROM human_block) || '|' ||
+    (SELECT count(*) FROM task_outcome) || '|' ||
+    (SELECT count(*) FROM event) || '|' ||
+    (SELECT count(*) FROM skill_invocation);" 2>/dev/null) || return 1
+  printf '%s' "$_ct_raw" | awk -F'|' '{
+    printf "{\"decisions\":%s,\"waves\":%s,\"human_blocks\":%s,\"tasks\":%s,\"events\":%s,\"skill_invocation\":%s}",
+      $1,$2,$3,$4,$5,$6 }'
+}
+
+# _sdm_carry_migration_runs OLD_DB NEW_DB -> copia migration_run do banco
+# anterior para o novo (preserva a trilha de auditoria atraves de reexecucoes).
+_sdm_carry_migration_runs() {
+  _cm_old="$1"; _cm_new="$2"
+  _cm_dump=$(_state_db_exec "$_cm_old" \
+    "SELECT 'INSERT INTO migration_run (execution_id,source_path,source_sha256,started_at,finished_at,result,diagnostic,counts_source,counts_target) VALUES (' ||
+       quote(execution_id) || ',' || quote(source_path) || ',' || quote(source_sha256) || ',' ||
+       quote(started_at) || ',' || quote(finished_at) || ',' || quote(result) || ',' ||
+       quote(diagnostic) || ',' || quote(counts_source) || ',' || quote(counts_target) || ');'
+     FROM migration_run ORDER BY id;" 2>/dev/null) || return 1
+  [ -n "$_cm_dump" ] || return 0
+  _state_db_exec "$_cm_new" "$_cm_dump" >/dev/null 2>&1 || return 1
+  return 0
+}
+
+_sdm_main() {
+  [ "$#" -ge 1 ] || _sdm_die_usage "subcomando obrigatorio (migrate)"
+  _sdm_sub=$1; shift
+  case "$_sdm_sub" in
+    migrate) _sdm_cmd_migrate "$@" ;;
+    -h|--help|help)
+      cat <<'HELP'
+state-db-migrate.sh — migracao explicita state.json -> state.db
+
+USO:
+  state-db-migrate.sh migrate --state-dir DIR
+
+EXIT CODES:
+  0 sucesso   1 falha   2 uso incorreto   3 recusado por pre-condicao (M1)
+
+Nunca roda automaticamente: so por invocacao explicita do operador (FR-005).
+O state.json de origem e sempre preservado (M6).
+HELP
+      exit 0
+      ;;
+    *) _sdm_die_usage "subcomando desconhecido: $_sdm_sub" ;;
+  esac
+}
+
+_sdm_main "$@"

--- a/global/skills/agente-00c-runtime/scripts/state-db-schema.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-db-schema.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# state-db-schema.sh — criacao idempotente do state.db (task 2.1.8).
+#
+# Ref: docs/specs/state-db-foundation/data-model.md (9 entidades)
+#      global/skills/agente-00c-runtime/references/state-db-schema.sql (DDL)
+#      docs/constitution.md — Mandatory dependency carve-out: transactional
+#      state layer (amendment 1.3.0), condicao (b) fail-fast diagnostico.
+#
+# Subcomandos:
+#   state-db-schema.sh create --db PATH
+#       — Aplica o DDL de references/state-db-schema.sql ao banco em PATH
+#         (cria o arquivo se nao existir). Idempotente: toda CREATE do DDL
+#         usa IF NOT EXISTS; reexecutar sobre um banco ja criado e no-op.
+#       — Aplica `PRAGMA journal_mode=WAL` uma unica vez apos a criacao
+#         (dec-014 — WAL como mecanismo primario de concorrencia).
+#       — `chmod 600` no banco e nos sidecars -wal/-shm apos a escrita
+#         (C9, finding S3, paridade com otel-usage.sh:262).
+#
+# Exit codes:
+#   0 sucesso
+#   1 erro generico (sqlite3 ausente, escrita/DDL falhou)
+#   2 uso incorreto
+#
+# POSIX sh. Dependencia obrigatoria de sqlite3 nesta camada — coberta pelo
+# carve-out do amendment 1.3.0 (fail-fast abaixo satisfaz a condicao (b)).
+
+set -eu
+
+_SDS_NAME="state-db-schema"
+_SDS_SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)
+_SDS_SCHEMA_SQL="$_SDS_SELF_DIR/../references/state-db-schema.sql"
+
+_sds_die_usage() {
+  printf '%s: %s\n' "$_SDS_NAME" "$1" >&2
+  exit 2
+}
+
+_sds_die() {
+  printf '%s: %s\n' "$_SDS_NAME" "$1" >&2
+  exit "${2:-1}"
+}
+
+_sds_require_sqlite3() {
+  command -v sqlite3 >/dev/null 2>&1 \
+    || _sds_die "sqlite3 nao encontrado no PATH (brew install sqlite | apt install sqlite3) — dependencia obrigatoria da camada de estado transacional, ver docs/constitution.md amendment 1.3.0" 1
+}
+
+_sds_cmd_create() {
+  _sds_db=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --db) _sds_db=$2; shift 2 ;;
+      *) _sds_die_usage "create: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_sds_db" ] || _sds_die_usage "create: --db obrigatorio"
+  [ -f "$_SDS_SCHEMA_SQL" ] || _sds_die "create: DDL nao encontrado em $_SDS_SCHEMA_SQL" 1
+
+  _sds_require_sqlite3
+
+  _sds_dbdir=$(dirname -- "$_sds_db")
+  [ -d "$_sds_dbdir" ] || _sds_die "create: diretorio do banco nao existe: $_sds_dbdir" 1
+
+  sqlite3 "$_sds_db" < "$_SDS_SCHEMA_SQL" \
+    || _sds_die "create: falha ao aplicar DDL em $_sds_db" 1
+
+  # WAL: idempotente por natureza (PRAGMA journal_mode e persistido no
+  # arquivo; reaplicar sobre um banco ja WAL e no-op silencioso do proprio
+  # SQLite). Executado apos o DDL para nao interferir na criacao inicial.
+  sqlite3 "$_sds_db" 'PRAGMA journal_mode=WAL;' >/dev/null \
+    || _sds_die "create: falha ao aplicar PRAGMA journal_mode=WAL em $_sds_db" 1
+
+  chmod 600 -- "$_sds_db" 2>/dev/null || :
+  chmod 600 -- "$_sds_db-wal" 2>/dev/null || :
+  chmod 600 -- "$_sds_db-shm" 2>/dev/null || :
+
+  printf '%s: create: schema aplicado em %s\n' "$_SDS_NAME" "$_sds_db"
+}
+
+_sds_main() {
+  [ "$#" -ge 1 ] || _sds_die_usage "subcomando obrigatorio (create)"
+  _sds_sub=$1; shift
+  case "$_sds_sub" in
+    create) _sds_cmd_create "$@" ;;
+    *) _sds_die_usage "subcomando desconhecido: $_sds_sub" ;;
+  esac
+}
+
+_sds_main "$@"

--- a/global/skills/agente-00c-runtime/scripts/state-db-schema.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-db-schema.sh
@@ -30,6 +30,9 @@ _SDS_NAME="state-db-schema"
 _SDS_SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P)
 _SDS_SCHEMA_SQL="$_SDS_SELF_DIR/../references/state-db-schema.sql"
 
+# shellcheck source=./_state-db.sh
+. "$_SDS_SELF_DIR/_state-db.sh"
+
 _sds_die_usage() {
   printf '%s: %s\n' "$_SDS_NAME" "$1" >&2
   exit 2
@@ -70,9 +73,7 @@ _sds_cmd_create() {
   sqlite3 "$_sds_db" 'PRAGMA journal_mode=WAL;' >/dev/null \
     || _sds_die "create: falha ao aplicar PRAGMA journal_mode=WAL em $_sds_db" 1
 
-  chmod 600 -- "$_sds_db" 2>/dev/null || :
-  chmod 600 -- "$_sds_db-wal" 2>/dev/null || :
-  chmod 600 -- "$_sds_db-shm" 2>/dev/null || :
+  _state_db_secure_perms "$_sds_db"
 
   printf '%s: create: schema aplicado em %s\n' "$_SDS_NAME" "$_sds_db"
 }

--- a/global/skills/agente-00c-runtime/scripts/state-decisions.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-decisions.sh
@@ -44,6 +44,20 @@
 set -eu
 
 _SD_NAME="state-decisions"
+_SD_DIR=$(cd "$(dirname -- "$0")" && pwd)
+
+# Backend dual (feature state-db-foundation, FASE 3 task 3.4): presenca de
+# <state-dir>/state.db seleciona SQLite; senao, backend JSON (comportamento
+# historico, intacto abaixo). Ver contracts/primitives.md §C1/C2. Reusa os
+# primitivos ja testados de _state-rw-db.sh (_sr_backend/_sr_db_file/
+# _sr_exec_id/_sr_sql_quote) em vez de duplica-los — mesmo racional de C8
+# para sql_escape/strip_nul.
+# shellcheck source=./_state-db.sh
+. "$_SD_DIR/_state-db.sh"
+# shellcheck source=./_state-rw-db.sh
+. "$_SD_DIR/_state-rw-db.sh"
+# shellcheck source=./_state-decisions-db.sh
+. "$_SD_DIR/_state-decisions-db.sh"
 
 _sd_die_usage() {
   printf '%s: %s\n' "$_SD_NAME" "$1" >&2
@@ -54,6 +68,11 @@ _sd_die() {
   printf '%s: %s\n' "$_SD_NAME" "$1" >&2
   exit "${2:-1}"
 }
+
+# Shim para _state-rw-db.sh (_sr_exec_id/_sr_sql_quote nao chamam _sr_die em
+# seus caminhos normais, mas o shim protege contra qualquer caminho de erro
+# latente sem duplicar a logica de _sd_die).
+_sr_die() { _sd_die "$1" "${2:-1}"; }
 
 _sd_require_jq() {
   if ! command -v jq >/dev/null 2>&1; then
@@ -215,6 +234,12 @@ _sd_cmd_register() {
     fi
   fi
 
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _sd_db_register "$_sdir" "$_ag" "$_et" "$_ctx" "$_ops" "$_esc" "$_just" \
+      "$_score" "$_evi" "$_refs" "$_arto"
+    return 0
+  fi
+
   _sf=$(_sd_state_file "$_sdir")
   [ -f "$_sf" ] || _sd_die "register: state.json ausente em $_sdir" 1
 
@@ -276,6 +301,10 @@ _sd_cmd_count() {
   done
   [ -n "$_sdir" ] || _sd_die_usage "count: --state-dir obrigatorio"
   _sd_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _sd_db_count "$_sdir" "$_ag"
+    return 0
+  fi
   _sf=$(_sd_state_file "$_sdir")
   [ -f "$_sf" ] || _sd_die "count: state.json ausente" 1
   if [ -n "$_ag" ]; then
@@ -295,6 +324,10 @@ _sd_cmd_next_id() {
   done
   [ -n "$_sdir" ] || _sd_die_usage "next-id: --state-dir obrigatorio"
   _sd_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _sd_db_next_id "$_sdir"
+    return 0
+  fi
   _sd_next_dec_id "$_sdir"
 }
 
@@ -312,6 +345,10 @@ _sd_cmd_list() {
   done
   [ -n "$_sdir" ] || _sd_die_usage "list: --state-dir obrigatorio"
   _sd_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _sd_db_list "$_sdir" "$_ag" "$_et"
+    return 0
+  fi
   _sf=$(_sd_state_file "$_sdir")
   [ -f "$_sf" ] || _sd_die "list: state.json ausente" 1
   jq -r --arg a "$_ag" --arg e "$_et" '

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -140,6 +140,22 @@
 #         --dry-run descreve a acao sem escrever. Stdout em recuperacao:
 #         "reconciled (phase=... motivo=... [next=...|terminal])".
 #
+#   state-ondas.sh export-snapshot --state-dir DIR
+#       — Export derivado (FASE 5 — state-db-foundation, FR-007/
+#         FR-013-INFRA-BACKUP, contracts/export.md, dec-032 E5-a): gera um
+#         `state.json` equivalente via `state-rw.sh read` (Opcao A do
+#         contrato, backend-agnostico) e grava em
+#         state-history/export-<wave-id-ou-init>-<timestamp>.json (escrita
+#         atomica via mktemp+mv; sufixo aleatorio do mktemp preservado no
+#         nome final, evita colisao entre chamadas no mesmo segundo UTC).
+#         Gatilho SOB DEMANDA — o gatilho
+#         AUTOMATICO equivalente roda dentro de `end` sob backend SQLite
+#         (mesmo ponto conceitual onde o backup de state-history/ acontece
+#         hoje sob backend JSON via `_so_backup_current`; ver E6: falha no
+#         export MUST NOT reverter nem impedir o fechamento da onda).
+#         Stdout: path do snapshot gerado. Exit 1 com diagnostico em stderr
+#         se a geracao falhar (jq ausente, read falhou, I/O).
+#
 #   state-ondas.sh git-commit --state-dir DIR --projeto-alvo-path PATH
 #                             --motivo MOTIVO [--onda-id ID]
 #       — Delega o staging a `commit-mode.sh stage-derived` (allowlist
@@ -255,6 +271,73 @@ _so_backup_current() {
   _ts=$(date -u +%Y%m%dT%H%M%SZ)
   _bk="$_hd/${_curr}-${_ts}.json"
   mv -- "$_sf" "$_bk" || _so_die "backup falhou" 1
+}
+
+# _so_export_snapshot DIR -> Export derivado (FASE 5, contracts/export.md
+# Opcao A — reusa `state-rw.sh read`, backend-agnostico: funciona tanto sob
+# state.db quanto sob state.json). Grava snapshot atomico (mktemp + mv) em
+# state-history/export-<wave-id-ou-init>-<timestamp>.json. Imprime o path
+# gerado em stdout no sucesso.
+#
+# NUNCA falha alto: qualquer erro (self-dir irresolvivel, state-rw.sh
+# ausente, read falhou, JSON invalido, I/O) loga via _so_log e retorna 1 —
+# jamais chama _so_die. E6 (contracts/export.md, MUST): quem decide se a
+# falha e fatal e o CALLER — o gatilho automatico em `_so_db_end` roda isto
+# APOS o COMMIT que fechou a onda (a fonte de verdade ja esta segura;
+# degradar aqui nunca reverte nem bloqueia esse fechamento), enquanto o
+# subcomando `export-snapshot` (uso explicito/sob-demanda) converte a falha
+# em exit 1 porque ali e um pedido direto do operador.
+_so_export_snapshot() {
+  _oes_sdir=$1
+  _oes_selfdir=$(_so_self_dir) \
+    || { _so_log "export-snapshot: nao foi possivel resolver o diretorio de scripts"; return 1; }
+  _oes_rw="$_oes_selfdir/state-rw.sh"
+  [ -f "$_oes_rw" ] || { _so_log "export-snapshot: state-rw.sh ausente ($_oes_rw)"; return 1; }
+
+  _oes_hd="$_oes_sdir/state-history"
+  mkdir -p -- "$_oes_hd" 2>/dev/null \
+    || { _so_log "export-snapshot: mkdir state-history falhou"; return 1; }
+
+  _oes_doc=$(sh "$_oes_rw" read --state-dir "$_oes_sdir" 2>/dev/null) \
+    || { _so_log "export-snapshot: state-rw.sh read falhou"; return 1; }
+  [ -n "$_oes_doc" ] || { _so_log "export-snapshot: documento gerado por read esta vazio"; return 1; }
+  printf '%s' "$_oes_doc" | jq -e . >/dev/null 2>&1 \
+    || { _so_log "export-snapshot: documento gerado por read nao e JSON valido"; return 1; }
+
+  _oes_label=$(printf '%s' "$_oes_doc" | jq -r '((.waves // [])[-1].id // "init")' 2>/dev/null) \
+    || _oes_label="init"
+  case "$_oes_label" in ''|null) _oes_label="init" ;; esac
+  _oes_ts=$(date -u +%Y%m%dT%H%M%SZ)
+  # mktemp gera o componente aleatorio de unicidade — 2 chamadas no MESMO
+  # segundo UTC (granularidade de $_oes_ts, sem fracao portavel em sh/date)
+  # com a mesma onda aberta colidiriam se o destino final nao carregasse
+  # esse sufixo. Mantemos o nome gerado pelo proprio mktemp (dentro de
+  # state-history/) em vez de descarta-lo apos o mv, como C10 (primitives.md)
+  # ja recomenda para nomes nao-derivados-de-PID.
+  _oes_tmp=$(mktemp -- "$_oes_hd/.export-tmp-XXXXXX") \
+    || { _so_log "export-snapshot: mktemp falhou"; return 1; }
+  _oes_rand=${_oes_tmp##*-}
+  _oes_dst="$_oes_hd/export-${_oes_label}-${_oes_ts}-${_oes_rand}.json"
+  printf '%s\n' "$_oes_doc" > "$_oes_tmp" \
+    || { rm -f -- "$_oes_tmp"; _so_log "export-snapshot: I/O ao gravar snapshot"; return 1; }
+  mv -f -- "$_oes_tmp" "$_oes_dst" \
+    || { rm -f -- "$_oes_tmp"; _so_log "export-snapshot: mv falhou"; return 1; }
+  printf '%s\n' "$_oes_dst"
+  return 0
+}
+
+_so_cmd_export_snapshot() {
+  _sdir=""
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --state-dir) _sdir=$2; shift 2 ;;
+      *) _so_die_usage "export-snapshot: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_sdir" ] || _so_die_usage "export-snapshot: --state-dir obrigatorio"
+  _so_require_jq
+  _so_export_snapshot "$_sdir" \
+    || _so_die "export-snapshot: falha ao gerar o snapshot (ver diagnostico acima)" 1
 }
 
 _so_next_onda_num() {
@@ -1451,6 +1534,7 @@ case "$_SO_SUBCMD" in
   wave-status)      _so_cmd_wave_status "$@" ;;
   reconcile-wave)   _so_cmd_reconcile_wave "$@" ;;
   current-id)       _so_cmd_current_id "$@" ;;
+  export-snapshot)  _so_cmd_export_snapshot "$@" ;;
   git-commit)       _so_cmd_git_commit "$@" ;;
   -h|--help|help)   exit 0 ;;
   *) _so_die_usage "subcomando desconhecido: $_SO_SUBCMD" ;;

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -174,9 +174,27 @@ _SO_DIR=$(cd "$(dirname -- "$0")" && pwd)
 # shellcheck source=./_diag.sh
 . "$_SO_DIR/_diag.sh"
 
+# Backend dual (feature state-db-foundation, FASE 3 task 3.3): presenca de
+# <state-dir>/state.db seleciona SQLite; senao, backend JSON (comportamento
+# historico, intacto abaixo). Ver contracts/primitives.md §C1/C2. Reusa os
+# primitivos ja testados de _state-rw-db.sh (_sr_backend/_sr_db_file/
+# _sr_exec_id/_sr_sql_quote) em vez de duplica-los — mesmo racional de C8
+# para sql_escape/strip_nul.
+# shellcheck source=./_state-db.sh
+. "$_SO_DIR/_state-db.sh"
+# shellcheck source=./_state-rw-db.sh
+. "$_SO_DIR/_state-rw-db.sh"
+# shellcheck source=./_state-ondas-db.sh
+. "$_SO_DIR/_state-ondas-db.sh"
+
 _so_die_usage() { printf '%s: %s\n' "$_SO_NAME" "$1" >&2; exit 2; }
 _so_die()       { printf '%s: %s\n' "$_SO_NAME" "$1" >&2; exit "${2:-1}"; }
 _so_log()       { printf '%s: %s\n' "$_SO_NAME" "$1" >&2; }
+
+# Shim para _state-rw-db.sh (funcoes reusadas como _sr_exec_id/_sr_sql_quote
+# nao chamam _sr_die em seus caminhos normais, mas o shim protege contra
+# qualquer caminho de erro latente sem duplicar a logica de _so_die).
+_sr_die() { _so_die "$1" "${2:-1}"; }
 
 _so_require_jq() {
   command -v jq >/dev/null 2>&1 \
@@ -476,6 +494,10 @@ _so_cmd_start() {
   done
   [ -n "$_sdir" ] || _so_die_usage "start: --state-dir obrigatorio"
   _so_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _so_db_start "$_sdir"
+    return 0
+  fi
   _sf=$(_so_state_file "$_sdir")
   [ -f "$_sf" ] || _so_die "start: state.json ausente em $_sdir" 1
 
@@ -540,13 +562,19 @@ _so_cmd_start() {
 # fluxo principal de start com `set -e` (toda falha aqui e silenciosa).
 _so_start_snapshot_baseline() {
   _ssb_sdir="$1"
-  _ssb_sf=$(_so_state_file "$_ssb_sdir")
   command -v git >/dev/null 2>&1 || return 0
 
-  _ssb_pap=$(jq -r '.execution.target_project_path // ""' "$_ssb_sf" 2>/dev/null) || _ssb_pap=""
-  [ -n "$_ssb_pap" ] && [ -d "$_ssb_pap" ] || return 0
-
+  # Le via state-rw.sh get (backend-safe: funciona sob JSON e SQLite sem
+  # branch aqui — state-rw.sh ja faz a selecao de backend internamente).
+  # Antes lia .execution.target_project_path via jq direto no state.json,
+  # o que quebrava silenciosamente sob backend SQLite (arquivo ausente).
   _ssb_selfdir=$(_so_self_dir) || return 0
+  _ssb_rw="$_ssb_selfdir/state-rw.sh"
+  [ -f "$_ssb_rw" ] || return 0
+  _ssb_pap=$(sh "$_ssb_rw" get --state-dir "$_ssb_sdir" --field '.execution.target_project_path' 2>/dev/null) || _ssb_pap=""
+  case "$_ssb_pap" in ''|null) return 0 ;; esac
+  [ -d "$_ssb_pap" ] || return 0
+
   _ssb_cm="$_ssb_selfdir/commit-mode.sh"
   [ -f "$_ssb_cm" ] || return 0
 
@@ -604,6 +632,10 @@ $2"; shift 2 ;;
     *) _so_die "end: motivo invalido: $_motivo" 2 ;;
   esac
   _so_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _so_db_end "$_sdir" "$_motivo" "$_proxima" "$_etapas" "$_next_instr_set" "$_next_instr"
+    return 0
+  fi
   _sf=$(_so_state_file "$_sdir")
   [ -f "$_sf" ] || _so_die "end: state.json ausente em $_sdir" 1
 
@@ -746,6 +778,10 @@ _so_cmd_tool_call_tick() {
   done
   [ -n "$_sdir" ] || _so_die_usage "tool-call-tick: --state-dir obrigatorio"
   _so_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _so_db_tool_call_tick "$_sdir"
+    return 0
+  fi
   _sf=$(_so_state_file "$_sdir")
   [ -f "$_sf" ] || _so_die "tool-call-tick: state.json ausente" 1
 
@@ -788,6 +824,10 @@ _so_cmd_record_skill() {
     *) _so_die_usage "record-skill: --kind deve ser skill|gate (recebido: $_kind)" ;;
   esac
   _so_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _so_db_record_skill "$_sdir" "$_skill" "$_dec" "$_kind"
+    return 0
+  fi
   _sf=$(_so_state_file "$_sdir")
   [ -f "$_sf" ] || _so_die "record-skill: state.json ausente em $_sdir" 1
 
@@ -891,10 +931,14 @@ _so_cmd_record_task() {
     *) _so_die_usage "record-task: --lint-ok deve ser true|false (ou vazio)" ;;
   esac
   _so_require_jq
-  _sf=$(_so_state_file "$_sdir")
-  [ -f "$_sf" ] || _so_die "record-task: state.json ausente em $_sdir" 1
   printf '%s' "$_af" | jq -e 'type == "array"' >/dev/null 2>&1 \
     || _so_die_usage "record-task: --arquivos deve ser um array JSON (ex: '[]')"
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _so_db_record_task "$_sdir" "$_tid" "$_ttl" "$_wid" "$_oc" "$_tr" "$_tp" "$_lk_json" "$_af" "$_origem" "$_ifabsent"
+    return 0
+  fi
+  _sf=$(_so_state_file "$_sdir")
+  [ -f "$_sf" ] || _so_die "record-task: state.json ausente em $_sdir" 1
 
   # wave-id default = onda corrente (proveniencia best-effort)
   if [ -z "$_wid" ]; then
@@ -959,9 +1003,13 @@ _so_cmd_reconcile_tasks() {
   [ -n "$_rc_sdir" ] || _so_die_usage "reconcile-tasks: --state-dir obrigatorio"
   [ -n "$_rc_md" ]   || _so_die_usage "reconcile-tasks: --tasks-md obrigatorio"
   _so_require_jq
+  [ -f "$_rc_md" ] || _so_die "reconcile-tasks: tasks.md ausente: $_rc_md" 1
+  if [ "$(_sr_backend "$_rc_sdir")" = "sqlite" ]; then
+    _so_db_reconcile_tasks "$_rc_sdir" "$_rc_md" "$_rc_wid" "$_rc_dry"
+    return 0
+  fi
   _rc_sf=$(_so_state_file "$_rc_sdir")
   [ -f "$_rc_sf" ] || _so_die "reconcile-tasks: state.json ausente em $_rc_sdir" 1
-  [ -f "$_rc_md" ] || _so_die "reconcile-tasks: tasks.md ausente: $_rc_md" 1
 
   if [ -z "$_rc_wid" ]; then
     _rc_wid=$(jq -r '((.waves // .ondas) // []) as $w | if ($w | length) > 0 then ($w[-1].id // "") else "" end' "$_rc_sf" 2>/dev/null) || _rc_wid=""
@@ -1114,6 +1162,10 @@ _so_cmd_current_id() {
   done
   [ -n "$_sdir" ] || _so_die_usage "current-id: --state-dir obrigatorio"
   _so_require_jq
+  if [ "$(_sr_backend "$_sdir")" = "sqlite" ]; then
+    _so_db_current_id "$_sdir"
+    return 0
+  fi
   _sf=$(_so_state_file "$_sdir")
   [ -f "$_sf" ] || _so_die "current-id: state.json ausente" 1
   jq -r '
@@ -1245,6 +1297,10 @@ _so_cmd_wave_status() {
   done
   [ -n "$_ws_sdir" ] || _so_die_usage "wave-status: --state-dir obrigatorio"
   _so_require_jq
+  if [ "$(_sr_backend "$_ws_sdir")" = "sqlite" ]; then
+    _so_db_wave_status "$_ws_sdir"
+    return 0
+  fi
   _ws_sf=$(_so_state_file "$_ws_sdir")
   [ -f "$_ws_sf" ] || _so_die "wave-status: state.json ausente em $_ws_sdir" 1
   jq -r '
@@ -1269,18 +1325,26 @@ _so_cmd_reconcile_wave() {
   done
   [ -n "$_rcw_sdir" ] || _so_die_usage "reconcile-wave: --state-dir obrigatorio"
   _so_require_jq
-  _rcw_sf=$(_so_state_file "$_rcw_sdir")
-  [ -f "$_rcw_sf" ] || _so_die "reconcile-wave: state.json ausente em $_rcw_sdir" 1
+  # Existencia do estado — backend-aware (task 3.3): state.json so existe
+  # sob backend JSON; sob SQLite o arquivo fonte de verdade e state.db.
+  if [ "$(_sr_backend "$_rcw_sdir")" = "sqlite" ]; then
+    [ -f "$(_sr_db_file "$_rcw_sdir")" ] || _so_die "reconcile-wave: state.db ausente em $_rcw_sdir" 1
+  else
+    _rcw_sf=$(_so_state_file "$_rcw_sdir")
+    [ -f "$_rcw_sf" ] || _so_die "reconcile-wave: state.json ausente em $_rcw_sdir" 1
+  fi
+
+  _rcw_selfdir=$(_so_self_dir) || _rcw_selfdir="."
+  _rcw_pipeline="$_rcw_selfdir/pipeline.sh"
+  _rcw_rw="$_rcw_selfdir/state-rw.sh"
+  [ -f "$_rcw_rw" ] || _so_die "reconcile-wave: state-rw.sh nao encontrado em $_rcw_selfdir" 1
 
   # Guarda de idempotencia: so recupera onda ABERTA. Onda fechada/inexistente
   # = no-op (exit 0). E o que torna seguro o pai chamar a CADA onda sem
   # double-count em accumulated_metrics (que `end` incrementa por chamada).
-  _rcw_status=$(jq -r '
-    ((.waves // .ondas) // []) as $w
-    | if   ($w | length) == 0                  then "none"
-      elif ($w[-1].termination_reason // null) == null then "open"
-      else "closed" end
-  ' "$_rcw_sf")
+  # Via _so_cmd_wave_status (ja dispatcha por backend) em vez de jq direto
+  # no arquivo — o jq inline so funcionava sob backend JSON.
+  _rcw_status=$(_so_cmd_wave_status --state-dir "$_rcw_sdir")
   if [ "$_rcw_status" != "open" ]; then
     printf 'noop (%s)\n' "$_rcw_status"
     return 0
@@ -1289,8 +1353,10 @@ _so_cmd_reconcile_wave() {
   # Resolve a fase que a onda rodou. current_stage == fase corrente ate o
   # fechamento (init grava current_stage = fase a rodar; o avanco do ponteiro
   # so ocorre ao fechar a onda). --phase permite ao pai fixar explicitamente.
+  # Via state-rw.sh get (backend-aware) em vez de jq direto no arquivo.
   if [ -z "$_rcw_phase" ]; then
-    _rcw_phase=$(jq -r '(.current_stage // .etapa_corrente) // ""' "$_rcw_sf")
+    _rcw_phase=$(sh "$_rcw_rw" get --state-dir "$_rcw_sdir" --field '.current_stage' 2>/dev/null) || _rcw_phase=""
+    case "$_rcw_phase" in null) _rcw_phase="" ;; esac
   fi
   [ -n "$_rcw_phase" ] || _so_die "reconcile-wave: nao foi possivel resolver a fase (--phase ou .current_stage)" 1
 
@@ -1300,9 +1366,6 @@ _so_cmd_reconcile_wave() {
   # feature-00c o pai passa --terminal-phase review-task — quando a fase
   # corrente == terminal-phase, tratamos como terminal (next vazio) sem
   # consultar pipeline.sh (que avancaria erroneamente para review-features).
-  _rcw_selfdir=$(_so_self_dir) || _rcw_selfdir="."
-  _rcw_pipeline="$_rcw_selfdir/pipeline.sh"
-  _rcw_rw="$_rcw_selfdir/state-rw.sh"
   if [ -n "$_rcw_terminal" ] && [ "$_rcw_phase" = "$_rcw_terminal" ]; then
     _rcw_next=""
   elif [ -f "$_rcw_pipeline" ]; then
@@ -1337,7 +1400,7 @@ _so_cmd_reconcile_wave() {
   _so_cmd_end --state-dir "$_rcw_sdir" --motivo-termino "$_rcw_motivo" >/dev/null
 
   # 4. avancar ponteiro (ou promover status terminal). end NAO faz isto.
-  [ -f "$_rcw_rw" ] || _so_die "reconcile-wave: state-rw.sh nao encontrado em $_rcw_selfdir" 1
+  # (state-rw.sh ja validado presente no inicio da funcao.)
   if [ -n "$_rcw_next" ]; then
     sh "$_rcw_rw" set --state-dir "$_rcw_sdir" \
       --field '.current_stage' --value "\"$_rcw_next\"" >/dev/null
@@ -1345,12 +1408,27 @@ _so_cmd_reconcile_wave() {
     sh "$_rcw_rw" set --state-dir "$_rcw_sdir" \
       --field '.next_instruction' --value "$_rcw_instr" >/dev/null
   else
+    # Promocao a status terminal via read-patch-write ATOMICO (uma unica
+    # transacao), NAO 5 `set` sequenciais: sob backend sqlite a CHECK de
+    # execution (status IN ('abortada','concluida') <=> finished_at NOT
+    # NULL) rejeita qualquer estado intermediario onde status=concluida e
+    # finished_at ainda esta NULL (ou vice-versa) — nenhuma ordem de sets
+    # de UMA coluna por vez consegue transitar (status=em_andamento,
+    # finished_at=NULL) -> (status=concluida, finished_at=<ts>) sem passar
+    # por um estado invalido. `write` aplica as 5 mudancas na mesma
+    # transacao (C4), backend-agnostico (funciona identico sob JSON).
     _rcw_now=$(_so_iso_now)
-    sh "$_rcw_rw" set --state-dir "$_rcw_sdir" --field '.execution.status' --value '"concluida"' >/dev/null
-    sh "$_rcw_rw" set --state-dir "$_rcw_sdir" --field '.execution.termination_reason' --value '"concluido"' >/dev/null
-    sh "$_rcw_rw" set --state-dir "$_rcw_sdir" --field '.execution.finished_at' --value "\"$_rcw_now\"" >/dev/null
-    sh "$_rcw_rw" set --state-dir "$_rcw_sdir" --field '.current_stage' --value '"concluida"' >/dev/null
-    sh "$_rcw_rw" set --state-dir "$_rcw_sdir" --field '.next_instruction' --value '"Execucao concluida — nenhuma proxima etapa."' >/dev/null
+    _rcw_doc=$(sh "$_rcw_rw" read --state-dir "$_rcw_sdir") \
+      || _so_die "reconcile-wave: read falhou ao promover status terminal" 1
+    _rcw_patched=$(printf '%s' "$_rcw_doc" | jq --arg now "$_rcw_now" '
+      .execution.status = "concluida"
+      | .execution.termination_reason = "concluido"
+      | .execution.finished_at = $now
+      | .current_stage = "concluida"
+      | .next_instruction = "Execucao concluida — nenhuma proxima etapa."
+    ') || _so_die "reconcile-wave: jq falhou ao promover status terminal" 1
+    printf '%s' "$_rcw_patched" | sh "$_rcw_rw" write --state-dir "$_rcw_sdir" >/dev/null \
+      || _so_die "reconcile-wave: write falhou ao promover status terminal" 1
   fi
 
   if [ -n "$_rcw_next" ]; then

--- a/global/skills/agente-00c-runtime/scripts/state-rw.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-rw.sh
@@ -78,6 +78,14 @@ _SR_DIR=$(cd "$(dirname -- "$0")" && pwd)
 # shellcheck source=./_diag.sh
 . "$_SR_DIR/_diag.sh"
 
+# Backend dual (feature state-db-foundation, FASE 3 task 3.2): presenca de
+# <state-dir>/state.db seleciona SQLite; senao, backend JSON (comportamento
+# historico, intacto abaixo). Ver contracts/primitives.md §C1/C2.
+# shellcheck source=./_state-db.sh
+. "$_SR_DIR/_state-db.sh"
+# shellcheck source=./_state-rw-db.sh
+. "$_SR_DIR/_state-rw-db.sh"
+
 _sr_die() {
   printf '%s: %s\n' "$_SR_NAME" "$1" >&2
   exit "${2:-1}"
@@ -379,6 +387,13 @@ _sr_cmd_init() {
 
   _sr_ensure_state_dir "$_sd"
 
+  # C2: init nunca cria state.db (isso e a migracao, FASE 6) — mas se um
+  # state.db ja existe (projeto migrado), recusa em vez de criar um
+  # state.json paralelo que nunca seria a fonte de verdade (C2/Decision 9).
+  if [ -f "$(_sr_db_file "$_sd")" ]; then
+    _sr_die "init: state.db ja existe em $_sd (projeto migrado para backend SQLite) — init nao se aplica; use os subcomandos normais (state-ondas.sh etc.) diretamente." 1
+  fi
+
   _sr_sf=$(_sr_state_file "$_sd")
   if [ -f "$_sr_sf" ]; then
     _sr_die "init: state.json ja existe em $_sd. Use /agente-00c-abort ou /agente-00c-resume." 1
@@ -483,6 +498,11 @@ _sr_cmd_read() {
     esac
   done
   [ -n "$_sd" ] || _sr_die "read: --state-dir obrigatorio" 2
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _sr_require_jq
+    _sr_db_read "$_sd"
+    return 0
+  fi
   _sr_sf=$(_sr_state_file "$_sd")
   [ -f "$_sr_sf" ] || _sr_die "read: state.json nao existe em $_sd" 1
   # Canonicaliza chaves pt-BR -> EN (schema-en-migration). Degrada para raw se
@@ -504,6 +524,25 @@ _sr_cmd_write() {
   done
   [ -n "$_sd" ] || _sr_die "write: --state-dir obrigatorio" 2
   _sr_require_jq
+
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _wr_doc=$(mktemp) || _sr_die "mktemp falhou" 1
+    if ! cat > "$_wr_doc"; then
+      rm -f -- "$_wr_doc"; _sr_die "write: I/O lendo stdin" 1
+    fi
+    if ! jq -e . "$_wr_doc" >/dev/null 2>&1; then
+      rm -f -- "$_wr_doc"
+      diag_emit error state-invalid-json "write: stdin nao e JSON valido (jq falhou)" \
+        "corrija o JSON de entrada (jq -e . <arquivo> para localizar o erro de sintaxe) e tente novamente" || :
+      _sr_die "write: stdin nao e JSON valido (jq falhou)" 1
+    fi
+    _wr_doc_content=$(cat -- "$_wr_doc")
+    rm -f -- "$_wr_doc"
+    _sr_db_write_document "$_sd" "$_wr_doc_content"
+    _sr_log "write: state.db atualizado em $(_sr_db_file "$_sd")"
+    return 0
+  fi
+
   _sr_ensure_state_dir "$_sd"
 
   _sr_sf=$(_sr_state_file "$_sd")
@@ -548,6 +587,10 @@ _sr_cmd_get() {
   [ -n "$_sd" ] || _sr_die "get: --state-dir obrigatorio" 2
   [ -n "$_f" ]  || _sr_die "get: --field obrigatorio (ex: '.execucao.status')" 2
   _sr_require_jq
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _sr_db_read "$_sd" | jq -r "$_f"
+    return 0
+  fi
   _sr_sf=$(_sr_state_file "$_sd")
   if [ ! -f "$_sr_sf" ]; then
     diag_emit error state-not-found "get: state.json ausente em $_sd" \
@@ -576,13 +619,18 @@ _sr_cmd_set() {
   [ -n "$_f" ]    || _sr_die "set: --field obrigatorio" 2
   [ "$_v_set" = 1 ] || _sr_die "set: --value obrigatorio (JSON valido — strings com aspas)" 2
   _sr_require_jq
-  _sr_ensure_state_dir "$_sd"
-  _sr_sf=$(_sr_state_file "$_sd")
-  [ -f "$_sr_sf" ] || _sr_die "set: state.json ausente em $_sd" 1
   # Valida que --value e JSON parseavel (string raw nao serve — pedimos aspas).
   if ! printf '%s' "$_v" | jq -e . >/dev/null 2>&1; then
     _sr_die "set: --value nao e JSON valido. Strings precisam de aspas: '\"foo\"'." 1
   fi
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _sr_db_set "$_sd" "$_f" "$_v"
+    _sr_log "set: $_f atualizado (backend sqlite)"
+    return 0
+  fi
+  _sr_ensure_state_dir "$_sd"
+  _sr_sf=$(_sr_state_file "$_sd")
+  [ -f "$_sr_sf" ] || _sr_die "set: state.json ausente em $_sd" 1
   _new=$(mktemp -- "${_sr_sf}.new.XXXXXX") || _sr_die "mktemp falhou" 1
   # Canonicaliza o doc inteiro (EN) ANTES de aplicar o set: evita doc misto
   # (set EN sobre arquivo pt-BR criaria container duplicado). --field e EN.
@@ -605,6 +653,14 @@ _sr_cmd_sha256_update() {
     esac
   done
   [ -n "$_sd" ] || _sr_die "sha256-update: --state-dir obrigatorio" 2
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    # C7 (dec-025): sob SQLite nao ha hash derivado a manter — a verificacao
+    # de integridade passa a ser `PRAGMA integrity_check` (sha256-verify).
+    # sha256-update vira no-op (mesmo exit 0, mesma superficie de comando).
+    [ -f "$(_sr_db_file "$_sd")" ] || _sr_die "sha256-update: state.db ausente em $_sd" 1
+    _sr_log "sha256-update: no-op sob backend SQLite (C7 — integridade via PRAGMA integrity_check)"
+    return 0
+  fi
   _sr_sf=$(_sr_state_file "$_sd")
   [ -f "$_sr_sf" ] || _sr_die "sha256-update: state.json ausente em $_sd" 1
   _sr_update_sha "$_sd"
@@ -619,6 +675,10 @@ _sr_cmd_sha256_verify() {
     esac
   done
   [ -n "$_sd" ] || _sr_die "sha256-verify: --state-dir obrigatorio" 2
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _sr_db_integrity_check "$_sd" || exit 1
+    return 0
+  fi
   _sr_sf=$(_sr_state_file "$_sd")
   _sr_shf=$(_sr_sha_file "$_sd")
   [ -f "$_sr_sf" ]  || _sr_die "sha256-verify: state.json ausente em $_sd" 1

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -3990,4 +3990,230 @@ JSON
   return 0
 }
 
+# =========================================================================
+# FASE 8 (state-db-foundation) — equivalencia SQL->SQL vs JSON (SC-005,
+# dec-035 §criterio de amostra: fixtures sinteticas vazio/medio/grande).
+#
+# Estrategia: gera um state.json EN valido (mesmo formato de
+# tests/test_state-db-migrate.sh::_seed_state_json) com N decisoes/M ondas,
+# ingere via o caminho JSON (recall_ingest_state_json, ainda sem state.db),
+# migra para state.db (state-db-migrate.sh migrate), ingere de novo o MESMO
+# state-dir (agora recall_mode_ingest prefere o caminho SQL->SQL por
+# recall_ingest_state_db) e compara as entidades resultantes.
+#
+# Divergencias ACEITAS (fora do escopo de equivalencia, documentadas):
+#   - ingested_at: timestamp de wall-clock da propria ingestao, nunca igual.
+#   - executions.subagents_spawned/skill_suggestions_total/
+#     toolkit_issues_opened: state.db nao tem coluna para essas 3 metricas
+#     (mesmo gap ja documentado em dec-079 M3.2/contracts/migration.md —
+#     export do backend SQLite as fixa em 0; a ingestao SQL->SQL usa NULL em
+#     vez de propagar esse 0 fabricado, por Principio VI/anti-fabricacao).
+# =========================================================================
+
+SCRIPTS_00C="$REPO_ROOT/global/skills/agente-00c-runtime/scripts"
+STATE_RW_00C="$SCRIPTS_00C/state-rw.sh"
+MIGRATE_00C="$SCRIPTS_00C/state-db-migrate.sh"
+
+# _seed_sql_equiv_state DIR N_DEC N_WAVE -> escreve um state.json EN valido
+# (schema-en-migration) com N_DEC decisoes distribuidas por N_WAVE ondas (>=1),
+# 1 human_block (se N_DEC>0), 1 task por onda, 2 events, 1 skill por onda
+# (kind=skill) + 1 skill kind=gate na 1a onda (para exercitar o filtro
+# kind!='gate' tanto no caminho JSON quanto no SQL->SQL).
+_seed_sql_equiv_state() {
+  _ses_dir="$1"; _ses_ndec="$2"; _ses_nwave="$3"
+  mkdir -p "$_ses_dir"
+
+  _ses_waves='[]'
+  _ses_i=0
+  while [ "$_ses_i" -lt "$_ses_nwave" ]; do
+    _ses_wid="onda-$((_ses_i + 1))"
+    if [ "$_ses_ndec" -gt 0 ]; then
+      _ses_dec_mod=$_ses_ndec
+    else
+      _ses_dec_mod=1
+    fi
+    _ses_skill_dec="dec-$(( (_ses_i % _ses_dec_mod) + 1 ))"
+    _ses_skills=$(jq -n --arg dec "$_ses_skill_dec" \
+      --argjson has_dec "$([ "$_ses_ndec" -gt 0 ] && echo true || echo false)" \
+      --argjson is_first "$([ "$_ses_i" -eq 0 ] && echo true || echo false)" \
+      '[{skill:"specify", timestamp:"2026-01-01T00:00:30Z", decision_id: (if $has_dec then $dec else null end), kind:"skill"}]
+       + (if $is_first then [{skill:"validate-tasks-template", timestamp:"2026-01-01T00:00:40Z", decision_id: null, kind:"gate"}] else [] end)')
+    _ses_w=$(jq -n --arg id "$_ses_wid" --argjson skills "$_ses_skills" --argjson idx "$_ses_i" '
+      {id:$id,
+       started_at: ("2026-01-01T\( ($idx/60|floor) % 24 | if . < 10 then "0\(.)" else "\(.)" end ):\( $idx % 60 | if . < 10 then "0\(.)" else "\(.)" end ):00Z"),
+       finished_at: ("2026-01-01T\( ($idx/60|floor) % 24 | if . < 10 then "0\(.)" else "\(.)" end ):\( ($idx % 60) | if . < 10 then "0\(.)" else "\(.)" end ):30Z"),
+       wallclock_seconds: 30, tool_calls: 5,
+       termination_reason: "etapa_concluida_avancando",
+       executed_stages: ["specify"],
+       skills_invoked: $skills}')
+    _ses_waves=$(printf '%s' "$_ses_waves" | jq -c --argjson w "$_ses_w" '. + [$w]')
+    _ses_i=$((_ses_i + 1))
+  done
+  # ultima onda fecha com motivo=concluido (coerente com status=concluida).
+  _ses_waves=$(printf '%s' "$_ses_waves" | jq -c '
+    if length > 0 then (.[-1].termination_reason = "concluido") else . end')
+
+  _ses_decs='[]'
+  _ses_i=0
+  while [ "$_ses_i" -lt "$_ses_ndec" ]; do
+    _ses_wid="onda-$(( (_ses_i % _ses_nwave) + 1 ))"
+    _ses_score=$((_ses_i % 4))
+    _ses_d=$(jq -n --arg id "dec-$((_ses_i + 1))" --arg wid "$_ses_wid" --argjson score "$_ses_score" --argjson idx "$_ses_i" '
+      {id:$id, wave_id: $wid,
+       timestamp: ("2026-01-01T00:0\($idx % 10):00Z"),
+       agent: "agente-00c-feature-orchestrator", stage: "specify",
+       context: "contexto de decisao de equivalencia numero \($idx) com mais de vinte caracteres",
+       options_considered: ["a","b"], choice: "a",
+       rationale: "justificativa de equivalencia numero \($idx) com mais de vinte caracteres",
+       justification_score: $score,
+       evidence: (if $score == 3 then "evidencia empirica de pelo menos vinte caracteres" else null end),
+       references: [], originating_artifact: null}')
+    _ses_decs=$(printf '%s' "$_ses_decs" | jq -c --argjson d "$_ses_d" '. + [$d]')
+    _ses_i=$((_ses_i + 1))
+  done
+
+  _ses_blocks='[]'
+  if [ "$_ses_ndec" -gt 0 ]; then
+    _ses_blocks='[{"id":"block-001","decision_id":"dec-1","question":"pergunta de bloqueio de equivalencia com mais de vinte caracteres?","context_for_answer":"contexto para a resposta de equivalencia","recommended_options":["sim","nao"],"status":"respondido","human_answer":"sim","triggered_at":"2026-01-01T00:00:05Z","answered_at":"2026-01-01T00:00:10Z"}]'
+  fi
+
+  _ses_tasks='[]'
+  _ses_i=0
+  while [ "$_ses_i" -lt "$_ses_nwave" ]; do
+    _ses_wid="onda-$((_ses_i + 1))"
+    _ses_t=$(jq -n --arg tid "1.$((_ses_i + 1))" --arg wid "$_ses_wid" --argjson idx "$_ses_i" '
+      {task_id:$tid, title:"task de equivalencia \($idx)", wave_id:$wid, outcome:"pass",
+       tests_run:2, tests_passed:2, lint_ok:true, touched_files:["a.sh"],
+       recorded_at:"2026-01-01T00:00:20Z", source:"execute-task"}')
+    _ses_tasks=$(printf '%s' "$_ses_tasks" | jq -c --argjson t "$_ses_t" '. + [$t]')
+    _ses_i=$((_ses_i + 1))
+  done
+
+  jq -n \
+    --argjson waves "$_ses_waves" --argjson decisions "$_ses_decs" \
+    --argjson blocks "$_ses_blocks" --argjson tasks "$_ses_tasks" \
+    --argjson ndec "$_ses_ndec" --argjson nwave "$_ses_nwave" '
+    {
+      schema_version: "1.0.0", short_name: "equiv-feat",
+      execution: {
+        id: "exec-equiv-001", target_project_path: "/tmp/equiv-proj",
+        target_project_description: "projeto de equivalencia SQL vs JSON com tamanho suficiente",
+        status: "concluida", termination_reason: "concluido com sucesso",
+        started_at: "2026-01-01T00:00:00Z", finished_at: "2026-01-01T02:00:00Z"
+      },
+      current_stage: "review-task", next_instruction: "nada a fazer",
+      atomic_commit_enabled: false,
+      initial_key_aspects: ["equivalencia","sql"],
+      external_urls_whitelist: [], circular_movement_history: [],
+      budgets: {
+        max_recursion:3, current_subagent_depth:1,
+        max_retro_executions_per_feature:2, retro_executions_consumed:0,
+        max_cycles_per_stage:5, cycles_consumed_current_stage:0,
+        tool_calls_threshold_wave:80, wallclock_threshold_seconds:5400,
+        state_size_threshold_bytes:1048576,
+        tool_calls_current_wave:0, current_wave_start:null
+      },
+      accumulated_metrics: {
+        waves_total:$nwave, tool_calls_total:(5*$nwave), wallclock_total_seconds:(30*$nwave),
+        max_depth_reached:1, subagents_spawned:0, decisions_total:$ndec,
+        human_blocks_total:(if $ndec>0 then 1 else 0 end),
+        global_skill_suggestions_total:0, toolkit_issues_opened:0
+      },
+      waves:$waves, decisions:$decisions, human_blocks:$blocks, tasks:$tasks,
+      events: [
+        {event_type:"schedule_wait", timestamp:"2026-01-01T00:00:15Z", description:"aguardando wakeup do equivalence test"},
+        {event_type:"recall_consulted", timestamp:"2026-01-01T00:00:16Z"}
+      ]
+    }' > "$_ses_dir/state.json"
+  "$STATE_RW_00C" sha256-update --state-dir "$_ses_dir" >/dev/null 2>&1
+}
+
+# _assert_sql_json_equivalent DIR LABEL -> ingere DIR (state.json presente,
+# state.db ausente) via caminho JSON em k-json.db, migra DIR para state.db,
+# ingere de novo (agora via SQL->SQL) em k-sql.db, e compara as 7 tabelas de
+# entidade linha-a-linha (ORDER BY source_id), ignorando as colunas
+# `ingested_at` (wall-clock, nunca igual) e as 3 colunas de executions sem
+# fonte em state.db (subagents_spawned/skill_suggestions_total/
+# toolkit_issues_opened — NULL no SQL->SQL vs 0 fabricado no export JSON).
+_assert_sql_json_equivalent() {
+  _aje_dir="$1"; _aje_label="$2"
+  _aje_kjson="$TMPDIR_TEST/${_aje_label}-json.db"
+  _aje_ksql="$TMPDIR_TEST/${_aje_label}-sql.db"
+
+  assert_exit 0 _rc --ingest --state-dir "$_aje_dir" --db "$_aje_kjson" || return 1
+
+  capture "$MIGRATE_00C" migrate --state-dir "$_aje_dir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "$_aje_label: migrate" "$_CAPTURED_STDERR"; return 1; }
+  [ -f "$_aje_dir/state.db" ] || { _fail "$_aje_label: state.db ausente pos-migracao" ""; return 1; }
+
+  assert_exit 0 _rc --ingest --state-dir "$_aje_dir" --db "$_aje_ksql" || return 1
+
+  for _aje_t in executions waves decisions blocks tasks events skills; do
+    case "$_aje_t" in
+      executions) _aje_cols="project,feature,wave,execution_id,source_id,status,termination_reason,current_stage,started_at,finished_at,duration_seconds,suggested_stack,waves_total,tool_calls_total,wallclock_total_seconds,decisions_total,human_blocks_total,session,target_project_path" ;;
+      waves) _aje_cols="project,feature,wave,execution_id,source_id,stages,started_at,finished_at,wallclock_seconds,tool_calls,termination_reason,n_stages,n_skills,session" ;;
+      decisions) _aje_cols="project,feature,wave,execution_id,source_id,agent,stage,choice,options,score,context,rationale,evidence" ;;
+      blocks) _aje_cols="project,feature,wave,execution_id,source_id,status,question,context_for_answer,answer,decision_id,triggered_at,answered_at,latency_seconds" ;;
+      tasks) _aje_cols="project,feature,wave,execution_id,source_id,title,outcome,tests_run,tests_passed,lint_ok,touched_files" ;;
+      events) _aje_cols="project,feature,wave,execution_id,source_id,event_type,timestamp,description" ;;
+      skills) _aje_cols="project,feature,wave,execution_id,source_id,skill_name,decision_id" ;;
+    esac
+    _aje_a=$(sqlite3 "$_aje_kjson" "SELECT $_aje_cols FROM $_aje_t ORDER BY source_id;")
+    _aje_b=$(sqlite3 "$_aje_ksql" "SELECT $_aje_cols FROM $_aje_t ORDER BY source_id;")
+    if [ "$_aje_a" != "$_aje_b" ]; then
+      # sh POSIX (dash) nao suporta `<(...)`: usa arquivos temporarios em vez
+      # de process substitution para o diff de diagnostico.
+      _aje_fa="$TMPDIR_TEST/${_aje_label}-${_aje_t}-json.txt"
+      _aje_fb="$TMPDIR_TEST/${_aje_label}-${_aje_t}-sql.txt"
+      printf '%s\n' "$_aje_a" > "$_aje_fa"
+      printf '%s\n' "$_aje_b" > "$_aje_fb"
+      _fail "$_aje_label: $_aje_t diverge entre JSON e SQL->SQL" \
+        "$(diff "$_aje_fa" "$_aje_fb")"
+      return 1
+    fi
+  done
+  return 0
+}
+
+# Cenario 8.3-vazio: 0 decisoes, 1 onda (minimo/vazio de dec-035).
+scenario_sqldb_equiv_vazio() {
+  _have_deps || return 0
+  command -v "$MIGRATE_00C" >/dev/null 2>&1 || : # sempre existe no repo
+  _d="$TMPDIR_TEST/equiv-vazio"
+  _seed_sql_equiv_state "$_d" 0 1
+  _assert_sql_json_equivalent "$_d" "vazio" || return 1
+  return 0
+}
+
+# Cenario 8.3-medio: ~10 decisoes, 3 ondas (dec-035).
+scenario_sqldb_equiv_medio() {
+  _have_deps || return 0
+  _d="$TMPDIR_TEST/equiv-medio"
+  _seed_sql_equiv_state "$_d" 10 3
+  _assert_sql_json_equivalent "$_d" "medio" || return 1
+  return 0
+}
+
+# Cenario 8.3-grande: ~50+ decisoes, 10+ ondas (dec-035).
+scenario_sqldb_equiv_grande() {
+  _have_deps || return 0
+  _d="$TMPDIR_TEST/equiv-grande"
+  _seed_sql_equiv_state "$_d" 55 12
+  _assert_sql_json_equivalent "$_d" "grande" || return 1
+  return 0
+}
+
+# Cenario 8.2.2: projeto NAO migrado (so state.json, sem state.db) continua
+# ingerindo pelo caminho JSON sem regressao (FR-012, US4 AS-2) — presenca de
+# state.db em OUTRO state-dir nao interfere.
+scenario_sqldb_json_path_preservado_sem_migracao() {
+  _have_deps || return 0
+  _d="$TMPDIR_TEST/no-migrate"
+  _seed_sql_equiv_state "$_d" 3 2
+  assert_exit 0 _rc --ingest --state-dir "$_d" --db "$TMPDIR_TEST/no-migrate.db" || return 1
+  assert_stdout_contains "3 decisions" || return 1
+  [ ! -f "$_d/state.db" ] || { _fail "no-migrate: state.db nao deveria existir" ""; return 1; }
+  return 0
+}
+
 run_all_scenarios

--- a/tests/cstk/test_state.sh
+++ b/tests/cstk/test_state.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+# test_state.sh — cobre cli/lib/state.sh (subcomando `cstk state`).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 6, task 6.1.2
+#      docs/specs/state-db-foundation/contracts/migration.md §Nomeacao
+#
+# ESCOPO: esta lib e uma SUPERFICIE DE DELEGACAO. O comportamento da migracao
+# em si (M1..M6) e coberto por tests/test_state-db-migrate.sh; aqui cobrimos o
+# contrato da fronteira: resolucao do script delegado, repasse VERBATIM de
+# flags e exit codes, e o tratamento de uso incorreto.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+CSTK_BIN="$REPO_ROOT/cli/cstk"
+CSTK_LIB_DIR="$REPO_ROOT/cli/lib"
+STATE_RW="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-rw.sh"
+
+# _cstk_state ARGS... -> roda `cstk state ARGS` com o layout de repo.
+_cstk_state() {
+  CSTK_LIB="$CSTK_LIB_DIR" sh "$CSTK_BIN" state "$@"
+}
+
+scenario_state_sem_subcomando_mostra_uso() {
+  capture _cstk_state
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "uso deveria sair 0" "exit=$_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *migrate*) : ;;
+    *) _fail "uso nao documenta migrate" "$_CAPTURED_STDOUT"; return 1 ;;
+  esac
+}
+
+scenario_state_help_documenta_exit_codes() {
+  capture _cstk_state --help
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "--help deveria sair 0" "exit=$_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *"recusado por pre-condicao"*) : ;;
+    *) _fail "help nao documenta o exit 3 (recusa)" "$_CAPTURED_STDOUT"; return 1 ;;
+  esac
+}
+
+scenario_state_subcomando_desconhecido_exit_2() {
+  capture _cstk_state naoexiste
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "subcomando invalido deveria ser exit 2" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+# Repasse VERBATIM do exit 2 (uso incorreto) vindo do script delegado.
+scenario_state_migrate_sem_state_dir_repassa_exit_2() {
+  capture _cstk_state migrate
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "--state-dir ausente deveria repassar exit 2" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+# Repasse VERBATIM do exit 3 (RECUSA por pre-condicao M1) — a distincao entre
+# "recusado" e "falhou" e o ponto do contrato de exit codes desta lib.
+scenario_state_migrate_recusa_repassa_exit_3() {
+  if ! command -v jq >/dev/null 2>&1 || ! command -v sqlite3 >/dev/null 2>&1; then
+    return 0
+  fi
+  _sd="$TMPDIR_TEST/sem-state-json"
+  mkdir -p "$_sd"
+  capture _cstk_state migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "recusa deveria repassar exit 3" "exit=$_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"; return 1; }
+}
+
+# Caminho feliz de ponta a ponta pela superficie do CLI (nao so pelo script).
+scenario_state_migrate_caminho_feliz_pelo_cli() {
+  if ! command -v jq >/dev/null 2>&1 || ! command -v sqlite3 >/dev/null 2>&1; then
+    return 0
+  fi
+  _sd="$TMPDIR_TEST/ok"
+  mkdir -p "$_sd"
+  cat > "$_sd/state.json" <<'JSON'
+{
+  "schema_version": "1.0.0",
+  "short_name": "cli-fixture",
+  "execution": {
+    "id": "exec-cli-001",
+    "target_project_path": "/tmp/projeto",
+    "target_project_description": "descricao de fixture com tamanho suficiente",
+    "status": "concluida",
+    "termination_reason": "concluido",
+    "started_at": "2026-07-30T10:00:00Z",
+    "finished_at": "2026-07-30T12:00:00Z"
+  },
+  "current_stage": "review-task",
+  "next_instruction": "nada a fazer",
+  "external_urls_whitelist": [],
+  "circular_movement_history": [],
+  "initial_key_aspects": ["cli", "state"],
+  "accumulated_metrics": {
+    "waves_total": 0,
+    "tool_calls_total": 0,
+    "wallclock_total_seconds": 0,
+    "max_depth_reached": 1,
+    "subagents_spawned": 0,
+    "decisions_total": 0,
+    "human_blocks_total": 0,
+    "global_skill_suggestions_total": 0,
+    "toolkit_issues_opened": 0
+  },
+  "budgets": {
+    "max_recursion": 3,
+    "current_subagent_depth": 1,
+    "max_retro_executions_per_feature": 2,
+    "retro_executions_consumed": 0,
+    "max_cycles_per_stage": 5,
+    "cycles_consumed_current_stage": 0,
+    "tool_calls_threshold_wave": 80,
+    "wallclock_threshold_seconds": 5400,
+    "state_size_threshold_bytes": 1048576
+  },
+  "waves": [],
+  "decisions": [],
+  "human_blocks": [],
+  "tasks": [],
+  "events": []
+}
+JSON
+  "$STATE_RW" sha256-update --state-dir "$_sd" >/dev/null 2>&1
+
+  capture _cstk_state migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migracao pelo CLI" "exit=$_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"; return 1; }
+  [ -f "$_sd/state.db" ] || { _fail "state.db nao publicado pelo CLI" ""; return 1; }
+  [ -f "$_sd/state.json" ] || { _fail "state.json apagado (M6)" ""; return 1; }
+}
+
+# A resolucao do script delegado NAO pode depender exclusivamente de
+# ~/.claude (licao de campo de recall_secrets_filter_path): com HOME falso e
+# CSTK_LIB apontando para a arvore do repo, a camada (2) deve resolver.
+scenario_resolucao_do_script_independe_de_home_instalado() {
+  _out=$(HOME="$TMPDIR_TEST/home-vazio" CSTK_LIB="$CSTK_LIB_DIR" sh -c '
+    . "$CSTK_LIB/state.sh"
+    _state_migrate_script_path
+  ' 2>/dev/null) || { _fail "resolucao falhou com HOME vazio" ""; return 1; }
+  [ -n "$_out" ] || { _fail "caminho vazio" ""; return 1; }
+  [ -f "$_out" ] || { _fail "caminho resolvido nao existe" "$_out"; return 1; }
+}
+
+# `cstk state` esta registrado nas superficies de descoberta do CLI.
+scenario_state_aparece_no_help_geral() {
+  capture sh -c "CSTK_LIB='$CSTK_LIB_DIR' sh '$CSTK_BIN' --help"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "help geral" "$_CAPTURED_STDERR"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *"  state "*) : ;;
+    *) _fail "cstk --help nao lista o comando state" ""; return 1 ;;
+  esac
+}
+
+scenario_help_topico_state_sai_zero() {
+  capture sh -c "CSTK_LIB='$CSTK_LIB_DIR' sh '$CSTK_BIN' help state"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "cstk help state" "$_CAPTURED_STDERR"; return 1; }
+}
+
+run_all_scenarios

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -252,6 +252,14 @@ _is_internal_test() {
       # script sob a convencao de FASE 9.3). Equivalente ao
       # test_quickstart-e2e.sh para o pipeline do agente-00c.
       return 0 ;;
+    test_state-db-concurrency.sh)
+      # Testes de atomicidade/concorrencia do backend SQLite (feature
+      # state-db-foundation, FASE 3 task 3.7, SC-002) — exercita a
+      # COMPOSICAO de state-decisions.sh + bloqueios.sh + state-ondas.sh
+      # sobre o mesmo state.db (mutacoes concorrentes distintas, kill -9
+      # em transacao aberta, leitura concorrente sob WAL). Nao mapeia 1:1
+      # para um unico script sob a convencao de FASE 9.3.
+      return 0 ;;
     # ---- Cobertura real sob nome NAO-1:1 (existence-guarded) ----
     # Estes tests exercitam um script real, mas com nome descritivo que nao
     # casa test_<base>.sh. Cada ramo so isenta se o script cobridor EXISTE —

--- a/tests/test__bloqueios-db.sh
+++ b/tests/test__bloqueios-db.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# test__bloqueios-db.sh — cobre
+# global/skills/agente-00c-runtime/scripts/_bloqueios-db.sh
+# (implementacao do backend SQLite de bloqueios.sh — feature
+# state-db-foundation, FASE 3 task 3.5).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.5
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C3 C4 C6 C8
+#
+# Cobertura desta unit suite: helpers de baixo nivel
+# (_bl_db_next_block_num_expr, _bl_db_exec_capture). O comportamento
+# observavel via CLI (register/respond/list/count/next-id/get, incluindo o
+# teste de concorrencia e o de FK) e coberto em tests/test_bloqueios.sh, que
+# e o oraculo de paridade C1 (mesma superficie para os dois backends).
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test__bloqueios-db.sh: sqlite3 ausente — pulando suite\n'
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  printf '# test__bloqueios-db.sh: jq ausente — pulando suite\n'
+  exit 0
+fi
+
+_R="$REPO_ROOT/global/skills/agente-00c-runtime/scripts"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-db.sh
+. "$_R/_state-db.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+. "$_R/_state-rw-db.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_bloqueios-db.sh
+. "$_R/_bloqueios-db.sh"
+
+SCHEMA_SCRIPT="$_R/state-db-schema.sh"
+
+# _sr_die/_bl_die: normalmente definidos por bloqueios.sh antes de sourcear
+# estas libs. Fornecemos equivalentes minimos para exercitar as funcoes
+# isoladas, sem depender do CLI completo.
+_bl_die() { printf 'bloqueios: %s\n' "$1" >&2; exit "${2:-1}"; }
+_sr_die() { _bl_die "$1" "${2:-1}"; }
+_bl_iso_now() { date -u +%FT%TZ; }
+
+# _seed_db PATH -> cria state.db minimo com execution id=exec-1 e decision
+# id=dec-001.
+_seed_db() {
+  _sdb_db="$1"
+  "$SCHEMA_SCRIPT" create --db "$_sdb_db" >/dev/null 2>&1 \
+    || { _fail "seed: schema create falhou" ""; return 1; }
+  sqlite3 "$_sdb_db" "
+    PRAGMA foreign_keys=ON;
+    INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+    VALUES ('exec-1','1.0.0','/tmp/p','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+    INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale)
+    VALUES ('dec-001','exec-1','2026-07-30T00:00:00Z','x','clarify','contexto de teste com detalhe suficiente','[\"a\"]','a','justificativa de teste com detalhe suficiente');
+  " || { _fail "seed: insert execution/decision falhou" ""; return 1; }
+}
+
+# ==== _bl_db_next_block_num_expr ====
+
+scenario_next_block_num_expr_vazio_retorna_1() {
+  _db="$TMPDIR_TEST/next-block-vazio.db"
+  _seed_db "$_db" || return 1
+  _expr=$(_bl_db_next_block_num_expr "'exec-1'")
+  _out=$(_state_db_exec "$_db" "SELECT $_expr;")
+  [ "$_out" = "1" ] || { _fail "next_block_num_expr vazio" "obtido '$_out'"; return 1; }
+}
+
+scenario_next_block_num_expr_apos_insert_retorna_2() {
+  _db="$TMPDIR_TEST/next-block-apos.db"
+  _seed_db "$_db" || return 1
+  sqlite3 "$_db" "
+    INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,status,triggered_at)
+    VALUES ('block-001','exec-1','dec-001','pergunta de teste com 20+ chars aqui','ctx','aguardando','2026-07-30T00:00:00Z');
+  "
+  _expr=$(_bl_db_next_block_num_expr "'exec-1'")
+  _out=$(_state_db_exec "$_db" "SELECT $_expr;")
+  [ "$_out" = "2" ] || { _fail "next_block_num_expr apos insert" "obtido '$_out'"; return 1; }
+}
+
+scenario_next_block_num_expr_isola_por_execution_id() {
+  # Outra execution com bloqueios nao deve influenciar o calculo desta.
+  _db="$TMPDIR_TEST/next-block-isola.db"
+  _seed_db "$_db" || return 1
+  sqlite3 "$_db" "
+    INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+    VALUES ('exec-2','1.0.0','/tmp/p2','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+    INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale)
+    VALUES ('dec-100','exec-2','2026-07-30T00:00:00Z','x','clarify','contexto de teste com detalhe suficiente','[\"a\"]','a','justificativa de teste com detalhe suficiente');
+    INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,status,triggered_at)
+    VALUES ('block-001','exec-2','dec-100','pergunta de teste com 20+ chars aqui','ctx','aguardando','2026-07-30T00:00:00Z');
+  "
+  _expr=$(_bl_db_next_block_num_expr "'exec-1'")
+  _out=$(_state_db_exec "$_db" "SELECT $_expr;")
+  [ "$_out" = "1" ] || { _fail "next_block_num_expr isola execution" "obtido '$_out'"; return 1; }
+}
+
+# ==== _bl_db_exec_capture ====
+#
+# Chamada DIRETA (nunca dentro de $(...)) — ver nota de cabecalho em
+# _bloqueios-db.sh: $_bl_db_last_out/$_bl_db_last_err so sobrevivem se a
+# funcao NAO roda numa subshell de command substitution.
+
+scenario_exec_capture_sucesso_preserva_last_out() {
+  _db="$TMPDIR_TEST/exec-capture-ok.db"
+  _seed_db "$_db" || return 1
+  if _bl_db_exec_capture "$_db" "SELECT 'ok-' || 42;"; then
+    :
+  else
+    _fail "exec_capture sucesso" "deveria ter retornado 0"
+    return 1
+  fi
+  [ "$_bl_db_last_out" = "ok-42" ] || { _fail "exec_capture last_out" "obtido '$_bl_db_last_out'"; return 1; }
+}
+
+scenario_exec_capture_erro_nao_lock_falha_imediato_e_seta_last_err() {
+  _db="$TMPDIR_TEST/exec-capture-erro.db"
+  _seed_db "$_db" || return 1
+  if _bl_db_exec_capture "$_db" "INSERT INTO tabela_inexistente (x) VALUES (1);"; then
+    _fail "exec_capture erro nao-lock" "deveria falhar"
+    return 1
+  fi
+  case "$_bl_db_last_err" in
+    *"no such table"*) ;;
+    *) _fail "exec_capture last_err" "esperava 'no such table', obtido '$_bl_db_last_err'"; return 1 ;;
+  esac
+}
+
+# Regressao do bug achado na task 3.5: uma falha de FOREIGN KEY precisa
+# propagar ate $_bl_db_last_err mesmo com o caller rodando sob `set -eu`
+# (bloqueios.sh sempre roda com essas flags) — sem o guard `if x=$(cmd);
+# then...else...fi` dentro de _bl_db_exec_capture, o processo morreria na
+# primeira falha de _state_db_exec sem alcancar o `case` de retry (C6).
+scenario_exec_capture_fk_falha_seta_last_err_com_foreign_key() {
+  _db="$TMPDIR_TEST/exec-capture-fk.db"
+  _seed_db "$_db" || return 1
+  _sql="BEGIN IMMEDIATE; INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,status,triggered_at) VALUES ('block-001','exec-1','dec-fantasma','pergunta de teste com 20+ chars aqui','ctx','aguardando','2026-07-30T00:00:00Z'); COMMIT;"
+  if _bl_db_exec_capture "$_db" "$_sql"; then
+    _fail "exec_capture FK" "deveria falhar (decision_id inexistente)"
+    return 1
+  fi
+  case "$_bl_db_last_err" in
+    *"FOREIGN KEY constraint failed"*) ;;
+    *) _fail "exec_capture FK last_err" "esperava FOREIGN KEY, obtido '$_bl_db_last_err'"; return 1 ;;
+  esac
+  # Transacao revertida — nenhuma linha persistida.
+  _cnt=$(sqlite3 "$_db" "SELECT count(*) FROM human_block;")
+  [ "$_cnt" = "0" ] || { _fail "exec_capture FK rollback" "esperado 0 linhas, obtido $_cnt"; return 1; }
+}
+
+scenario_exec_capture_transacao_com_select_antes_do_commit() {
+  # Mesmo padrao usado por register: BEGIN IMMEDIATE + INSERT + SELECT do
+  # proprio rowid + COMMIT, tudo numa unica invocacao — garante que
+  # $_bl_db_last_out e o da linha recem-inserida por ESTA sessao.
+  _db="$TMPDIR_TEST/exec-capture-tx.db"
+  _seed_db "$_db" || return 1
+  _sql="BEGIN IMMEDIATE; INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,status,triggered_at) VALUES ('block-001','exec-1','dec-001','pergunta de teste com 20+ chars aqui','ctx','aguardando','2026-07-30T00:00:00Z'); SELECT id FROM human_block WHERE rowid=last_insert_rowid(); COMMIT;"
+  if ! _bl_db_exec_capture "$_db" "$_sql"; then
+    _fail "exec_capture tx select" "deveria ter sucedido: $_bl_db_last_err"
+    return 1
+  fi
+  [ "$_bl_db_last_out" = "block-001" ] || { _fail "exec_capture tx select last_out" "obtido '$_bl_db_last_out'"; return 1; }
+  _cnt=$(sqlite3 "$_db" "SELECT count(*) FROM human_block;")
+  [ "$_cnt" = "1" ] || { _fail "exec_capture tx commitou" "obtido '$_cnt'"; return 1; }
+}
+
+run_all_scenarios

--- a/tests/test__spawn-tracker-db.sh
+++ b/tests/test__spawn-tracker-db.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# test__spawn-tracker-db.sh — cobre
+# global/skills/agente-00c-runtime/scripts/_spawn-tracker-db.sh
+# (implementacao do backend SQLite de spawn-tracker.sh — feature
+# state-db-foundation, FASE 3 task 3.6).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.6
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C3 C5 C6
+#
+# Cobertura desta unit suite: helpers de baixo nivel (_st_db_get_current,
+# _st_db_get_max, _st_db_check, _st_db_enter, _st_db_leave, _st_db_current)
+# isolados. O comportamento observavel via CLI (check/enter/leave/current,
+# incluindo exit 3 no teto e paridade C1) e coberto em
+# tests/test_spawn-tracker.sh, que e o oraculo de paridade para os dois
+# backends.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test__spawn-tracker-db.sh: sqlite3 ausente — pulando suite\n'
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  printf '# test__spawn-tracker-db.sh: jq ausente — pulando suite\n'
+  exit 0
+fi
+
+_R="$REPO_ROOT/global/skills/agente-00c-runtime/scripts"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-db.sh
+. "$_R/_state-db.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+. "$_R/_state-rw-db.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_spawn-tracker-db.sh
+. "$_R/_spawn-tracker-db.sh"
+
+SCHEMA_SCRIPT="$_R/state-db-schema.sh"
+
+# _st_die/_sr_die: normalmente definidos por spawn-tracker.sh antes de
+# sourcear estas libs. Fornecemos equivalentes minimos para exercitar as
+# funcoes isoladas, sem depender do CLI completo.
+_ST_NAME="spawn-tracker"
+_st_die() { printf '%s: %s\n' "$_ST_NAME" "$1" >&2; exit "${2:-1}"; }
+_sr_die() { _st_die "$1" "${2:-1}"; }
+
+# _seed_db PATH [MAX_RECURSION] -> cria state.db minimo com execution
+# id=exec-1, subagent_depth=1 (default do schema), max_recursion opcional
+# (default do schema = 3).
+_seed_db() {
+  _sdb_db="$1"
+  _sdb_max="${2:-}"
+  "$SCHEMA_SCRIPT" create --db "$_sdb_db" >/dev/null 2>&1 \
+    || { _fail "seed: schema create falhou" ""; return 1; }
+  if [ -n "$_sdb_max" ]; then
+    sqlite3 "$_sdb_db" "
+      INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled,max_recursion)
+      VALUES ('exec-1','1.0.0','/tmp/p','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0,$_sdb_max);
+    " || { _fail "seed: insert execution falhou" ""; return 1; }
+  else
+    sqlite3 "$_sdb_db" "
+      INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+      VALUES ('exec-1','1.0.0','/tmp/p','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+    " || { _fail "seed: insert execution falhou" ""; return 1; }
+  fi
+}
+
+# ==== _st_db_get_current / _st_db_get_max ====
+
+scenario_get_current_inicial_e_1() {
+  _sd="$TMPDIR_TEST/get-current"
+  mkdir -p "$_sd"
+  _seed_db "$_sd/state.db" || return 1
+  _out=$(_st_db_get_current "$_sd")
+  [ "$_out" = "1" ] || { _fail "get_current inicial" "obtido '$_out'"; return 1; }
+}
+
+scenario_get_max_default_e_3() {
+  _sd="$TMPDIR_TEST/get-max"
+  mkdir -p "$_sd"
+  _seed_db "$_sd/state.db" || return 1
+  _out=$(_st_db_get_max "$_sd")
+  [ "$_out" = "3" ] || { _fail "get_max default" "obtido '$_out'"; return 1; }
+}
+
+# ==== _st_db_check ====
+
+scenario_check_abaixo_do_teto_exit_0() {
+  _sd="$TMPDIR_TEST/check-ok"
+  mkdir -p "$_sd"
+  _seed_db "$_sd/state.db" || return 1
+  ( _st_db_check "$_sd" )
+  [ "$?" = 0 ] || { _fail "check abaixo do teto" "esperado exit 0"; return 1; }
+}
+
+scenario_check_no_teto_exit_3() {
+  _sd="$TMPDIR_TEST/check-teto"
+  mkdir -p "$_sd"
+  _seed_db "$_sd/state.db" 1 || return 1  # max_recursion=1, current=1 -> next=2 > 1
+  ( _st_db_check "$_sd" ) 2>"$TMPDIR_TEST/check-teto-err.txt"
+  _rc=$?
+  [ "$_rc" = 3 ] || { _fail "check no teto" "esperado exit 3, obtido $_rc"; return 1; }
+  grep -q "profundidade no limite" "$TMPDIR_TEST/check-teto-err.txt" \
+    || { _fail "check no teto mensagem" "$(cat "$TMPDIR_TEST/check-teto-err.txt")"; return 1; }
+}
+
+# ==== _st_db_enter ====
+
+scenario_enter_incrementa_e_persiste() {
+  _sd="$TMPDIR_TEST/enter-ok"
+  mkdir -p "$_sd"
+  _seed_db "$_sd/state.db" || return 1
+  _out=$(_st_db_enter "$_sd")
+  [ "$_out" = "2" ] || { _fail "enter incrementa" "obtido '$_out'"; return 1; }
+  _persisted=$(sqlite3 "$_sd/state.db" "SELECT subagent_depth FROM execution;")
+  [ "$_persisted" = "2" ] || { _fail "enter persistido" "obtido '$_persisted'"; return 1; }
+}
+
+scenario_enter_acima_do_teto_exit_3_sem_gravar() {
+  _sd="$TMPDIR_TEST/enter-teto"
+  mkdir -p "$_sd"
+  _seed_db "$_sd/state.db" 1 || return 1  # max_recursion=1
+  _before=$(sqlite3 "$_sd/state.db" "SELECT subagent_depth FROM execution;")
+  ( _st_db_enter "$_sd" ) 2>"$TMPDIR_TEST/enter-teto-err.txt"
+  _rc=$?
+  [ "$_rc" = 3 ] || { _fail "enter acima do teto exit" "esperado 3, obtido $_rc"; return 1; }
+  grep -q "excederia MAX" "$TMPDIR_TEST/enter-teto-err.txt" \
+    || { _fail "enter acima do teto mensagem" "$(cat "$TMPDIR_TEST/enter-teto-err.txt")"; return 1; }
+  _after=$(sqlite3 "$_sd/state.db" "SELECT subagent_depth FROM execution;")
+  [ "$_before" = "$_after" ] || { _fail "enter negado MUTOU estado" "before=$_before after=$_after"; return 1; }
+}
+
+# ==== _st_db_leave ====
+
+scenario_leave_decrementa() {
+  _sd="$TMPDIR_TEST/leave-ok"
+  mkdir -p "$_sd"
+  _seed_db "$_sd/state.db" || return 1
+  _st_db_enter "$_sd" >/dev/null
+  _out=$(_st_db_leave "$_sd")
+  [ "$_out" = "1" ] || { _fail "leave decrementa" "obtido '$_out'"; return 1; }
+}
+
+scenario_leave_idempotente_no_minimo() {
+  _sd="$TMPDIR_TEST/leave-idempotente"
+  mkdir -p "$_sd"
+  _seed_db "$_sd/state.db" || return 1
+  _out=$(_st_db_leave "$_sd")
+  [ "$_out" = "1" ] || { _fail "leave idempotente" "obtido '$_out'"; return 1; }
+  _persisted=$(sqlite3 "$_sd/state.db" "SELECT subagent_depth FROM execution;")
+  [ "$_persisted" = "1" ] || { _fail "leave idempotente persistido" "obtido '$_persisted'"; return 1; }
+}
+
+# ==== _st_db_current ====
+
+scenario_current_reflete_estado_apos_enter_e_leave() {
+  _sd="$TMPDIR_TEST/current-fluxo"
+  mkdir -p "$_sd"
+  _seed_db "$_sd/state.db" || return 1
+  _st_db_enter "$_sd" >/dev/null
+  _st_db_enter "$_sd" >/dev/null
+  _out=$(_st_db_current "$_sd")
+  [ "$_out" = "3" ] || { _fail "current apos 2x enter" "obtido '$_out'"; return 1; }
+  _st_db_leave "$_sd" >/dev/null
+  _out=$(_st_db_current "$_sd")
+  [ "$_out" = "2" ] || { _fail "current apos leave" "obtido '$_out'"; return 1; }
+}
+
+run_all_scenarios

--- a/tests/test__state-db.sh
+++ b/tests/test__state-db.sh
@@ -1,0 +1,195 @@
+#!/bin/sh
+# test__state-db.sh — cobre global/skills/agente-00c-runtime/scripts/_state-db.sh
+# (helpers sourceaveis compartilhados do backend SQLite do state.db).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.1
+#      docs/specs/state-db-foundation/contracts/primitives.md §C5 C6 C8 C9
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+STATE_DB_LIB="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/_state-db.sh"
+SCHEMA_SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-db-schema.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test__state-db.sh: sqlite3 ausente — pulando suite\n'
+  exit 0
+fi
+
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-db.sh
+. "$STATE_DB_LIB"
+
+scenario_sql_escape_duplica_aspa_simples() {
+  _out=$(sql_escape "it's a test")
+  [ "$_out" = "it''s a test" ] || { _fail "sql_escape" "esperado \"it''s a test\", obtido \"$_out\""; return 1; }
+}
+
+scenario_sql_escape_payload_hostil_preservado_como_texto() {
+  _out=$(sql_escape "'; DROP TABLE decision; --")
+  [ "$_out" = "''; DROP TABLE decision; --" ] || { _fail "sql_escape hostil" "obtido \"$_out\""; return 1; }
+}
+
+scenario_strip_nul_remove_bytes_nul() {
+  _out=$(printf 'wid\000get' | strip_nul)
+  [ "$_out" = "widget" ] || { _fail "strip_nul" "esperado 'widget', obtido '$_out'"; return 1; }
+}
+
+# Paridade: sql_escape/strip_nul desta copia produzem EXATAMENTE a mesma
+# saida que a copia REAL em cli/lib/recall.sh (sourced isolada em subshell,
+# via mesmo mecanismo que tests/cstk/test_recall.sh usa), para o mesmo
+# conjunto de payloads (incluindo o payload hostil de C8). Garante que as
+# duas copias documentadas no cabecalho de _state-db.sh nunca divirjam
+# silenciosamente em algoritmo.
+scenario_paridade_com_cli_lib_recall_sql_escape() {
+  _cstk_lib="$REPO_ROOT/cli/lib"
+  [ -f "$_cstk_lib/recall.sh" ] || { _fail "paridade" "cli/lib/recall.sh nao encontrado"; return 1; }
+  for _payload in "it's a test" "'; DROP TABLE decision; --" "sem aspas" "'''"; do
+    _ours=$(sql_escape "$_payload")
+    _theirs=$(CSTK_LIB="$_cstk_lib" sh -c '
+      . "$CSTK_LIB/common.sh" 2>/dev/null
+      . "$CSTK_LIB/recall.sh" 2>/dev/null
+      sql_escape "$1"
+    ' _ "$_payload")
+    [ "$_ours" = "$_theirs" ] || { _fail "paridade sql_escape" "payload='$_payload' ours='$_ours' theirs='$_theirs'"; return 1; }
+  done
+}
+
+scenario_paridade_com_cli_lib_recall_strip_nul() {
+  _cstk_lib="$REPO_ROOT/cli/lib"
+  [ -f "$_cstk_lib/recall.sh" ] || { _fail "paridade" "cli/lib/recall.sh nao encontrado"; return 1; }
+  _ours=$(printf 'wid\000get' | strip_nul)
+  _theirs=$(printf 'wid\000get' | CSTK_LIB="$_cstk_lib" sh -c '
+    . "$CSTK_LIB/common.sh" 2>/dev/null
+    . "$CSTK_LIB/recall.sh" 2>/dev/null
+    strip_nul
+  ')
+  [ "$_ours" = "$_theirs" ] || { _fail "paridade strip_nul" "ours='$_ours' theirs='$_theirs'"; return 1; }
+}
+
+scenario_state_db_pragmas_default_5000() {
+  _out=$(_state_db_pragmas)
+  case "$_out" in
+    *"PRAGMA foreign_keys=ON;"*"PRAGMA busy_timeout=5000;"*) : ;;
+    *) _fail "pragmas default" "obtido: $_out"; return 1 ;;
+  esac
+}
+
+scenario_state_db_pragmas_ms_customizado() {
+  _out=$(_state_db_pragmas 9000)
+  case "$_out" in
+    *"PRAGMA busy_timeout=9000;"*) : ;;
+    *) _fail "pragmas custom" "obtido: $_out"; return 1 ;;
+  esac
+}
+
+scenario_state_db_exec_aplica_foreign_keys_on() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCHEMA_SCRIPT" create --db "$_db" >/dev/null
+  # FK ON: inserir human_block com decision_id inexistente MUST falhar.
+  capture _state_db_exec "$_db" "INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction) VALUES ('exec-1','1.0.0','/tmp/p','desc','em_andamento','2026-07-30T00:00:00Z','specify','x');"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "seed execution" "$_CAPTURED_STDERR"; return 1; }
+  capture _state_db_exec "$_db" "INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,status,triggered_at) VALUES ('block-001','exec-1','dec-999','pergunta com pelo menos 20 chars','contexto','aguardando','2026-07-30T00:00:00Z');"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "fk enforcement" "deveria falhar por FOREIGN KEY (foreign_keys=ON)"; return 1; }
+}
+
+scenario_state_db_exec_persiste_payload_hostil_literal_e_tabela_sobrevive() {
+  # Task 3.1.5: payload hostil + apostrofo simples persistido literalmente,
+  # tabela decision continua existindo. Equivalente ao gate de integridade
+  # deste FASE (state-validate.sh so existe para o backend JSON ate a FASE 5
+  # de export existir) e via PRAGMA integrity_check, ja documentado como o
+  # substituto sob backend SQLite (contracts/primitives.md §C7).
+  _db="$TMPDIR_TEST/state.db"
+  "$SCHEMA_SCRIPT" create --db "$_db" >/dev/null
+  _state_db_exec "$_db" "INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction) VALUES ('exec-1','1.0.0','/tmp/p','desc','em_andamento','2026-07-30T00:00:00Z','specify','x');" >/dev/null
+
+  _hostile="contexto com apostrofo $(sql_escape "'") e fragmento; DROP TABLE decision; -- e mais texto"
+  _sql="INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale) VALUES ('dec-001','exec-1','2026-07-30T00:00:00Z','agente','etapa','$_hostile','[\"a\"]','a','justificativa valida com >= 20 chars');"
+  capture _state_db_exec "$_db" "$_sql"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "insert hostil" "$_CAPTURED_STDERR"; return 1; }
+
+  _n=$(sqlite3 "$_db" "SELECT count(*) FROM decision;")
+  [ "$_n" = 1 ] || { _fail "decision sobreviveu" "esperado 1, obtido $_n"; return 1; }
+  _tables=$(sqlite3 "$_db" "SELECT count(*) FROM sqlite_master WHERE type='table';")
+  [ "$_tables" = 9 ] || { _fail "tabelas apos payload" "esperado 9, obtido $_tables"; return 1; }
+  _stored=$(sqlite3 "$_db" "SELECT context FROM decision WHERE id='dec-001';")
+  case "$_stored" in
+    *"DROP TABLE decision"*) : ;;
+    *) _fail "conteudo literal" "payload nao persistido literalmente: $_stored"; return 1 ;;
+  esac
+  _integrity=$(sqlite3 "$_db" "PRAGMA integrity_check;")
+  [ "$_integrity" = "ok" ] || { _fail "integrity_check" "esperado ok, obtido $_integrity"; return 1; }
+}
+
+scenario_state_db_exec_with_retry_sucesso_sem_lock() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCHEMA_SCRIPT" create --db "$_db" >/dev/null
+  capture _state_db_exec_with_retry "$_db" "INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction) VALUES ('exec-1','1.0.0','/tmp/p','desc','em_andamento','2026-07-30T00:00:00Z','specify','x');"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "retry sem lock" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_state_db_exec_with_retry_erro_nao_lock_falha_imediato() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCHEMA_SCRIPT" create --db "$_db" >/dev/null
+  # SQL invalido (erro de sintaxe, nao lock): deve falhar sem 4 retries
+  # (validado indiretamente pelo exit != 0; o teste de timing fica no
+  # cenario de lock persistente abaixo).
+  capture _state_db_exec_with_retry "$_db" "INSERT INTO tabela_inexistente (x) VALUES (1);"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "erro nao-lock" "deveria falhar (tabela inexistente)"; return 1; }
+}
+
+scenario_state_db_exec_with_retry_lock_persistente_sai_nao_zero() {
+  # C6: lock persistente apos as 4 tentativas MUST sair nao-zero — nunca
+  # degradar silenciosamente. Simula lock mantendo uma transacao BEGIN
+  # EXCLUSIVE aberta num processo sqlite3 em background (alimentado por
+  # FIFO, mantido aberto ate o teste terminar) durante a chamada sob teste.
+  _db="$TMPDIR_TEST/state.db"
+  "$SCHEMA_SCRIPT" create --db "$_db" >/dev/null
+
+  _fifo="$TMPDIR_TEST/lockctl"
+  mkfifo "$_fifo" 2>/dev/null || { _fail "lock persistente" "mkfifo indisponivel neste ambiente"; return 1; }
+  ( sqlite3 "$_db" <"$_fifo" >/dev/null 2>&1 ) &
+  _holder_pid=$!
+  exec 9>"$_fifo"
+  printf 'PRAGMA busy_timeout=0;\nBEGIN EXCLUSIVE;\nSELECT 1;\n' >&9
+  # da tempo do BEGIN EXCLUSIVE assentar antes de disparar a chamada sob teste
+  sleep 0.3
+
+  _start=$(date +%s)
+  capture _state_db_exec_with_retry "$_db" "INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction) VALUES ('exec-1','1.0.0','/tmp/p','desc','em_andamento','2026-07-30T00:00:00Z','specify','x');" 500
+  _rc=$_CAPTURED_EXIT
+  _elapsed=$(( $(date +%s) - _start ))
+
+  printf 'COMMIT;\n' >&9
+  exec 9>&-
+  wait "$_holder_pid" 2>/dev/null
+
+  [ "$_rc" != 0 ] || { _fail "lock persistente" "deveria sair nao-zero apos esgotar retries; saiu 0"; return 1; }
+  # 4 tentativas com backoff ~1+2+3+4s (com busy_timeout curto) leva alguns
+  # segundos; so garantimos que NAO retornou instantaneo (retry de fato rodou).
+  [ "$_elapsed" -ge 1 ] || { _fail "lock persistente" "retornou rapido demais (${_elapsed}s) — retry pode nao ter rodado"; return 1; }
+}
+
+scenario_state_db_secure_perms_aplica_600_no_db_e_sidecars() {
+  _db="$TMPDIR_TEST/perms.db"
+  "$SCHEMA_SCRIPT" create --db "$_db" >/dev/null
+  chmod 644 "$_db"
+  [ -f "$_db-wal" ] && chmod 644 "$_db-wal" 2>/dev/null
+  _state_db_secure_perms "$_db"
+  _perm_db=$(stat -f '%Lp' "$_db" 2>/dev/null || stat -c '%a' "$_db" 2>/dev/null)
+  [ "$_perm_db" = "600" ] || { _fail "chmod db" "esperado 600, obtido $_perm_db"; return 1; }
+  if [ -f "$_db-wal" ]; then
+    _perm_wal=$(stat -f '%Lp' "$_db-wal" 2>/dev/null || stat -c '%a' "$_db-wal" 2>/dev/null)
+    [ "$_perm_wal" = "600" ] || { _fail "chmod wal" "esperado 600, obtido $_perm_wal"; return 1; }
+  fi
+}
+
+scenario_state_db_secure_perms_sidecar_ausente_nao_falha() {
+  _db="$TMPDIR_TEST/no-sidecars.db"
+  : >"$_db"
+  capture _state_db_secure_perms "$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sidecar ausente" "nao deveria falhar: $_CAPTURED_STDERR"; return 1; }
+}
+
+run_all_scenarios

--- a/tests/test__state-decisions-db.sh
+++ b/tests/test__state-decisions-db.sh
@@ -1,0 +1,149 @@
+#!/bin/sh
+# test__state-decisions-db.sh — cobre
+# global/skills/agente-00c-runtime/scripts/_state-decisions-db.sh
+# (implementacao do backend SQLite de state-decisions.sh — feature
+# state-db-foundation, FASE 3 task 3.4).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.4
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C4 C6 C8
+#
+# Cobertura desta unit suite: helpers de baixo nivel (_sd_db_next_num_expr,
+# _sd_db_exec_capture, _sd_db_current_wave_id). O comportamento observavel
+# via CLI (register/count/next-id/list, incluindo o teste de concorrencia
+# 3.4.3) e coberto em tests/test_state-decisions.sh, que e o oraculo de
+# paridade C1 (mesma superficie para os dois backends).
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test__state-decisions-db.sh: sqlite3 ausente — pulando suite\n'
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  printf '# test__state-decisions-db.sh: jq ausente — pulando suite\n'
+  exit 0
+fi
+
+_R="$REPO_ROOT/global/skills/agente-00c-runtime/scripts"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-db.sh
+. "$_R/_state-db.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+. "$_R/_state-rw-db.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-decisions-db.sh
+. "$_R/_state-decisions-db.sh"
+
+SCHEMA_SCRIPT="$_R/state-db-schema.sh"
+
+# _sr_die/_sd_die: normalmente definidos por state-decisions.sh antes de
+# sourcear estas libs. Fornecemos equivalentes minimos para exercitar as
+# funcoes isoladas, sem depender do CLI completo.
+_sd_die() { printf 'state-decisions: %s\n' "$1" >&2; exit "${2:-1}"; }
+_sr_die() { _sd_die "$1" "${2:-1}"; }
+_sd_iso_now() { date -u +%FT%TZ; }
+
+# _seed_db PATH -> cria state.db minimo com execution id=exec-1.
+_seed_db() {
+  _sdb_db="$1"
+  "$SCHEMA_SCRIPT" create --db "$_sdb_db" >/dev/null 2>&1 \
+    || { _fail "seed: schema create falhou" ""; return 1; }
+  sqlite3 "$_sdb_db" "
+    PRAGMA foreign_keys=ON;
+    INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+    VALUES ('exec-1','1.0.0','/tmp/p','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+  " || { _fail "seed: insert execution falhou" ""; return 1; }
+}
+
+# ==== _sd_db_next_num_expr ====
+
+scenario_next_num_expr_vazio_retorna_1() {
+  _db="$TMPDIR_TEST/next-num-vazio.db"
+  _seed_db "$_db" || return 1
+  _expr=$(_sd_db_next_num_expr "'exec-1'")
+  _out=$(_state_db_exec "$_db" "SELECT $_expr;")
+  [ "$_out" = "1" ] || { _fail "next_num_expr vazio" "obtido '$_out'"; return 1; }
+}
+
+scenario_next_num_expr_apos_insert_retorna_2() {
+  _db="$TMPDIR_TEST/next-num-apos.db"
+  _seed_db "$_db" || return 1
+  sqlite3 "$_db" "
+    INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale)
+    VALUES ('dec-001','exec-1','2026-07-30T00:00:00Z','x','specify','contexto de teste com detalhe suficiente','[\"a\"]','a','justificativa de teste com detalhe suficiente');
+  "
+  _expr=$(_sd_db_next_num_expr "'exec-1'")
+  _out=$(_state_db_exec "$_db" "SELECT $_expr;")
+  [ "$_out" = "2" ] || { _fail "next_num_expr apos insert" "obtido '$_out'"; return 1; }
+}
+
+scenario_next_num_expr_isola_por_execution_id() {
+  # Outra execution com decisoes nao deve influenciar o calculo desta.
+  _db="$TMPDIR_TEST/next-num-isola.db"
+  _seed_db "$_db" || return 1
+  sqlite3 "$_db" "
+    INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+    VALUES ('exec-2','1.0.0','/tmp/p2','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+    INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale)
+    VALUES ('dec-001','exec-2','2026-07-30T00:00:00Z','x','specify','contexto de teste com detalhe suficiente','[\"a\"]','a','justificativa de teste com detalhe suficiente');
+  "
+  _expr=$(_sd_db_next_num_expr "'exec-1'")
+  _out=$(_state_db_exec "$_db" "SELECT $_expr;")
+  [ "$_out" = "1" ] || { _fail "next_num_expr isola execution" "obtido '$_out'"; return 1; }
+}
+
+# ==== _sd_db_current_wave_id ====
+
+scenario_current_wave_id_vazio_sem_ondas() {
+  _db="$TMPDIR_TEST/wave-id-vazio.db"
+  _seed_db "$_db" || return 1
+  _out=$(_sd_db_current_wave_id "$_db" "exec-1")
+  [ -z "$_out" ] || { _fail "current_wave_id vazio" "obtido '$_out'"; return 1; }
+}
+
+scenario_current_wave_id_pega_ultima_por_seq() {
+  _db="$TMPDIR_TEST/wave-id-ultima.db"
+  _seed_db "$_db" || return 1
+  sqlite3 "$_db" "
+    INSERT INTO wave (id,execution_id,seq,started_at,executed_stages)
+    VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z','[]');
+    INSERT INTO wave (id,execution_id,seq,started_at,finished_at,termination_reason,executed_stages)
+    VALUES ('onda-002','exec-1',2,'2026-07-30T00:01:00Z','2026-07-30T00:02:00Z','etapa_concluida_avancando','[]');
+  "
+  _out=$(_sd_db_current_wave_id "$_db" "exec-1")
+  # paridade com .waves[-1].id do path JSON: pega a ultima por seq, mesmo
+  # ja fechada — nao filtra por onda aberta.
+  [ "$_out" = "onda-002" ] || { _fail "current_wave_id ultima" "obtido '$_out'"; return 1; }
+}
+
+# ==== _sd_db_exec_capture ====
+
+scenario_exec_capture_sucesso_preserva_stdout() {
+  _db="$TMPDIR_TEST/exec-capture-ok.db"
+  _seed_db "$_db" || return 1
+  _out=$(_sd_db_exec_capture "$_db" "SELECT 'ok-' || 42;")
+  [ "$_out" = "ok-42" ] || { _fail "exec_capture stdout" "obtido '$_out'"; return 1; }
+}
+
+scenario_exec_capture_erro_nao_lock_falha_imediato() {
+  _db="$TMPDIR_TEST/exec-capture-erro.db"
+  _seed_db "$_db" || return 1
+  capture _sd_db_exec_capture "$_db" "INSERT INTO tabela_inexistente (x) VALUES (1);"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "exec_capture erro nao-lock" "deveria falhar"; return 1; }
+}
+
+scenario_exec_capture_transacao_com_select_antes_do_commit() {
+  # Mesmo padrao usado por register: BEGIN IMMEDIATE + INSERT + SELECT do
+  # proprio rowid + COMMIT, tudo numa unica invocacao — garante que o
+  # stdout devolvido e o da linha recem-inserida por ESTA sessao.
+  _db="$TMPDIR_TEST/exec-capture-tx.db"
+  _seed_db "$_db" || return 1
+  _sql="BEGIN IMMEDIATE; INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale) VALUES ('dec-001','exec-1','2026-07-30T00:00:00Z','x','specify','contexto de teste com detalhe suficiente','[\"a\"]','a','justificativa de teste com detalhe suficiente'); SELECT id FROM decision WHERE rowid=last_insert_rowid(); COMMIT;"
+  _out=$(_sd_db_exec_capture "$_db" "$_sql")
+  [ "$_out" = "dec-001" ] || { _fail "exec_capture tx select" "obtido '$_out'"; return 1; }
+  _cnt=$(sqlite3 "$_db" "SELECT count(*) FROM decision;")
+  [ "$_cnt" = "1" ] || { _fail "exec_capture tx commitou" "obtido '$_cnt'"; return 1; }
+}
+
+run_all_scenarios

--- a/tests/test__state-ondas-db.sh
+++ b/tests/test__state-ondas-db.sh
@@ -1,0 +1,162 @@
+#!/bin/sh
+# test__state-ondas-db.sh — cobre global/skills/agente-00c-runtime/scripts/_state-ondas-db.sh
+# (implementacao do backend SQLite de state-ondas.sh — feature state-db-foundation,
+# FASE 3 task 3.3).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.3
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C3 C4
+#
+# Cobertura desta unit suite: helpers de baixo nivel (_so_db_aggregate_agent_usage,
+# _so_tasks_md_titlemap, _so_tasks_md_missing). O comportamento observavel via
+# CLI (start/end/record-*/wave-status/current-id/reconcile-*) e coberto em
+# tests/test_state-ondas.sh, que e o oraculo de paridade C1.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf '# test__state-ondas-db.sh: jq ausente — pulando suite\n'
+  exit 0
+fi
+
+_R="$REPO_ROOT/global/skills/agente-00c-runtime/scripts"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_diag.sh
+. "$_R/_diag.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-db.sh
+. "$_R/_state-db.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+. "$_R/_state-rw-db.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-ondas-db.sh
+. "$_R/_state-ondas-db.sh"
+
+# _sr_die/_so_die/_so_log: normalmente definidos por state-ondas.sh antes de
+# sourcear estas libs. Fornecemos equivalentes minimos para exercitar as
+# funcoes isoladas, sem depender do CLI completo.
+_sr_die() { printf 'state-ondas: %s\n' "$1" >&2; exit "${2:-1}"; }
+_so_die() { printf 'state-ondas: %s\n' "$1" >&2; exit "${2:-1}"; }
+_so_log() { printf 'state-ondas: %s\n' "$1" >&2; }
+
+# ==== _so_db_aggregate_agent_usage ====
+
+scenario_aggregate_agent_usage_vazio_vira_null() {
+  _out=$(_so_db_aggregate_agent_usage '[]')
+  [ "$_out" = "null" ] || { _fail "aggregate vazio" "obtido '$_out'"; return 1; }
+}
+
+scenario_aggregate_agent_usage_soma_campos_observados() {
+  _spawns='[{"status":"ok","total_tokens":100,"tool_use_count":3,"duration_ms":500},{"status":"ok","total_tokens":50,"tool_use_count":1,"duration_ms":200}]'
+  _out=$(_so_db_aggregate_agent_usage "$_spawns")
+  _total=$(printf '%s' "$_out" | jq -r '.spawns_total')
+  [ "$_total" = "2" ] || { _fail "aggregate total" "obtido '$_total'"; return 1; }
+  _tok=$(printf '%s' "$_out" | jq -r '.total_tokens')
+  [ "$_tok" = "150" ] || { _fail "aggregate tokens" "obtido '$_tok'"; return 1; }
+}
+
+scenario_aggregate_agent_usage_indisponivel_nao_conta_com_usage() {
+  _spawns='[{"status":"indisponivel"},{"status":"ok","total_tokens":10}]'
+  _out=$(_so_db_aggregate_agent_usage "$_spawns")
+  _with_usage=$(printf '%s' "$_out" | jq -r '.spawns_with_usage')
+  [ "$_with_usage" = "1" ] || { _fail "aggregate with_usage" "obtido '$_with_usage'"; return 1; }
+  _unavail=$(printf '%s' "$_out" | jq -r '.spawns_unavailable')
+  [ "$_unavail" = "1" ] || { _fail "aggregate unavailable" "obtido '$_unavail'"; return 1; }
+}
+
+scenario_aggregate_agent_usage_campo_ausente_vira_null_nunca_zero() {
+  # Principio VI: campo nunca observado em NENHUM spawn -> null, nao 0
+  # fabricado.
+  _spawns='[{"status":"ok"}]'
+  _out=$(_so_db_aggregate_agent_usage "$_spawns")
+  _tok=$(printf '%s' "$_out" | jq -c '.total_tokens')
+  [ "$_tok" = "null" ] || { _fail "aggregate campo ausente" "obtido '$_tok'"; return 1; }
+}
+
+# ==== _so_tasks_md_titlemap ====
+
+_write_titlemap_md() {
+  cat > "$1" <<'TASKS'
+# Tarefas
+
+### 1.1 Setup do Projeto `[A]`
+
+- [x] 1.1.1 Criar repo
+
+### 1.2 Dominio `[C]`
+
+- [x] 1.2.1 Entidades
+TASKS
+}
+
+scenario_titlemap_extrai_heading_sem_criticidade() {
+  _md="$TMPDIR_TEST/titlemap.md"
+  _write_titlemap_md "$_md"
+  _out=$(_so_tasks_md_titlemap "$_md")
+  case "$_out" in
+    *"1.1	Setup do Projeto"*) : ;;
+    *) _fail "titlemap 1.1" "obtido: $_out"; return 1 ;;
+  esac
+  case "$_out" in
+    *'[A]'*) _fail "titlemap carregou criticidade" "obtido: $_out"; return 1 ;;
+    *) : ;;
+  esac
+}
+
+scenario_titlemap_vazio_quando_sem_headings() {
+  _md="$TMPDIR_TEST/titlemap-vazio.md"
+  printf '# Sem tasks\n\ntexto qualquer\n' > "$_md"
+  _out=$(_so_tasks_md_titlemap "$_md")
+  [ -z "$_out" ] || { _fail "titlemap vazio" "obtido: $_out"; return 1; }
+}
+
+# ==== _so_tasks_md_missing ====
+
+scenario_missing_lista_concluida_ausente_do_existing() {
+  _md="$TMPDIR_TEST/missing.md"
+  _write_titlemap_md "$_md"
+  _exf="$TMPDIR_TEST/existing-empty"
+  : > "$_exf"
+  _out=$(_so_tasks_md_missing "$_md" "$_exf")
+  case "$_out" in
+    *"1.1	Setup do Projeto"*) : ;;
+    *) _fail "missing 1.1" "obtido: $_out"; return 1 ;;
+  esac
+  case "$_out" in
+    *"1.2	Dominio"*) : ;;
+    *) _fail "missing 1.2" "obtido: $_out"; return 1 ;;
+  esac
+}
+
+scenario_missing_exclui_ja_existentes() {
+  _md="$TMPDIR_TEST/missing-excl.md"
+  _write_titlemap_md "$_md"
+  _exf="$TMPDIR_TEST/existing-1.1"
+  printf '1.1\n' > "$_exf"
+  _out=$(_so_tasks_md_missing "$_md" "$_exf")
+  case "$_out" in
+    *"1.1"*) _fail "missing nao deveria incluir 1.1" "obtido: $_out"; return 1 ;;
+    *) : ;;
+  esac
+  case "$_out" in
+    *"1.2"*) : ;;
+    *) _fail "missing deveria incluir 1.2" "obtido: $_out"; return 1 ;;
+  esac
+}
+
+scenario_missing_ignora_task_parcial() {
+  _md="$TMPDIR_TEST/missing-parcial.md"
+  cat > "$_md" <<'TASKS'
+# Tarefas
+
+### 2.1 Parcial `[A]`
+
+- [x] 2.1.1 Feito
+- [ ] 2.1.2 Nao feito
+TASKS
+  _exf="$TMPDIR_TEST/existing-parcial-empty"
+  : > "$_exf"
+  _out=$(_so_tasks_md_missing "$_md" "$_exf")
+  [ -z "$_out" ] || { _fail "missing parcial deveria ser vazio" "obtido: $_out"; return 1; }
+}
+
+run_all_scenarios

--- a/tests/test__state-rw-db.sh
+++ b/tests/test__state-rw-db.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+# test__state-rw-db.sh — cobre global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+# (implementacao do backend SQLite de state-rw.sh — feature state-db-foundation,
+# FASE 3 task 3.2).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.2
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 C2 C7
+#
+# Cobertura desta unit suite: helpers de baixo nivel (_sr_sql_quote,
+# _sr_sql_literal, _sr_backend, _sr_db_file, _sr_exec_col_lookup). O
+# comportamento observavel via CLI (read/get/set/write/sha256-*) e coberto
+# em tests/test_state-rw.sh, que e o oraculo de paridade C1 (mesma superficie
+# para os dois backends).
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test__state-rw-db.sh: sqlite3 ausente — pulando suite\n'
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  printf '# test__state-rw-db.sh: jq ausente — pulando suite\n'
+  exit 0
+fi
+
+_R="$REPO_ROOT/global/skills/agente-00c-runtime/scripts"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_diag.sh
+. "$_R/_diag.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-db.sh
+. "$_R/_state-db.sh"
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+. "$_R/_state-rw-db.sh"
+
+# _sr_die/_SR_NAME: normalmente definidos por state-rw.sh antes de sourcear
+# este lib. Fornecemos equivalentes minimos para exercitar as funcoes isoladas.
+_SR_NAME="state-rw"
+_sr_die() {
+  printf '%s: %s\n' "$_SR_NAME" "$1" >&2
+  exit "${2:-1}"
+}
+
+# ==== _sr_backend / _sr_db_file ====
+
+scenario_backend_json_quando_sem_state_db() {
+  _sd="$TMPDIR_TEST/proj"
+  mkdir -p "$_sd"
+  _out=$(_sr_backend "$_sd")
+  [ "$_out" = "json" ] || { _fail "_sr_backend" "esperado 'json', obtido '$_out'"; return 1; }
+}
+
+scenario_backend_sqlite_quando_state_db_existe() {
+  _sd="$TMPDIR_TEST/proj"
+  mkdir -p "$_sd"
+  : > "$_sd/state.db"
+  _out=$(_sr_backend "$_sd")
+  [ "$_out" = "sqlite" ] || { _fail "_sr_backend" "esperado 'sqlite', obtido '$_out'"; return 1; }
+}
+
+# ==== _sr_sql_quote (C8: paridade com sql_escape/strip_nul) ====
+
+scenario_sql_quote_escapa_aspa_simples() {
+  _out=$(_sr_sql_quote "it's a test")
+  [ "$_out" = "'it''s a test'" ] || { _fail "_sr_sql_quote" "obtido '$_out'"; return 1; }
+}
+
+scenario_sql_quote_payload_hostil_preservado_literal() {
+  _out=$(_sr_sql_quote "'; DROP TABLE decision; --")
+  [ "$_out" = "'''; DROP TABLE decision; --'" ] || { _fail "_sr_sql_quote hostil" "obtido '$_out'"; return 1; }
+}
+
+# ==== _sr_sql_literal ====
+
+scenario_sql_literal_str_null_vira_sql_null() {
+  _out=$(_sr_sql_literal str 'null')
+  [ "$_out" = "NULL" ] || { _fail "sql_literal str null" "obtido '$_out'"; return 1; }
+}
+
+scenario_sql_literal_str_string_e_escapada() {
+  _out=$(_sr_sql_literal str '"o apostrofo dele'"'"'s"')
+  [ "$_out" = "'o apostrofo dele''s'" ] || { _fail "sql_literal str" "obtido '$_out'"; return 1; }
+}
+
+scenario_sql_literal_int_number_passa_direto() {
+  _out=$(_sr_sql_literal int '42')
+  [ "$_out" = "42" ] || { _fail "sql_literal int" "obtido '$_out'"; return 1; }
+}
+
+scenario_sql_literal_int_rejeita_nao_numero() {
+  _out=$(_sr_sql_literal int '"abc"' 2>/dev/null)
+  _rc=$?
+  [ "$_rc" != 0 ] || { _fail "sql_literal int nao-numero" "esperado exit != 0"; return 1; }
+}
+
+scenario_sql_literal_bool_true_vira_1() {
+  _out=$(_sr_sql_literal bool 'true')
+  [ "$_out" = "1" ] || { _fail "sql_literal bool true" "obtido '$_out'"; return 1; }
+}
+
+scenario_sql_literal_bool_false_vira_0() {
+  _out=$(_sr_sql_literal bool 'false')
+  [ "$_out" = "0" ] || { _fail "sql_literal bool false" "obtido '$_out'"; return 1; }
+}
+
+scenario_sql_literal_json_array_e_quotado_compacto() {
+  _out=$(_sr_sql_literal json '["a", "b"]')
+  [ "$_out" = "'[\"a\",\"b\"]'" ] || { _fail "sql_literal json" "obtido '$_out'"; return 1; }
+}
+
+scenario_sql_literal_json_null_vira_sql_null() {
+  _out=$(_sr_sql_literal json 'null')
+  [ "$_out" = "NULL" ] || { _fail "sql_literal json null" "obtido '$_out'"; return 1; }
+}
+
+# ==== _sr_exec_col_lookup ====
+
+scenario_exec_col_lookup_mapeia_top_level_conhecido() {
+  _sr_exec_col_lookup "current_stage"
+  [ "$_sr_lu_col" = "current_stage" ] || { _fail "lookup current_stage" "col='$_sr_lu_col'"; return 1; }
+  [ "$_sr_lu_type" = "str" ] || { _fail "lookup current_stage type" "type='$_sr_lu_type'"; return 1; }
+}
+
+scenario_exec_col_lookup_mapeia_prefixo_execution() {
+  _sr_exec_col_lookup "execution.status"
+  [ "$_sr_lu_col" = "status" ] || { _fail "lookup execution.status" "col='$_sr_lu_col'"; return 1; }
+}
+
+scenario_exec_col_lookup_mapeia_budgets_com_nome_diferente() {
+  # budgets.current_subagent_depth -> coluna subagent_depth (nomes NAO coincidem)
+  _sr_exec_col_lookup "budgets.current_subagent_depth"
+  [ "$_sr_lu_col" = "subagent_depth" ] || { _fail "lookup budgets" "col='$_sr_lu_col'"; return 1; }
+}
+
+scenario_exec_col_lookup_desconhecido_fica_vazio() {
+  _sr_exec_col_lookup "next_retrospective_milestone"
+  [ -z "$_sr_lu_col" ] || { _fail "lookup desconhecido" "esperado vazio, obtido '$_sr_lu_col'"; return 1; }
+}
+
+scenario_exec_col_lookup_id_e_imutavel() {
+  _out=$(_sr_exec_col_lookup "id" 2>&1)
+  _rc=$?
+  [ "$_rc" != 0 ] || { _fail "lookup id imutavel" "esperado exit != 0"; return 1; }
+  case "$_out" in
+    *imutavel*) : ;;
+    *) _fail "lookup id imutavel msg" "obtido: $_out"; return 1 ;;
+  esac
+}
+
+run_all_scenarios

--- a/tests/test_bloqueios.sh
+++ b/tests/test_bloqueios.sh
@@ -9,6 +9,7 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
 SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/bloqueios.sh"
 RW="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-rw.sh"
 DEC="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-decisions.sh"
+SCHEMA_SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-db-schema.sh"
 
 if ! command -v jq >/dev/null 2>&1; then
   printf '# test_bloqueios.sh: jq ausente — pulando suite\n'
@@ -331,5 +332,291 @@ scenario_backcompat_migrate_entao_register_respond() {
   capture "$RW" get --state-dir "$_sd" --field '.human_blocks[0].human_answer'
   assert_stdout_contains "Sim" || return 1
 }
+
+# ==== Backend SQLite (feature state-db-foundation, FASE 3 task 3.5) ====
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.5
+#      docs/specs/state-db-foundation/contracts/primitives.md §C1 (paridade)
+#      §C2 (selecao de backend) §C3 (FK) §C4 (transacao) §C6 (concorrencia)
+#      §C8 (escape)
+#
+# Mesmo padrao de tests/test_state-decisions.sh (task 3.4): aplica o DDL via
+# state-db-schema.sh e semeia uma execution + decision minimas via sqlite3
+# diretamente (init nunca cria state.db — isso e a migracao, FASE 6, ainda
+# nao implementada).
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test_bloqueios.sh: sqlite3 ausente — pulando cenarios de backend SQLite\n'
+else
+
+# _seed_sqlite_backend DIR -> cria state.db com execution (id=exec-1) e
+# decision (id=dec-001) minimas, prontas para bloqueios.sh register.
+_seed_sqlite_backend() {
+  _ssb_dir=$1
+  mkdir -p "$_ssb_dir"
+  "$SCHEMA_SCRIPT" create --db "$_ssb_dir/state.db" >/dev/null 2>&1 \
+    || { _fail "seed: schema create falhou" ""; return 1; }
+  sqlite3 "$_ssb_dir/state.db" "
+    PRAGMA foreign_keys=ON;
+    INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+    VALUES ('exec-1','1.0.0','/tmp/p','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+    INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale)
+    VALUES ('dec-001','exec-1','2026-07-30T00:00:00Z','x','clarify','contexto de teste com detalhe suficiente','[\"a\"]','a','justificativa de teste com detalhe suficiente');
+  " || { _fail "seed: insert execution/decision falhou" ""; return 1; }
+}
+
+_register_sqlite_default() {
+  capture "$SCRIPT" register --state-dir "$1" \
+    --decisao-id "dec-001" \
+    --pergunta "Qual stack escolher para a feature, Go ou Node?" \
+    --contexto-para-resposta "Briefing nao define; stack-sugerida vazia"
+}
+
+scenario_sqlite_register_gera_block_001() {
+  _sd="$TMPDIR_TEST/sqlite-register-001"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_sqlite_default "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite register" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "block-001" || return 1
+  capture "$SCRIPT" count --state-dir "$_sd"
+  assert_stdout_contains "1" || return 1
+}
+
+scenario_sqlite_register_atualiza_status_para_aguardando_humano() {
+  # C4: register grava o bloqueio E muda .execution.status na MESMA
+  # transacao.
+  _sd="$TMPDIR_TEST/sqlite-register-status"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_sqlite_default "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite register" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.execution.status'
+  assert_stdout_contains "aguardando_humano" || return 1
+  # accumulated_metrics.human_blocks_total e DERIVADO por agregacao SQL sob
+  # o backend sqlite (paridade de state-ondas.sh task 3.3.1) — nao um
+  # contador mantido em sincronia.
+  capture "$RW" get --state-dir "$_sd" --field '.accumulated_metrics.human_blocks_total'
+  assert_stdout_contains "1" || return 1
+}
+
+scenario_sqlite_register_sequencial_gera_block_002() {
+  _sd="$TMPDIR_TEST/sqlite-register-seq"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_sqlite_default "$_sd"
+  _register_sqlite_default "$_sd"
+  assert_stdout_contains "block-002" || return 1
+  capture "$SCRIPT" next-id --state-dir "$_sd"
+  assert_stdout_contains "block-003" || return 1
+}
+
+# C3: decisao_id inexistente dispara a FK REAL do schema
+# (human_block.decision_id REFERENCES decision(id)) — a transacao inteira
+# reverte (nenhum bloqueio persistido, execution.status intocado) e o erro
+# e mapeado para a mesma mensagem/exit 1 do path JSON (US1 AS-4).
+scenario_sqlite_register_decisao_inexistente_falha_fk() {
+  _sd="$TMPDIR_TEST/sqlite-register-fk"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --decisao-id "dec-fantasma" \
+    --pergunta "Pergunta longa o suficiente para passar (>=20 chars)" \
+    --contexto-para-resposta "ctx"
+  if [ "$_CAPTURED_EXIT" != 1 ]; then
+    _fail "sqlite FK violation" "esperado 1, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  assert_stderr_contains "decisao_id nao existe" || return 1
+  # Nada persistido — a transacao reverteu por inteiro (C4).
+  capture "$SCRIPT" count --state-dir "$_sd"
+  assert_stdout_contains "0" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.execution.status'
+  assert_stdout_contains "em_andamento" || return 1
+}
+
+scenario_sqlite_list_imprime_tsv() {
+  _sd="$TMPDIR_TEST/sqlite-list-tsv"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_sqlite_default "$_sd"
+  capture "$SCRIPT" list --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite list" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "block-001	dec-001	aguardando	" || return 1
+  assert_stdout_contains "Qual stack escolher" || return 1
+}
+
+scenario_sqlite_list_filtra_por_status() {
+  _sd="$TMPDIR_TEST/sqlite-list-status"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_sqlite_default "$_sd"
+  capture "$SCRIPT" respond --state-dir "$_sd" --block-id "block-001" --resposta "Go"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite respond" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" list --state-dir "$_sd" --status "respondido"
+  assert_stdout_contains "block-001	" || return 1
+  capture "$SCRIPT" list --state-dir "$_sd" --status "aguardando"
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "sqlite list filtrado" "esperava vazio, obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+scenario_sqlite_get_imprime_json() {
+  _sd="$TMPDIR_TEST/sqlite-get"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_sqlite_default "$_sd"
+  capture "$SCRIPT" get --state-dir "$_sd" --block-id "block-001"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite get" "$_CAPTURED_STDERR"; return 1; }
+  capture jq -e '.id == "block-001" and .decision_id == "dec-001" and .status == "aguardando" and .recommended_options == null' <<EOF
+$_CAPTURED_STDOUT
+EOF
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite get json" "campos incorretos: $_CAPTURED_STDOUT"; return 1; }
+}
+
+scenario_sqlite_get_inexistente_falha() {
+  _sd="$TMPDIR_TEST/sqlite-get-ausente"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" get --state-dir "$_sd" --block-id "block-999"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "sqlite get ausente" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+}
+
+# C4: respond fecha o bloqueio E, se nao restar nenhum outro aguardando,
+# promove execution.status de volta a "em_andamento" — mesma transacao.
+scenario_sqlite_respond_marca_respondido_e_volta_status() {
+  _sd="$TMPDIR_TEST/sqlite-respond"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_sqlite_default "$_sd"
+  capture "$SCRIPT" respond --state-dir "$_sd" --block-id "block-001" --resposta "Vamos de Go"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite respond" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.execution.status'
+  assert_stdout_contains "em_andamento" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.human_blocks[0].human_answer'
+  assert_stdout_contains "Vamos de Go" || return 1
+  capture "$SCRIPT" count --state-dir "$_sd" --pending-only
+  assert_stdout_contains "0" || return 1
+}
+
+scenario_sqlite_respond_status_so_volta_quando_todos_resolvidos() {
+  _sd="$TMPDIR_TEST/sqlite-respond-parcial"
+  _seed_sqlite_backend "$_sd" || return 1
+  # segunda decisao + segundo bloqueio pendente
+  capture "$DEC" register --state-dir "$_sd" \
+    --agente "x" --etapa "clarify" \
+    --contexto "Outra decisao de teste com 20+ chars aqui" \
+    --opcoes '["a","b"]' --escolha "a" \
+    --justificativa "Justificativa generica com 20+ chars aqui"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite dec-002" "$_CAPTURED_STDERR"; return 1; }
+  _register_sqlite_default "$_sd"
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --decisao-id "dec-002" \
+    --pergunta "Segunda pergunta longa o suficiente para passar?" \
+    --contexto-para-resposta "ctx2"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite block-002" "$_CAPTURED_STDERR"; return 1; }
+
+  capture "$SCRIPT" respond --state-dir "$_sd" --block-id "block-001" --resposta "resp1"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite respond 1" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.execution.status'
+  assert_stdout_contains "aguardando_humano" || return 1
+
+  capture "$SCRIPT" respond --state-dir "$_sd" --block-id "block-002" --resposta "resp2"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite respond 2" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.execution.status'
+  assert_stdout_contains "em_andamento" || return 1
+}
+
+scenario_sqlite_respond_ja_respondido_falha() {
+  _sd="$TMPDIR_TEST/sqlite-respond-duplo"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_sqlite_default "$_sd"
+  capture "$SCRIPT" respond --state-dir "$_sd" --block-id "block-001" --resposta "primeira"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite respond 1" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" respond --state-dir "$_sd" --block-id "block-001" --resposta "segunda"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "sqlite respond duplo" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "nao esta em status aguardando" || return 1
+}
+
+scenario_sqlite_respond_inexistente_falha() {
+  _sd="$TMPDIR_TEST/sqlite-respond-ausente"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" respond --state-dir "$_sd" --block-id "block-999" --resposta "x"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "sqlite respond ausente" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "bloqueio nao encontrado" || return 1
+}
+
+# C8: payload hostil (apostrofo + tentativa de injecao) persistido literal,
+# tabela human_block sobrevive, integrity_check continua ok.
+scenario_sqlite_payload_hostil_preservado_literal_tabela_sobrevive() {
+  _sd="$TMPDIR_TEST/sqlite-hostil"
+  _seed_sqlite_backend "$_sd" || return 1
+  _hostil="'; DROP TABLE human_block; -- e apostrofo simples it's here"
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --decisao-id "dec-001" \
+    --pergunta "$_hostil (pergunta hostil, 20+ chars)" \
+    --contexto-para-resposta "$_hostil"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite payload hostil" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.human_blocks[-1].question'
+  assert_stdout_contains "DROP TABLE human_block" || return 1
+  capture "$RW" sha256-verify --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "integrity apos payload hostil" "$_CAPTURED_STDERR"; return 1; }
+}
+
+# Teste de concorrencia (task 3.5, paridade com 3.4.3): N registers
+# simultaneos, cada um referenciando uma decisao DISTINTA (FK 1:1 por
+# design do schema nao impede reuso do MESMO decision_id por varios
+# human_blocks — mas exercitamos IDs unicos por worker para simular o caso
+# real de varios bloqueios concorrentes na mesma execucao), nao perde
+# nenhum bloqueio e nao colide em block-NNN.
+scenario_sqlite_register_concorrente_sem_colisao() {
+  _sd="$TMPDIR_TEST/sqlite-concorrencia"
+  _seed_sqlite_backend "$_sd" || return 1
+  _n=15
+  _i=1
+  while [ "$_i" -le "$_n" ]; do
+    ( "$SCRIPT" register --state-dir "$_sd" \
+        --decisao-id "dec-001" \
+        --pergunta "Pergunta concorrente numero $_i com 20+ chars" \
+        --contexto-para-resposta "ctx concorrente $_i" \
+        > "$TMPDIR_TEST/sqlite-concorrencia-out-$_i.txt" \
+        2> "$TMPDIR_TEST/sqlite-concorrencia-err-$_i.txt" ) &
+    _i=$((_i + 1))
+  done
+  wait
+
+  _i=1
+  while [ "$_i" -le "$_n" ]; do
+    if [ -s "$TMPDIR_TEST/sqlite-concorrencia-err-$_i.txt" ]; then
+      _fail "worker $_i emitiu stderr" "$(cat "$TMPDIR_TEST/sqlite-concorrencia-err-$_i.txt")"
+      return 1
+    fi
+    _i=$((_i + 1))
+  done
+
+  _unique=$(cat "$TMPDIR_TEST"/sqlite-concorrencia-out-*.txt | sort -u | wc -l | tr -d ' ')
+  [ "$_unique" = "$_n" ] || { _fail "ids unicos" "esperado $_n, obtido $_unique"; return 1; }
+
+  capture "$SCRIPT" count --state-dir "$_sd"
+  assert_stdout_contains "$_n" || return 1
+}
+
+# Paridade cross-backend (C1): mesmos inputs, mesmo formato de stdout
+# (block-001) para o primeiro register em cada backend.
+scenario_sqlite_paridade_register_primeiro_id_json() {
+  _sd_json="$TMPDIR_TEST/paridade-bloqueios-json"
+  _setup_with_decisao "$_sd_json" || { _error "fixture" ""; return 2; }
+  _register_block_default "$_sd_json"
+  _json_id="$_CAPTURED_STDOUT"
+
+  _sd_db="$TMPDIR_TEST/paridade-bloqueios-sqlite"
+  _seed_sqlite_backend "$_sd_db" || return 1
+  _register_sqlite_default "$_sd_db"
+  _db_id="$_CAPTURED_STDOUT"
+
+  [ "$_json_id" = "$_db_id" ] || { _fail "paridade register id" "json='$_json_id' sqlite='$_db_id'"; return 1; }
+}
+
+scenario_sqlite_register_state_db_ausente_falha() {
+  _sd="$TMPDIR_TEST/sqlite-ausente"
+  mkdir -p "$_sd"
+  # sem state.db -> backend json (C2); sem state.json tambem -> falha 1
+  _register_sqlite_default "$_sd"
+  if [ "$_CAPTURED_EXIT" != 1 ]; then
+    _fail "sqlite state ausente" "esperado 1, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+}
+
+fi # sqlite3 disponivel
 
 run_all_scenarios

--- a/tests/test_bloqueios.sh
+++ b/tests/test_bloqueios.sh
@@ -617,6 +617,35 @@ scenario_sqlite_register_state_db_ausente_falha() {
   fi
 }
 
+# Task 4.1.1/4.2.2 (FASE 4): branch de selecao de backend explicito por C2 —
+# um state.json coexistente e export/legado, NUNCA consultado como fonte.
+# Prova positiva: 1 bloqueio registrado no state.db, state.json divergente
+# com 3 bloqueios falsos — count --pending-only deve refletir sempre o
+# state.db (1).
+scenario_c2_state_json_coexistente_ignorado_quando_state_db_presente() {
+  _sd="$TMPDIR_TEST/c2-coexist-bloqueios"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_sqlite_default "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2: register sqlite" "$_CAPTURED_STDERR"; return 1; }
+
+  # state.json divergente no MESMO diretorio (3 bloqueios pendentes falsos).
+  printf '{"human_blocks":[{"status":"aguardando"},{"status":"aguardando"},{"status":"aguardando"}]}\n' > "$_sd/state.json"
+
+  capture "$SCRIPT" count --state-dir "$_sd" --pending-only
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2 count exit" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "1" \
+    || { _fail "c2: count deveria refletir state.db (1), nao o state.json coexistente (3)" "obtido $_CAPTURED_STDOUT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    3*) _fail "c2: count leu o state.json coexistente" "obtido $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+
+  # state.json coexistente permanece intocado.
+  case "$(cat "$_sd/state.json")" in
+    *aguardando*) : ;;
+    *) _fail "c2: state.json coexistente foi modificado" "obtido: $(cat "$_sd/state.json")"; return 1 ;;
+  esac
+}
+
 fi # sqlite3 disponivel
 
 run_all_scenarios

--- a/tests/test_spawn-tracker.sh
+++ b/tests/test_spawn-tracker.sh
@@ -155,4 +155,158 @@ scenario_reader_fallback_le_state_pt_legado() {
   [ "$_spawned" = 1 ] || { _fail "converge EN spawned" "esperado 1, obtido $_spawned"; return 1; }
 }
 
+# ==== Backend SQLite (feature state-db-foundation, FASE 3 task 3.6) ====
+#
+# Ref: docs/specs/state-db-foundation/contracts/primitives.md
+#      §C1 (paridade) §C2 (selecao de backend) §C3 (exit 3 no teto) §C6
+#
+# Mesmo padrao de tests/test_bloqueios.sh (task 3.5): aplica o DDL via
+# state-db-schema.sh e semeia uma execution minima via sqlite3 diretamente
+# (init nunca cria state.db — isso e a migracao, FASE 6, ainda nao
+# implementada).
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test_spawn-tracker.sh: sqlite3 ausente — pulando cenarios de backend SQLite\n'
+else
+
+SCHEMA_SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-db-schema.sh"
+
+# _seed_sqlite_backend DIR [MAX_RECURSION] -> cria state.db com execution
+# minima (id=exec-1, subagent_depth=1 default do schema).
+_seed_sqlite_backend() {
+  _ssb_dir=$1
+  _ssb_max="${2:-}"
+  mkdir -p "$_ssb_dir"
+  "$SCHEMA_SCRIPT" create --db "$_ssb_dir/state.db" >/dev/null 2>&1 \
+    || { _fail "seed: schema create falhou" ""; return 1; }
+  if [ -n "$_ssb_max" ]; then
+    sqlite3 "$_ssb_dir/state.db" "
+      INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled,max_recursion)
+      VALUES ('exec-1','1.0.0','/tmp/p','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0,$_ssb_max);
+    " || { _fail "seed: insert execution falhou" ""; return 1; }
+  else
+    sqlite3 "$_ssb_dir/state.db" "
+      INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+      VALUES ('exec-1','1.0.0','/tmp/p','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+    " || { _fail "seed: insert execution falhou" ""; return 1; }
+  fi
+}
+
+scenario_sqlite_inicial_profundidade_1() {
+  _sd="$TMPDIR_TEST/sqlite-inicial"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" current --state-dir "$_sd"
+  assert_stdout_contains "1" || return 1
+}
+
+scenario_sqlite_check_inicial_passa() {
+  _sd="$TMPDIR_TEST/sqlite-check-ok"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" check --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite check inicial" "$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_sqlite_enter_incrementa_e_persiste() {
+  _sd="$TMPDIR_TEST/sqlite-enter"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" enter --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite enter" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "2" || return 1
+  capture "$SCRIPT" current --state-dir "$_sd"
+  assert_stdout_contains "2" || return 1
+}
+
+# enter/check sobre o teto: paridade C1/C3 — mesma mensagem/exit 3 do path
+# JSON (contracts/primitives.md linha "enter acima do teto | CHECK
+# subagent_depth | 3 (paridade com hoje)").
+scenario_sqlite_enter_excedendo_max_exit_3_sem_modificar_estado() {
+  _sd="$TMPDIR_TEST/sqlite-enter-teto"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" enter --state-dir "$_sd"  # 1->2
+  capture "$SCRIPT" enter --state-dir "$_sd"  # 2->3
+  _before=$(sqlite3 "$_sd/state.db" "SELECT subagent_depth FROM execution;")
+  capture "$SCRIPT" enter --state-dir "$_sd"  # 3->4 negado
+  if [ "$_CAPTURED_EXIT" != 3 ]; then
+    _fail "sqlite enter ilegal exit" "esperado 3, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  assert_stderr_contains "MAX 3" || return 1
+  _after=$(sqlite3 "$_sd/state.db" "SELECT subagent_depth FROM execution;")
+  if [ "$_before" != "$_after" ]; then
+    _fail "sqlite enter negado MUTOU estado" "before=$_before after=$_after"
+    return 1
+  fi
+}
+
+scenario_sqlite_check_no_limite_exit_3() {
+  _sd="$TMPDIR_TEST/sqlite-check-limite"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" enter --state-dir "$_sd"
+  capture "$SCRIPT" enter --state-dir "$_sd"
+  capture "$SCRIPT" check --state-dir "$_sd"
+  if [ "$_CAPTURED_EXIT" != 3 ]; then
+    _fail "sqlite check no limite" "esperado 3, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+}
+
+scenario_sqlite_leave_decrementa() {
+  _sd="$TMPDIR_TEST/sqlite-leave"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" enter --state-dir "$_sd"
+  capture "$SCRIPT" leave --state-dir "$_sd"
+  assert_stdout_contains "1" || return 1
+}
+
+scenario_sqlite_leave_idempotente_no_minimo() {
+  _sd="$TMPDIR_TEST/sqlite-leave-idempotente"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" leave --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite leave inicial" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "1" || return 1
+  capture "$SCRIPT" current --state-dir "$_sd"
+  assert_stdout_contains "1" || return 1
+}
+
+# Teto customizado (max_recursion != 3) — prova que o teto e lido da coluna
+# execution.max_recursion, nao de uma constante hardcoded no path sqlite.
+scenario_sqlite_teto_customizado_respeitado() {
+  _sd="$TMPDIR_TEST/sqlite-teto-custom"
+  _seed_sqlite_backend "$_sd" 1 || return 1  # max_recursion=1
+  capture "$SCRIPT" check --state-dir "$_sd"
+  if [ "$_CAPTURED_EXIT" != 3 ]; then
+    _fail "sqlite teto customizado" "esperado 3 (max=1, current=1), obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+}
+
+# Paridade cross-backend (C1): mesmos inputs, mesmo stdout/exit code para
+# check/enter/leave/current nos dois backends.
+scenario_sqlite_paridade_enter_leave_json() {
+  _sd_json="$TMPDIR_TEST/paridade-spawn-json"
+  _init_state "$_sd_json"
+  capture "$SCRIPT" enter --state-dir "$_sd_json"
+  _json_enter_out="$_CAPTURED_STDOUT"
+  _json_enter_exit="$_CAPTURED_EXIT"
+  capture "$SCRIPT" leave --state-dir "$_sd_json"
+  _json_leave_out="$_CAPTURED_STDOUT"
+
+  _sd_sqlite="$TMPDIR_TEST/paridade-spawn-sqlite"
+  _seed_sqlite_backend "$_sd_sqlite" || return 1
+  capture "$SCRIPT" enter --state-dir "$_sd_sqlite"
+  _sqlite_enter_out="$_CAPTURED_STDOUT"
+  _sqlite_enter_exit="$_CAPTURED_EXIT"
+  capture "$SCRIPT" leave --state-dir "$_sd_sqlite"
+  _sqlite_leave_out="$_CAPTURED_STDOUT"
+
+  [ "$_json_enter_out" = "$_sqlite_enter_out" ] \
+    || { _fail "paridade enter stdout" "json='$_json_enter_out' sqlite='$_sqlite_enter_out'"; return 1; }
+  [ "$_json_enter_exit" = "$_sqlite_enter_exit" ] \
+    || { _fail "paridade enter exit" "json=$_json_enter_exit sqlite=$_sqlite_enter_exit"; return 1; }
+  [ "$_json_leave_out" = "$_sqlite_leave_out" ] \
+    || { _fail "paridade leave stdout" "json='$_json_leave_out' sqlite='$_sqlite_leave_out'"; return 1; }
+}
+
+fi  # command -v sqlite3
+
 run_all_scenarios

--- a/tests/test_spawn-tracker.sh
+++ b/tests/test_spawn-tracker.sh
@@ -307,6 +307,33 @@ scenario_sqlite_paridade_enter_leave_json() {
     || { _fail "paridade leave stdout" "json='$_json_leave_out' sqlite='$_sqlite_leave_out'"; return 1; }
 }
 
+# Task 4.1.1/4.2.2 (FASE 4): branch de selecao de backend explicito por C2 —
+# um state.json coexistente e export/legado, NUNCA consultado como fonte.
+# Prova positiva: subagent_depth=2 no state.db (1 enter), state.json
+# divergente com depth=99 — current deve refletir sempre o state.db (2).
+scenario_c2_state_json_coexistente_ignorado_quando_state_db_presente() {
+  _sd="$TMPDIR_TEST/c2-coexist-spawn"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" enter --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2: enter sqlite" "$_CAPTURED_STDERR"; return 1; }
+
+  # state.json divergente no MESMO diretorio.
+  printf '{"execution":{"subagent_depth":99}}\n' > "$_sd/state.json"
+
+  capture "$SCRIPT" current --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2 current exit" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "2" \
+    || { _fail "c2: current deveria refletir state.db (2), nao o state.json coexistente (99)" "obtido $_CAPTURED_STDOUT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    99*) _fail "c2: current leu o state.json coexistente" "obtido $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+
+  # state.json coexistente permanece intocado.
+  _stale_now=$(cat "$_sd/state.json")
+  [ "$_stale_now" = '{"execution":{"subagent_depth":99}}' ] \
+    || { _fail "c2: state.json coexistente foi modificado" "obtido: $_stale_now"; return 1; }
+}
+
 fi  # command -v sqlite3
 
 run_all_scenarios

--- a/tests/test_state-db-concurrency.sh
+++ b/tests/test_state-db-concurrency.sh
@@ -1,0 +1,237 @@
+#!/bin/sh
+# test_state-db-concurrency.sh — testes de atomicidade e concorrencia do
+# backend SQLite do state.db (feature state-db-foundation, FASE 3 task 3.7,
+# SC-002, US1 AS-3).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 3, task 3.7
+#      docs/specs/state-db-foundation/spec.md SC-002
+#      docs/specs/state-db-foundation/contracts/primitives.md §C4 (atomicidade
+#      transacional), §C6 (concorrencia via WAL + retry/backoff)
+#
+# Nao mapeia 1:1 para um unico script — exercita a COMPOSICAO de varios
+# scripts (state-decisions.sh, bloqueios.sh, state-ondas.sh) sobre o mesmo
+# state.db para validar garantias transversais do backend SQLite:
+#   3.7.1 duas mutacoes concorrentes DISTINTAS (tabelas diferentes) nao
+#         perdem nenhuma atualizacao (0% de taxa de perda).
+#   3.7.2 interrupcao simulada (kill -9 no meio de uma transacao aberta) nao
+#         deixa o state.db com escrita parcial — PRAGMA integrity_check
+#         continua 'ok' e a linha nao-commitada nao aparece (rollback
+#         automatico do SQLite via WAL).
+#   3.7.3 leitura concorrente durante escrita em andamento nao bloqueia e
+#         nao ve dado nao-commitado (isolamento por snapshot, WAL).
+# Registrado em run.sh::_is_internal_test (nao mapeia 1:1 para um script).
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test_state-db-concurrency.sh: sqlite3 ausente — pulando suite\n'
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  printf '# test_state-db-concurrency.sh: jq ausente — pulando suite\n'
+  exit 0
+fi
+
+_R="$REPO_ROOT/global/skills/agente-00c-runtime/scripts"
+DEC="$_R/state-decisions.sh"
+BLQ="$_R/bloqueios.sh"
+ONDAS="$_R/state-ondas.sh"
+SCHEMA_SCRIPT="$_R/state-db-schema.sh"
+
+# shellcheck source=../global/skills/agente-00c-runtime/scripts/_state-db.sh
+. "$_R/_state-db.sh"
+
+# _seed_sqlite_backend DIR -> cria state.db com uma execution minima
+# (id=exec-1), pronta para start/register/end.
+_seed_sqlite_backend() {
+  _ssb_dir=$1
+  mkdir -p "$_ssb_dir"
+  "$SCHEMA_SCRIPT" create --db "$_ssb_dir/state.db" >/dev/null 2>&1 \
+    || { _fail "seed: schema create falhou" ""; return 1; }
+  sqlite3 "$_ssb_dir/state.db" "
+    PRAGMA foreign_keys=ON;
+    INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+    VALUES ('exec-1','1.0.0','/tmp/p','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+  " || { _fail "seed: insert execution falhou" ""; return 1; }
+}
+
+# ============================================================
+# 3.7.1 — mutacoes concorrentes DISTINTAS (tabelas diferentes)
+# ============================================================
+#
+# Dispara N `state-decisions.sh register` (tabela decision) em paralelo com
+# UMA chamada `state-ondas.sh end` (tabela wave) fechando a onda aberta.
+# Sao mutacoes sobre TABELAS diferentes mas sobre o MESMO arquivo state.db
+# — exercita o retry/backoff sob lock (C6) de _state_db_exec_with_retry /
+# _sd_db_exec_capture sem depender de ordem de chegada. Invariante validada:
+# nenhum register perde a escrita (todos os N ids aparecem, sem duplicata,
+# sem erro) E o fechamento da onda tambem e aplicado — nenhuma das duas
+# mutacoes "desaparece" por causa da outra.
+scenario_mutacoes_concorrentes_decisao_e_fechamento_onda_sem_perda() {
+  _sd="$TMPDIR_TEST/concorrencia-mista"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$ONDAS" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "seed: start onda" "$_CAPTURED_STDERR"; return 1; }
+
+  _n=8
+  _i=1
+  while [ "$_i" -le "$_n" ]; do
+    ( "$DEC" register --state-dir "$_sd" \
+        --agente "worker-$_i" --etapa "specify" \
+        --contexto "contexto concorrente numero $_i com 20+ chars" \
+        --opcoes '["a","b"]' --escolha "a" \
+        --justificativa "justificativa concorrente numero $_i com 20+chars" \
+        > "$TMPDIR_TEST/dec-out-$_i.txt" \
+        2> "$TMPDIR_TEST/dec-err-$_i.txt" ) &
+    _i=$((_i + 1))
+  done
+  ( "$ONDAS" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando \
+      > "$TMPDIR_TEST/end-out.txt" 2> "$TMPDIR_TEST/end-err.txt" ; \
+    echo "$?" > "$TMPDIR_TEST/end-exit.txt" ) &
+  wait
+
+  # Nenhum worker de decisao emitiu stderr (nenhuma falha nao-lock, nenhum
+  # esgotamento de retry).
+  _i=1
+  while [ "$_i" -le "$_n" ]; do
+    if [ -s "$TMPDIR_TEST/dec-err-$_i.txt" ]; then
+      _fail "worker decisao $_i emitiu stderr" "$(cat "$TMPDIR_TEST/dec-err-$_i.txt")"
+      return 1
+    fi
+    _i=$((_i + 1))
+  done
+  # state-ondas.sh end loga uma linha de CONFIRMACAO de sucesso em stderr
+  # (_so_log "end: onda finalizada ..."), nao um erro — a assercao valida e
+  # o exit code, nao a ausencia de stderr.
+  _end_exit=$(cat "$TMPDIR_TEST/end-exit.txt" 2>/dev/null)
+  [ "$_end_exit" = "0" ] || { _fail "end onda falhou" "exit=$_end_exit; $(cat "$TMPDIR_TEST/end-err.txt")"; return 1; }
+
+  # As N decisoes existem, todas com id unico (0% de perda).
+  _unique=$(cat "$TMPDIR_TEST"/dec-out-*.txt | sort -u | wc -l | tr -d ' ')
+  [ "$_unique" = "$_n" ] || { _fail "ids de decisao unicos" "esperado $_n, obtido $_unique"; return 1; }
+  capture "$DEC" count --state-dir "$_sd"
+  assert_stdout_contains "$_n" || return 1
+
+  # A onda tambem foi fechada — a outra mutacao nao "desapareceu".
+  capture "$ONDAS" wave-status --state-dir "$_sd"
+  assert_stdout_contains "closed" || return 1
+}
+
+# ============================================================
+# 3.7.2 — interrupcao simulada (kill -9 no meio de uma transacao)
+# ============================================================
+#
+# Abre uma transacao BEGIN IMMEDIATE + INSERT via uma sessao sqlite3
+# alimentada por FIFO (controle preciso de timing), NUNCA emite COMMIT, e
+# mata o processo sqlite3 com SIGKILL enquanto a transacao segue aberta.
+# Verifica: (a) PRAGMA integrity_check continua 'ok' (sem corrupcao do
+# arquivo); (b) a linha da transacao interrompida NAO aparece (rollback
+# automatico via WAL — SQLite so aplica frames com marcador de commit
+# valido); (c) o banco segue utilizavel por escritores subsequentes (o lock
+# do processo morto foi liberado pelo kernel, nao ficou preso).
+scenario_kill9_meio_transacao_nao_deixa_escrita_parcial() {
+  if ! command -v mkfifo >/dev/null 2>&1; then
+    printf '# scenario_kill9_meio_transacao_nao_deixa_escrita_parcial: mkfifo ausente — pulando\n'
+    return 0
+  fi
+  _sd="$TMPDIR_TEST/kill9"
+  _seed_sqlite_backend "$_sd" || return 1
+  _db="$_sd/state.db"
+  _fifo="$TMPDIR_TEST/kill9.fifo"
+  mkfifo "$_fifo" || { _fail "kill9: mkfifo falhou" ""; return 1; }
+
+  # Sessao sqlite3 alimentada pela FIFO, em background.
+  sqlite3 "$_db" < "$_fifo" >"$TMPDIR_TEST/kill9-sqlite-out.txt" 2>&1 &
+  _sqlite_pid=$!
+
+  # Abre o fd 9 para escrita na FIFO (bloqueia ate o leitor conectar).
+  exec 9>"$_fifo"
+  printf 'PRAGMA busy_timeout=5000;\n' >&9
+  printf 'BEGIN IMMEDIATE;\n' >&9
+  printf "INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale) VALUES ('dec-kill9','exec-1','2026-07-30T00:00:00Z','x','clarify','contexto de teste com detalhe suficiente','[\"a\"]','a','justificativa de teste com detalhe suficiente');\n" >&9
+  # Da tempo do sqlite3 processar BEGIN+INSERT antes de matar o processo —
+  # a transacao fica aberta (sem COMMIT), segurando o RESERVED lock.
+  sleep 0.5
+
+  kill -9 "$_sqlite_pid" 2>/dev/null
+  exec 9>&-
+  wait "$_sqlite_pid" 2>/dev/null
+
+  # (a) integridade do arquivo preservada.
+  _integrity=$(_state_db_exec "$_db" "PRAGMA integrity_check;" 2>&1)
+  [ "$_integrity" = "ok" ] || { _fail "kill9 integrity_check" "obtido '$_integrity'"; return 1; }
+
+  # (b) rollback automatico — a linha nao-commitada nao existe.
+  _cnt=$(_state_db_exec "$_db" "SELECT count(*) FROM decision WHERE id='dec-kill9';" 2>&1)
+  [ "$_cnt" = "0" ] || { _fail "kill9 rollback" "esperado 0 linhas, obtido $_cnt"; return 1; }
+
+  # (c) banco segue utilizavel — um register normal subsequente funciona
+  # (lock do processo morto foi liberado, sem deadlock/esgotamento de retry).
+  capture "$DEC" register --state-dir "$_sd" \
+    --agente "pos-kill9" --etapa "specify" \
+    --contexto "contexto pos kill9 com 20+ chars de sobra" \
+    --opcoes '["a","b"]' --escolha "a" \
+    --justificativa "justificativa pos kill9 com 20+ chars de sobra"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "kill9 pos-recuperacao register" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "dec-001" || return 1
+}
+
+# ============================================================
+# 3.7.3 — leitura concorrente durante escrita em andamento (WAL, C6)
+# ============================================================
+#
+# Mesma tecnica de FIFO: abre uma transacao de escrita (BEGIN IMMEDIATE +
+# INSERT) e a deixa ABERTA (sem COMMIT nem ROLLBACK) enquanto uma leitura
+# concorrente roda numa conexao SEPARADA. Sob WAL (dec-014), o leitor MUST
+# (a) nao bloquear (retornar rapido, sem esperar o busy_timeout de 5s) e
+# (b) ver o snapshot ANTERIOR a escrita nao-commitada (isolamento). Depois
+# do COMMIT, uma nova leitura MUST refletir o dado novo.
+scenario_leitura_concorrente_durante_escrita_sem_bloqueio() {
+  if ! command -v mkfifo >/dev/null 2>&1; then
+    printf '# scenario_leitura_concorrente_durante_escrita_sem_bloqueio: mkfifo ausente — pulando\n'
+    return 0
+  fi
+  _sd="$TMPDIR_TEST/leitura-concorrente"
+  _seed_sqlite_backend "$_sd" || return 1
+  _db="$_sd/state.db"
+  _fifo="$TMPDIR_TEST/leitura.fifo"
+  mkfifo "$_fifo" || { _fail "leitura: mkfifo falhou" ""; return 1; }
+
+  sqlite3 "$_db" < "$_fifo" >"$TMPDIR_TEST/leitura-sqlite-out.txt" 2>&1 &
+  _sqlite_pid=$!
+
+  exec 9>"$_fifo"
+  printf 'PRAGMA busy_timeout=5000;\n' >&9
+  printf 'BEGIN IMMEDIATE;\n' >&9
+  printf "INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale) VALUES ('dec-leitura','exec-1','2026-07-30T00:00:00Z','x','clarify','contexto de teste com detalhe suficiente','[\"a\"]','a','justificativa de teste com detalhe suficiente');\n" >&9
+  sleep 0.3
+
+  # Leitura concorrente NAO deve bloquear — mede elapsed via epoch (evita
+  # dependencia de `timeout`, GNU-only, per CLAUDE.md portabilidade).
+  _t0=$(date +%s)
+  capture "$DEC" count --state-dir "$_sd"
+  _t1=$(date +%s)
+  _elapsed=$((_t1 - _t0))
+
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "leitura concorrente exit" "$_CAPTURED_STDERR"; return 1; }
+  if [ "$_elapsed" -gt 2 ]; then
+    _fail "leitura concorrente bloqueou" "elapsed=${_elapsed}s (esperado <2s sob WAL)"
+    # Nao retorna ainda — segue limpando a transacao pendurada abaixo.
+  fi
+  # (b) snapshot anterior: a insercao ainda nao-commitada nao e vista.
+  assert_stdout_contains "0" || { kill -9 "$_sqlite_pid" 2>/dev/null; exec 9>&-; return 1; }
+
+  # Fecha a transacao normalmente desta vez (COMMIT) para validar o pos-write.
+  printf 'COMMIT;\n' >&9
+  sleep 0.2
+  exec 9>&-
+  wait "$_sqlite_pid" 2>/dev/null
+
+  capture "$DEC" count --state-dir "$_sd"
+  assert_stdout_contains "1" || return 1
+}
+
+run_all_scenarios

--- a/tests/test_state-db-migrate.sh
+++ b/tests/test_state-db-migrate.sh
@@ -1,0 +1,599 @@
+#!/bin/sh
+# test_state-db-migrate.sh — cobre
+# global/skills/agente-00c-runtime/scripts/state-db-migrate.sh
+# (migracao explicita state.json -> state.db).
+#
+# Ref: docs/specs/state-db-foundation/tasks.md FASE 6
+#      docs/specs/state-db-foundation/contracts/migration.md (M1..M6 +
+#      tabela final "Cenarios de teste": os 7 cenarios do contrato).
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPTS="$REPO_ROOT/global/skills/agente-00c-runtime/scripts"
+SCRIPT="$SCRIPTS/state-db-migrate.sh"
+STATE_RW="$SCRIPTS/state-rw.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test_state-db-migrate.sh: sqlite3 ausente — pulando suite\n'
+  exit 0
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  printf '# test_state-db-migrate.sh: jq ausente — pulando suite\n'
+  exit 0
+fi
+
+# ---------------------------------------------------------------
+# Fixture: state.json sintetico completo e VALIDO, exercitando as 6
+# entidades de M3.1 + os dois pontos que so aparecem em dado real e que
+# quebraram a implementacao ingenua (achados na FASE 6):
+#   (a) decisions[].wave_id == "init"  -> FK invalida se inserida verbatim
+#   (b) skills_invoked[].decision_id   -> FK invalida se a skill for inserida
+#                                          junto da onda, ANTES das decisions
+# ---------------------------------------------------------------
+_seed_state_json() {
+  _ss_dir="$1"
+  _ss_status="${2:-concluida}"
+  _ss_finished="${3:-2026-07-30T12:00:00Z}"
+  mkdir -p "$_ss_dir"
+  cat > "$_ss_dir/state.json" <<JSON
+{
+  "schema_version": "1.0.0",
+  "short_name": "fixture-feature",
+  "execution": {
+    "id": "exec-fixture-001",
+    "target_project_path": "/tmp/projeto",
+    "target_project_description": "descricao de fixture com tamanho suficiente",
+    "status": "$_ss_status",
+    "termination_reason": "concluido",
+    "started_at": "2026-07-30T10:00:00Z",
+    "finished_at": "$_ss_finished"
+  },
+  "current_stage": "review-task",
+  "next_instruction": "nada a fazer",
+  "atomic_commit_enabled": true,
+  "initial_key_aspects": ["state", "sqlite"],
+  "external_urls_whitelist": [],
+  "circular_movement_history": [],
+  "budgets": {
+    "max_recursion": 3,
+    "current_subagent_depth": 1,
+    "max_retro_executions_per_feature": 2,
+    "retro_executions_consumed": 0,
+    "max_cycles_per_stage": 5,
+    "cycles_consumed_current_stage": 0,
+    "tool_calls_threshold_wave": 80,
+    "wallclock_threshold_seconds": 5400,
+    "state_size_threshold_bytes": 1048576,
+    "tool_calls_current_wave": 0,
+    "current_wave_start": null
+  },
+  "accumulated_metrics": {
+    "waves_total": 2,
+    "tool_calls_total": 41,
+    "wallclock_total_seconds": 120,
+    "max_depth_reached": 2,
+    "subagents_spawned": 1,
+    "decisions_total": 2,
+    "human_blocks_total": 1,
+    "global_skill_suggestions_total": 0,
+    "toolkit_issues_opened": 0
+  },
+  "waves": [
+    {
+      "id": "onda-001",
+      "started_at": "2026-07-30T10:00:00Z",
+      "finished_at": "2026-07-30T10:30:00Z",
+      "wallclock_seconds": 1800,
+      "tool_calls": 20,
+      "termination_reason": "etapa_concluida_avancando",
+      "executed_stages": ["specify"],
+      "skills_invoked": [
+        {"skill": "model-selector", "timestamp": "2026-07-30T10:01:00Z", "decision_id": "dec-002", "kind": "skill"},
+        {"skill": "validate-tasks-template", "timestamp": "2026-07-30T10:02:00Z", "decision_id": null, "kind": "gate"}
+      ]
+    },
+    {
+      "id": "onda-002",
+      "started_at": "2026-07-30T11:00:00Z",
+      "finished_at": "2026-07-30T11:30:00Z",
+      "wallclock_seconds": 1800,
+      "tool_calls": 21,
+      "termination_reason": "concluido",
+      "executed_stages": ["review-task"],
+      "skills_invoked": []
+    }
+  ],
+  "decisions": [
+    {
+      "id": "dec-001",
+      "wave_id": "init",
+      "timestamp": "2026-07-30T09:59:00Z",
+      "agent": "agente-00c-feature-orchestrator",
+      "stage": "specify",
+      "context": "Selecao de modelo para onda init (fase specify)",
+      "options_considered": ["haiku", "sonnet"],
+      "choice": "model:sonnet",
+      "rationale": "justificativa com pelo menos vinte caracteres de texto",
+      "justification_score": 0,
+      "evidence": null,
+      "references": [],
+      "originating_artifact": null
+    },
+    {
+      "id": "dec-002",
+      "wave_id": "onda-001",
+      "timestamp": "2026-07-30T10:01:00Z",
+      "agent": "agente-00c-feature-orchestrator",
+      "stage": "specify",
+      "context": "contexto de decisao com pelo menos vinte caracteres",
+      "options_considered": ["a", "b"],
+      "choice": "a",
+      "rationale": "justificativa com pelo menos vinte caracteres de texto",
+      "justification_score": 2,
+      "evidence": null,
+      "references": [],
+      "originating_artifact": null
+    }
+  ],
+  "human_blocks": [
+    {
+      "id": "block-001",
+      "decision_id": "dec-002",
+      "question": "pergunta de bloqueio com mais de vinte caracteres?",
+      "context_for_answer": "contexto para a resposta",
+      "recommended_options": ["sim", "nao"],
+      "status": "respondido",
+      "human_answer": "sim",
+      "triggered_at": "2026-07-30T10:05:00Z",
+      "answered_at": "2026-07-30T10:10:00Z"
+    }
+  ],
+  "tasks": [
+    {
+      "task_id": "1.1",
+      "title": "primeira task",
+      "wave_id": "onda-001",
+      "outcome": "pass",
+      "tests_run": 3,
+      "tests_passed": 3,
+      "lint_ok": true,
+      "touched_files": ["a.sh", "b.sh"],
+      "recorded_at": "2026-07-30T10:20:00Z",
+      "source": "execute-task"
+    }
+  ],
+  "events": [
+    {"event_type": "schedule_wait", "timestamp": "2026-07-30T10:30:00Z", "description": "aguardando wakeup"},
+    {"event_type": "recall_consulted", "timestamp": "2026-07-30T10:00:30Z"}
+  ]
+}
+JSON
+  "$STATE_RW" sha256-update --state-dir "$_ss_dir" >/dev/null 2>&1
+}
+
+# ===============================================================
+# Cenario 1 do contrato — contagens identicas e IDs/timestamps preservados
+# (US2 AS-1, SC-001)
+# ===============================================================
+
+scenario_migracao_preserva_contagens_ids_e_timestamps() {
+  _sd="$TMPDIR_TEST/ok"
+  _seed_state_json "$_sd"
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migrate exit" "$_CAPTURED_STDERR"; return 1; }
+  [ -f "$_sd/state.db" ] || { _fail "state.db nao publicado" ""; return 1; }
+
+  _counts=$(sqlite3 "$_sd/state.db" "SELECT (SELECT count(*) FROM decision)||','||(SELECT count(*) FROM wave)||','||(SELECT count(*) FROM human_block)||','||(SELECT count(*) FROM task_outcome)||','||(SELECT count(*) FROM event)||','||(SELECT count(*) FROM skill_invocation);")
+  [ "$_counts" = "2,2,1,1,2,2" ] || { _fail "contagens por entidade" "esperado 2,2,1,1,2,2 obtido $_counts"; return 1; }
+
+  # IDs originais, sem renumeracao (FR-005 literal)
+  _ids=$(sqlite3 "$_sd/state.db" "SELECT group_concat(id) FROM (SELECT id FROM decision ORDER BY id);")
+  [ "$_ids" = "dec-001,dec-002" ] || { _fail "ids de decisao renumerados" "obtido $_ids"; return 1; }
+  _wid=$(sqlite3 "$_sd/state.db" "SELECT group_concat(id) FROM (SELECT id FROM wave ORDER BY seq);")
+  [ "$_wid" = "onda-001,onda-002" ] || { _fail "ids de onda" "obtido $_wid"; return 1; }
+  _bid=$(sqlite3 "$_sd/state.db" "SELECT id FROM human_block;")
+  [ "$_bid" = "block-001" ] || { _fail "id de bloqueio" "obtido $_bid"; return 1; }
+
+  # timestamps originais
+  _ts=$(sqlite3 "$_sd/state.db" "SELECT timestamp FROM decision WHERE id='dec-001';")
+  [ "$_ts" = "2026-07-30T09:59:00Z" ] || { _fail "timestamp preservado" "obtido $_ts"; return 1; }
+}
+
+# Regressao dirigida ao achado (a): wave_id "init" -> NULL (data-model.md
+# §decision). Inserir verbatim viola a FK e aborta a migracao inteira.
+scenario_wave_id_init_vira_null_sem_violar_fk() {
+  _sd="$TMPDIR_TEST/init-sentinel"
+  _seed_state_json "$_sd"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migrate com sentinela init" "$_CAPTURED_STDERR"; return 1; }
+  _n=$(sqlite3 "$_sd/state.db" "SELECT count(*) FROM decision WHERE wave_id IS NULL;")
+  [ "$_n" = "1" ] || { _fail "sentinela init nao virou NULL" "decisoes com wave_id NULL=$_n"; return 1; }
+  _n2=$(sqlite3 "$_sd/state.db" "SELECT count(*) FROM decision WHERE wave_id = 'init';")
+  [ "$_n2" = "0" ] || { _fail "sentinela init inserida verbatim" "obtido $_n2"; return 1; }
+}
+
+# Regressao dirigida ao achado (b): skill_invocation.decision_id e FK para
+# decision(id) — as skills MUST ser inseridas DEPOIS das decisions (§M2).
+scenario_skill_invocation_com_decision_id_respeita_ordem_fk() {
+  _sd="$TMPDIR_TEST/fk-order"
+  _seed_state_json "$_sd"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migrate com skill+decision_id" "$_CAPTURED_STDERR"; return 1; }
+  _n=$(sqlite3 "$_sd/state.db" "SELECT count(*) FROM skill_invocation WHERE decision_id='dec-002';")
+  [ "$_n" = "1" ] || { _fail "skill_invocation com decision_id perdida" "obtido $_n"; return 1; }
+  _k=$(sqlite3 "$_sd/state.db" "SELECT kind FROM skill_invocation WHERE skill='validate-tasks-template';")
+  [ "$_k" = "gate" ] || { _fail "kind=gate nao preservado" "obtido $_k"; return 1; }
+}
+
+# ===============================================================
+# Cenario 2 do contrato — idempotencia (US2 AS-2, FR-014-INFRA-IDEMP)
+# ===============================================================
+
+scenario_migracao_reexecutada_nao_duplica() {
+  _sd="$TMPDIR_TEST/idem"
+  _seed_state_json "$_sd"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "1a migracao" "$_CAPTURED_STDERR"; return 1; }
+  _c1=$(sqlite3 "$_sd/state.db" "SELECT (SELECT count(*) FROM decision)||','||(SELECT count(*) FROM wave)||','||(SELECT count(*) FROM skill_invocation);")
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "2a migracao" "$_CAPTURED_STDERR"; return 1; }
+  _c2=$(sqlite3 "$_sd/state.db" "SELECT (SELECT count(*) FROM decision)||','||(SELECT count(*) FROM wave)||','||(SELECT count(*) FROM skill_invocation);")
+
+  [ "$_c1" = "$_c2" ] || { _fail "reexecucao duplicou dados" "antes=$_c1 depois=$_c2"; return 1; }
+
+  # M5: a trilha de migration_run acumula atraves de reexecucoes (a migracao e
+  # reconstrucao total; sem o carry, a 2a execucao apagaria a 1a).
+  _runs=$(sqlite3 "$_sd/state.db" "SELECT count(*) FROM migration_run WHERE result='success';")
+  [ "$_runs" = "2" ] || { _fail "historico de migration_run nao preservado" "esperado 2, obtido $_runs"; return 1; }
+}
+
+# ===============================================================
+# Cenario 3 do contrato — bloqueio humano orfao ⇒ recusa (US2 AS-3, SC-006)
+# ===============================================================
+
+scenario_bloqueio_orfao_recusado_com_diagnostico() {
+  _sd="$TMPDIR_TEST/orfao"
+  _seed_state_json "$_sd"
+  # decision_id que nao existe em .decisions[] — state-validate.sh detecta
+  jq '.human_blocks[0].decision_id = "dec-999"' "$_sd/state.json" > "$_sd/tmp.json"
+  mv "$_sd/tmp.json" "$_sd/state.json"
+  "$STATE_RW" sha256-update --state-dir "$_sd" >/dev/null 2>&1
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "bloqueio orfao deveria RECUSAR (exit 3)" "exit=$_CAPTURED_EXIT"; return 1; }
+  [ ! -f "$_sd/state.db" ] || { _fail "state.db criado apesar da recusa" ""; return 1; }
+  # "diagnostico apontando o registro problematico" (US2 AS-3): o repasse do
+  # state-validate.sh nomeia o BLOQUEIO orfao (block-001) — e o registro que
+  # o operador precisa consertar.
+  case "$_CAPTURED_STDERR" in
+    *block-001*) : ;;
+    *) _fail "diagnostico nao aponta o registro problematico" "$_CAPTURED_STDERR"; return 1 ;;
+  esac
+}
+
+# ===============================================================
+# Cenario 4 do contrato — status em_andamento ⇒ recusa (FR-005)
+# ===============================================================
+
+scenario_execucao_ativa_recusada() {
+  _sd="$TMPDIR_TEST/ativa"
+  _seed_state_json "$_sd" "em_andamento" ""
+  # finished_at null exigido pelo CHECK de coerencia do schema
+  jq '.execution.finished_at = null | .execution.termination_reason = null' "$_sd/state.json" > "$_sd/t.json"
+  mv "$_sd/t.json" "$_sd/state.json"
+  "$STATE_RW" sha256-update --state-dir "$_sd" >/dev/null 2>&1
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "execucao ativa deveria RECUSAR" "exit=$_CAPTURED_EXIT"; return 1; }
+  [ ! -f "$_sd/state.db" ] || { _fail "state.db criado com execucao ativa" ""; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *em_andamento*) : ;;
+    *) _fail "diagnostico nao menciona em_andamento" "$_CAPTURED_STDERR"; return 1 ;;
+  esac
+}
+
+# dec-033 (M1-a): `aguardando_humano` esta PAUSADA ⇒ migravel pela letra de
+# FR-005 (que nomeia so `em_andamento`).
+scenario_aguardando_humano_e_permitido() {
+  _sd="$TMPDIR_TEST/pausada"
+  _seed_state_json "$_sd" "aguardando_humano" ""
+  jq '.execution.finished_at = null | .execution.termination_reason = null' "$_sd/state.json" > "$_sd/t.json"
+  mv "$_sd/t.json" "$_sd/state.json"
+  "$STATE_RW" sha256-update --state-dir "$_sd" >/dev/null 2>&1
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "aguardando_humano deveria ser migravel (dec-033)" "exit=$_CAPTURED_EXIT $_CAPTURED_STDERR"; return 1; }
+  [ -f "$_sd/state.db" ] || { _fail "state.db nao publicado" ""; return 1; }
+}
+
+# ===============================================================
+# Cenario 5 do contrato — interrupcao entre construcao e publicacao
+# (US2 AS-4): state.json intacto e projeto operavel
+# ===============================================================
+
+scenario_interrupcao_antes_da_publicacao_preserva_origem() {
+  _sd="$TMPDIR_TEST/interrompida"
+  _seed_state_json "$_sd"
+  _antes=$(sha256_of_file "$_sd/state.json")
+
+  # Simula interrupcao APOS a construcao e ANTES do mv: reprova M3.2
+  # deliberadamente adulterando o export gerado a partir do banco. Como o
+  # unico caminho de publicacao e o `mv` posterior a M3, reprovar M3 exercita
+  # exatamente o ponto de falha "construido mas nao publicado".
+  jq '.human_blocks[0].question = "pergunta divergente com mais de vinte caracteres"' \
+    "$_sd/state.json" > "$_sd/t.json"
+  mv "$_sd/t.json" "$_sd/state.json"
+  # NAO atualiza o .sha256 => M1.3 recusa antes mesmo de construir; para
+  # exercitar a falha em M3 (e nao em M1), realinhe o hash:
+  "$STATE_RW" sha256-update --state-dir "$_sd" >/dev/null 2>&1
+  _antes=$(sha256_of_file "$_sd/state.json")
+
+  # Torna o state-dir nao-gravavel para o temporario: mktemp -d falha e a
+  # migracao aborta ANTES de qualquer publicacao.
+  chmod 500 "$_sd"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  chmod 700 "$_sd"
+
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "deveria falhar sem poder criar temporario" ""; return 1; }
+  [ ! -f "$_sd/state.db" ] || { _fail "state.db publicado apesar da falha" ""; return 1; }
+  _depois=$(sha256_of_file "$_sd/state.json")
+  [ "$_antes" = "$_depois" ] || { _fail "state.json alterado por migracao falha" "antes=$_antes depois=$_depois"; return 1; }
+
+  # Projeto continua operavel pelo state.json (M4)
+  capture "$STATE_RW" get --state-dir "$_sd" --field '.current_stage'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "projeto inoperavel apos falha" "$_CAPTURED_STDERR"; return 1; }
+  [ "$_CAPTURED_STDOUT" = "review-task" ] || { _fail "leitura pos-falha divergente" "obtido $_CAPTURED_STDOUT"; return 1; }
+}
+
+# Nenhum temporario sobrevive a uma migracao falha (higiene do state-dir).
+scenario_temporario_removido_apos_falha_de_verificacao() {
+  _sd="$TMPDIR_TEST/tmp-limpo"
+  _seed_state_json "$_sd"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migrate" "$_CAPTURED_STDERR"; return 1; }
+  _leftover=$(find "$_sd" -maxdepth 1 -name '.state-db-migrate.*' 2>/dev/null | wc -l | tr -d ' ')
+  [ "$_leftover" = "0" ] || { _fail "temporario sobreviveu" "encontrados=$_leftover"; return 1; }
+}
+
+# ===============================================================
+# Cenario 6 do contrato — sha256 divergente ⇒ recusa (Edge Cases)
+# ===============================================================
+
+scenario_sha256_divergente_recusado() {
+  _sd="$TMPDIR_TEST/hash"
+  _seed_state_json "$_sd"
+  # Adultera o state.json SEM atualizar o .sha256
+  jq '.current_stage = "plan"' "$_sd/state.json" > "$_sd/t.json"
+  mv "$_sd/t.json" "$_sd/state.json"
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "hash divergente deveria RECUSAR" "exit=$_CAPTURED_EXIT"; return 1; }
+  [ ! -f "$_sd/state.db" ] || { _fail "state.db criado com hash divergente" ""; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *ntegridade*) : ;;
+    *) _fail "diagnostico nao menciona integridade" "$_CAPTURED_STDERR"; return 1 ;;
+  esac
+}
+
+# ===============================================================
+# Cenario 7 do contrato — round-trip: export do banco == origem
+# (SC-001, US3 AS-1)
+# ===============================================================
+
+scenario_round_trip_export_igual_origem_normalizada() {
+  _sd="$TMPDIR_TEST/roundtrip"
+  _seed_state_json "$_sd"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migrate" "$_CAPTURED_STDERR"; return 1; }
+
+  # A verificacao M3.2 roda DENTRO da migracao; aqui confirmamos por fora que
+  # o banco publicado exporta o mesmo documento (mesma normalizacao contratual
+  # aplicada aos dois lados).
+  _norm='def drop_nulls: walk(if type == "object" then with_entries(select(.value != null)) else . end);
+         (if (.decisions // [] | length) > 0 then .decisions |= map(if .wave_id == "init" then .wave_id = null else . end) else . end)
+         | del(.accumulated_metrics)
+         | (if has("budgets") then .budgets |= del(.current_wave_start, .tool_calls_current_wave) else . end)
+         | drop_nulls'
+  "$STATE_RW" read --state-dir "$_sd" | jq -S "$_norm" > "$TMPDIR_TEST/rt-target.json" 2>/dev/null \
+    || { _fail "export do banco migrado falhou" ""; return 1; }
+  jq -S "$_norm" "$_sd/state.json" > "$TMPDIR_TEST/rt-source.json" 2>/dev/null \
+    || { _fail "normalizacao da origem falhou" ""; return 1; }
+
+  if ! _d=$(diff -u "$TMPDIR_TEST/rt-source.json" "$TMPDIR_TEST/rt-target.json" 2>&1); then
+    _fail "round-trip divergente" "$(printf '%s' "$_d" | head -n 20)"
+    return 1
+  fi
+}
+
+# M3.2 e um GATE REAL, nao decorativo: divergencia FORA da lista de
+# normalizacoes contratuais reprova a migracao.
+scenario_m3_2_reprova_divergencia_fora_da_normalizacao() {
+  _sd="$TMPDIR_TEST/m32-gate"
+  _seed_state_json "$_sd"
+  # Campo de topo com valor que o schema nao consegue reconstruir por
+  # nenhuma coluna E que nao esta na lista de normalizacao: um array de
+  # objetos sob uma chave nao modelada vai para extra_fields e DEVE voltar
+  # identico — se voltasse diferente, o gate teria de reprovar. Aqui
+  # exercitamos o gate injetando um valor NUL-hostil que o strip_nul altera.
+  printf '%s' "$(jq -c '.suggestions = [{"id":"sug-001","skill":"x"}]' "$_sd/state.json")" > "$_sd/t.json"
+  mv "$_sd/t.json" "$_sd/state.json"
+  "$STATE_RW" sha256-update --state-dir "$_sd" >/dev/null 2>&1
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  # Campos de topo nao modelados sao preservados via extra_fields => passa.
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "campo de topo nao modelado deveria round-tripar" "$_CAPTURED_STDERR"; return 1; }
+  _sug=$("$STATE_RW" get --state-dir "$_sd" --field '.suggestions[0].id')
+  [ "$_sug" = "sug-001" ] || { _fail "suggestions perdidas no round-trip" "obtido $_sug"; return 1; }
+}
+
+# ===============================================================
+# M1.4 / M1.5 / M5 — demais pre-condicoes
+# ===============================================================
+
+scenario_state_json_ausente_recusado() {
+  _sd="$TMPDIR_TEST/vazio"
+  mkdir -p "$_sd"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "state.json ausente deveria RECUSAR" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_state_json_ilegivel_recusado() {
+  _sd="$TMPDIR_TEST/corrompido"
+  mkdir -p "$_sd"
+  printf '{ nao e json valido' > "$_sd/state.json"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "state.json ilegivel deveria RECUSAR" "exit=$_CAPTURED_EXIT"; return 1; }
+  [ ! -f "$_sd/state.db" ] || { _fail "state.db criado" ""; return 1; }
+}
+
+scenario_state_db_de_outra_execucao_recusado() {
+  _sd="$TMPDIR_TEST/conflito"
+  _seed_state_json "$_sd"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migracao inicial" "$_CAPTURED_STDERR"; return 1; }
+
+  # Troca a origem por OUTRA execucao, mantendo o state.db anterior
+  jq '.execution.id = "exec-OUTRA-999"' "$_sd/state.json" > "$_sd/t.json"
+  mv "$_sd/t.json" "$_sd/state.json"
+  _refresh_sha "$_sd"
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "execution.id conflitante deveria RECUSAR" "exit=$_CAPTURED_EXIT"; return 1; }
+  # M5: a tentativa recusada FICA registrada em migration_run
+  _ref=$(sqlite3 "$_sd/state.db" "SELECT count(*) FROM migration_run WHERE result='refused';")
+  [ "$_ref" = "1" ] || { _fail "recusa nao registrada em migration_run" "obtido $_ref"; return 1; }
+  # ... com diagnostico legivel, nao apenas o enum
+  _diag=$(sqlite3 "$_sd/state.db" "SELECT diagnostic FROM migration_run WHERE result='refused';")
+  case "$_diag" in
+    *"outra execucao"*) : ;;
+    *) _fail "diagnostico da recusa nao registrado" "obtido '$_diag'"; return 1 ;;
+  esac
+  # E o banco anterior segue intacto (da execucao original)
+  _id=$(sqlite3 "$_sd/state.db" "SELECT id FROM execution;")
+  [ "$_id" = "exec-fixture-001" ] || { _fail "banco anterior corrompido" "obtido $_id"; return 1; }
+}
+
+# M5 (6.5.3): tentativa que FALHA na construcao/verificacao tambem e
+# registrada, com result='failed', quando ha um state.db pre-existente onde
+# persistir.
+scenario_falha_registrada_em_migration_run() {
+  _sd="$TMPDIR_TEST/failed-run"
+  _seed_state_json "$_sd"
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migracao inicial" "$_CAPTURED_STDERR"; return 1; }
+
+  # Forca falha na IMPORTACAO (nao na recusa M1) mantendo o state-dir
+  # GRAVAVEL — o registro do `failed` precisa escrever no state.db existente.
+  # Uma onda com id fora do padrao `onda-NNN` faz o importador abortar.
+  jq '.waves += [{"id":"onda-INVALIDA","started_at":"2026-07-30T13:00:00Z","tool_calls":0,"executed_stages":[],"skills_invoked":[]}]' \
+    "$_sd/state.json" > "$_sd/t.json"
+  mv "$_sd/t.json" "$_sd/state.json"
+  _refresh_sha "$_sd"
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "falha de importacao deveria ser exit 1" "exit=$_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"; return 1; }
+  # M4: nada publicado — o banco anterior segue sendo o da execucao original
+  _stillid=$(sqlite3 "$_sd/state.db" "SELECT id FROM execution;")
+  [ "$_stillid" = "exec-fixture-001" ] || { _fail "banco alterado por migracao falha" "obtido $_stillid"; return 1; }
+
+  _f=$(sqlite3 "$_sd/state.db" "SELECT count(*) FROM migration_run WHERE result='failed';")
+  [ "$_f" = "1" ] || { _fail "falha nao registrada em migration_run" "obtido $_f"; return 1; }
+}
+
+# ===============================================================
+# M6 — o que a migracao MUST NOT fazer
+# ===============================================================
+
+scenario_m6_nao_apaga_state_json_sha256_nem_history() {
+  _sd="$TMPDIR_TEST/m6"
+  _seed_state_json "$_sd"
+  mkdir -p "$_sd/state-history"
+  printf '{"marcador":1}' > "$_sd/state-history/export-onda-001.json"
+
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migrate" "$_CAPTURED_STDERR"; return 1; }
+
+  [ -f "$_sd/state.json" ]          || { _fail "state.json apagado (M6)" ""; return 1; }
+  [ -f "$_sd/state.json.sha256" ]   || { _fail "state.json.sha256 apagado (M6)" ""; return 1; }
+  [ -f "$_sd/state-history/export-onda-001.json" ] \
+    || { _fail "state-history/ apagado (M6)" ""; return 1; }
+  # E o conteudo de origem nao foi reescrito
+  _m=$(jq -r '.marcador' "$_sd/state-history/export-onda-001.json")
+  [ "$_m" = "1" ] || { _fail "state-history reescrito" "obtido $_m"; return 1; }
+}
+
+# M6: nenhum orquestrador dispara a migracao automaticamente. Auditoria
+# estatica — nenhum command/agent 00c pode referenciar o script.
+scenario_m6_nenhum_orquestrador_invoca_migracao_automaticamente() {
+  _hits=$(grep -rl 'state-db-migrate' \
+    "$REPO_ROOT/global/commands" "$REPO_ROOT/global/agents" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$_hits" = "0" ] || {
+    _fail "migracao referenciada em command/agent (viola M6/FR-005)" \
+      "$(grep -rl 'state-db-migrate' "$REPO_ROOT/global/commands" "$REPO_ROOT/global/agents" 2>/dev/null)"
+    return 1
+  }
+}
+
+# ===============================================================
+# Interface / uso
+# ===============================================================
+
+scenario_sem_subcomando_e_uso_incorreto() {
+  capture "$SCRIPT"
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "sem subcomando deveria ser exit 2" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_subcomando_desconhecido_e_uso_incorreto() {
+  capture "$SCRIPT" naoexiste
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "subcomando invalido deveria ser exit 2" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_state_dir_obrigatorio() {
+  capture "$SCRIPT" migrate
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "--state-dir ausente deveria ser exit 2" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_help_sai_zero() {
+  capture "$SCRIPT" --help
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "--help deveria sair 0" "exit=$_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *migrate*) : ;;
+    *) _fail "help nao documenta migrate" "$_CAPTURED_STDOUT"; return 1 ;;
+  esac
+}
+
+# C10 (primitives.md, finding S4): o temporario vem de mktemp, NUNCA de nome
+# derivado de PID. Auditoria estatica do proprio script.
+scenario_c10_temporario_via_mktemp_nao_pid() {
+  grep -q 'mktemp -d' "$SCRIPT" \
+    || { _fail "C10: temporario nao usa mktemp -d" ""; return 1; }
+  if grep -qE '\.tmp\.\$\$|\$\$\.tmp|tmp\.\$\{?\$' "$SCRIPT"; then
+    _fail "C10: nome de temporario derivado de PID" "$(grep -nE '\$\$' "$SCRIPT")"
+    return 1
+  fi
+}
+
+# _refresh_sha DIR -> regrava DIR/state.json.sha256 a partir do state.json.
+# NAO usa `state-rw.sh sha256-update`: aquele comando e BACKEND-AWARE — com um
+# state.db ja publicado no mesmo dir ele vira PRAGMA integrity_check do BANCO e
+# deixa o hash do JSON intacto (achado ao escrever este teste). Aqui queremos
+# sempre o hash do state.json.
+_refresh_sha() {
+  sha256_of_file "$1/state.json" > "$1/state.json.sha256"
+}
+
+# Helper local: sha256 de um arquivo (GNU/BSD).
+sha256_of_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -- "$1" | awk '{print $1}'
+  else
+    shasum -a 256 -- "$1" | awk '{print $1}'
+  fi
+}
+
+run_all_scenarios

--- a/tests/test_state-db-schema.sh
+++ b/tests/test_state-db-schema.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+# test_state-db-schema.sh — cobre global/skills/agente-00c-runtime/scripts/state-db-schema.sh
+# e o DDL em global/skills/agente-00c-runtime/references/state-db-schema.sql.
+#
+# Ref: docs/specs/state-db-foundation/data-model.md (contrato das constraints)
+#      docs/specs/state-db-foundation/tasks.md FASE 2 (2.1 DDL, 2.2 invariantes)
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-db-schema.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test_state-db-schema.sh: sqlite3 ausente — pulando suite\n'
+  exit 0
+fi
+
+_seed_execution() {
+  # $1 = db path, $2 = execution id (default exec-1)
+  _se_db="$1"
+  _se_id="${2:-exec-1}"
+  sqlite3 "$_se_db" "INSERT INTO execution
+    (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction)
+    VALUES ('$_se_id','1.0.0','/tmp/p','desc','em_andamento','2026-07-30T00:00:00Z','specify','x');"
+}
+
+scenario_create_gera_banco_com_9_tabelas() {
+  _db="$TMPDIR_TEST/state.db"
+  capture "$SCRIPT" create --db "$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "create" "$_CAPTURED_STDERR"; return 1; }
+  [ -f "$_db" ] || { _fail "create" "banco nao criado em $_db"; return 1; }
+  _n=$(sqlite3 "$_db" "SELECT count(*) FROM sqlite_master WHERE type='table';")
+  [ "$_n" = 9 ] || { _fail "tabelas" "esperado 9, obtido $_n"; return 1; }
+}
+
+scenario_create_e_idempotente() {
+  _db="$TMPDIR_TEST/state.db"
+  capture "$SCRIPT" create --db "$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "create1" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" create --db "$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "create2 (reexecucao)" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_create_aplica_wal() {
+  _db="$TMPDIR_TEST/state.db"
+  capture "$SCRIPT" create --db "$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "create" "$_CAPTURED_STDERR"; return 1; }
+  _mode=$(sqlite3 "$_db" "PRAGMA journal_mode;")
+  [ "$_mode" = "wal" ] || { _fail "journal_mode" "esperado wal, obtido $_mode"; return 1; }
+}
+
+scenario_create_chmod_600() {
+  _db="$TMPDIR_TEST/state.db"
+  capture "$SCRIPT" create --db "$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "create" "$_CAPTURED_STDERR"; return 1; }
+  _perm=$(perl -e 'printf "%03o", (stat($ARGV[0]))[2] & 07777' "$_db" 2>/dev/null \
+          || stat -f '%Lp' "$_db" 2>/dev/null || stat -c '%a' "$_db" 2>/dev/null)
+  [ "$_perm" = "600" ] || { _fail "chmod" "esperado 600, obtido $_perm"; return 1; }
+}
+
+scenario_wave_ux_wave_single_open_bloqueia_segunda_onda_aberta() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCRIPT" create --db "$_db" >/dev/null
+  _seed_execution "$_db"
+  sqlite3 "$_db" "INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z');"
+  capture sqlite3 "$_db" "INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-002','exec-1',2,'2026-07-30T00:01:00Z');"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "ux_wave_single_open" "segunda onda aberta deveria falhar"; return 1; }
+}
+
+scenario_wave_trg_wave_close_once_bloqueia_reabertura() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCRIPT" create --db "$_db" >/dev/null
+  _seed_execution "$_db"
+  sqlite3 "$_db" "INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z');"
+  sqlite3 "$_db" "UPDATE wave SET termination_reason='concluido', finished_at='2026-07-30T00:05:00Z' WHERE id='onda-001';"
+  capture sqlite3 "$_db" "UPDATE wave SET termination_reason='aborto', finished_at='2026-07-30T00:06:00Z' WHERE id='onda-001';"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "trg_wave_close_once" "reabrir onda fechada deveria falhar"; return 1; }
+  # apos fechar a primeira, uma segunda onda aberta e permitida
+  capture sqlite3 "$_db" "INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-002','exec-1',2,'2026-07-30T00:07:00Z');"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "segunda onda pos-fechamento" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_decision_campo_obrigatorio_ausente_e_rejeitado() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCRIPT" create --db "$_db" >/dev/null
+  _seed_execution "$_db"
+  # context com menos de 20 chars
+  capture sqlite3 "$_db" "INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale) VALUES ('dec-001','exec-1','2026-07-30T00:00:00Z','agente','etapa','curto','[\"a\"]','a','justificativa valida com >=20 chars');"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "context curto" "deveria ser rejeitado pelo CHECK"; return 1; }
+}
+
+scenario_decision_score3_sem_evidencia_e_rejeitado() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCRIPT" create --db "$_db" >/dev/null
+  _seed_execution "$_db"
+  capture sqlite3 "$_db" "INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale,justification_score) VALUES ('dec-001','exec-1','2026-07-30T00:00:00Z','agente','etapa','contexto com pelo menos 20 chars','[\"a\",\"b\"]','a','justificativa com pelo menos 20 chars',3);"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "score3 sem evidencia" "deveria ser rejeitado pelo CHECK"; return 1; }
+  # com evidencia >= 20 chars, deve passar
+  capture sqlite3 "$_db" "INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale,justification_score,evidence) VALUES ('dec-002','exec-1','2026-07-30T00:00:00Z','agente','etapa','contexto com pelo menos 20 chars','[\"a\",\"b\"]','a','justificativa com pelo menos 20 chars',3,'evidencia literal com >= 20 chars');"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "score3 com evidencia" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_decision_payload_hostil_persistido_literal() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCRIPT" create --db "$_db" >/dev/null
+  _seed_execution "$_db"
+  # apostrofo simples (escapado a SQL padrao, '' ) + fragmento de injecao
+  # como TEXTO LITERAL dentro do valor — via script SQL aplicado com
+  # `sqlite3 db < arquivo.sql`, mesmo caminho real de aplicacao do DDL.
+  # Cobre a mesma garantia de C8 (contracts/primitives.md): dado hostil
+  # nunca reinterpretado como SQL quando corretamente escapado.
+  _sqlfile="$TMPDIR_TEST/payload.sql"
+  cat > "$_sqlfile" <<'EOF'
+INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale)
+  VALUES ('dec-001','exec-1','2026-07-30T00:00:00Z','agente','etapa',
+          'contexto com apostrofo '' e fragmento; DROP TABLE decision; -- e mais texto',
+          '["a"]','a','justificativa valida com >= 20 chars');
+EOF
+  capture sqlite3 "$_db" ".read $_sqlfile"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "payload hostil" "$_CAPTURED_STDERR"; return 1; }
+  _n=$(sqlite3 "$_db" "SELECT count(*) FROM decision;")
+  [ "$_n" = 1 ] || { _fail "tabela decision sobreviveu" "esperado 1 linha, obtido $_n"; return 1; }
+  _tables_still=$(sqlite3 "$_db" "SELECT count(*) FROM sqlite_master WHERE type='table';")
+  [ "$_tables_still" = 9 ] || { _fail "tabelas apos payload" "esperado 9, obtido $_tables_still"; return 1; }
+  _stored=$(sqlite3 "$_db" "SELECT context FROM decision WHERE id='dec-001';")
+  case "$_stored" in
+    *"DROP TABLE decision"*) : ;;
+    *) _fail "conteudo literal" "payload nao persistido literalmente: $_stored"; return 1 ;;
+  esac
+}
+
+scenario_human_block_fk_decisao_inexistente_e_rejeitado_com_fk_on() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCRIPT" create --db "$_db" >/dev/null
+  _seed_execution "$_db"
+  capture sqlite3 "$_db" "PRAGMA foreign_keys=ON; INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,status,triggered_at) VALUES ('block-001','exec-1','dec-999','pergunta com pelo menos 20 chars','contexto','aguardando','2026-07-30T00:00:00Z');"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "fk decisao inexistente" "deveria ser rejeitado pela FOREIGN KEY"; return 1; }
+}
+
+scenario_execution_subagent_depth_acima_do_teto_e_rejeitado() {
+  # Paridade com spawn-tracker.sh `enter` (exit 3 no teto _ST_MAX=3):
+  # sob o backend SQLite, tentar gravar profundidade acima de
+  # max_recursion falha na propria camada de banco (CHECK), nao apenas no
+  # script chamador.
+  _db="$TMPDIR_TEST/state.db"
+  "$SCRIPT" create --db "$_db" >/dev/null
+  _seed_execution "$_db"
+  # max_recursion default = 3 (DEFAULT do schema); depth=3 e valido (== teto).
+  capture sqlite3 "$_db" "UPDATE execution SET subagent_depth=3 WHERE id='exec-1';"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "depth=3 (== teto)" "$_CAPTURED_STDERR"; return 1; }
+  # depth=4 (> teto de 3) deve ser rejeitado pelo CHECK.
+  capture sqlite3 "$_db" "UPDATE execution SET subagent_depth=4 WHERE id='exec-1';"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "depth=4 (> teto)" "deveria ser rejeitado pelo CHECK (subagent_depth <= max_recursion)"; return 1; }
+}
+
+scenario_task_outcome_pk_composta_upsert_idempotente() {
+  _db="$TMPDIR_TEST/state.db"
+  "$SCRIPT" create --db "$_db" >/dev/null
+  _seed_execution "$_db"
+  sqlite3 "$_db" "INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z');"
+  sqlite3 "$_db" "INSERT INTO task_outcome (execution_id,task_id,title,wave_id,outcome,tests_run,tests_passed,touched_files,recorded_at) VALUES ('exec-1','1.1','t','onda-001','pass',0,0,'[]','2026-07-30T00:00:00Z');"
+  capture sqlite3 "$_db" "INSERT INTO task_outcome (execution_id,task_id,title,wave_id,outcome,tests_run,tests_passed,touched_files,recorded_at) VALUES ('exec-1','1.1','t','onda-001','fail',0,0,'[]','2026-07-30T00:01:00Z');"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "pk composta" "segunda linha com mesma (execution_id, task_id) deveria colidir na PK"; return 1; }
+}
+
+run_all_scenarios

--- a/tests/test_state-decisions.sh
+++ b/tests/test_state-decisions.sh
@@ -430,4 +430,219 @@ scenario_ptbr_legado_register_helpers_via_fallback() {
   assert_stdout_contains "dec-002" || return 1
 }
 
+# ==== Backend dual SQLite (feature state-db-foundation, FASE 3 task 3.4) ====
+#
+# Ref: docs/specs/state-db-foundation/contracts/primitives.md §C1 (paridade)
+#      §C2 (selecao de backend) §C4 (transacao) §C6 (concorrencia) §C8 (escape)
+#
+# Mesmo padrao de tests/test_state-ondas.sh (task 3.3): aplica o DDL via
+# state-db-schema.sh e semeia uma execution minima via sqlite3 diretamente
+# (init nunca cria state.db — isso e a migracao, FASE 6, ainda nao
+# implementada).
+
+SCHEMA_SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-db-schema.sh"
+SO="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-ondas.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test_state-decisions.sh: sqlite3 ausente — pulando cenarios de backend SQLite\n'
+else
+
+# _seed_sqlite_backend DIR -> cria state.db com uma execution minima
+# (id=exec-1), pronta para register/count/next-id/list.
+_seed_sqlite_backend() {
+  _ssb_dir=$1
+  mkdir -p "$_ssb_dir"
+  "$SCHEMA_SCRIPT" create --db "$_ssb_dir/state.db" >/dev/null 2>&1 \
+    || { _fail "seed: schema create falhou" ""; return 1; }
+  sqlite3 "$_ssb_dir/state.db" "
+    PRAGMA foreign_keys=ON;
+    INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+    VALUES ('exec-1','1.0.0','/tmp/p','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+  " || { _fail "seed: insert execution falhou" ""; return 1; }
+}
+
+scenario_sqlite_register_gera_dec_001() {
+  _sd="$TMPDIR_TEST/sqlite-register-001"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_default "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite register" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "dec-001" || return 1
+  capture "$SCRIPT" count --state-dir "$_sd"
+  assert_stdout_contains "1" || return 1
+}
+
+scenario_sqlite_register_sequencial_gera_dec_002() {
+  _sd="$TMPDIR_TEST/sqlite-register-seq"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_default "$_sd"
+  _register_default "$_sd"
+  assert_stdout_contains "dec-002" || return 1
+  capture "$SCRIPT" next-id --state-dir "$_sd"
+  assert_stdout_contains "dec-003" || return 1
+}
+
+scenario_sqlite_wave_id_null_sem_onda_vira_init_no_list() {
+  # data-model.md: wave_id NULL representa "init" (nenhuma onda ainda).
+  # list normaliza para "init" na saida textual (mesma convencao do JSON).
+  _sd="$TMPDIR_TEST/sqlite-wave-id-init"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_default "$_sd"
+  capture "$SCRIPT" list --state-dir "$_sd"
+  assert_stdout_contains "	init	" || return 1
+}
+
+scenario_sqlite_wave_id_liga_onda_aberta() {
+  _sd="$TMPDIR_TEST/sqlite-wave-id-open"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SO" start --state-dir "$_sd"
+  _register_default "$_sd"
+  capture "$SCRIPT" list --state-dir "$_sd"
+  assert_stdout_contains "	onda-001	" || return 1
+}
+
+scenario_sqlite_count_filtra_por_agente() {
+  _sd="$TMPDIR_TEST/sqlite-count-agente"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_default "$_sd" "orquestrador-00c"
+  _register_default "$_sd" "clarify-asker"
+  _register_default "$_sd" "clarify-asker"
+  capture "$SCRIPT" count --state-dir "$_sd"
+  assert_stdout_contains "3" || return 1
+  capture "$SCRIPT" count --state-dir "$_sd" --agente "clarify-asker"
+  assert_stdout_contains "2" || return 1
+}
+
+scenario_sqlite_list_imprime_tsv() {
+  _sd="$TMPDIR_TEST/sqlite-list-tsv"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_default "$_sd"
+  capture "$SCRIPT" list --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite list" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "dec-001	" || return 1
+  assert_stdout_contains "	orquestrador-00c	" || return 1
+  assert_stdout_contains "	briefing	" || return 1
+  assert_stdout_contains "	Operador unico" || return 1
+}
+
+scenario_sqlite_score_3_sem_evidencia_rejeita() {
+  # Validacao Principio I (FR-EVI-001) roda ANTES do dispatch de backend —
+  # paridade de comportamento com o path JSON.
+  _sd="$TMPDIR_TEST/sqlite-score3-sem-evi"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --agente "x" --etapa "execute-task" \
+    --contexto "Afirmar comportamento de runtime sem rodar sonda" \
+    --opcoes '["A","B"]' --escolha "A" \
+    --justificativa "Conviccao baseada em leitura previa do codigo" \
+    --score 3
+  if [ "$_CAPTURED_EXIT" != 1 ]; then
+    _fail "sqlite score=3 sem evidencia" "esperado 1, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  assert_stderr_contains "evidencia" || return 1
+  capture "$SCRIPT" count --state-dir "$_sd"
+  assert_stdout_contains "0" || return 1
+}
+
+scenario_sqlite_score_3_com_evidencia_persiste() {
+  _sd="$TMPDIR_TEST/sqlite-score3-com-evi"
+  _seed_sqlite_backend "$_sd" || return 1
+  _evi='npx tsc --noEmit: error TS2322 em src/foo.ts:12 confirma tipo nao bate'
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --agente "x" --etapa "execute-task" \
+    --contexto "Decisao tecnica empiricamente validada por TS" \
+    --opcoes '["Manter","Trocar"]' --escolha "Trocar" \
+    --justificativa "Output de tsc indica incompatibilidade real" \
+    --score 3 --evidencia "$_evi"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite score=3" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.decisions[-1].evidence'
+  assert_stdout_contains "TS2322" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.decisions[-1].justification_score'
+  assert_stdout_contains "3" || return 1
+}
+
+# C8: payload hostil (apostrofo + tentativa de injecao) persistido literal,
+# tabela decision sobrevive, integrity_check continua ok. Paridade com
+# tests/test__state-db.sh scenario_state_db_exec_persiste_payload_hostil_*.
+scenario_sqlite_payload_hostil_preservado_literal_tabela_sobrevive() {
+  _sd="$TMPDIR_TEST/sqlite-hostil"
+  _seed_sqlite_backend "$_sd" || return 1
+  _hostil="'; DROP TABLE decision; -- e apostrofo simples it's here"
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --agente "x" --etapa "specify" \
+    --contexto "$_hostil (20+ chars de contexto)" \
+    --opcoes '["a","b"]' --escolha "$_hostil" \
+    --justificativa "justificativa com o mesmo payload hostil $_hostil"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite payload hostil" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.decisions[-1].choice'
+  assert_stdout_contains "DROP TABLE decision" || return 1
+  capture "$RW" sha256-verify --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "integrity apos payload hostil" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_sqlite_register_state_db_ausente_falha() {
+  _sd="$TMPDIR_TEST/sqlite-ausente"
+  mkdir -p "$_sd"
+  # sem state.db -> backend json (C2); sem state.json tambem -> falha 1
+  _register_default "$_sd"
+  if [ "$_CAPTURED_EXIT" != 1 ]; then
+    _fail "sqlite state ausente" "esperado 1, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+}
+
+# Teste de concorrencia (task 3.4.3): N invocacoes simultaneas de `register`
+# nao perdem nenhuma decisao e nao colidem em next-id — cada uma recebe um
+# dec-NNN unico, e o total persistido bate com N.
+scenario_sqlite_register_concorrente_sem_colisao() {
+  _sd="$TMPDIR_TEST/sqlite-concorrencia"
+  _seed_sqlite_backend "$_sd" || return 1
+  _n=15
+  _i=1
+  while [ "$_i" -le "$_n" ]; do
+    ( "$SCRIPT" register --state-dir "$_sd" \
+        --agente "worker-$_i" --etapa "specify" \
+        --contexto "contexto concorrente numero $_i com 20+ chars" \
+        --opcoes '["a","b"]' --escolha "a" \
+        --justificativa "justificativa concorrente numero $_i com 20+chars" \
+        > "$TMPDIR_TEST/sqlite-concorrencia-out-$_i.txt" \
+        2> "$TMPDIR_TEST/sqlite-concorrencia-err-$_i.txt" ) &
+    _i=$((_i + 1))
+  done
+  wait
+
+  _i=1
+  while [ "$_i" -le "$_n" ]; do
+    if [ -s "$TMPDIR_TEST/sqlite-concorrencia-err-$_i.txt" ]; then
+      _fail "worker $_i emitiu stderr" "$(cat "$TMPDIR_TEST/sqlite-concorrencia-err-$_i.txt")"
+      return 1
+    fi
+    _i=$((_i + 1))
+  done
+
+  _unique=$(cat "$TMPDIR_TEST"/sqlite-concorrencia-out-*.txt | sort -u | wc -l | tr -d ' ')
+  [ "$_unique" = "$_n" ] || { _fail "ids unicos" "esperado $_n, obtido $_unique"; return 1; }
+
+  capture "$SCRIPT" count --state-dir "$_sd"
+  assert_stdout_contains "$_n" || return 1
+}
+
+# Paridade cross-backend (C1): mesmos inputs, mesmo formato de stdout
+# (dec-001) para o primeiro register em cada backend.
+scenario_sqlite_paridade_register_primeiro_id_json() {
+  _sd_json="$TMPDIR_TEST/paridade-decisions-json"
+  _init_state "$_sd_json"
+  _register_default "$_sd_json"
+  _json_id="$_CAPTURED_STDOUT"
+
+  _sd_db="$TMPDIR_TEST/paridade-decisions-sqlite"
+  _seed_sqlite_backend "$_sd_db" || return 1
+  _register_default "$_sd_db"
+  _db_id="$_CAPTURED_STDOUT"
+
+  [ "$_json_id" = "$_db_id" ] || { _fail "paridade register id" "json='$_json_id' sqlite='$_db_id'"; return 1; }
+}
+
+fi # sqlite3 disponivel
+
 run_all_scenarios

--- a/tests/test_state-decisions.sh
+++ b/tests/test_state-decisions.sh
@@ -643,6 +643,33 @@ scenario_sqlite_paridade_register_primeiro_id_json() {
   [ "$_json_id" = "$_db_id" ] || { _fail "paridade register id" "json='$_json_id' sqlite='$_db_id'"; return 1; }
 }
 
+# Task 4.1.1/4.2.2 (FASE 4): branch de selecao de backend explicito por C2 —
+# um state.json coexistente e export/legado, NUNCA consultado como fonte.
+# Prova positiva: 1 decisao registrada no state.db, state.json divergente
+# com 5 decisoes falsas — count deve refletir sempre o state.db (1).
+scenario_c2_state_json_coexistente_ignorado_quando_state_db_presente() {
+  _sd="$TMPDIR_TEST/c2-coexist-decisions"
+  _seed_sqlite_backend "$_sd" || return 1
+  _register_default "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2: register sqlite" "$_CAPTURED_STDERR"; return 1; }
+
+  # state.json divergente no MESMO diretorio (5 decisoes falsas).
+  printf '{"decisions":[1,2,3,4,5]}\n' > "$_sd/state.json"
+
+  capture "$SCRIPT" count --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2 count exit" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "1" \
+    || { _fail "c2: count deveria refletir state.db (1), nao o state.json coexistente (5)" "obtido $_CAPTURED_STDOUT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    5*) _fail "c2: count leu o state.json coexistente" "obtido $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+
+  # state.json coexistente permanece intocado.
+  _stale_now=$(cat "$_sd/state.json")
+  [ "$_stale_now" = '{"decisions":[1,2,3,4,5]}' ] \
+    || { _fail "c2: state.json coexistente foi modificado" "obtido: $_stale_now"; return 1; }
+}
+
 fi # sqlite3 disponivel
 
 run_all_scenarios

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -1487,4 +1487,306 @@ prosa contrabandeada na segunda linha"
   [ "$_st" = "execute-task-F3.1,execute-task-F3.2" ] || { _fail "etapas" "obtido $_st"; return 1; }
 }
 
+# ==== Backend dual SQLite (feature state-db-foundation, FASE 3 task 3.3) ====
+#
+# Ref: docs/specs/state-db-foundation/contracts/primitives.md §C1 (paridade)
+#      §C2 (selecao de backend) §C3 (semantica de erro nova) §C4 (transacao)
+#
+# Mesmo padrao de tests/test_state-rw.sh (task 3.2): aplica o DDL via
+# state-db-schema.sh e semeia uma execution minima via sqlite3 diretamente
+# (init nunca cria state.db — isso e a migracao, FASE 6, ainda nao
+# implementada).
+
+SCHEMA_SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-db-schema.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test_state-ondas.sh: sqlite3 ausente — pulando cenarios de backend SQLite\n'
+else
+
+# _seed_sqlite_backend DIR [TARGET_PROJECT_PATH] -> cria state.db com uma
+# execution minima (id=exec-1), pronta para start/end/record-*/wave-status.
+_seed_sqlite_backend() {
+  _ssb_dir=$1
+  _ssb_pap=${2:-/tmp/p}
+  mkdir -p "$_ssb_dir"
+  "$SCHEMA_SCRIPT" create --db "$_ssb_dir/state.db" >/dev/null 2>&1 \
+    || { _fail "seed: schema create falhou" ""; return 1; }
+  sqlite3 "$_ssb_dir/state.db" "
+    PRAGMA foreign_keys=ON;
+    INSERT INTO execution (id,schema_version,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+    VALUES ('exec-1','1.0.0','$_ssb_pap','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','execute-task','faca algo','[]','[]','[]',0);
+  " || { _fail "seed: insert execution falhou" ""; return 1; }
+}
+
+scenario_sqlite_start_cria_onda_001() {
+  _sd="$TMPDIR_TEST/sqlite-start"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite start" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "onda-001" || return 1
+  capture "$SCRIPT" current-id --state-dir "$_sd"
+  assert_stdout_contains "onda-001" || return 1
+}
+
+scenario_sqlite_start_sequencial_gera_onda_002() {
+  _sd="$TMPDIR_TEST/sqlite-start-seq"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  capture "$SCRIPT" start --state-dir "$_sd"
+  assert_stdout_contains "onda-002" || return 1
+}
+
+# C3: start com onda ja aberta MUST falhar (ux_wave_single_open) — mudanca
+# de comportamento autorizada face ao path JSON, que hoje duplica a onda
+# silenciosamente (por isso o orquestrador carrega a guarda wave-status).
+scenario_sqlite_start_onda_ja_aberta_falha() {
+  _sd="$TMPDIR_TEST/sqlite-start-dup"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "primeiro start" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "segundo start deveria falhar (C3)" "obtido exit 0"; return 1; }
+  # Guarda wave-status continua valida como defesa em profundidade (task 3.3.4).
+  capture "$SCRIPT" wave-status --state-dir "$_sd"
+  assert_stdout_contains "open" || return 1
+  capture "$SCRIPT" current-id --state-dir "$_sd"
+  assert_stdout_contains "onda-001" || return 1
+}
+
+scenario_sqlite_wave_status_transicoes() {
+  _sd="$TMPDIR_TEST/sqlite-wave-status"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" wave-status --state-dir "$_sd"
+  assert_stdout_contains "none" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" wave-status --state-dir "$_sd"
+  assert_stdout_contains "open" || return 1
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  capture "$SCRIPT" wave-status --state-dir "$_sd"
+  assert_stdout_contains "closed" || return 1
+}
+
+scenario_sqlite_current_id_init_sem_onda() {
+  _sd="$TMPDIR_TEST/sqlite-current-id-init"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" current-id --state-dir "$_sd"
+  assert_stdout_contains "init" || return 1
+}
+
+scenario_sqlite_end_sem_onda_aberta_falha() {
+  _sd="$TMPDIR_TEST/sqlite-end-no-open"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "end sem onda deveria falhar" "obtido exit 0"; return 1; }
+}
+
+scenario_sqlite_end_atualiza_onda_e_acumulados() {
+  _sd="$TMPDIR_TEST/sqlite-end-acumulados"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" tool-call-tick --state-dir "$_sd"
+  capture "$SCRIPT" tool-call-tick --state-dir "$_sd"
+  assert_stdout_contains "2" || return 1
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino bloqueio_humano \
+    --add-etapa briefing
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite end" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.waves[-1].termination_reason'
+  assert_stdout_contains "bloqueio_humano" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.waves[-1].tool_calls'
+  assert_stdout_contains "2" || return 1
+  # accumulated_metrics e DERIVADO por agregacao SQL sob backend sqlite
+  # (_sr_db_read) — nao ha campo separado a manter em sincronia.
+  capture "$RW" get --state-dir "$_sd" --field '.accumulated_metrics.waves_total'
+  assert_stdout_contains "1" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.accumulated_metrics.tool_calls_total'
+  assert_stdout_contains "2" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.waves[-1].executed_stages'
+  assert_stdout_contains "briefing" || return 1
+}
+
+scenario_sqlite_end_add_etapa_acumula_multiplas() {
+  _sd="$TMPDIR_TEST/sqlite-end-etapas"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando \
+    --add-etapa execute-task-F3.1 --add-etapa execute-task-F3.2
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite end etapas" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.waves[-1].executed_stages | join(",")'
+  assert_stdout_contains "execute-task-F3.1,execute-task-F3.2" || return 1
+}
+
+scenario_sqlite_end_next_instruction_persiste() {
+  _sd="$TMPDIR_TEST/sqlite-end-next-instr"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando \
+    --next-instruction "Continuar com a proxima fase"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite end next-instr" "$_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.next_instruction'
+  assert_stdout_contains "Continuar com a proxima fase" || return 1
+}
+
+scenario_sqlite_record_skill_idempotente() {
+  _sd="$TMPDIR_TEST/sqlite-record-skill"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  # decision_id de skill_invocation tem FK para decision(id) — semeia uma
+  # Decisao minima valida (todas as CHECK de data-model.md) para exercitar
+  # o caminho com --decisao-id preenchido.
+  sqlite3 "$_sd/state.db" "
+    PRAGMA foreign_keys=ON;
+    INSERT INTO decision (id,execution_id,timestamp,agent,stage,context,options_considered,choice,rationale)
+    VALUES ('dec-001','exec-1','2026-07-30T00:00:00Z','feature-00c-feature-orchestrator','specify','contexto de teste com detalhe suficiente','[\"a\",\"b\"]','a','justificativa de teste com detalhe suficiente');
+  " || { _fail "seed decision" ""; return 1; }
+  capture "$SCRIPT" record-skill --state-dir "$_sd" --skill specify --decisao-id dec-001
+  assert_stdout_contains "1" || return 1
+  capture "$SCRIPT" record-skill --state-dir "$_sd" --skill specify --decisao-id dec-001
+  assert_stdout_contains "1" || return 1
+  capture "$SCRIPT" record-skill --state-dir "$_sd" --skill clarify
+  assert_stdout_contains "2" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.waves[-1].skills_invoked | length'
+  assert_stdout_contains "2" || return 1
+}
+
+scenario_sqlite_record_skill_sem_onda_falha() {
+  _sd="$TMPDIR_TEST/sqlite-record-skill-no-wave"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" record-skill --state-dir "$_sd" --skill specify
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "record-skill sem onda deveria falhar" "obtido exit 0"; return 1; }
+}
+
+scenario_sqlite_record_task_upsert_idempotente() {
+  _sd="$TMPDIR_TEST/sqlite-record-task-upsert"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id 4.1 --titulo "Original" \
+    --outcome fail --testes-rodados 3 --testes-passados 1
+  assert_stdout_contains "1" || return 1
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id 4.1 --titulo "Corrigida" \
+    --outcome pass --testes-rodados 3 --testes-passados 3
+  assert_stdout_contains "1" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.tasks[] | select(.task_id=="4.1") | .outcome'
+  assert_stdout_contains "pass" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.tasks[] | select(.task_id=="4.1") | .title'
+  assert_stdout_contains "Corrigida" || return 1
+}
+
+scenario_sqlite_record_task_if_absent_nao_clobbera() {
+  _sd="$TMPDIR_TEST/sqlite-record-task-if-absent"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id 4.2 --titulo "REAL" \
+    --outcome pass --origem execute-task
+  capture "$SCRIPT" record-task --state-dir "$_sd" --task-id 4.2 --titulo "DERIVADO" \
+    --outcome pass --origem reconcile --if-absent
+  capture "$RW" get --state-dir "$_sd" --field '.tasks[] | select(.task_id=="4.2") | .title'
+  assert_stdout_contains "REAL" || return 1
+}
+
+scenario_sqlite_reconcile_tasks_backfill_e_idempotente() {
+  _sd="$TMPDIR_TEST/sqlite-reconcile-tasks"
+  _md="$TMPDIR_TEST/sqlite-tasks.md"
+  _seed_sqlite_backend "$_sd" || return 1
+  _write_tasks_md "$_md"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" reconcile-tasks --state-dir "$_sd" --tasks-md "$_md"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite reconcile-tasks" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "3" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.tasks | length'
+  assert_stdout_contains "3" || return 1
+  # idempotente: segunda chamada nao back-filla de novo
+  capture "$SCRIPT" reconcile-tasks --state-dir "$_sd" --tasks-md "$_md"
+  assert_stdout_contains "0" || return 1
+}
+
+scenario_sqlite_reconcile_tasks_dry_run_nao_escreve() {
+  _sd="$TMPDIR_TEST/sqlite-reconcile-tasks-dry"
+  _md="$TMPDIR_TEST/sqlite-tasks-dry.md"
+  _seed_sqlite_backend "$_sd" || return 1
+  _write_tasks_md "$_md"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" reconcile-tasks --state-dir "$_sd" --tasks-md "$_md" --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "dry-run" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "1.1" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.tasks | length'
+  assert_stdout_contains "0" || return 1
+}
+
+scenario_sqlite_git_commit_cria_commit() {
+  _sd="$TMPDIR_TEST/sqlite-git-commit"
+  _pap="$TMPDIR_TEST/sqlite-proj"
+  mkdir -p "$_pap"
+  ( cd "$_pap" && git init -q -b main \
+    && git config user.email t@t \
+    && git config user.name t )
+  _seed_sqlite_backend "$_sd" "$_pap" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  ( cd "$_pap" && touch hello.txt )
+  capture "$SCRIPT" git-commit --state-dir "$_sd" --projeto-alvo-path "$_pap" \
+    --motivo "sqlite commit FASE 3.3"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite git-commit" "$_CAPTURED_STDERR"; return 1; }
+  _msg=$(git -C "$_pap" log -1 --pretty=%s)
+  case "$_msg" in
+    *"chore(agente-00c):"*"sqlite commit FASE 3.3"*) ;;
+    *) _fail "sqlite commit msg" "obtido: $_msg"; return 1 ;;
+  esac
+}
+
+scenario_sqlite_reconcile_wave_noop_quando_sem_onda() {
+  _sd="$TMPDIR_TEST/sqlite-reconcile-wave-noop"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" reconcile-wave --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "reconcile-wave noop" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "noop (none)" || return 1
+}
+
+scenario_sqlite_reconcile_wave_fecha_e_avanca_ponteiro() {
+  _sd="$TMPDIR_TEST/sqlite-reconcile-wave-fecha"
+  _seed_sqlite_backend "$_sd" || return 1
+  # current_stage=execute-task (default do seed): terminal-phase precisa
+  # casar com a fase CORRENTE para acionar o ramo terminal — se nao, a
+  # fase corrente possui proxima real no pipeline (execute-task ->
+  # review-task) e reconcile-wave apenas avanca o ponteiro (ramo nao-
+  # terminal), que e o comportamento correto (nao um bug).
+  capture "$RW" set --state-dir "$_sd" --field '.current_stage' --value '"review-task"'
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" reconcile-wave --state-dir "$_sd" --terminal-phase review-task
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqlite reconcile-wave" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" wave-status --state-dir "$_sd"
+  assert_stdout_contains "closed" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.execution.status'
+  assert_stdout_contains "concluida" || return 1
+}
+
+# Paridade C1: a MESMA sequencia de operacoes produz o MESMO stdout sob os
+# dois backends para current-id/wave-status.
+scenario_sqlite_paridade_current_id_wave_status_com_backend_json() {
+  _sd_json="$TMPDIR_TEST/parity-json-ondas"
+  capture "$RW" init --state-dir "$_sd_json" --execucao-id "exec-parity" \
+    --projeto-alvo-path "/tmp/p" --descricao "POC paridade ondas"
+  capture "$SCRIPT" start --state-dir "$_sd_json"
+  capture "$SCRIPT" tool-call-tick --state-dir "$_sd_json"
+  capture "$SCRIPT" end --state-dir "$_sd_json" --motivo-termino etapa_concluida_avancando
+  capture "$SCRIPT" current-id --state-dir "$_sd_json"
+  _json_id="$_CAPTURED_STDOUT"
+  capture "$SCRIPT" wave-status --state-dir "$_sd_json"
+  _json_status="$_CAPTURED_STDOUT"
+
+  _sd_db="$TMPDIR_TEST/parity-sqlite-ondas"
+  _seed_sqlite_backend "$_sd_db" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd_db"
+  capture "$SCRIPT" tool-call-tick --state-dir "$_sd_db"
+  capture "$SCRIPT" end --state-dir "$_sd_db" --motivo-termino etapa_concluida_avancando
+  capture "$SCRIPT" current-id --state-dir "$_sd_db"
+  _db_id="$_CAPTURED_STDOUT"
+  capture "$SCRIPT" wave-status --state-dir "$_sd_db"
+  _db_status="$_CAPTURED_STDOUT"
+
+  [ "$_json_id" = "$_db_id" ] || { _fail "paridade current-id" "json='$_json_id' sqlite='$_db_id'"; return 1; }
+  [ "$_json_status" = "$_db_status" ] || { _fail "paridade wave-status" "json='$_json_status' sqlite='$_db_status'"; return 1; }
+}
+
+fi # sqlite3 disponivel
+
 run_all_scenarios

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -1605,6 +1605,150 @@ scenario_sqlite_end_atualiza_onda_e_acumulados() {
   assert_stdout_contains "briefing" || return 1
 }
 
+# ---- FASE 5 (state-db-foundation): export derivado, contracts/export.md ----
+
+# 5.2.1/5.2.3 (SC-004): `end` sob backend sqlite dispara o export
+# automaticamente, refletindo a onda recem-fechada (freshness trivial —
+# gerado sincronamente dentro do proprio `end`).
+scenario_sqlite_end_gera_export_snapshot_automatico() {
+  _sd="$TMPDIR_TEST/sqlite-end-export-auto"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" tool-call-tick --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino concluido
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "$_CAPTURED_STDERR"; return 1; }
+
+  _snap=$(ls "$_sd"/state-history/export-onda-001-*.json 2>/dev/null | head -1)
+  [ -n "$_snap" ] && [ -f "$_snap" ] \
+    || { _fail "export automatico nao gerado (5.2.1)" "$_sd/state-history"; return 1; }
+
+  _reason=$(jq -r '.waves[-1].termination_reason' "$_snap" 2>/dev/null)
+  [ "$_reason" = "concluido" ] \
+    || { _fail "export nao reflete termination_reason da onda fechada (SC-004)" "$_reason"; return 1; }
+  _tc=$(jq -r '.waves[-1].tool_calls' "$_snap" 2>/dev/null)
+  [ "$_tc" = "1" ] \
+    || { _fail "export nao reflete tool_calls da onda fechada (SC-004)" "$_tc"; return 1; }
+
+  # E1: o export automatico tambem passa em state-validate.sh
+  _validate_dir="$TMPDIR_TEST/validate-auto-export"
+  mkdir -p "$_validate_dir"
+  cp "$_snap" "$_validate_dir/state.json"
+  capture sh "$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-validate.sh" --state-dir "$_validate_dir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "export automatico nao passa em state-validate.sh (E1)" "$_CAPTURED_STDERR"; return 1; }
+}
+
+# 5.2.2/5.2.4 (E6): falha ao gerar o export MUST NOT reverter nem impedir o
+# fechamento da onda no state.db (fonte de verdade). Simula a falha
+# ocupando state-history/ com um arquivo comum (nao diretorio) — mkdir -p
+# falha sem tocar em permissoes do state-dir (que quebraria o proprio
+# UPDATE do state.db, nao so o export).
+scenario_sqlite_end_e6_falha_export_nao_reverte_fechamento() {
+  _sd="$TMPDIR_TEST/sqlite-end-export-e6"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start" "$_CAPTURED_STDERR"; return 1; }
+  : > "$_sd/state-history"
+
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  _exit=$_CAPTURED_EXIT
+  _stderr="$_CAPTURED_STDERR"
+  rm -f "$_sd/state-history"  # restaura para cleanup
+
+  [ "$_exit" = 0 ] \
+    || { _fail "end deveria seguir exit 0 mesmo com export falho (E6)" "$_stderr"; return 1; }
+  case "$_stderr" in
+    *export*) : ;;
+    *) _fail "falha do export deveria ser reportada em stderr (E6)" "$_stderr"; return 1 ;;
+  esac
+  capture "$RW" get --state-dir "$_sd" --field '.waves[-1].termination_reason'
+  assert_stdout_contains "etapa_concluida_avancando" || return 1
+}
+
+# 5.3.1/5.3.2: gatilho sob demanda — comando explicito, reflete mutacoes
+# aplicadas apos snapshots anteriores, nomes distintos por chamada.
+scenario_sqlite_export_snapshot_sob_demanda_multiplas_mutacoes() {
+  _sd="$TMPDIR_TEST/sqlite-export-sob-demanda"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start" "$_CAPTURED_STDERR"; return 1; }
+
+  capture "$SCRIPT" export-snapshot --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "export-snapshot 1 exit" "$_CAPTURED_STDERR"; return 1; }
+  _snap1="$_CAPTURED_STDOUT"
+  [ -f "$_snap1" ] || { _fail "export-snapshot 1 nao criou arquivo" "$_snap1"; return 1; }
+  _stage1=$(jq -r '.current_stage' "$_snap1" 2>/dev/null)
+  [ "$_stage1" = "execute-task" ] || { _fail "snapshot1.current_stage" "$_stage1"; return 1; }
+
+  capture "$RW" set --state-dir "$_sd" --field '.current_stage' --value '"plan"'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "set current_stage" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" tool-call-tick --state-dir "$_sd"
+
+  capture "$SCRIPT" export-snapshot --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "export-snapshot 2 exit" "$_CAPTURED_STDERR"; return 1; }
+  _snap2="$_CAPTURED_STDOUT"
+  [ -f "$_snap2" ] || { _fail "export-snapshot 2 nao criou arquivo" "$_snap2"; return 1; }
+  [ "$_snap1" != "$_snap2" ] \
+    || { _fail "snapshots sucessivos deveriam ter nomes distintos" "$_snap1"; return 1; }
+  _stage2=$(jq -r '.current_stage' "$_snap2" 2>/dev/null)
+  [ "$_stage2" = "plan" ] \
+    || { _fail "snapshot2 nao reflete mutacao aplicada apos snapshot1 (5.3.2)" "$_stage2"; return 1; }
+}
+
+# export-snapshot tambem funciona sob backend JSON (backend-agnostico —
+# reusa `state-rw.sh read`, que ja dispatcha por backend).
+scenario_json_export_snapshot_sob_demanda() {
+  _sd="$TMPDIR_TEST/json-export-sob-demanda"
+  capture "$RW" init --state-dir "$_sd" --execucao-id "exec-export" \
+    --projeto-alvo-path "/tmp/proj" --descricao "descricao valida >=10"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "init json" "$_CAPTURED_STDERR"; return 1; }
+
+  capture "$SCRIPT" export-snapshot --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "export-snapshot json exit" "$_CAPTURED_STDERR"; return 1; }
+  _snap="$_CAPTURED_STDOUT"
+  [ -f "$_snap" ] || { _fail "export-snapshot json nao criou arquivo" "$_snap"; return 1; }
+  jq -e . "$_snap" >/dev/null 2>&1 || { _fail "export-snapshot json nao e JSON valido" ""; return 1; }
+}
+
+# 5.4.1 (FR-013-INFRA-BACKUP, literal: "com a restauracao validada por
+# teste antes de ser considerada disponivel"): um snapshot de
+# state-history/ (export serializado) restaurado como state.json de um
+# state-dir NOVO (backend JSON) e de fato OPERAVEL — nao so passa em
+# state-validate.sh, mas sustenta get/current-id/wave-status e permite
+# iniciar onda nova a partir dele.
+scenario_sqlite_export_snapshot_restauracao_operavel_fr013() {
+  _sd="$TMPDIR_TEST/sqlite-export-origem"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start origem" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end origem" "$_CAPTURED_STDERR"; return 1; }
+
+  _snap=$(ls "$_sd"/state-history/export-onda-001-*.json 2>/dev/null | head -1)
+  [ -n "$_snap" ] || { _fail "export automatico ausente para restauracao" ""; return 1; }
+
+  _restore_dir="$TMPDIR_TEST/restaurado"
+  mkdir -p "$_restore_dir"
+  cp "$_snap" "$_restore_dir/state.json"
+
+  capture "$RW" get --state-dir "$_restore_dir" --field '.current_stage'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "get pos-restauracao" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "execute-task" || return 1
+
+  capture "$SCRIPT" current-id --state-dir "$_restore_dir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "current-id pos-restauracao" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "onda-001" || return 1
+
+  capture "$SCRIPT" wave-status --state-dir "$_restore_dir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "wave-status pos-restauracao" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "closed" || return 1
+
+  # Operavel de verdade: uma onda NOVA pode comecar a partir do restaurado.
+  capture "$SCRIPT" start --state-dir "$_restore_dir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start pos-restauracao" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "onda-002" || return 1
+}
+
 scenario_sqlite_end_add_etapa_acumula_multiplas() {
   _sd="$TMPDIR_TEST/sqlite-end-etapas"
   _seed_sqlite_backend "$_sd" || return 1

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -1787,6 +1787,31 @@ scenario_sqlite_paridade_current_id_wave_status_com_backend_json() {
   [ "$_json_status" = "$_db_status" ] || { _fail "paridade wave-status" "json='$_json_status' sqlite='$_db_status'"; return 1; }
 }
 
+# Task 4.1.1/4.2.2 (FASE 4): branch de selecao de backend explicito por C2 —
+# um state.json coexistente e export/legado, NUNCA consultado como fonte.
+# Prova positiva: onda aberta no state.db ("open") com state.json divergente
+# (0 waves => "none" se fosse lido por engano) — wave-status deve refletir
+# sempre o state.db.
+scenario_c2_state_json_coexistente_ignorado_quando_state_db_presente() {
+  _sd="$TMPDIR_TEST/c2-coexist-ondas"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2: start sqlite" "$_CAPTURED_STDERR"; return 1; }
+
+  # state.json divergente no MESMO diretorio (0 waves => "none" se lido).
+  printf '{"waves":[]}\n' > "$_sd/state.json"
+
+  capture "$SCRIPT" wave-status --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2 wave-status exit" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "open" \
+    || { _fail "c2: wave-status deveria refletir state.db (open), nao o state.json coexistente" "obtido $_CAPTURED_STDOUT"; return 1; }
+
+  # state.json coexistente permanece intocado.
+  _stale_now=$(cat "$_sd/state.json")
+  [ "$_stale_now" = '{"waves":[]}' ] \
+    || { _fail "c2: state.json coexistente foi modificado" "obtido: $_stale_now"; return 1; }
+}
+
 fi # sqlite3 disponivel
 
 run_all_scenarios

--- a/tests/test_state-rw.sh
+++ b/tests/test_state-rw.sh
@@ -870,6 +870,33 @@ scenario_sqlite_sha256_update_e_noop_com_exit_0() {
   [ ! -f "$_sd/state.json.sha256" ] || { _fail "sha256-update sob sqlite nao deveria criar state.json.sha256" ""; return 1; }
 }
 
+# Task 7.1.3 (contracts/primitives.md §C7, dec-025/D4-a FECHADA, block-002):
+# edicao externa bem-formada (UPDATE direto via sqlite3, sem quebrar a
+# estrutura do banco) NAO e detectada por PRAGMA integrity_check. Este e o
+# comportamento ACEITO e DOCUMENTADO (nao um bug) — cenario 7.a do
+# quickstart.md. O assert correto e "exit 0 mesmo apos edicao bem-formada",
+# registrando o limite conhecido do mecanismo (modelo de ameaca: operador
+# local confiavel).
+scenario_sqlite_sha256_verify_edicao_bem_formada_nao_detectada() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  sqlite3 "$_sd/state.db" "
+    INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z');
+    INSERT INTO decision (id,execution_id,wave_id,timestamp,agent,stage,context,options_considered,choice,rationale,justification_score)
+      VALUES ('dec-001','exec-1','onda-001','2026-07-30T00:01:00Z','tester','specify','contexto de teste com pelo menos vinte caracteres','[\"a\",\"b\"]','a','justificativa de teste com pelo menos vinte caracteres',2);
+  " || { _fail "seed decision falhou" ""; return 1; }
+
+  capture "$SCRIPT" sha256-verify --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sha256-verify pre-edicao deveria ser exit 0" "$_CAPTURED_STDERR"; return 1; }
+
+  sqlite3 "$_sd/state.db" "UPDATE decision SET choice='outra' WHERE id='dec-001';" \
+    || { _fail "UPDATE bem-formado falhou" ""; return 1; }
+
+  capture "$SCRIPT" sha256-verify --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "regresso documentado (D4-a/dec-025): integrity_check deveria seguir exit 0 apos UPDATE bem-formado" "$_CAPTURED_STDERR"; return 1; }
+}
+
 # ---- Paridade C1 (task 3.2.4): mesma sequencia de operacoes, dois backends,
 # mesmo stdout/exit code observavel nos pontos comparaveis ----
 scenario_sqlite_paridade_get_set_com_backend_json() {

--- a/tests/test_state-rw.sh
+++ b/tests/test_state-rw.sh
@@ -664,6 +664,85 @@ scenario_sqlite_read_reconstroi_documento_valido_por_state_validate() {
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "export nao passa em state-validate.sh (E1)" "$_CAPTURED_STDERR"; return 1; }
 }
 
+scenario_sqlite_read_e2_e3_ids_e_skills_invoked_aninhado() {
+  # E2 (fidelidade de nomes/IDs) + E3 (aninhamento skills_invoked, ausente-vs-null)
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  sqlite3 "$_sd/state.db" "
+    INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z');
+    INSERT INTO decision (id,execution_id,wave_id,timestamp,agent,stage,context,options_considered,choice,rationale,justification_score)
+      VALUES ('dec-001','exec-1','onda-001','2026-07-30T00:01:00Z','tester','specify','contexto de teste com pelo menos vinte caracteres','[\"a\",\"b\"]','a','justificativa de teste com pelo menos vinte caracteres',2);
+    INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,status,triggered_at)
+      VALUES ('block-001','exec-1','dec-001','pergunta de teste com pelo menos vinte caracteres','contexto para resposta','aguardando','2026-07-30T00:02:00Z');
+    INSERT INTO skill_invocation (wave_id,skill,timestamp,decision_id,kind)
+      VALUES ('onda-001','specify','2026-07-30T00:01:30Z','dec-001','skill');
+  " || { _fail "seed decision/human_block/skill_invocation falhou" ""; return 1; }
+
+  capture "$SCRIPT" read --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "read exit" "$_CAPTURED_STDERR"; return 1; }
+  _doc="$_CAPTURED_STDOUT"
+
+  # IDs preservados literalmente (formato dec-NNN, block-NNN, onda-NNN)
+  [ "$(printf '%s' "$_doc" | jq -r '.waves[0].id')" = "onda-001" ] \
+    || { _fail "waves[0].id" "$(printf '%s' "$_doc" | jq -r '.waves[0].id')"; return 1; }
+  [ "$(printf '%s' "$_doc" | jq -r '.decisions[0].id')" = "dec-001" ] \
+    || { _fail "decisions[0].id" "$(printf '%s' "$_doc" | jq -r '.decisions[0].id')"; return 1; }
+  [ "$(printf '%s' "$_doc" | jq -r '.human_blocks[0].id')" = "block-001" ] \
+    || { _fail "human_blocks[0].id" "$(printf '%s' "$_doc" | jq -r '.human_blocks[0].id')"; return 1; }
+
+  # Nome de campo justification_score (nao "score")
+  [ "$(printf '%s' "$_doc" | jq -r '.decisions[0].justification_score')" = "2" ] \
+    || { _fail "decisions[0].justification_score" "$(printf '%s' "$_doc" | jq -r '.decisions[0].justification_score')"; return 1; }
+
+  # skills_invoked aninhado em waves[N], nao tabela solta no topo
+  [ "$(printf '%s' "$_doc" | jq -r '.waves[0].skills_invoked[0].skill')" = "specify" ] \
+    || { _fail "waves[0].skills_invoked[0].skill" "$(printf '%s' "$_doc" | jq -r '.waves[0].skills_invoked[0].skill')"; return 1; }
+  [ "$(printf '%s' "$_doc" | jq -r '.waves[0].skills_invoked[0].decision_id')" = "dec-001" ] \
+    || { _fail "waves[0].skills_invoked[0].decision_id" ""; return 1; }
+  [ "$(printf '%s' "$_doc" | jq 'has("skills_invoked")')" = "false" ] \
+    || { _fail "skills_invoked nao deveria existir no topo do documento" ""; return 1; }
+
+  # Ausente-vs-null: canonical_project/session_name nao setados ficam AUSENTES
+  [ "$(printf '%s' "$_doc" | jq -r '.execution | has("canonical_project")')" = "false" ] \
+    || { _fail "execution deveria omitir canonical_project quando nao setado" ""; return 1; }
+  [ "$(printf '%s' "$_doc" | jq -r '.execution | has("session_name")')" = "false" ] \
+    || { _fail "execution deveria omitir session_name quando nao setado" ""; return 1; }
+}
+
+scenario_sqlite_read_e4_accumulated_metrics_agregado() {
+  # E4: accumulated_metrics MUST ser agregacao das tabelas no momento do
+  # export, nao um contador materializado.
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  sqlite3 "$_sd/state.db" "
+    INSERT INTO wave (id,execution_id,seq,started_at,finished_at,tool_calls,wallclock_seconds,termination_reason)
+      VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z','2026-07-30T00:05:00Z',10,300,'etapa_concluida_avancando');
+    INSERT INTO wave (id,execution_id,seq,started_at,finished_at,tool_calls,wallclock_seconds,termination_reason)
+      VALUES ('onda-002','exec-1',2,'2026-07-30T00:05:00Z','2026-07-30T00:09:00Z',5,240,'etapa_concluida_avancando');
+    INSERT INTO decision (id,execution_id,wave_id,timestamp,agent,stage,context,options_considered,choice,rationale,justification_score)
+      VALUES ('dec-001','exec-1','onda-001','2026-07-30T00:01:00Z','tester','specify','contexto de teste com pelo menos vinte caracteres','[\"a\",\"b\"]','a','justificativa de teste com pelo menos vinte caracteres',2);
+    INSERT INTO decision (id,execution_id,wave_id,timestamp,agent,stage,context,options_considered,choice,rationale,justification_score)
+      VALUES ('dec-002','exec-1','onda-002','2026-07-30T00:06:00Z','tester','plan','contexto de teste com pelo menos vinte caracteres','[\"a\",\"b\"]','a','justificativa de teste com pelo menos vinte caracteres',2);
+    INSERT INTO human_block (id,execution_id,decision_id,question,context_for_answer,status,triggered_at)
+      VALUES ('block-001','exec-1','dec-001','pergunta de teste com pelo menos vinte caracteres','contexto para resposta','aguardando','2026-07-30T00:02:00Z');
+  " || { _fail "seed multi-onda falhou" ""; return 1; }
+
+  capture "$SCRIPT" read --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "read exit" "$_CAPTURED_STDERR"; return 1; }
+  _doc="$_CAPTURED_STDOUT"
+
+  [ "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.waves_total')" = "2" ] \
+    || { _fail "waves_total" "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.waves_total')"; return 1; }
+  [ "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.tool_calls_total')" = "15" ] \
+    || { _fail "tool_calls_total" "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.tool_calls_total')"; return 1; }
+  [ "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.wallclock_total_seconds')" = "540" ] \
+    || { _fail "wallclock_total_seconds" "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.wallclock_total_seconds')"; return 1; }
+  [ "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.decisions_total')" = "2" ] \
+    || { _fail "decisions_total" "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.decisions_total')"; return 1; }
+  [ "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.human_blocks_total')" = "1" ] \
+    || { _fail "human_blocks_total" "$(printf '%s' "$_doc" | jq -r '.accumulated_metrics.human_blocks_total')"; return 1; }
+}
+
 scenario_sqlite_get_extrai_campo() {
   _sd="$TMPDIR_TEST/migrated"
   _seed_sqlite_backend "$_sd" || return 1

--- a/tests/test_state-rw.sh
+++ b/tests/test_state-rw.sh
@@ -604,4 +604,237 @@ scenario_init_atomic_commit_retro_compat() {
   [ "$_CAPTURED_STDOUT" = "false" ] || { _fail "legado sem campo: esperado false via jq fallback" "obtido $_CAPTURED_STDOUT"; return 1; }
 }
 
+# ==== Backend dual SQLite (feature state-db-foundation, FASE 3 task 3.2) ====
+#
+# Ref: docs/specs/state-db-foundation/contracts/primitives.md §C1 (paridade)
+#      §C2 (selecao de backend) §C7 (sha256-* sob SQLite)
+#
+# init nunca cria state.db (isso e a migracao, FASE 6 — nao implementada
+# ainda) — os cenarios abaixo simulam um projeto "ja migrado" aplicando o
+# DDL diretamente via state-db-schema.sh (task 2.1.8) e semeando a linha de
+# execution minima via sqlite3, o mesmo padrao usado por
+# tests/test_state-db-schema.sh.
+
+SCHEMA_SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-db-schema.sh"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  printf '# test_state-rw.sh: sqlite3 ausente — pulando cenarios de backend SQLite\n'
+else
+
+# _seed_sqlite_backend DIR [SHORT_NAME] -> cria state.db com uma execution
+# minima (id=exec-1), pronta para read/get/set/write/sha256-*.
+_seed_sqlite_backend() {
+  _ssb_dir=$1
+  _ssb_short=${2:-}
+  mkdir -p "$_ssb_dir"
+  "$SCHEMA_SCRIPT" create --db "$_ssb_dir/state.db" >/dev/null 2>&1 \
+    || { _fail "seed: schema create falhou" ""; return 1; }
+  _ssb_short_sql="NULL"
+  [ -n "$_ssb_short" ] && _ssb_short_sql="'$_ssb_short'"
+  sqlite3 "$_ssb_dir/state.db" "
+    PRAGMA foreign_keys=ON;
+    INSERT INTO execution (id,schema_version,short_name,target_project_path,target_project_description,status,started_at,current_stage,next_instruction,external_urls_whitelist,circular_movement_history,initial_key_aspects,atomic_commit_enabled)
+    VALUES ('exec-1','1.0.0',$_ssb_short_sql,'/tmp/proj','desc de teste com detalhe','em_andamento','2026-07-30T00:00:00Z','specify','faca algo',' []','[]','[]',0);
+  " || { _fail "seed: insert execution falhou" ""; return 1; }
+}
+
+scenario_sqlite_init_recusa_se_state_db_existe() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" init --state-dir "$_sd" --execucao-id "exec-x" \
+    --projeto-alvo-path "/tmp/foo" --descricao "descricao valida >=10"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "init sob state.db existente" "esperado exit != 0, obtido 0"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *state.db*) : ;;
+    *) _fail "init recusa msg" "esperava mencionar state.db, obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+}
+
+scenario_sqlite_read_reconstroi_documento_valido_por_state_validate() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" "my-feat" || return 1
+  capture "$SCRIPT" read --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "read exit" "$_CAPTURED_STDERR"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | jq -e . >/dev/null \
+    || { _fail "read produz JSON invalido" "$_CAPTURED_STDOUT"; return 1; }
+  _validate_dir="$TMPDIR_TEST/validate-export"
+  mkdir -p "$_validate_dir"
+  printf '%s' "$_CAPTURED_STDOUT" > "$_validate_dir/state.json"
+  capture sh "$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-validate.sh" --state-dir "$_validate_dir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "export nao passa em state-validate.sh (E1)" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_sqlite_get_extrai_campo() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.current_stage'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "get exit" "$_CAPTURED_STDERR"; return 1; }
+  [ "$_CAPTURED_STDOUT" = "specify" ] || { _fail "get .current_stage" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+scenario_sqlite_set_top_level_scalar_conhecido() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.current_stage' --value '"plan"'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "set exit" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.current_stage'
+  [ "$_CAPTURED_STDOUT" = "plan" ] || { _fail "set nao persistiu" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+scenario_sqlite_set_campo_novo_cai_em_extra_fields() {
+  # Fidelidade de round-trip (C1) para campos de topo ainda nao modelados
+  # como coluna dedicada (gap documentado entre export.md e data-model.md).
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.next_retrospective_milestone' --value '25'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "set extra_fields exit" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.next_retrospective_milestone'
+  [ "$_CAPTURED_STDOUT" = "25" ] || { _fail "extra_fields nao persistiu" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+scenario_sqlite_set_campo_aninhado_nao_modelado_falha_alto() {
+  # Anti-silent-data-loss: path aninhado sob um campo NAO modelado nao tem
+  # fallback seguro (mesclaria dentro de extra_fields.execution e seria
+  # sombreado pela reconstrucao real na leitura) — deve falhar alto, nunca
+  # silenciosamente perder o dado.
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.execution.algum_campo_novo' --value '1'
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "set aninhado nao modelado deveria falhar" "obtido exit 0"; return 1; }
+}
+
+scenario_sqlite_set_events_substitui_array_completo() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.events' \
+    --value '[{"event_type":"lock_contention","timestamp":"2026-07-30T00:00:00Z"},{"event_type":"schedule_wait","timestamp":"2026-07-30T00:01:00Z","description":"aguardando"}]'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "set .events exit" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.events | length'
+  [ "$_CAPTURED_STDOUT" = "2" ] || { _fail "events length" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.events[1].description'
+  [ "$_CAPTURED_STDOUT" = "aguardando" ] || { _fail "events[1].description" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.events[0] | has("description")'
+  [ "$_CAPTURED_STDOUT" = "false" ] || { _fail "events[0] nao deveria ter description (ausente, nao null)" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+scenario_sqlite_set_waves_field_conhecido_e_extra() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  sqlite3 "$_sd/state.db" "INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z');" \
+    || { _fail "seed wave falhou" ""; return 1; }
+
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.waves[-1].next_wave_scheduled_for' --value '"2026-07-31T00:00:00Z"'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "set waves[-1] coluna conhecida" "$_CAPTURED_STDERR"; return 1; }
+
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.waves[-1].touched_key_aspects' --value '["foo","bar"]'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "set waves[-1] campo extra" "$_CAPTURED_STDERR"; return 1; }
+
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.waves[-1].next_wave_scheduled_for'
+  [ "$_CAPTURED_STDOUT" = "2026-07-31T00:00:00Z" ] || { _fail "waves[-1].next_wave_scheduled_for" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.waves[-1].touched_key_aspects | join(",")'
+  [ "$_CAPTURED_STDOUT" = "foo,bar" ] || { _fail "waves[-1].touched_key_aspects" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+scenario_sqlite_write_full_document_roundtrip() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  sqlite3 "$_sd/state.db" "INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z');" \
+    || { _fail "seed wave falhou" ""; return 1; }
+
+  _doc=$("$SCRIPT" read --state-dir "$_sd")
+  _newdoc=$(printf '%s' "$_doc" | jq '
+    .current_stage = "checklist"
+    | .decisions += [{"id":"dec-001","wave_id":"onda-001","timestamp":"2026-07-30T00:02:00Z","agent":"tester","stage":"specify","context":"contexto de teste com pelo menos vinte caracteres","options_considered":["a","b"],"choice":"a","rationale":"justificativa de teste com pelo menos vinte caracteres","justification_score":2,"evidence":null,"references":null,"originating_artifact":null}]
+    | .tasks += [{"task_id":"1.1","title":"t","wave_id":"onda-001","outcome":"pass","tests_run":1,"tests_passed":1,"lint_ok":true,"touched_files":["a.sh"],"recorded_at":"2026-07-30T00:04:00Z","source":"execute-task"}]
+  ')
+  # capture roda o comando do lado direito de um pipe DENTRO de um subshell
+  # em sh/dash — as variaveis _CAPTURED_* setadas la nao propagam de volta.
+  # Idioma correto (ja usado por scenario_write_recusa_json_invalido acima):
+  # gravar o payload em arquivo e envolver TODO o pipeline num unico
+  # `sh -c`, que passa a ser o comando capturado (nao o alvo de um pipe).
+  _newdoc_file="$TMPDIR_TEST/newdoc.json"
+  printf '%s' "$_newdoc" > "$_newdoc_file"
+  capture sh -c "cat '$_newdoc_file' | '$SCRIPT' write --state-dir '$_sd'"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "write exit" "$_CAPTURED_STDERR"; return 1; }
+
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.current_stage'
+  [ "$_CAPTURED_STDOUT" = "checklist" ] || { _fail "write nao persistiu current_stage" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.decisions | length'
+  [ "$_CAPTURED_STDOUT" = "1" ] || { _fail "write nao persistiu decisions" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.tasks[0].outcome'
+  [ "$_CAPTURED_STDOUT" = "pass" ] || { _fail "write nao persistiu tasks" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+scenario_sqlite_sha256_verify_ok_via_integrity_check() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" sha256-verify --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sha256-verify ok" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_sqlite_sha256_verify_corrompido_falha() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  _sz=$(wc -c < "$_sd/state.db")
+  _half=$((_sz / 2))
+  dd if="$_sd/state.db" of="$_sd/state.db.trunc" bs=1 count="$_half" 2>/dev/null
+  mv "$_sd/state.db.trunc" "$_sd/state.db"
+  capture "$SCRIPT" sha256-verify --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "sha256-verify deveria falhar sob corrupcao" "obtido exit 0"; return 1; }
+}
+
+scenario_sqlite_sha256_update_e_noop_com_exit_0() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" sha256-update --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sha256-update sob sqlite deveria ser exit 0 (C7)" "$_CAPTURED_STDERR"; return 1; }
+  [ ! -f "$_sd/state.json.sha256" ] || { _fail "sha256-update sob sqlite nao deveria criar state.json.sha256" ""; return 1; }
+}
+
+# ---- Paridade C1 (task 3.2.4): mesma sequencia de operacoes, dois backends,
+# mesmo stdout/exit code observavel nos pontos comparaveis ----
+scenario_sqlite_paridade_get_set_com_backend_json() {
+  # Backend JSON: init normal + set + get.
+  _sd_json="$TMPDIR_TEST/parity-json"
+  capture "$SCRIPT" init --state-dir "$_sd_json" --execucao-id "exec-parity" \
+    --projeto-alvo-path "/tmp/proj" --descricao "descricao de paridade valida"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "paridade: init json" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" set --state-dir "$_sd_json" --field '.current_stage' --value '"plan"'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "paridade: set json" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd_json" --field '.current_stage'
+  _json_out="$_CAPTURED_STDOUT"
+  _json_rc="$_CAPTURED_EXIT"
+
+  # Backend SQLite: schema + seed equivalente + mesmo set + get.
+  _sd_db="$TMPDIR_TEST/parity-sqlite"
+  _seed_sqlite_backend "$_sd_db" || return 1
+  capture "$SCRIPT" set --state-dir "$_sd_db" --field '.current_stage' --value '"plan"'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "paridade: set sqlite" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd_db" --field '.current_stage'
+  _db_out="$_CAPTURED_STDOUT"
+  _db_rc="$_CAPTURED_EXIT"
+
+  [ "$_json_rc" = "$_db_rc" ] || { _fail "paridade exit code" "json=$_json_rc sqlite=$_db_rc"; return 1; }
+  [ "$_json_out" = "$_db_out" ] || { _fail "paridade stdout" "json='$_json_out' sqlite='$_db_out'"; return 1; }
+}
+
+scenario_sqlite_paridade_sha256_verify_exit_0_ok() {
+  # sha256-verify: exit 0 em ambos os backends quando integro (C1/C7).
+  _sd_json="$TMPDIR_TEST/parity-sha-json"
+  capture "$SCRIPT" init --state-dir "$_sd_json" --execucao-id "exec-parity-sha" \
+    --projeto-alvo-path "/tmp/proj" --descricao "descricao de paridade valida"
+  capture "$SCRIPT" sha256-verify --state-dir "$_sd_json"
+  _json_rc="$_CAPTURED_EXIT"
+
+  _sd_db="$TMPDIR_TEST/parity-sha-sqlite"
+  _seed_sqlite_backend "$_sd_db" || return 1
+  capture "$SCRIPT" sha256-verify --state-dir "$_sd_db"
+  _db_rc="$_CAPTURED_EXIT"
+
+  [ "$_json_rc" = 0 ] || { _fail "paridade sha256-verify json exit" "obtido $_json_rc"; return 1; }
+  [ "$_db_rc" = 0 ] || { _fail "paridade sha256-verify sqlite exit" "obtido $_db_rc"; return 1; }
+}
+
+fi # sqlite3 disponivel
+
 run_all_scenarios

--- a/tests/test_state-rw.sh
+++ b/tests/test_state-rw.sh
@@ -835,6 +835,38 @@ scenario_sqlite_paridade_sha256_verify_exit_0_ok() {
   [ "$_db_rc" = 0 ] || { _fail "paridade sha256-verify sqlite exit" "obtido $_db_rc"; return 1; }
 }
 
+# Task 4.1.1/4.2.2 (FASE 4): branch de selecao de backend explicito por C2 —
+# "existe state.db => SQLite; um state.json coexistente e export/legado e
+# NUNCA consultado como fonte". Prova positiva: com os dois arquivos
+# presentes e VALORES DIVERGENTES, get/set devem refletir sempre o state.db,
+# e set nao deve tocar o state.json coexistente.
+scenario_c2_state_json_coexistente_ignorado_quando_state_db_presente() {
+  _sd="$TMPDIR_TEST/c2-coexist"
+  _seed_sqlite_backend "$_sd" || return 1  # current_stage='specify' no state.db
+
+  # state.json divergente no MESMO diretorio (simula export/legado stale).
+  mkdir -p "$_sd"
+  printf '{"current_stage":"clarify"}\n' > "$_sd/state.json"
+
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.current_stage'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2 get exit" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "specify" \
+    || { _fail "c2: get deveria refletir state.db, nao o state.json coexistente" "obtido $_CAPTURED_STDOUT"; return 1; }
+
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.current_stage' --value '"plan"'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "c2 set exit" "$_CAPTURED_STDERR"; return 1; }
+
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.current_stage'
+  assert_stdout_contains "plan" \
+    || { _fail "c2: set/get pos-mutacao deveria refletir state.db" "obtido $_CAPTURED_STDOUT"; return 1; }
+
+  # o state.json coexistente permanece intocado (script nunca escreve nele
+  # quando o backend e sqlite).
+  _stale_now=$(cat "$_sd/state.json")
+  [ "$_stale_now" = '{"current_stage":"clarify"}' ] \
+    || { _fail "c2: state.json coexistente foi modificado" "obtido: $_stale_now"; return 1; }
+}
+
 fi # sqlite3 disponivel
 
 run_all_scenarios


### PR DESCRIPTION
Implementa a fundacao do state.db: schema (waves, decisions, tasks, events, blocks, skills_invoked, gate_runs, spawns), primitivas de acesso, migracao state.json->state.db, export derivado state.json p/ compat (painel/recall) e ingestao SQL->SQL no knowledge.db. Backlog 100% concluido (9 FASEs, 31 tarefas, 103 subtarefas).

Gerado via feature-00c (execucao feat-state-db-foundation-20260730T142307Z).