### PR TITLE
fix(tests): hermeticidade da suite (HOME sandbox) + espelho de PATH sem docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,25 @@ automático. Feature executada de ponta a ponta pela pipeline `/feature-00c`
 - **`CLAUDE.md`/`SKILL.md` do runtime** documentam a camada `cstk mcp` e o
   contrato de queda mid-onda (erro de transporte ⇒ 0 retries + 1 confirmação
   via `status --live` ⇒ comutação para Bash no resto da onda).
+- **`test_serve-docker.sh` alinhado à leitura ratificada do carve-out
+  docker** (dec-074): confinamento por par (dependência, feature) —
+  `serve-docker.sh` e `mcp-docker.sh` são os arquivos confinados; novo check
+  de invocação FUNCIONAL de docker cobre todo `cli/` fora deles.
+
+### Fixed
+
+- **Hermeticidade da suite (paridade local↔CI).** `tests/run.sh` passa a
+  executar cada test file com `HOME` sandbox vazio e canonicalizado — a
+  config global do operador (`~/.claude/cstk/config`, ex.:
+  `state_backend=sqlite`) vazava para os cenários e produzia 191 FAILs
+  falsos locais com CI verde. Escape hatch de depuração:
+  `CSTK_TESTS_REAL_HOME=1`.
+- **`_path_without_docker` por espelho de diretório.** Os cenários "docker
+  ausente" (`test_mcp.sh`, `test_orchestrator-mcp-fallback.sh`) removiam o
+  diretório inteiro que contém `docker` — no CI Ubuntu isso é `/usr/bin` e
+  arrancava `sed`/`jq`/`awk` do SUT (7 FAILs no primeiro run do release
+  v6.1.0). Agora o dir é substituído por espelho com symlinks a tudo exceto
+  `docker` — `command -v docker` falha de verdade em qualquer host.
 
 ## [6.0.0] - 2026-08-01
 

--- a/tests/cstk/test_mcp.sh
+++ b/tests/cstk/test_mcp.sh
@@ -76,27 +76,45 @@ _isolated_sh_dir() {
   printf '%s' "$_ish_dir"
 }
 
-# _path_without_docker -> imprime uma copia do PATH corrente removendo
-# APENAS o(s) diretorio(s) que de fato contem um binario `docker`
-# executavel — nunca um PATH hardcoded/minimo (CLAUDE.md "PATH-stub nao
-# esconde binario de /usr/bin": um PATH artificial pode nao refletir onde
-# o SUT (aqui, o proprio binario `cstk`, que precisa de sed/jq/etc.)
-# realmente busca seus utilitarios; passa local e quebra no CI). Deriva
-# dinamicamente de $PATH — funciona independente de onde o `docker` do
-# host esteja instalado.
+# _path_without_docker -> imprime uma copia do PATH corrente em que cada
+# diretorio que contem um `docker` executavel e SUBSTITUIDO por um espelho
+# (symlinks a todo o conteudo EXCETO `docker`). A versao anterior REMOVIA o
+# diretorio inteiro — no CI Ubuntu docker mora em /usr/bin, e remover o dir
+# arrancava junto sed/jq/awk do SUT: os cenarios "docker ausente" passavam
+# local (macOS, docker em dir dedicado) e quebravam no CI com outra falha
+# que nao docker-absent (variante nova da armadilha CLAUDE.md "PATH-stub
+# nao esconde binario de /usr/bin", caso real: release v6.1.0 run
+# 30751019774). O espelho preserva todos os utilitarios e faz
+# `command -v docker` falhar de verdade em qualquer host.
 _path_without_docker() {
   _pwd_out=""
+  _pwd_mirrors="$TMPDIR_TEST/path-no-docker"
+  _pwd_n=0
   _pwd_ifs_save=$IFS
   IFS=:
   for _pwd_dir in $PATH; do
     IFS=$_pwd_ifs_save
     [ -n "$_pwd_dir" ] || continue
-    [ -x "$_pwd_dir/docker" ] && continue
+    if [ -x "$_pwd_dir/docker" ]; then
+      _pwd_n=$((_pwd_n + 1))
+      _pwd_m="$_pwd_mirrors/$_pwd_n"
+      if [ ! -d "$_pwd_m" ]; then
+        mkdir -p "$_pwd_m"
+        for _pwd_f in "$_pwd_dir"/*; do
+          [ -e "$_pwd_f" ] || continue
+          _pwd_b=${_pwd_f##*/}
+          [ "$_pwd_b" = "docker" ] && continue
+          ln -s "$_pwd_f" "$_pwd_m/$_pwd_b" 2>/dev/null || :
+        done
+      fi
+      _pwd_dir="$_pwd_m"
+    fi
     if [ -z "$_pwd_out" ]; then
       _pwd_out="$_pwd_dir"
     else
       _pwd_out="$_pwd_out:$_pwd_dir"
     fi
+    IFS=:
   done
   IFS=$_pwd_ifs_save
   printf '%s' "$_pwd_out"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -123,6 +123,15 @@ export TESTS_ROOT REPO_ROOT
 # Imprime caminho absoluto de cada test_*.sh, filtrado por PATTERN (substring
 # sobre o path) se fornecido. Cobre tests/ (toplevel) e tests/cstk/ (FASE 9.3).
 # Ordena para determinismo.
+# Limpeza do loop de execucao: tmpfile de captura + sandbox HOME (este
+# ultimo SOMENTE quando criado por nos — nunca remove o HOME real).
+_rw_cleanup() {
+  rm -f "${_TMPOUT:-}" 2>/dev/null || :
+  if [ -n "${_SANDBOX_HOME:-}" ] && [ "$_SANDBOX_HOME" != "${HOME:-}" ]; then
+    rm -rf "$_SANDBOX_HOME" 2>/dev/null || :
+  fi
+}
+
 _find_test_files() {
   _filter="${1:-}"
   _all=$(
@@ -595,8 +604,33 @@ mode_run() {
     printf 'run.sh: mktemp indisponivel\n' >&2
     return 2
   }
-  # Limpeza por trap cobre ctrl+c / term.
-  trap 'rm -f "$_TMPOUT"' EXIT INT TERM
+
+  # Hermeticidade / CI-parity: cada test file roda com HOME sandbox VAZIO —
+  # a config global do operador (ex.: ~/.claude/cstk/config com
+  # state_backend=sqlite) nao pode vazar para os cenarios. Caso real
+  # (2026-08-02): com a config sqlite presente, `state-rw.sh init` cria
+  # state.db em vez de state.json e 191 cenarios pre-existentes falham
+  # localmente enquanto o CI (HOME limpo) fica verde. O sandbox torna
+  # local == CI por construcao. Escape hatch para depurar interacao com o
+  # HOME real: CSTK_TESTS_REAL_HOME=1.
+  if [ "${CSTK_TESTS_REAL_HOME:-0}" = "1" ]; then
+    _SANDBOX_HOME="$HOME"
+  else
+    _SANDBOX_HOME=$(mktemp -d 2>/dev/null) || {
+      printf 'run.sh: mktemp -d indisponivel (sandbox HOME)\n' >&2
+      return 2
+    }
+    # Canonicaliza (pwd -P): no macOS o mktemp devolve /var/folders/... que
+    # e symlink de /private/var/... — sem isso, cenarios que comparam paths
+    # contra "$HOME" resolvido falham por divergencia literal-vs-fisico.
+    _SANDBOX_HOME=$(cd "$_SANDBOX_HOME" && pwd -P) || {
+      printf 'run.sh: falha ao canonicalizar sandbox HOME\n' >&2
+      return 2
+    }
+  fi
+
+  # Limpeza por trap cobre ctrl+c / term (sandbox so e removido se criado).
+  trap '_rw_cleanup' EXIT INT TERM
 
   _OLD_IFS="$IFS"
   IFS='
@@ -608,7 +642,7 @@ mode_run() {
 
     # Executa test em subshell, capturando stdout+stderr num tmpfile.
     # Nao abortamos se test falha (por design — _e_ o que estamos medindo).
-    sh "$_test" > "$_TMPOUT" 2>&1 || :
+    HOME="$_SANDBOX_HOME" sh "$_test" > "$_TMPOUT" 2>&1 || :
     # Reemite o output integral para o usuario (preserva TAP + diagnostico).
     cat "$_TMPOUT"
 

--- a/tests/test_orchestrator-mcp-fallback.sh
+++ b/tests/test_orchestrator-mcp-fallback.sh
@@ -123,22 +123,41 @@ scenario_resume_feat_mcp_stop_best_effort() {
 
 # ---------- 6.3.2: prova funcional (SC-004) ----------
 
-# _path_without_docker -> copia do PATH real removendo so o(s) dir(s) com
-# `docker` executavel (derivado dinamicamente — CLAUDE.md "PATH-stub nao
-# esconde binario de /usr/bin"; mesmo padrao de tests/cstk/test_mcp.sh).
+# _path_without_docker -> copia do PATH real em que cada dir com `docker`
+# executavel e SUBSTITUIDO por um espelho (symlinks a tudo EXCETO docker) —
+# remover o dir inteiro arrancava sed/jq/awk no CI Ubuntu (/usr/bin);
+# mesmo padrao e racional de tests/cstk/test_mcp.sh (caso real: release
+# v6.1.0 run 30751019774, variante da armadilha CLAUDE.md "PATH-stub nao
+# esconde binario de /usr/bin").
 _path_without_docker() {
   _pwd_out=""
+  _pwd_mirrors="$TMPDIR_TEST/path-no-docker"
+  _pwd_n=0
   _pwd_ifs_save=$IFS
   IFS=:
   for _pwd_dir in $PATH; do
     IFS=$_pwd_ifs_save
     [ -n "$_pwd_dir" ] || continue
-    [ -x "$_pwd_dir/docker" ] && continue
+    if [ -x "$_pwd_dir/docker" ]; then
+      _pwd_n=$((_pwd_n + 1))
+      _pwd_m="$_pwd_mirrors/$_pwd_n"
+      if [ ! -d "$_pwd_m" ]; then
+        mkdir -p "$_pwd_m"
+        for _pwd_f in "$_pwd_dir"/*; do
+          [ -e "$_pwd_f" ] || continue
+          _pwd_b=${_pwd_f##*/}
+          [ "$_pwd_b" = "docker" ] && continue
+          ln -s "$_pwd_f" "$_pwd_m/$_pwd_b" 2>/dev/null || :
+        done
+      fi
+      _pwd_dir="$_pwd_m"
+    fi
     if [ -z "$_pwd_out" ]; then
       _pwd_out="$_pwd_dir"
     else
       _pwd_out="$_pwd_out:$_pwd_dir"
     fi
+    IFS=:
   done
   IFS=$_pwd_ifs_save
   printf '%s' "$_pwd_out"


### PR DESCRIPTION
## Resumo

Dois bugs de ambiente que quebravam a paridade local↔CI da suite:

1. **HOME sandbox por test file** (`tests/run.sh`): a config global do operador (`~/.claude/cstk/config` com `state_backend=sqlite`) vazava para os cenários — 191 FAILs falsos locais com CI verde. Agora cada teste roda com HOME vazio canonicalizado (`pwd -P`, evita o symlink `/var/folders` do macOS). Escape hatch: `CSTK_TESTS_REAL_HOME=1`.
2. **`_path_without_docker` por espelho** (`test_mcp.sh`, `test_orchestrator-mcp-fallback.sh`): remover o diretório inteiro que contém `docker` arranca `sed`/`jq`/`awk` no CI Ubuntu (`/usr/bin`) — causa dos 7 FAILs que derrubaram o primeiro run do release v6.1.0 (30751019774). O dir agora é substituído por espelho de symlinks (tudo exceto `docker`).

Inclui a entrada de changelog na seção 6.1.0 — a tag será recriada sobre este merge.

## Testado

- Suite completa local `LC_ALL=C ./tests/run.sh`: **2311/2311 PASS, 0 FAIL** (666s), com a config sqlite do operador presente.
- `--check-coverage`: zero órfãos. shellcheck: sem findings novos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa