### PR TITLE
fix(tests): stat GNU-first nos tests de permissao do state.db

### DIFF
--- a/tests/test__state-db.sh
+++ b/tests/test__state-db.sh
@@ -177,10 +177,12 @@ scenario_state_db_secure_perms_aplica_600_no_db_e_sidecars() {
   chmod 644 "$_db"
   [ -f "$_db-wal" ] && chmod 644 "$_db-wal" 2>/dev/null
   _state_db_secure_perms "$_db"
-  _perm_db=$(stat -f '%Lp' "$_db" 2>/dev/null || stat -c '%a' "$_db" 2>/dev/null)
+  # GNU-first: no GNU stat, `-f` e modo filesystem — imprime bloco no stdout
+  # E sai != 0, poluindo o $() com lixo concatenado ao fallback (CI Ubuntu).
+  _perm_db=$(stat -c '%a' "$_db" 2>/dev/null) || _perm_db=$(stat -f '%Lp' "$_db" 2>/dev/null)
   [ "$_perm_db" = "600" ] || { _fail "chmod db" "esperado 600, obtido $_perm_db"; return 1; }
   if [ -f "$_db-wal" ]; then
-    _perm_wal=$(stat -f '%Lp' "$_db-wal" 2>/dev/null || stat -c '%a' "$_db-wal" 2>/dev/null)
+    _perm_wal=$(stat -c '%a' "$_db-wal" 2>/dev/null) || _perm_wal=$(stat -f '%Lp' "$_db-wal" 2>/dev/null)
     [ "$_perm_wal" = "600" ] || { _fail "chmod wal" "esperado 600, obtido $_perm_wal"; return 1; }
   fi
 }

--- a/tests/test_state-db-schema.sh
+++ b/tests/test_state-db-schema.sh
@@ -55,8 +55,9 @@ scenario_create_chmod_600() {
   _db="$TMPDIR_TEST/state.db"
   capture "$SCRIPT" create --db "$_db"
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "create" "$_CAPTURED_STDERR"; return 1; }
-  _perm=$(perl -e 'printf "%03o", (stat($ARGV[0]))[2] & 07777' "$_db" 2>/dev/null \
-          || stat -f '%Lp' "$_db" 2>/dev/null || stat -c '%a' "$_db" 2>/dev/null)
+  _perm=$(perl -e 'printf "%03o", (stat($ARGV[0]))[2] & 07777' "$_db" 2>/dev/null) \
+    || _perm=$(stat -c '%a' "$_db" 2>/dev/null) \
+    || _perm=$(stat -f '%Lp' "$_db" 2>/dev/null)
   [ "$_perm" = "600" ] || { _fail "chmod" "esperado 600, obtido $_perm"; return 1; }
 }
 


### PR DESCRIPTION
Corrige a unica falha do release run 30603614827 (v6.0.0-alpha.1): `test__state-db.sh :: scenario_state_db_secure_perms_aplica_600_no_db_e_sidecars` quebrava no Ubuntu porque o `stat` estava BSD-first — no GNU, `-f` e modo filesystem (stdout poluido + exit != 0, lixo concatenado no $()). Invertida a ordem para o padrao canonico GNU-first (mesmo ja usado em `cli/lib/recall.sh` e `tests/cstk/test_recall.sh`); fallback latente de `test_state-db-schema.sh` corrigido junto.

Testado: `test__state-db` 14/14 e `test_state-db-schema` 12/12 verdes no macOS (lado BSD do fallback intacto); o lado GNU sera exercido pelo proprio CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CWkpFGn4hCrw1b8G11pMqm