### PR TITLE
fix(mcp): mcp-launch serve stub idle sem execucao ativa — elimina -32000 no boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [6.2.1] - 2026-08-02
+
+### Fixed
+
+- **`Failed to reconnect to cstk-state: -32000` em todo boot de sessão sem
+  execução 00c ativa.** A entrada estática do `.mcp.json` (`cstk mcp
+  install`) é conectada pelo harness em todo boot, mas `mcp-launch.sh`
+  saía com exit 3 quando não havia token/execução — o caso mais comum —
+  e o harness reportava a conexão como falha. O launcher agora serve um
+  **stub MCP idle** (sh+jq, JSON-RPC newline-delimited): `initialize`
+  ecoando o `protocolVersion` do cliente, `tools/list` com lista vazia
+  (zero mutação possível — SEC-H3 intacto), `ping`, `-32601` para o
+  resto; EOF encerra com exit 0. O `/mcp` passa a mostrar `cstk-state`
+  conectado (validado E2E com `claude mcp list`: ✔ Connected). Token
+  fornecido e divergente segue exit 3 (violação de capacidade);
+  `jq`/`mcp-session.sh` ausentes seguem exit 1 (mecanismo). Para anexar
+  ao container após `cstk mcp start`, reconecte o MCP ou abra sessão
+  nova. +2 cenários em `tests/test_mcp-launch.sh`; contrato atualizado em
+  `contracts/mcp-session-lifecycle.md`.
+
 ## [6.2.0] - 2026-08-02
 
 Fecha as quatro pendências registradas no review-task da `state-mcp-server`
@@ -4747,6 +4767,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[6.2.1]: https://github.com/JotJunior/cstk/releases/tag/v6.2.1
 [6.2.0]: https://github.com/JotJunior/cstk/releases/tag/v6.2.0
 [6.1.0]: https://github.com/JotJunior/cstk/releases/tag/v6.1.0
 [6.0.0]: https://github.com/JotJunior/cstk/releases/tag/v6.0.0

--- a/docs/specs/state-mcp-server/contracts/mcp-session-lifecycle.md
+++ b/docs/specs/state-mcp-server/contracts/mcp-session-lifecycle.md
@@ -50,6 +50,24 @@ Deliberadamente **sem `env` com valores interpolados**: a sintaxe exata de
 expansao de variaveis em `.mcp.json` e [NAO-VERIFICADO] (spike S5). O launcher
 descobre tudo do disco — nao depende de env injetada pelo harness.
 
+**Modo IDLE do launcher** (fix pos-v6.2.0; bug observado: `Failed to
+reconnect to cstk-state: -32000` em todo boot de sessao sem execucao 00c
+ativa): a entrada estatica e conectada pelo harness em TODO boot, entao a
+ausencia de execucao NAO pode ser tratada como erro. Sem
+`MCP_SESSION_TOKEN` (boot normal) ou com execucao resolvida sem container
+(`mode=bash-fallback`/stopped), `mcp-launch.sh` serve um stub MCP minimo
+em sh+jq (JSON-RPC newline-delimited [VERIFICADO:
+`@modelcontextprotocol/sdk` `shared/stdio.js` — `JSON.stringify(msg) +
+'\n'`]): responde `initialize` (ecoa o `protocolVersion` do cliente),
+`tools/list` com lista **VAZIA** e `ping`; metodo desconhecido com `id`
+recebe `-32601`; EOF encerra com exit 0. Zero tools ⇒ zero mutacao
+possivel — SEC-H3 permanece intacto. Token **fornecido** e divergente
+segue exit 3 barulhento (violacao de capacidade, nunca degrada para
+idle); `jq`/`mcp-session.sh` ausentes seguem exit 1 (falha de mecanismo).
+Para anexar ao container depois de `cstk mcp start`, reconectar o MCP
+(`/mcp` → reconnect) ou abrir sessao nova. Cobertura:
+`tests/test_mcp-launch.sh` (idle sem token, handshake, bash-fallback).
+
 ### `cstk mcp status [--state-dir DIR] [--project-path PATH]`
 
 **Satisfaz FR-015**: responde sem que o operador inspecione Docker.

--- a/global/skills/agente-00c-runtime/scripts/mcp-launch.sh
+++ b/global/skills/agente-00c-runtime/scripts/mcp-launch.sh
@@ -24,12 +24,23 @@
 # SINTETICO exportado na mesma env cobre o roteamento (mesmo mecanismo
 # ja usado pelos testes de mcp-session.sh/task 1.3).
 #
-# Falha de resolucao (token ausente/invalido/colisao, ou sessao sem
-# container docker ativo) => exit != 0 SEM tentar `docker attach` — o
-# harness reporta a tool como indisponivel para ESTA sessao, mas isso
-# nunca bloqueia a execucao: o command pai ja decidiu ANTES do spawn (via
-# `cstk mcp status`) se usa o caminho MCP ou o caminho Bash de sempre
-# (FR-007/FR-012) — este script nunca e o unico guardiao dessa decisao.
+# AUSENCIA GRACIOSA (modo IDLE — fix pos-v6.2.0, bug "-32000 no boot"):
+# a entrada do `.mcp.json` e estatica e o harness a conecta em TODO boot
+# de sessao — inclusive (caso mais comum) sem nenhuma execucao 00c ativa.
+# Sair com exit != 0 aqui fazia o harness reportar "Failed to reconnect
+# to cstk-state: -32000" em toda sessao normal. Em vez disso:
+#   - SEM token de sessao (MCP_SESSION_TOKEN vazio — boot normal), ou
+#     sessao resolvida SEM container docker (mode=bash-fallback/stopped):
+#     servir um stub MCP IDLE em sh+jq — responde initialize/tools/list
+#     (ZERO tools)/ping e nada mais. Zero tools => zero mutacao possivel
+#     (SEC-H3 intacto); o /mcp mostra o servidor conectado, sem erro.
+#   - Token FORNECIDO e divergente => exit 3 barulhento (violacao de
+#     capacidade, nunca e caso benigno).
+#   - Falha de MECANISMO (mcp-session.sh/jq ausentes) => exit 1 barulhento.
+# O command pai segue decidindo ANTES do spawn (via `cstk mcp status`) se
+# a onda usa o caminho MCP ou o Bash (FR-007/FR-012) — este script nunca
+# e o unico guardiao dessa decisao. Para anexar ao container depois de
+# `cstk mcp start`, reconecte o MCP (/mcp) ou abra sessao nova.
 #
 # `exec docker attach <container>` substitui o PROCESSO deste script
 # (nao um subshell) — o stdio do harness passa a falar DIRETAMENTE com o
@@ -43,12 +54,12 @@
 # mcp-session.sh (jq, indiretamente).
 #
 # Exit codes:
-#   0  nunca observado em uso normal (docker attach so retorna quando a
-#      sessao MCP encerra do lado do container — o proprio exit code do
-#      attach e propagado via exec)
-#   1  erro de resolucao (mcp-session.sh ausente, docker ausente)
-#   3  SESSION_MISMATCH (propagado de mcp-session.sh resolve) ou sessao
-#      resolvida sem container docker ativo (mode != docker)
+#   0  modo IDLE encerrado por EOF do harness (sessao fechou), ou attach
+#      encerrado normalmente
+#   1  falha de MECANISMO (mcp-session.sh ausente, jq ausente no idle,
+#      docker ausente quando a sessao exige attach)
+#   3  SESSION_MISMATCH com token FORNECIDO (violacao de capacidade —
+#      nunca degrada para idle)
 
 set -eu
 
@@ -57,6 +68,42 @@ _ML_NAME="mcp-launch"
 _ml_die() {
   printf '%s: %s\n' "$_ML_NAME" "$1" >&2
   exit "${2:-1}"
+}
+
+# Stub MCP idle: JSON-RPC newline-delimited (framing VERIFICADO em
+# @modelcontextprotocol/sdk dist/esm/shared/stdio.js — serialize =
+# JSON.stringify(msg) + '\n'). Responde o minimo do protocolo com ZERO
+# tools; tudo que tem id e nao e reconhecido recebe -32601. EOF => exit 0.
+_ml_idle_serve() {
+  printf '%s: %s — servindo em modo IDLE (0 tools). Apos iniciar uma execucao 00c com Docker (`cstk mcp start` via command pai), reconecte o MCP (/mcp) para anexar ao container.\n' \
+    "$_ML_NAME" "$1" >&2
+  command -v jq >/dev/null 2>&1 || _ml_die "jq necessario para o modo idle"
+  while IFS= read -r _ml_line; do
+    [ -n "$_ml_line" ] || continue
+    _ml_method=$(printf '%s' "$_ml_line" | jq -r '.method // ""' 2>/dev/null) || continue
+    case "$_ml_method" in
+      initialize)
+        printf '%s' "$_ml_line" | jq -c \
+          '{jsonrpc:"2.0", id:.id, result:{protocolVersion:(.params.protocolVersion // "2024-11-05"), capabilities:{tools:{}}, serverInfo:{name:"cstk-state-idle", version:"idle"}}}'
+        ;;
+      tools/list)
+        printf '%s' "$_ml_line" | jq -c '{jsonrpc:"2.0", id:.id, result:{tools:[]}}'
+        ;;
+      ping)
+        printf '%s' "$_ml_line" | jq -c '{jsonrpc:"2.0", id:.id, result:{}}'
+        ;;
+      notifications/*)
+        : # notificacoes nao recebem resposta
+        ;;
+      *)
+        if printf '%s' "$_ml_line" | jq -e 'has("id")' >/dev/null 2>&1; then
+          printf '%s' "$_ml_line" | jq -c \
+            '{jsonrpc:"2.0", id:.id, error:{code:-32601, message:"cstk-state em modo idle: nenhuma execucao 00c ativa"}}'
+        fi
+        ;;
+    esac
+  done
+  exit 0
 }
 
 # Diretorio deste proprio script — mcp-session.sh vive ao lado dele tanto
@@ -69,13 +116,18 @@ _ml_session_sh="$_ml_script_dir/mcp-session.sh"
 [ -f "$_ml_session_sh" ] || _ml_die "mcp-session.sh nao encontrado em $_ml_script_dir"
 [ -x "$_ml_session_sh" ] || _ml_die "mcp-session.sh sem permissao de execucao em $_ml_script_dir"
 
-command -v docker >/dev/null 2>&1 || _ml_die "docker nao encontrado no PATH"
-
 # Project-path: o harness invoca com CWD = raiz do projeto-alvo (onde
 # vive o .mcp.json que referencia este script — doc oficial do .mcp.json,
 # nao [VERIFICADO] neste repo). Override via CSTK_MCP_PROJECT_PATH para
 # testes/dev, onde o CWD do processo pode nao ser o projeto-alvo.
 _ml_project_path="${CSTK_MCP_PROJECT_PATH:-$(pwd)}"
+
+# Sem token de sessao = boot normal do harness fora de execucao 00c — o
+# caso mais comum. Nao ha o que rotear (mutacao exige token, SEC-H3):
+# modo idle, nunca erro.
+if [ -z "${MCP_SESSION_TOKEN:-}" ]; then
+  _ml_idle_serve "nenhuma execucao 00c ativa nesta sessao (sem token)"
+fi
 
 if _ml_resolved=$("$_ml_session_sh" resolve --project-path "$_ml_project_path" 2>&1); then
   _ml_rc=0
@@ -84,6 +136,8 @@ else
 fi
 
 if [ "$_ml_rc" -ne 0 ]; then
+  # Token FORNECIDO e resolucao falhou: capacidade divergente/colisao —
+  # NUNCA degrada para idle (SEC-H3), falha barulhenta como antes.
   printf '%s: resolve falhou (exit %s): %s\n' "$_ML_NAME" "$_ml_rc" "$_ml_resolved" >&2
   exit "$_ml_rc"
 fi
@@ -92,8 +146,12 @@ _ml_container=$(printf '%s\n' "$_ml_resolved" | sed -n 's/^container=//p')
 _ml_mode=$(printf '%s\n' "$_ml_resolved" | sed -n 's/^mode=//p')
 
 if [ "$_ml_mode" != "docker" ] || [ -z "$_ml_container" ] || [ "$_ml_container" = "-" ]; then
-  _ml_die "sessao resolvida sem container docker ativo (mode=${_ml_mode:-'-'} container=${_ml_container:-'-'}) — nada para conectar" 3
+  # Execucao ativa mas sem container (bash-fallback/stopped): benigno —
+  # a onda roda pelo caminho Bash; o MCP fica conectado em idle.
+  _ml_idle_serve "execucao resolvida sem container docker (mode=${_ml_mode:-'-'})"
 fi
+
+command -v docker >/dev/null 2>&1 || _ml_die "docker nao encontrado no PATH (sessao exige attach)"
 
 # exec: substitui este processo — o stdio do harness passa a ser o stdio
 # do container (mantido aberto desde `docker run -d -i` em

--- a/tests/test_mcp-launch.sh
+++ b/tests/test_mcp-launch.sh
@@ -69,13 +69,40 @@ _run_launch() {
   fi
 }
 
-scenario_sem_token_exit_3_sem_chamar_docker() {
+# Fix "-32000 no boot": sem token (boot normal do harness, nenhuma
+# execucao 00c ativa) o launcher NAO pode morrer — serve o stub MCP idle
+# e encerra 0 no EOF do stdin.
+scenario_sem_token_serve_idle_exit_0() {
   _proj="$TMPDIR_TEST/proj1"
   mkdir -p "$_proj"
   _run_launch "$_proj"
-  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "sem token exit" "esperado 3, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sem token exit" "esperado 0 (idle), obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "modo IDLE" || return 1
   case "$(_docker_launch_calls)" in
     *attach*) _fail "docker attach nao deveria ter sido chamado" "$(_docker_launch_calls)"; return 1 ;;
+  esac
+}
+
+# Handshake do stub idle: initialize ecoa o protocolVersion do cliente,
+# tools/list responde lista VAZIA (zero mutacao possivel — SEC-H3),
+# metodo desconhecido com id recebe -32601.
+scenario_idle_handshake_initialize_e_tools_vazio() {
+  _proj="$TMPDIR_TEST/proj1b"
+  mkdir -p "$_proj"
+  _hs_in="$TMPDIR_TEST/idle-handshake-in"
+  printf '%s\n%s\n%s\n%s\n' \
+    '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}' \
+    '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
+    '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+    '{"jsonrpc":"2.0","id":3,"method":"prompts/list"}' > "$_hs_in"
+  capture sh -c 'env CSTK_MCP_PROJECT_PATH="$1" "$2" < "$3"' _ "$_proj" "$SCRIPT" "$_hs_in"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "idle handshake exit" "esperado 0, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains '"protocolVersion":"2025-06-18"' || return 1
+  assert_stdout_contains '"tools":[]' || return 1
+  assert_stdout_contains '"code":-32601' || return 1
+  # Notificacao nao gera resposta: nenhuma linha com id nulo/ausente.
+  case "$_CAPTURED_STDOUT" in
+    *'"id":null'*) _fail "notificacao nao deveria receber resposta" "$_CAPTURED_STDOUT"; return 1 ;;
   esac
 }
 
@@ -90,13 +117,16 @@ scenario_token_desconhecido_exit_3_sem_chamar_docker() {
   esac
 }
 
-scenario_sessao_bash_fallback_exit_3_sem_chamar_docker() {
+# Execucao ativa mas SEM container (bash-fallback): benigno — a onda roda
+# pelo caminho Bash e o launcher serve idle em vez de morrer.
+scenario_sessao_bash_fallback_serve_idle_exit_0() {
   _proj="$TMPDIR_TEST/proj3"
   _sd="$_proj/.claude/agente-00c-state"
   _write_descriptor "$_sd" "tok-bf" "-" "bash-fallback"
   _run_launch "$_proj" "tok-bf"
-  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "bash-fallback exit" "esperado 3, obtido $_CAPTURED_EXIT"; return 1; }
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "bash-fallback exit" "esperado 0 (idle), obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
   assert_stderr_contains "mode=bash-fallback" || return 1
+  assert_stderr_contains "modo IDLE" || return 1
   case "$(_docker_launch_calls)" in
     *attach*) _fail "docker attach nao deveria ter sido chamado (mode=bash-fallback)" "$(_docker_launch_calls)"; return 1 ;;
   esac


### PR DESCRIPTION
## Resumo

Bug reportado: `Failed to reconnect to cstk-state: -32000` ao iniciar o Claude Code com o MCP registrado. Root cause: a entrada estática do `.mcp.json` conecta em **todo** boot, e `mcp-launch.sh` saía com exit 3 quando não havia execução 00c ativa (o estado normal fora de pipeline) — processo morto = conexão fechada = `-32000`.

Fix: **modo idle** no launcher — stub MCP mínimo em sh+jq (JSON-RPC newline-delimited, framing verificado no SDK): `initialize` ecoando o protocolVersion do cliente, `tools/list` vazio (zero mutação possível — SEC-H3 intacto), `ping`, `-32601` no resto, EOF ⇒ exit 0. Token fornecido e divergente segue exit 3 (capacidade); mecanismo ausente segue exit 1.

## Testado

- E2E real: `claude mcp add -s user` + `claude mcp list` ⇒ **✔ Connected** (antes: erro), registro removido após o teste.
- `tests/test_mcp-launch.sh` 6/6 (+2 cenários: idle sem token, handshake completo); suites vizinhas `test_mcp` 118/118 e `cstk/test_mcp` 94/94.
- Suite completa `LC_ALL=C ./tests/run.sh`: **2320/2320 PASS** (723s). Coverage zero órfãos; doctor drift zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa