### PR TITLE
feat: pendencias pos-state-mcp-server — token no spawn, SEC-L1, finalize, locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [6.2.0] - 2026-08-02
+
+Fecha as quatro pendências registradas no review-task da `state-mcp-server`
+(v6.1.0): consuma a coordenação cross-feature do token de capacidade nos
+commands pai, implementa o teto de chamadas SEC-L1 no servidor MCP e corrige
+dois bugs de campo (finalize do atomic-commit e locale no otel-usage).
+
+### Added
+
+- **Injeção do token de capacidade no spawn (dec-043 consumada, SEC-H3).**
+  Os 4 commands 00c (`/agente-00c`, `/feature-00c` e resumes) leem
+  `<state-dir>/mcp-server.json` após `cstk mcp start`/`status --live` e,
+  quando `mode=docker`, injetam o `session_id` no contexto do spawn do
+  orquestrador com a instrução de preferir as tools `mcp__cstk-state__*`
+  apresentando o token em cada chamada. Token vazio/`bash-fallback` ⇒
+  prompt sem menção a MCP (zero regressão, SC-004); o token nunca é ecoado
+  em stdout/logs. Cobertura: +6 cenários em
+  `tests/test_command-spawn-mcp-lifecycle.sh`.
+- **Teto de chamadas por sessão no servidor MCP (SEC-L1/LLM10, server
+  0.4.0).** Contador único por sessão/processo compartilhado pelas 7 tools;
+  exceder rejeita com o novo código enumerado `TOOL_CALL_LIMIT_EXCEEDED`
+  (o servidor permanece de pé — o cliente comuta para Bash). Default 2000;
+  override via env `MCP_MAX_TOOL_CALLS` (allowlist: inteiro positivo;
+  inválido ⇒ default, nunca desabilitado), com passthrough no `docker run`
+  (`cli/lib/mcp-docker.sh`). Cobertura: `mcp/state-server/test/call-limit.test.ts`
+  (+3, 113 no total) e +2 cenários em `tests/cstk/test_mcp-docker.sh`.
+  Contrato atualizado em `contracts/mcp-tools.md`.
+
+### Fixed
+
+- **`commit-mode.sh finalize` consertado nas duas pontas (sug-007/sug-008,
+  regressões de campo da execução state-mcp-server).** (1) Sem
+  `--title`/`--body`, o `gh pr create` não-interativo falhava e o PR nunca
+  era criado — agora usa `--fill` como default. (2) Com PR OPEN
+  pré-existente, o finalize retornava `pr-exists` SEM empurrar a branch,
+  deixando commits locais fora do PR — agora o push acontece antes
+  (só PR MERGED dispensa push). +2 cenários com remote bare real em
+  `tests/test_commit-mode.sh`.
+- **`otel-usage.sh` pina `LC_ALL=C`.** O script parseia e emite números
+  (awk float) — sob `LANG=pt_BR.UTF-8` o separador decimal vira vírgula e
+  a agregação quebra (2 cenários de `test_otel-usage.sh` falhavam no shell
+  do operador). O pin protege produção (hooks rodando no locale do
+  operador), não apenas os testes.
+
 ## [6.1.0] - 2026-08-02
 
 Servidor MCP de estado (`cstk mcp`) — 3º pilar do estudo da v6: as primitivas
@@ -4703,6 +4747,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[6.2.0]: https://github.com/JotJunior/cstk/releases/tag/v6.2.0
 [6.1.0]: https://github.com/JotJunior/cstk/releases/tag/v6.1.0
 [6.0.0]: https://github.com/JotJunior/cstk/releases/tag/v6.0.0
 [6.0.0-alpha.2]: https://github.com/JotJunior/cstk/releases/tag/v6.0.0-alpha.2

--- a/cli/lib/mcp-docker.sh
+++ b/cli/lib/mcp-docker.sh
@@ -345,6 +345,7 @@ _mcp_docker_run() {
         -e "CSTK_MCP_ENFORCEMENT_LOG_PATH=${_MD_ENFORCEMENT_LOG_CONTAINER_PATH}" \
         -e "CSTK_MCP_STATE_DIR=${_MD_STATE_CONTAINER_DIR}" \
         -e "MCP_SESSION_TOKEN=${_mdr_token}" \
+        ${MCP_MAX_TOOL_CALLS:+-e "MCP_MAX_TOOL_CALLS=${MCP_MAX_TOOL_CALLS}"} \
         --cap-drop ALL \
         --security-opt no-new-privileges \
         --read-only \

--- a/docs/specs/state-mcp-server/contracts/mcp-tools.md
+++ b/docs/specs/state-mcp-server/contracts/mcp-tools.md
@@ -91,6 +91,7 @@ isentos de (b) — a mensagem e do Zod, nao do helper.
 | `SESSION_MISMATCH` | `session_id` nao corresponde ao token de capacidade da sessao (FR-008; ver `mcp-session-lifecycle.md` §SEC-H3) |
 | `EXECUTION_TERMINAL` | `execution.status` ∈ `abortada\|concluida` — nao se muta execucao terminal |
 | `HELPER_FAILED` | Helper POSIX retornou != 0; `reason` carrega o stderr do helper (scrubbed e limitado — ver SEC-M1) |
+| `TOOL_CALL_LIMIT_EXCEEDED` | Teto de chamadas da sessao atingido (SEC-L1/LLM10; server >= 0.4.0). Contador UNICO por sessao/processo, compartilhado entre todas as tools (inclusive `get_status`). Default 2000; override via env `MCP_MAX_TOOL_CALLS` no launcher (inteiro positivo; ausente/invalido ⇒ default — o teto nunca e desabilitado). O servidor REJEITA e permanece de pe (nunca encerra); o cliente comuta para o caminho Bash |
 
 ---
 
@@ -465,7 +466,10 @@ avancou de `0.1.0` para `0.2.0` ao registrar as 5 tools novas de F3
 (`record_decision`, `open_wave`, `record_task`, `register_human_block`,
 `get_status`) — bump **MINOR**, nao MAJOR: nenhuma tool/campo existente
 (`record_skill`) foi removido ou redefinido, mudanca puramente aditiva
-conforme a regra abaixo.
+conforme a regra abaixo. `0.4.0` (pos-v6.1.0): teto de chamadas por sessao
+(SEC-L1) — aditivo: novo codigo de erro `TOOL_CALL_LIMIT_EXCEEDED` + env
+`MCP_MAX_TOOL_CALLS`; payloads que ja passavam continuam passando enquanto
+a sessao esta dentro do teto (default folgado: 2000).
 
 - **Mudanca aditiva/retrocompativel** → bump **PATCH** ou **MINOR**:
   - Campo NOVO **opcional** no `inputSchema`, com o handler tratando a

--- a/global/commands/agente-00c-resume.md
+++ b/global/commands/agente-00c-resume.md
@@ -201,9 +201,27 @@ cstk mcp status --state-dir <SD> --live >/dev/null 2>&1 || :
 
 Se a sonda reportar `status=unavailable` (container caiu durante a
 pausa), nenhuma acao adicional AQUI — o proximo spawn segue via caminho
-Bash de hoje (o roteamento de tools MCP por token depende de 1.2,
-cross-feature). Esta task cobre so a verificacao de saude, nao a
-comutacao mid-onda (protocolo da task 5.5).
+Bash. Esta etapa cobre so a verificacao de saude, nao a comutacao
+mid-onda (protocolo da task 5.5).
+
+**Injecao do token de capacidade (dec-043 / SEC-H3)**: apos a sonda, leia
+o descritor e injete o token no contexto do spawn (mesmo protocolo do
+/agente-00c inicial):
+
+```bash
+_mcp_mode=$(jq -r '.mode // "-"' "<SD>/mcp-server.json" 2>/dev/null) || _mcp_mode="-"
+_mcp_token=""
+if [ "$_mcp_mode" = "docker" ]; then
+  _mcp_token=$(jq -r '.session_id // ""' "<SD>/mcp-server.json" 2>/dev/null) || _mcp_token=""
+fi
+```
+
+- Token NAO-vazio E sonda saudavel ⇒ linha no prompt do orquestrador:
+  `MCP: servidor de estado ativo; session_id=<token>. Prefira as tools
+  mcp__cstk-state__* apresentando ESTE session_id; em erro de transporte,
+  contrato de queda mid-onda e comutacao para Bash.`
+- Token vazio ou sonda unavailable ⇒ NAO mencione MCP no prompt (caminho
+  Bash, zero regressao). Token NUNCA ecoado em stdout/logs.
 
 ### 6. Spawnar agente-orquestrador (continuacao da pipeline)
 

--- a/global/commands/agente-00c.md
+++ b/global/commands/agente-00c.md
@@ -321,12 +321,30 @@ else
 fi
 ```
 
-> **Fora de escopo desta task (6.2.1)**: geracao/injecao do token de capacidade
-> no prompt de spawn do orquestrador (task 1.2, coordenacao
-> cross-feature) e `cstk mcp stop` no encerramento (task 6.2.3, `-resume`
-> em 6.2.2). Este passo apenas garante que, quando Docker estiver
-> disponivel, o container MCP dedicado da execucao ja esteja de pe antes
-> da primeira onda.
+> **Injecao do token de capacidade (dec-043 / SEC-H3)** — consumacao da
+> coordenacao cross-feature da task 1.2. Apos o `start`, leia o descritor
+> e injete o token no CONTEXTO do spawn do orquestrador:
+>
+> ```bash
+> _mcp_mode=$(jq -r '.mode // "-"' "<SD>/mcp-server.json" 2>/dev/null) || _mcp_mode="-"
+> _mcp_token=""
+> if [ "$_mcp_mode" = "docker" ]; then
+>   _mcp_token=$(jq -r '.session_id // ""' "<SD>/mcp-server.json" 2>/dev/null) || _mcp_token=""
+> fi
+> ```
+>
+> - `_mcp_token` NAO-vazio ⇒ inclua no prompt do orquestrador a linha:
+>   `MCP: servidor de estado ativo; session_id=<token>. Prefira as tools
+>   mcp__cstk-state__* (open_wave, record_decision, record_skill,
+>   record_task, register_human_block, close_wave, get_status)
+>   apresentando ESTE session_id em cada chamada; em erro de transporte,
+>   contrato de queda mid-onda (0 retries + 1 confirmacao via cstk mcp
+>   status --live) e comutacao para Bash no resto da onda.`
+> - `_mcp_token` vazio (`bash-fallback` / sem descritor) ⇒ NAO mencione MCP
+>   no prompt; o orquestrador segue o caminho Bash (zero regressao, SC-004).
+> - O token NUNCA e ecoado em stdout/stderr/logs do command — vive apenas
+>   no descritor (`chmod 600`) e no prompt do spawn (SEC-H3: roteamento por
+>   capacidade, nunca por precedencia).
 
 ### 4. Selecao de modelo da onda + delegacao ao orquestrador
 

--- a/global/commands/feature-00c-resume.md
+++ b/global/commands/feature-00c-resume.md
@@ -141,9 +141,25 @@ fi
 
    Se a sonda reportar `status=unavailable` (container caiu durante a
    pausa), nenhuma acao adicional AQUI — o proximo spawn segue via
-   caminho Bash de hoje (o roteamento de tools MCP por token depende de
-   1.2, cross-feature). Esta task cobre so a verificacao de saude, nao a
+   caminho Bash. Esta etapa cobre so a verificacao de saude, nao a
    comutacao mid-onda (essa e o protocolo da task 5.5).
+
+   **Injecao do token de capacidade (dec-043 / SEC-H3)**: apos a sonda,
+   leia o descritor e injete o token no contexto do spawn (mesmo protocolo
+   do /feature-00c inicial):
+
+     _mcp_mode=$(jq -r '.mode // "-"' "$AGENTE_00C_STATE_DIR/mcp-server.json" 2>/dev/null) || _mcp_mode="-"
+     _mcp_token=""
+     if [ "$_mcp_mode" = "docker" ]; then
+       _mcp_token=$(jq -r '.session_id // ""' "$AGENTE_00C_STATE_DIR/mcp-server.json" 2>/dev/null) || _mcp_token=""
+     fi
+
+   - Token NAO-vazio E sonda saudavel ⇒ linha no prompt do orquestrador:
+     `MCP: servidor de estado ativo; session_id=<token>. Prefira as tools
+     mcp__cstk-state__* apresentando ESTE session_id; em erro de
+     transporte, contrato de queda mid-onda e comutacao para Bash.`
+   - Token vazio ou sonda unavailable ⇒ NAO mencione MCP no prompt
+     (caminho Bash, zero regressao). Token NUNCA ecoado em stdout/logs.
 
 7. selecionar modelo da onda + delegar ao orquestrador
 

--- a/global/commands/feature-00c.md
+++ b/global/commands/feature-00c.md
@@ -283,12 +283,30 @@ else
 fi
 ```
 
-> **Fora de escopo desta task (6.2.1)**: geracao/injecao do token de capacidade
-> no prompt de spawn do orquestrador (task 1.2, coordenacao
-> cross-feature) e `cstk mcp stop` no encerramento (task 6.2.3, `-resume`
-> em 6.2.2). Este passo apenas garante que, quando Docker estiver
-> disponivel, o container MCP dedicado da execucao ja esteja de pe antes
-> da primeira onda.
+> **Injecao do token de capacidade (dec-043 / SEC-H3)** — consumacao da
+> coordenacao cross-feature da task 1.2. Apos o `start`, leia o descritor
+> e injete o token no CONTEXTO do spawn do orquestrador:
+>
+> ```bash
+> _mcp_mode=$(jq -r '.mode // "-"' "$AGENTE_00C_STATE_DIR/mcp-server.json" 2>/dev/null) || _mcp_mode="-"
+> _mcp_token=""
+> if [ "$_mcp_mode" = "docker" ]; then
+>   _mcp_token=$(jq -r '.session_id // ""' "$AGENTE_00C_STATE_DIR/mcp-server.json" 2>/dev/null) || _mcp_token=""
+> fi
+> ```
+>
+> - `_mcp_token` NAO-vazio ⇒ inclua no prompt do orquestrador a linha:
+>   `MCP: servidor de estado ativo; session_id=<token>. Prefira as tools
+>   mcp__cstk-state__* (open_wave, record_decision, record_skill,
+>   record_task, register_human_block, close_wave, get_status)
+>   apresentando ESTE session_id em cada chamada; em erro de transporte,
+>   contrato de queda mid-onda (0 retries + 1 confirmacao via cstk mcp
+>   status --live) e comutacao para Bash no resto da onda.`
+> - `_mcp_token` vazio (`bash-fallback` / sem descritor) ⇒ NAO mencione MCP
+>   no prompt; o orquestrador segue o caminho Bash (zero regressao, SC-004).
+> - O token NUNCA e ecoado em stdout/stderr/logs do command — vive apenas
+>   no descritor (`chmod 600`) e no prompt do spawn (SEC-H3: roteamento por
+>   capacidade, nunca por precedencia).
 
 ### 4. Selecionar modelo da onda + delegar ao orquestrador via Agent
 

--- a/global/skills/agente-00c-runtime/scripts/commit-mode.sh
+++ b/global/skills/agente-00c-runtime/scripts/commit-mode.sh
@@ -715,13 +715,27 @@ _cm_cmd_finalize() {
     [ -n "$_body" ]  && _cstk_args="$_cstk_args --body $_body"
 
     # Checar idempotencia: PR ja existe?
+    # sug-008: com PR OPEN pre-existente, o push AINDA e obrigatorio —
+    # retornar pr-exists sem empurrar deixava commits locais fora do PR
+    # (caso real: state-mcp-server, push pulado com PR #69 aberto).
     _ex_json=$(gh pr view "$_curr_branch" --json url,state 2>/dev/null) || _ex_json=""
     if [ -n "$_ex_json" ]; then
       case "$_ex_json" in
-        *'"state":"OPEN"'*|*'"state":"MERGED"'*)
+        *'"state":"OPEN"'*)
+          _ex_url=$(printf '%s' "$_ex_json" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
+          if git -C "$_pap" push -u origin "$_curr_branch" 2>/dev/null; then
+            _cm_out "finalize: PR ja existe (pr-exists), branch empurrada: $_ex_url"
+            _cm_record_result "pr-exists" "$_curr_branch" "$_ex_url" "PR pre-existente reusado; push executado"
+          else
+            _cm_err "finalize: PR existe mas 'git push' falhou — commits locais fora do PR"
+            _cm_record_result "error" "$_curr_branch" "$_ex_url" "PR pre-existente; git push falhou"
+          fi
+          return 0
+          ;;
+        *'"state":"MERGED"'*)
           _ex_url=$(printf '%s' "$_ex_json" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
           _cm_out "finalize: PR ja existe (pr-exists): $_ex_url"
-          _cm_record_result "pr-exists" "$_curr_branch" "$_ex_url" "PR pre-existente reusado"
+          _cm_record_result "pr-exists" "$_curr_branch" "$_ex_url" "PR pre-existente (merged)"
           return 0
           ;;
       esac
@@ -747,18 +761,17 @@ _cm_cmd_finalize() {
   fi
 
   # Passo 7: fallback — git push + gh pr create diretamente
-  # Idempotencia: checar PR existente
+  # sug-008: push ANTES do check de PR existente — com PR OPEN, o push
+  # continua obrigatorio (atualiza o PR); so MERGED dispensa push.
   _ex_json=$(gh pr view "$_curr_branch" --json url,state 2>/dev/null) || _ex_json=""
-  if [ -n "$_ex_json" ]; then
-    case "$_ex_json" in
-      *'"state":"OPEN"'*|*'"state":"MERGED"'*)
-        _ex_url=$(printf '%s' "$_ex_json" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
-        _cm_out "finalize: PR ja existe (pr-exists): $_ex_url"
-        _cm_record_result "pr-exists" "$_curr_branch" "$_ex_url" "PR pre-existente reusado"
-        return 0
-        ;;
-    esac
-  fi
+  case "$_ex_json" in
+    *'"state":"MERGED"'*)
+      _ex_url=$(printf '%s' "$_ex_json" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
+      _cm_out "finalize: PR ja existe (pr-exists): $_ex_url"
+      _cm_record_result "pr-exists" "$_curr_branch" "$_ex_url" "PR pre-existente (merged)"
+      return 0
+      ;;
+  esac
 
   # Push
   if ! git -C "$_pap" push -u origin "$_curr_branch" 2>/dev/null; then
@@ -768,10 +781,27 @@ _cm_cmd_finalize() {
     return 0
   fi
 
+  # PR OPEN pre-existente: push ja feito acima — reusar.
+  case "$_ex_json" in
+    *'"state":"OPEN"'*)
+      _ex_url=$(printf '%s' "$_ex_json" | sed -n 's/.*"url":"\([^"]*\)".*/\1/p')
+      _cm_out "finalize: PR ja existe (pr-exists), branch empurrada: $_ex_url"
+      _cm_record_result "pr-exists" "$_curr_branch" "$_ex_url" "PR pre-existente reusado; push executado"
+      return 0
+      ;;
+  esac
+
   # gh pr create
+  # sug-007: sem --title/--body o gh nao-interativo FALHA (era a causa de
+  # "push feito, PR nao criado" — caso real state-mcp-server). Default:
+  # --fill (titulo/corpo derivados dos commits da branch).
   _gh_args="--base $_default --head $_curr_branch"
-  [ -n "$_title" ] && _gh_args="$_gh_args --title $_title"
-  [ -n "$_body" ]  && _gh_args="$_gh_args --body $_body"
+  if [ -n "$_title" ] || [ -n "$_body" ]; then
+    [ -n "$_title" ] && _gh_args="$_gh_args --title $_title"
+    [ -n "$_body" ]  && _gh_args="$_gh_args --body $_body"
+  else
+    _gh_args="$_gh_args --fill"
+  fi
 
   _pr_url=$(eval "cd $_pap && gh pr create $_gh_args" 2>/dev/null) || _pr_url=""
   if [ -z "$_pr_url" ]; then

--- a/global/skills/agente-00c-runtime/scripts/otel-usage.sh
+++ b/global/skills/agente-00c-runtime/scripts/otel-usage.sh
@@ -111,6 +111,15 @@
 
 set -eu
 
+# Locale pinado: o script parseia e emite numeros (awk float, sort) — sob
+# locale pt_BR o printf de float produz virgula decimal e a comparacao
+# numerica quebra (caso real: 2 cenarios de test_otel-usage falhavam para
+# operadores com LANG=pt_BR.UTF-8; suite CI passa porque roda em C).
+# Pinar aqui protege PRODUCAO (hooks rodando no shell do operador), nao
+# apenas os testes.
+LC_ALL=C
+export LC_ALL
+
 _OU_NAME="otel-usage"
 # Endpoint default do exporter Prometheus do Claude Code. Override via
 # CSTK_OTEL_ENDPOINT para porta customizada (OTEL_EXPORTER_PROMETHEUS_PORT

--- a/mcp/state-server/package.json
+++ b/mcp/state-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk/state-mcp-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "MCP server exposing state.json/state.db mutation tools to the cstk 00c orchestrators (stdio transport, one container per execution).",
   "type": "module",

--- a/mcp/state-server/src/index.ts
+++ b/mcp/state-server/src/index.ts
@@ -63,7 +63,28 @@ const SERVER_NAME = "cstk-state";
 // mudanca ADITIVA (nenhuma tool/campo existente removido ou redefinido) —
 // bump MINOR conforme contracts/mcp-tools.md §Versionamento de contrato.
 // F4 (task 4.1): tool `close_wave` (atomicidade, FR-003) — tambem aditiva.
-const SERVER_VERSION = "0.3.0";
+// 0.4.0: teto de chamadas por sessao (SEC-L1/LLM10, pos-MVP consumado) —
+// aditivo (novo codigo de erro TOOL_CALL_LIMIT_EXCEEDED + env
+// MCP_MAX_TOOL_CALLS; nenhum contrato existente alterado).
+const SERVER_VERSION = "0.4.0";
+
+// SEC-L1 (LLM10 — consumo nao-limitado): teto de chamadas de tool por
+// sessao/processo. dec-093 ratificou o adiamento pos-MVP; consumado aqui.
+// budget.sh orca a ONDA (tool_calls_total ~80-142 observados) do lado do
+// orquestrador; este teto e a rede do lado do SERVIDOR contra loop
+// desgovernado de um cliente comprometido — por isso o default e folgado
+// (varias ondas na mesma sessao) e configuravel via MCP_MAX_TOOL_CALLS
+// no env do launcher (mcp-launch.sh / docker run). Allowlist do valor:
+// inteiro positivo; ausente/invalido ⇒ default (nunca desabilitado).
+const DEFAULT_MAX_TOOL_CALLS = 2000;
+
+export function parseMaxToolCalls(raw: string | undefined): number {
+  if (raw === undefined || raw === "") return DEFAULT_MAX_TOOL_CALLS;
+  if (!/^[0-9]+$/.test(raw)) return DEFAULT_MAX_TOOL_CALLS;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return DEFAULT_MAX_TOOL_CALLS;
+  return parsed;
+}
 
 /** Envelope generico de resposta de tool (accepted/rejected/stage/result — contracts/mcp-tools.md). */
 interface ToolEnvelope {
@@ -103,6 +124,30 @@ export async function bootstrap(
 
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
 
+  // SEC-L1: contador unico por processo (sessao == processo, um container
+  // por execucao). Excedeu ⇒ toda chamada subsequente e rejeitada com
+  // codigo enumerado — o cliente (orquestrador) trata como erro de tool e
+  // comuta para o caminho Bash (o teto NUNCA derruba o servidor).
+  const maxToolCalls = parseMaxToolCalls(env.MCP_MAX_TOOL_CALLS);
+  let toolCallsUsed = 0;
+  let limitWarned = false;
+  const checkCallLimit = (): ToolEnvelope | null => {
+    toolCallsUsed += 1;
+    if (toolCallsUsed <= maxToolCalls) return null;
+    if (!limitWarned) {
+      limitWarned = true;
+      console.error(
+        `${SERVER_NAME}: TOOL_CALL_LIMIT_EXCEEDED — teto de ${maxToolCalls} chamadas da sessao atingido (SEC-L1/LLM10); chamadas subsequentes serao rejeitadas`,
+      );
+    }
+    return {
+      outcome: "rejected",
+      reason: `TOOL_CALL_LIMIT_EXCEEDED: chamada ${toolCallsUsed} excede o teto de ${maxToolCalls} por sessao (SEC-L1/LLM10). Comute para o caminho Bash; se o teto for baixo para esta execucao, ajuste MCP_MAX_TOOL_CALLS no launcher`,
+      stage: null,
+      result: null,
+    };
+  };
+
   server.registerTool(
     "record_skill",
     {
@@ -112,6 +157,8 @@ export async function bootstrap(
       inputSchema: recordSkillInputShape,
     },
     async (input) => {
+      const limited = checkCallLimit();
+      if (limited) return toCallToolResult("record_skill", limited);
       const response: RecordSkillResponse = await handleRecordSkill(input, { session, env });
       return toCallToolResult("record_skill", response);
     },
@@ -126,6 +173,8 @@ export async function bootstrap(
       inputSchema: recordDecisionInputSchema,
     },
     async (input) => {
+      const limited = checkCallLimit();
+      if (limited) return toCallToolResult("record_decision", limited);
       const response: RecordDecisionResponse = await handleRecordDecision(input, { session, env });
       return toCallToolResult("record_decision", response);
     },
@@ -140,6 +189,8 @@ export async function bootstrap(
       inputSchema: openWaveInputShape,
     },
     async (input) => {
+      const limited = checkCallLimit();
+      if (limited) return toCallToolResult("open_wave", limited);
       const response: OpenWaveResponse = await handleOpenWave(input, { session, env });
       return toCallToolResult("open_wave", response);
     },
@@ -154,6 +205,8 @@ export async function bootstrap(
       inputSchema: recordTaskInputSchema,
     },
     async (input) => {
+      const limited = checkCallLimit();
+      if (limited) return toCallToolResult("record_task", limited);
       const response: RecordTaskResponse = await handleRecordTask(input, { session, env });
       return toCallToolResult("record_task", response);
     },
@@ -168,6 +221,8 @@ export async function bootstrap(
       inputSchema: registerHumanBlockInputShape,
     },
     async (input) => {
+      const limited = checkCallLimit();
+      if (limited) return toCallToolResult("register_human_block", limited);
       const response: RegisterHumanBlockResponse = await handleRegisterHumanBlock(input, {
         session,
         env,
@@ -185,6 +240,8 @@ export async function bootstrap(
       inputSchema: getStatusInputShape,
     },
     async (input) => {
+      const limited = checkCallLimit();
+      if (limited) return toCallToolResult("get_status", limited);
       const response: GetStatusResponse = await handleGetStatus(input, { session, env });
       return toCallToolResult("get_status", response);
     },
@@ -199,6 +256,8 @@ export async function bootstrap(
       inputSchema: closeWaveInputShape,
     },
     async (input) => {
+      const limited = checkCallLimit();
+      if (limited) return toCallToolResult("close_wave", limited);
       const response: CloseWaveResponse = await handleCloseWave(input, { session, env });
       return toCallToolResult("close_wave", response);
     },

--- a/mcp/state-server/test/call-limit.test.ts
+++ b/mcp/state-server/test/call-limit.test.ts
@@ -1,0 +1,99 @@
+// test/call-limit.test.ts — SEC-L1 (LLM10): teto de chamadas de tool por
+// sessao (MCP_MAX_TOOL_CALLS). Cobre: parsing/allowlist do env, rejeicao
+// enumerada TOOL_CALL_LIMIT_EXCEEDED apos o teto, contagem compartilhada
+// entre tools distintas e o invariante "o teto rejeita chamadas, nunca
+// derruba o servidor".
+//
+// Invocamos o handler registrado (`_registeredTools[name].handler` —
+// mesma via de introspeccao de test/index.test.ts; propriedade verificada
+// em node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js) — o
+// guard roda ANTES do handler da tool, entao a fixture de get_status so e
+// tocada nas chamadas dentro do teto.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { bootstrap, parseMaxToolCalls } from "../src/index.js";
+
+const FIXTURES_DIR = join(process.cwd(), "test", "fixtures");
+
+interface RegisteredTool {
+  handler: (input: Record<string, unknown>) => Promise<{
+    isError: boolean;
+    structuredContent: { outcome: string; reason: string | null };
+  }>;
+}
+
+function registeredTool(server: McpServer, name: string): RegisteredTool {
+  const withPrivateAccess = server as unknown as {
+    _registeredTools: Record<string, RegisteredTool>;
+  };
+  const tool = withPrivateAccess._registeredTools[name];
+  assert.ok(tool, `tool ${name} nao registrada`);
+  return tool;
+}
+
+function bootEnv(maxCalls?: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    MCP_SESSION_TOKEN: "synthetic-token-abc123",
+    CSTK_MCP_PROJECT_PATH: "/work",
+    CSTK_MCP_SCRIPTS_DIR: join(FIXTURES_DIR, "scripts-ok"),
+    ...(maxCalls === undefined ? {} : { MCP_MAX_TOOL_CALLS: maxCalls }),
+  };
+}
+
+test("parseMaxToolCalls: allowlist — inteiro positivo passa; ausente/invalido/zero caem no default", () => {
+  const def = parseMaxToolCalls(undefined);
+  assert.ok(def >= 1, "default deve ser positivo");
+  assert.equal(parseMaxToolCalls("7"), 7);
+  assert.equal(parseMaxToolCalls(""), def);
+  assert.equal(parseMaxToolCalls("0"), def);
+  assert.equal(parseMaxToolCalls("-5"), def);
+  assert.equal(parseMaxToolCalls("abc"), def);
+  assert.equal(parseMaxToolCalls("1,5"), def);
+  assert.equal(parseMaxToolCalls("2e3"), def);
+});
+
+test("SEC-L1: chamada alem do teto e rejeitada com TOOL_CALL_LIMIT_EXCEEDED (contagem compartilhada entre tools)", async () => {
+  const server = await bootstrap(bootEnv("2"));
+  const getStatus = registeredTool(server, "get_status");
+  const input = { session_id: "synthetic-token-abc123" };
+
+  // Chamadas 1 e 2: dentro do teto — o guard deixa passar (o resultado do
+  // handler em si depende da fixture; o que o teto NAO pode fazer e
+  // rejeitar com o codigo de limite).
+  for (let i = 0; i < 2; i += 1) {
+    const res = await getStatus.handler(input);
+    assert.ok(
+      !(res.structuredContent.reason ?? "").includes("TOOL_CALL_LIMIT_EXCEEDED"),
+      `chamada ${i + 1} dentro do teto nao pode ser rejeitada por limite`,
+    );
+  }
+
+  // Chamada 3 (via OUTRA tool): excede — contador e por sessao, nao por tool.
+  const openWave = registeredTool(server, "open_wave");
+  const res3 = await openWave.handler({ session_id: "synthetic-token-abc123" });
+  assert.equal(res3.isError, true);
+  assert.equal(res3.structuredContent.outcome, "rejected");
+  assert.ok(
+    (res3.structuredContent.reason ?? "").includes("TOOL_CALL_LIMIT_EXCEEDED"),
+    `esperado TOOL_CALL_LIMIT_EXCEEDED, obtido: ${res3.structuredContent.reason}`,
+  );
+
+  // Invariante: o servidor continua de pe e respondendo (rejeita, nao cai).
+  const res4 = await getStatus.handler(input);
+  assert.equal(res4.isError, true);
+  assert.ok((res4.structuredContent.reason ?? "").includes("TOOL_CALL_LIMIT_EXCEEDED"));
+});
+
+test("SEC-L1: MCP_MAX_TOOL_CALLS invalido cai no default folgado (nunca desabilita nem trava em zero)", async () => {
+  const server = await bootstrap(bootEnv("nao-numerico"));
+  const getStatus = registeredTool(server, "get_status");
+  const res = await getStatus.handler({ session_id: "synthetic-token-abc123" });
+  assert.ok(
+    !(res.structuredContent.reason ?? "").includes("TOOL_CALL_LIMIT_EXCEEDED"),
+    "com valor invalido o default (folgado) vale — 1a chamada jamais e rejeitada por limite",
+  );
+});

--- a/tests/cstk/test_mcp-docker.sh
+++ b/tests/cstk/test_mcp-docker.sh
@@ -445,6 +445,39 @@ scenario_run_env_cstk_mcp_state_dir_container_mode() {
   esac
 }
 
+# SEC-L1 (pos-v6.1.0): MCP_MAX_TOOL_CALLS do ambiente do operador e
+# repassado ao container QUANDO setado; ausente => nenhum -e extra (o
+# servidor usa o default interno).
+scenario_run_env_max_tool_calls_passthrough() {
+  _make_bin_dir
+  _stub_docker "$_STUB_BIN"
+  _setup_run_fixture
+  MCP_MAX_TOOL_CALLS=350
+  export MCP_MAX_TOOL_CALLS
+  _run_mcp_docker_fn _mcp_docker_run "cstk-mcp-state-demo" "cstk-mcp-state:test" \
+    "$_RF_STATE_DIR" "$_RF_SCRIPTS_DIR" "$_RF_LOG_PATH" "$_RF_PROJECT_PATH" "tok3n"
+  unset MCP_MAX_TOOL_CALLS
+  _line=$(_docker_run_line)
+  case "$_line" in
+    *'-e MCP_MAX_TOOL_CALLS=350'*) : ;;
+    *) _fail "run_env_max_tool_calls" "faltou -e MCP_MAX_TOOL_CALLS=350 (SEC-L1): $_line"; return 1 ;;
+  esac
+}
+
+scenario_run_env_max_tool_calls_ausente_sem_flag() {
+  _make_bin_dir
+  _stub_docker "$_STUB_BIN"
+  _setup_run_fixture
+  unset MCP_MAX_TOOL_CALLS 2>/dev/null || :
+  _run_mcp_docker_fn _mcp_docker_run "cstk-mcp-state-demo" "cstk-mcp-state:test" \
+    "$_RF_STATE_DIR" "$_RF_SCRIPTS_DIR" "$_RF_LOG_PATH" "$_RF_PROJECT_PATH" "tok3n"
+  _line=$(_docker_run_line)
+  case "$_line" in
+    *'MCP_MAX_TOOL_CALLS'*) _fail "run_env_max_tool_calls_ausente" "flag nao deveria aparecer sem env: $_line"; return 1 ;;
+    *) : ;;
+  esac
+}
+
 # 5.2.3 — assercao estatica obrigatoria: nenhuma linha `docker run` monta
 # .claude como DIRETORIO, $HOME, /, ou docker.sock (SEC-H2). O fixture
 # acima ja coloca o enforcement-log SOB .claude/ deliberadamente -- esta

--- a/tests/test_command-spawn-mcp-lifecycle.sh
+++ b/tests/test_command-spawn-mcp-lifecycle.sh
@@ -126,16 +126,51 @@ scenario_resume_feat_nao_para_em_aguardando_humano() {
   assert_exit 0 grep -Eq 'aguardando_humano.*NAO e terminal|NAO e terminal' "$CMD_RES_FEAT" || return 1
 }
 
-# ==== 6.2.4: token de capacidade explicitamente adiado (fora do escopo) ====
+# ==== dec-043 (consumada): injecao do token de capacidade no spawn ====
+# A coordenacao cross-feature da task 1.2 foi CONSUMADA pos-v6.1.0: os 4
+# commands leem o descritor mcp-server.json e injetam o session_id no
+# contexto do spawn do orquestrador (SEC-H3: capacidade, nunca precedencia).
 
-scenario_init_agente_documenta_token_fora_de_escopo() {
+scenario_init_agente_injeta_token_no_spawn() {
   assert_exit 0 grep -Eiq 'token de capacidade' "$CMD_INIT_AGENTE" || return 1
-  assert_exit 0 grep -Eiq 'fora de escopo|cross-feature' "$CMD_INIT_AGENTE" || return 1
+  assert_exit 0 grep -Eq 'mcp-server\.json' "$CMD_INIT_AGENTE" || return 1
+  assert_exit 0 grep -Eq '\.session_id' "$CMD_INIT_AGENTE" || return 1
+  assert_exit 0 grep -Eq 'mcp__cstk-state__' "$CMD_INIT_AGENTE" || return 1
 }
 
-scenario_init_feat_documenta_token_fora_de_escopo() {
+scenario_init_feat_injeta_token_no_spawn() {
   assert_exit 0 grep -Eiq 'token de capacidade' "$CMD_INIT_FEAT" || return 1
-  assert_exit 0 grep -Eiq 'fora de escopo|cross-feature' "$CMD_INIT_FEAT" || return 1
+  assert_exit 0 grep -Eq 'mcp-server\.json' "$CMD_INIT_FEAT" || return 1
+  assert_exit 0 grep -Eq '\.session_id' "$CMD_INIT_FEAT" || return 1
+  assert_exit 0 grep -Eq 'mcp__cstk-state__' "$CMD_INIT_FEAT" || return 1
+}
+
+scenario_resume_agente_injeta_token_no_spawn() {
+  assert_exit 0 grep -Eq 'mcp-server\.json' "$CMD_RES_AGENTE" || return 1
+  assert_exit 0 grep -Eq '\.session_id' "$CMD_RES_AGENTE" || return 1
+  assert_exit 0 grep -Eq 'mcp__cstk-state__' "$CMD_RES_AGENTE" || return 1
+}
+
+scenario_resume_feat_injeta_token_no_spawn() {
+  assert_exit 0 grep -Eq 'mcp-server\.json' "$CMD_RES_FEAT" || return 1
+  assert_exit 0 grep -Eq '\.session_id' "$CMD_RES_FEAT" || return 1
+  assert_exit 0 grep -Eq 'mcp__cstk-state__' "$CMD_RES_FEAT" || return 1
+}
+
+scenario_token_nunca_ecoado_em_logs() {
+  # Os 4 arquivos declaram explicitamente que o token nao vai a stdout/logs.
+  for _f in "$CMD_INIT_AGENTE" "$CMD_INIT_FEAT" "$CMD_RES_AGENTE" "$CMD_RES_FEAT"; do
+    grep -Eiq 'token NUNCA e? ?ecoado' "$_f" \
+      || { _fail "declaracao de nao-eco do token ausente" "$_f"; return 1; }
+  done
+}
+
+scenario_token_fallback_sem_mcp_no_prompt() {
+  # Token vazio => prompt sem mencao a MCP (zero regressao, SC-004).
+  for _f in "$CMD_INIT_AGENTE" "$CMD_INIT_FEAT" "$CMD_RES_AGENTE" "$CMD_RES_FEAT"; do
+    grep -Eiq 'NAO mencione MCP' "$_f" \
+      || { _fail "instrucao de fallback sem-MCP ausente" "$_f"; return 1; }
+  done
 }
 
 # ==== Best-effort: chamadas MCP nunca abortam a pipeline (FR-007/FR-012) ====

--- a/tests/test_commit-mode.sh
+++ b/tests/test_commit-mode.sh
@@ -776,4 +776,124 @@ scenario_5_3_5_roundtrip_git_show_alien_ausente() {
   esac
 }
 
+# ==== sug-008: PR OPEN pre-existente NAO dispensa o push ====
+# Regressao de campo (state-mcp-server): finalize retornava pr-exists sem
+# empurrar, deixando commits locais fora do PR aberto.
+
+scenario_finalize_pr_aberto_ainda_empurra_push() {
+  _gdir="$TMPDIR_TEST/repo-propen"
+  _sd="$TMPDIR_TEST/fin-propen"
+  _init_state "$_sd" true
+  _init_git_repo "$_gdir" "feat/pr-open"
+
+  git -C "$_gdir" branch main 2>/dev/null || :
+  git -C "$_gdir" update-ref refs/remotes/origin/main "$(git -C "$_gdir" rev-parse main)" 2>/dev/null || :
+  git -C "$_gdir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || :
+
+  # Remote REAL (bare) para o push acontecer de verdade.
+  _bare="$TMPDIR_TEST/origin-propen.git"
+  git init -q --bare "$_bare" 2>/dev/null
+  git -C "$_gdir" remote add origin "$_bare" 2>/dev/null
+
+  printf 'change\n' >> "$_gdir/README.md"
+  git -C "$_gdir" add README.md 2>/dev/null
+  git -C "$_gdir" commit -q -m "feat: change" 2>/dev/null
+  _head_sha=$(git -C "$_gdir" rev-parse HEAD)
+
+  # gh stub: autenticado; pr view responde OPEN; pr create NUNCA deve rodar.
+  _stub="$TMPDIR_TEST/stub-propen"
+  mkdir -p "$_stub"
+  cat > "$_stub/gh" <<GHEOF
+#!/bin/sh
+case "\$1 \$2" in
+  "auth status") exit 0 ;;
+  "pr view")     printf '{"url":"https://example.test/pr/1","state":"OPEN"}\n'; exit 0 ;;
+  "pr create")   printf 'create-nao-deveria-rodar\n' >> "$_stub/pr-create-called"; exit 1 ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_stub/gh"
+
+  _orig_path="$PATH"
+  PATH="$_stub:$_orig_path"
+  export PATH
+
+  capture "$SCRIPT" finalize --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  _fin_exit=$_CAPTURED_EXIT
+  _fin_out=$_CAPTURED_STDOUT
+
+  PATH="$_orig_path"
+  export PATH
+
+  [ "$_fin_exit" = 0 ] || { _fail "exit esperado 0" "obtido $_fin_exit"; return 1; }
+  printf '%s' "$_fin_out" | grep -q '"status":"pr-exists"' \
+    || { _fail "status esperado pr-exists" "stdout: $_fin_out"; return 1; }
+  # A prova do sug-008: o remoto bare TEM o commit local apos o finalize.
+  _remote_sha=$(git -C "$_bare" rev-parse refs/heads/feat/pr-open 2>/dev/null) || _remote_sha=""
+  [ "$_remote_sha" = "$_head_sha" ] \
+    || { _fail "push nao aconteceu com PR OPEN (sug-008)" "remoto=$_remote_sha esperado=$_head_sha"; return 1; }
+  [ ! -f "$_stub/pr-create-called" ] \
+    || { _fail "pr create nao deveria rodar com PR pre-existente" "foi chamado"; return 1; }
+}
+
+# ==== sug-007: sem --title/--body, pr create usa --fill ====
+# Regressao de campo: gh nao-interativo FALHA sem title/body — finalize
+# empurrava a branch e nunca criava o PR.
+
+scenario_finalize_sem_titulo_usa_fill() {
+  _gdir="$TMPDIR_TEST/repo-fill"
+  _sd="$TMPDIR_TEST/fin-fill"
+  _init_state "$_sd" true
+  _init_git_repo "$_gdir" "feat/fill"
+
+  git -C "$_gdir" branch main 2>/dev/null || :
+  git -C "$_gdir" update-ref refs/remotes/origin/main "$(git -C "$_gdir" rev-parse main)" 2>/dev/null || :
+  git -C "$_gdir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || :
+
+  _bare="$TMPDIR_TEST/origin-fill.git"
+  git init -q --bare "$_bare" 2>/dev/null
+  git -C "$_gdir" remote add origin "$_bare" 2>/dev/null
+
+  printf 'change\n' >> "$_gdir/README.md"
+  git -C "$_gdir" add README.md 2>/dev/null
+  git -C "$_gdir" commit -q -m "feat: change" 2>/dev/null
+
+  # gh stub: sem PR previo (view falha); pr create grava argv e responde URL.
+  _stub="$TMPDIR_TEST/stub-fill"
+  mkdir -p "$_stub"
+  cat > "$_stub/gh" <<GHEOF
+#!/bin/sh
+case "\$1 \$2" in
+  "auth status") exit 0 ;;
+  "pr view")     exit 1 ;;
+  "pr create")   printf '%s\n' "\$*" > "$_stub/pr-create-args"
+                 printf 'https://example.test/pr/2\n'; exit 0 ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_stub/gh"
+
+  _orig_path="$PATH"
+  PATH="$_stub:$_orig_path"
+  export PATH
+
+  capture "$SCRIPT" finalize --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  _fin_exit=$_CAPTURED_EXIT
+  _fin_out=$_CAPTURED_STDOUT
+
+  PATH="$_orig_path"
+  export PATH
+
+  [ "$_fin_exit" = 0 ] || { _fail "exit esperado 0" "obtido $_fin_exit"; return 1; }
+  [ -f "$_stub/pr-create-args" ] \
+    || { _fail "gh pr create nao foi invocado (sug-007)" "stdout: $_fin_out"; return 1; }
+  grep -q -- '--fill' "$_stub/pr-create-args" \
+    || { _fail "esperado --fill nos args do pr create" "args: $(cat "$_stub/pr-create-args")"; return 1; }
+  if grep -q -- '--title' "$_stub/pr-create-args"; then
+    _fail "--title nao deveria aparecer sem input do operador" "args: $(cat "$_stub/pr-create-args")"; return 1
+  fi
+  printf '%s' "$_fin_out" | grep -q '"status":"pr-opened"' \
+    || { _fail "status esperado pr-opened" "stdout: $_fin_out"; return 1; }
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Resumo

Fecha as 4 pendências do review-task da state-mcp-server (v6.1.0):

1. **Token de capacidade no spawn (dec-043 consumada)** — os 4 commands 00c leem `mcp-server.json` e injetam o `session_id` no contexto do spawn do orquestrador (SEC-H3, fail-safe para Bash sem token, nunca ecoado em logs).
2. **SEC-L1 (server 0.4.0)** — teto de chamadas por sessão nas 7 tools (`TOOL_CALL_LIMIT_EXCEEDED`, default 2000, `MCP_MAX_TOOL_CALLS` com passthrough no docker run; servidor rejeita e permanece de pé).
3. **`commit-mode.sh finalize`** — sug-007 (`--fill` quando sem título/corpo) e sug-008 (push com PR OPEN pré-existente).
4. **`otel-usage.sh`** — pina `LC_ALL=C` (parsing numérico quebrava sob pt_BR no shell do operador).

## Testado

- Suite shell completa `LC_ALL=C ./tests/run.sh`: **2319/2319 PASS** (620s), incluindo 10 cenários novos.
- `mcp/state-server`: **113/113 `node:test`** via docker (`npm ci` + build isolados no container).
- shellcheck sem findings novos; `--check-coverage` zero órfãos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa