### PR TITLE
fix: distribuicao do servidor MCP + preflight/report backend-agnosticos (6.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,20 @@ este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
   `tests/cstk/test_build-release.sh` (+layout do tarball),
   `test_install.sh` (+2), `test_update.sh` (+1, prova o replace atômico) e
   `test_mcp.sh` (reason novo).
+- **`feature-00c-preflight.sh` e `report.sh` inertes sob backend SQLite.**
+  Com `state.db`, o preflight reportava "state.json ausente" e a validação
+  de drift de briefing/constitution (FR-PRE-004) nunca rodava nas
+  retomadas; o `report.sh generate/emit` falhava mascarado e nenhum
+  relatório de auditoria era gerado (casos reais na execução
+  `document-templates` do meta-gob-ms). Ambos agora materializam o estado
+  canônico via `state-rw.sh read` (cross-backend, com fallback ao
+  `state.json` direto). Cenários novos em `tests/test_feature-00c-preflight.sh`
+  (+2: drift detectado sob sqlite) e `tests/test_report.sh` (+1: relatório
+  gerado a partir de `state.db`). É o fix mínimo dos furos mascarados — o
+  porte completo da classe (~16 leitores diretos restantes, `set`
+  multi-campo compatível com a CHECK constraint, `acquire --force` do
+  contrato de abort) fica registrado como feature própria
+  (`state-db-runtime-parity`).
 
 ## [6.2.1] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [6.2.2] - 2026-08-02
+
+### Fixed
+
+- **Modo docker do `cstk mcp` nunca funcionava fora do repo do cstk** (bug
+  observado no meta-gob-ms: `bash-fallback` com Docker saudável). A fonte
+  de build do servidor (`mcp/state-server/`) não era empacotada no tarball
+  nem instalada — os 3 caminhos de `_mcp_context_dir` falhavam em ambiente
+  instalado e todo `cstk mcp start` degradava para fallback. Agora: o
+  tarball empacota `catalog/mcp/state-server/` (src + package.json +
+  lockfile + tsconfig + .dockerignore; nunca node_modules/dist/test) e
+  `cstk install`/`cstk update` espelham em `~/.claude/mcp/state-server`
+  (replace atômico, escopo global). Após `cstk update`, o próximo
+  `/feature-00c` com Docker de pé sobe o container de verdade.
+- **Reason honesto para fonte ausente**: contexto de build não encontrado
+  agora grava `server-source-missing` (com dica de `cstk update` no
+  stderr) em vez de mascarar como `image-build-failed` — este fica
+  reservado para falha real de `docker build`. Contrato atualizado em
+  `contracts/mcp-session-lifecycle.md`; cobertura em
+  `tests/cstk/test_build-release.sh` (+layout do tarball),
+  `test_install.sh` (+2), `test_update.sh` (+1, prova o replace atômico) e
+  `test_mcp.sh` (reason novo).
+
 ## [6.2.1] - 2026-08-02
 
 ### Fixed
@@ -4767,6 +4790,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[6.2.2]: https://github.com/JotJunior/cstk/releases/tag/v6.2.2
 [6.2.1]: https://github.com/JotJunior/cstk/releases/tag/v6.2.1
 [6.2.0]: https://github.com/JotJunior/cstk/releases/tag/v6.2.0
 [6.1.0]: https://github.com/JotJunior/cstk/releases/tag/v6.1.0

--- a/cli/lib/install.sh
+++ b/cli/lib/install.sh
@@ -761,7 +761,8 @@ _install_apply_extra_kinds() {
 # identico ao de skills, reaproveitando manifest.sh sem alteracao.
 # _install_apply_mcp_server: espelha catalog/mcp/state-server no destino
 # instalado (~/.claude/mcp/state-server). Conteudo versionado com a release
-# (fonte de build da imagem docker, consumido por `docker build` + npm ci);
+# (fonte de build da imagem do servidor, consumida pelo helper confinado de
+# container + npm ci dentro da imagem);
 # sem manifest por arquivo: replace atomico do diretorio inteiro (rm+cp),
 # mesmo espirito do provisionamento de hooks. Escopo global apenas — o
 # resolve de _mcp_context_dir so olha ~/.claude. Catalogo sem mcp/ (release

--- a/cli/lib/install.sh
+++ b/cli/lib/install.sh
@@ -214,6 +214,12 @@ install_main() {
   # (sem filtro de profile) porque sao infraestrutura global do toolkit.
   _install_apply_extra_kinds
 
+  # state-mcp-server: fonte de build do servidor MCP (catalog/mcp/state-server
+  # -> ~/.claude/mcp/state-server, caminho 3 de _mcp_context_dir em
+  # cli/lib/mcp.sh). Sem isto, `cstk mcp start` em ambiente instalado nunca
+  # acha o contexto de build e degrada sempre para bash-fallback.
+  _install_apply_mcp_server
+
   _install_emit_summary
   return 0
 }
@@ -753,6 +759,30 @@ _install_apply_extra_kinds() {
 #
 # Usa manifest dedicado por kind (~/.claude/<kind>/.cstk-manifest) — schema
 # identico ao de skills, reaproveitando manifest.sh sem alteracao.
+# _install_apply_mcp_server: espelha catalog/mcp/state-server no destino
+# instalado (~/.claude/mcp/state-server). Conteudo versionado com a release
+# (fonte de build da imagem docker, consumido por `docker build` + npm ci);
+# sem manifest por arquivo: replace atomico do diretorio inteiro (rm+cp),
+# mesmo espirito do provisionamento de hooks. Escopo global apenas — o
+# resolve de _mcp_context_dir so olha ~/.claude. Catalogo sem mcp/ (release
+# antiga) = no-op silencioso.
+_install_apply_mcp_server() {
+  _iams_src="$_install_catalog_dir/mcp/state-server"
+  [ -d "$_iams_src" ] && [ -f "$_iams_src/package.json" ] || return 0
+  [ "$_install_scope" = "global" ] || return 0
+
+  _iams_dst="${HOME:?HOME nao setado}/.claude/mcp/state-server"
+  if [ "$_install_dry_run" = 1 ]; then
+    log_info "[dry-run] mcp/state-server -> $_iams_dst"
+    return 0
+  fi
+  mkdir -p -- "${_iams_dst%/state-server}"
+  rm -rf -- "$_iams_dst"
+  cp -R -- "$_iams_src" "$_iams_dst"
+  log_info "mcp/state-server instalado em $_iams_dst"
+  return 0
+}
+
 _install_apply_kind() {
   _iak_kind=$1
   _iak_src_dir="$_install_catalog_dir/$_iak_kind"

--- a/cli/lib/mcp.sh
+++ b/cli/lib/mcp.sh
@@ -487,13 +487,18 @@ _mcp_cmd_start() {
     return 3
   fi
 
-  # contexto de build (arvore-fonte mcp/state-server/).
+  # contexto de build (arvore-fonte mcp/state-server/). Reason DISTINTO de
+  # image-build-failed: aqui nada chegou a buildar — a fonte do servidor nao
+  # esta instalada (fix pos-6.2.1: o tarball passou a empacotar
+  # catalog/mcp/state-server e o install/update a espelhar em
+  # ~/.claude/mcp/state-server; reason server-source-missing indica
+  # instalacao antiga => rode `cstk update`).
   if ! _mst_context=$(_mcp_context_dir); then
-    printf 'cstk mcp start: aviso: contexto de build (mcp/state-server/) nao encontrado — mode=bash-fallback\n' >&2
+    printf 'cstk mcp start: aviso: fonte do servidor (mcp/state-server/) nao instalada — rode `cstk update`; mode=bash-fallback\n' >&2
     _mcp_write_descriptor "$_mst_state_dir" "$_mst_token" "$_mst_kind" "$_mst_short" \
-      "$_mst_target_path" "-" "bash-fallback" "image-build-failed" "$_mst_started_at" "-"
+      "$_mst_target_path" "-" "bash-fallback" "server-source-missing" "$_mst_started_at" "-"
     printf 'status=unavailable\n'
-    printf 'reason=image-build-failed\n'
+    printf 'reason=server-source-missing\n'
     printf 'container=-\n'
     printf 'session_id=%s\n' "$_mst_token"
     printf 'mode=bash-fallback\n'

--- a/cli/lib/update.sh
+++ b/cli/lib/update.sh
@@ -194,6 +194,11 @@ update_main() {
   # profile ou cherry-pick de skills.
   _update_apply_extra_kinds || return 1
 
+  # Espelha install: espelho de catalog/mcp/state-server (fonte de build do
+  # servidor MCP) em ~/.claude/mcp/state-server — sem isto o update deixa a
+  # fonte stale (ou ausente) e `cstk mcp start` degrada para bash-fallback.
+  _update_apply_mcp_server
+
   _update_emit_summary
 
   if [ "$_update_count_skipped_edits" -gt 0 ] \
@@ -629,6 +634,28 @@ _update_do_prune() {
 # Espelha _install_apply_extra_kinds em install.sh, mas com semantica de
 # update: detecta edits locais, respeita --force/--keep, reporta uptodate
 # quando release_hash == stored_sha (idempotencia SC-002).
+# _update_apply_mcp_server: identico ao _install_apply_mcp_server
+# (cli/lib/install.sh) — replace atomico de ~/.claude/mcp/state-server a
+# partir de catalog/mcp/state-server. Global apenas; catalogo sem mcp/
+# (release antiga) = no-op; dry-run reporta sem escrever. Best-effort no
+# fluxo do update (nunca gateia o update de skills).
+_update_apply_mcp_server() {
+  _uams_src="$_update_catalog_dir/mcp/state-server"
+  [ -d "$_uams_src" ] && [ -f "$_uams_src/package.json" ] || return 0
+  [ "$_update_scope" = "global" ] || return 0
+
+  _uams_dst="${HOME:?HOME nao setado}/.claude/mcp/state-server"
+  if [ "$_update_dry_run" = 1 ]; then
+    log_info "[dry-run] mcp/state-server -> $_uams_dst"
+    return 0
+  fi
+  mkdir -p -- "${_uams_dst%/state-server}"
+  rm -rf -- "$_uams_dst"
+  cp -R -- "$_uams_src" "$_uams_dst"
+  log_info "mcp/state-server atualizado em $_uams_dst"
+  return 0
+}
+
 _update_apply_extra_kinds() {
   for _uaek_kind in commands agents; do
     _update_apply_kind "$_uaek_kind" || return 1

--- a/docs/specs/state-mcp-server/contracts/mcp-session-lifecycle.md
+++ b/docs/specs/state-mcp-server/contracts/mcp-session-lifecycle.md
@@ -90,7 +90,10 @@ mode=docker|bash-fallback
 | 2 | Uso incorreto |
 
 Motivos canonicos de `unavailable`: `docker-absent`, `daemon-unreachable`,
-`image-build-failed`, `health-timeout`, `no-active-execution`.
+`server-source-missing` (fonte `mcp/state-server` nao instalada em
+`~/.claude/mcp/` — instalacao anterior ao empacotamento da fonte no
+tarball; `cstk update` resolve), `image-build-failed`, `health-timeout`,
+`no-active-execution`.
 
 ### `cstk mcp start --state-dir DIR` / `cstk mcp stop --state-dir DIR`
 

--- a/global/skills/agente-00c-runtime/scripts/feature-00c-preflight.sh
+++ b/global/skills/agente-00c-runtime/scripts/feature-00c-preflight.sh
@@ -68,8 +68,25 @@ _fp_cmd_check() {
   [ -n "$_state_dir" ] || _fp_die_usage "check: --state-dir obrigatorio"
   [ -d "$_state_dir" ] || _fp_die_io   "check: state-dir nao existe ou nao e dir: $_state_dir"
 
-  _state_file="$_state_dir/state.json"
-  [ -f "$_state_file" ] || _fp_die_io "check: state.json ausente em $_state_dir"
+  # Backend-agnostico (fix pos-6.2.1: com backend sqlite este check era
+  # INERTE — "state.json ausente" e a validacao de drift FR-PRE-004 nunca
+  # rodava nas retomadas). Materializa o estado canonico via
+  # `state-rw.sh read` (json E sqlite); fallback ao state.json direto so
+  # quando o sibling nao existe (layout degradado).
+  _fp_scripts_dir=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd -P) || _fp_scripts_dir=""
+  _state_file=""
+  if [ -n "$_fp_scripts_dir" ] && [ -x "$_fp_scripts_dir/state-rw.sh" ]; then
+    _state_file=$(mktemp 2>/dev/null) || _fp_die_io "check: mktemp indisponivel"
+    trap 'rm -f "$_state_file" 2>/dev/null' EXIT INT TERM
+    if ! sh "$_fp_scripts_dir/state-rw.sh" read --state-dir "$_state_dir" > "$_state_file" 2>/dev/null; then
+      rm -f "$_state_file" 2>/dev/null
+      _state_file=""
+    fi
+  fi
+  if [ -z "$_state_file" ] || [ ! -s "$_state_file" ]; then
+    _state_file="$_state_dir/state.json"
+    [ -f "$_state_file" ] || _fp_die_io "check: estado ausente em $_state_dir (nem state-rw read nem state.json)"
+  fi
 
   # Extrair campos de prerequisites (FR-PRE-004). Reader-fallback EN->pt (schema-en-migration).
   _br_path=$(jq -r '(.prerequisites.briefing.path // .pre_requisitos.briefing.path) // empty' "$_state_file" 2>/dev/null)

--- a/global/skills/agente-00c-runtime/scripts/report.sh
+++ b/global/skills/agente-00c-runtime/scripts/report.sh
@@ -60,7 +60,39 @@ _rp_require_jq() {
 }
 
 _rp_iso_now() { date -u +%FT%TZ; }
-_rp_state_file() { printf '%s/state.json\n' "$1"; }
+
+# _rp_state_file SD — materializa o estado canonico como ARQUIVO json e
+# imprime o path. Backend-agnostico (fix pos-6.2.1: com backend sqlite o
+# report reclamava "state.json ausente" e nenhum relatorio era gerado —
+# falha de auditoria mascarada): state.json existente e usado direto;
+# senao tenta `state-rw.sh read` (cobre state.db) num tmp; sem nenhum dos
+# dois, imprime o path inexistente e o caller morre no proprio check -f.
+# Tmps sao registrados em _RP_TMP_STATE e removidos no trap do dispatch.
+_RP_TMP_STATE=""
+_rp_state_file() {
+  if [ -f "$1/state.json" ]; then
+    printf '%s/state.json\n' "$1"
+    return 0
+  fi
+  _rpsf_rw="$(dirname -- "$0")/state-rw.sh"
+  if [ -x "$_rpsf_rw" ]; then
+    _rpsf_tmp=$(mktemp 2>/dev/null) || { printf '%s/state.json\n' "$1"; return 0; }
+    if sh "$_rpsf_rw" read --state-dir "$1" > "$_rpsf_tmp" 2>/dev/null && [ -s "$_rpsf_tmp" ]; then
+      _RP_TMP_STATE="$_RP_TMP_STATE $_rpsf_tmp"
+      printf '%s\n' "$_rpsf_tmp"
+      return 0
+    fi
+    rm -f -- "$_rpsf_tmp" 2>/dev/null
+  fi
+  printf '%s/state.json\n' "$1"
+}
+_rp_cleanup_tmp_state() {
+  # Lista separada por espaco (paths de mktemp, sem espacos internos) —
+  # expansao sem aspas e intencional.
+  # shellcheck disable=SC2086
+  [ -n "$_RP_TMP_STATE" ] && rm -f -- $_RP_TMP_STATE 2>/dev/null || :
+}
+trap _rp_cleanup_tmp_state EXIT INT TERM
 
 # _rp_wave_usage_json STATE_DIR — agregado read-only de consumo de
 # tokens/tool-uses/duracao de subagente (FASE 4.2 de wave-token-metrics,
@@ -417,7 +449,7 @@ _rp_cmd_generate() {
   [ -n "$_sd" ] || _rp_die_usage "generate: --state-dir obrigatorio"
   _rp_require_jq
   _sf=$(_rp_state_file "$_sd")
-  [ -f "$_sf" ] || _rp_die "generate: state.json ausente em $_sd" 1
+  [ -f "$_sf" ] || _rp_die "generate: estado ausente (state.json/state.db) em $_sd" 1
 
   _now=$(_rp_iso_now)
   _wu_json=$(_rp_wave_usage_json "$_sd")
@@ -517,7 +549,7 @@ _rp_cmd_emit() {
 
   _rp_require_jq
   _sf=$(_rp_state_file "$_sd")
-  [ -f "$_sf" ] || _rp_die "emit: state.json ausente em $_sd" 1
+  [ -f "$_sf" ] || _rp_die "emit: estado ausente (state.json/state.db) em $_sd" 1
 
   # secrets-filter OBRIGATORIO (ver doc da funcao): ausencia/inacessibilidade
   # = erro, NUNCA grava relatorio nao-filtrado.

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -210,6 +210,27 @@ done
 # usuarios instalam. Prune defensivo sob todo o catalog/.
 find "$STAGE_ROOT/catalog" -type d -name evals -prune -exec rm -rf -- {} +
 
+# ==== 3c. catalog/mcp/state-server/ (fonte de build do servidor MCP) ====
+# Sem isto, ambientes INSTALADOS nunca conseguem buildar a imagem docker do
+# cstk mcp: `_mcp_context_dir` (cli/lib/mcp.sh) cai nos 3 caminhos e o start
+# degrada SEMPRE para bash-fallback (bug observado no meta-gob-ms,
+# reason=image-build-failed com docker saudavel). Destino instalado:
+# ~/.claude/mcp/state-server (caminho 3 do resolve). So o necessario para o
+# `docker build` (npm ci + tsc dentro da imagem): src/, package.json,
+# package-lock.json, tsconfig.json, .dockerignore — NUNCA node_modules/,
+# dist/ ou test/.
+# Tolerante a arvores sem mcp/ (fixtures de teste com REPO_ROOT fake); no
+# repo real a presenca e gateada por scenario_build_release_estrutura_layout.
+if [ -f "$REPO_ROOT/mcp/state-server/package.json" ]; then
+  mkdir -p -- "$STAGE_ROOT/catalog/mcp/state-server"
+  cp -R -- "$REPO_ROOT/mcp/state-server/src" "$STAGE_ROOT/catalog/mcp/state-server/src"
+  for _mcpf in package.json package-lock.json tsconfig.json .dockerignore; do
+    cp -- "$REPO_ROOT/mcp/state-server/$_mcpf" "$STAGE_ROOT/catalog/mcp/state-server/$_mcpf"
+  done
+else
+  printf 'build-release: aviso: mcp/state-server ausente em %s — tarball sem fonte do servidor MCP\n' "$REPO_ROOT" >&2
+fi
+
 # ==== 4. catalog/VERSION ====
 printf '%s\n' "$VERSION_BARE" > "$STAGE_ROOT/catalog/VERSION"
 

--- a/tests/cstk/test_build-release.sh
+++ b/tests/cstk/test_build-release.sh
@@ -101,6 +101,26 @@ scenario_build_release_estrutura_layout() {
     _fail "language/go/skills ausente" ""
     return 1
   fi
+
+  # catalog/mcp/state-server/ (fonte de build do servidor MCP — fix
+  # pos-6.2.1): sem ela, ambiente instalado nunca sai de bash-fallback.
+  for _mcp_expected in \
+    'cstk-0.1.0/catalog/mcp/state-server/package.json' \
+    'cstk-0.1.0/catalog/mcp/state-server/package-lock.json' \
+    'cstk-0.1.0/catalog/mcp/state-server/tsconfig.json' \
+    'cstk-0.1.0/catalog/mcp/state-server/.dockerignore' \
+    'cstk-0.1.0/catalog/mcp/state-server/src/index.ts'
+  do
+    if ! printf '%s\n' "$_list" | grep -qx -- "$_mcp_expected"; then
+      _fail "mcp/state-server entry ausente" "$_mcp_expected"
+      return 1
+    fi
+  done
+  # NUNCA empacotar node_modules/dist/test do servidor.
+  if printf '%s\n' "$_list" | grep -qE '^cstk-0\.1\.0/catalog/mcp/state-server/(node_modules|dist|test)/'; then
+    _fail "mcp/state-server com conteudo proibido no tarball" "node_modules/dist/test"
+    return 1
+  fi
 }
 
 # ==== Checksum file ====

--- a/tests/cstk/test_install.sh
+++ b/tests/cstk/test_install.sh
@@ -414,4 +414,42 @@ scenario_install_host_file_scheme_regressao() {
   [ -f "$_h/.claude/skills/foo/SKILL.md" ] || { _fail "file scheme regressao instalacao" ""; return 1; }
 }
 
+# ==== mcp/state-server: espelho em ~/.claude/mcp (fix pos-6.2.1) ====
+# Catalogo COM catalog/mcp/state-server -> install espelha no HOME; sem a
+# secao (release antiga, caso do _make_fixture_release padrao) -> no-op.
+
+scenario_install_espelha_mcp_state_server() {
+  _h="$TMPDIR_TEST/home-mcp"
+  _r="$TMPDIR_TEST/release-mcp"
+  _make_fixture_release "$_r" || { _error "fixture" "tarball build falhou"; return 2; }
+  # Reabre o fixture e adiciona catalog/mcp/state-server antes de re-tarar.
+  _root="$_r/cstk-test-v0.1.0"
+  mkdir -p "$_root/catalog/mcp/state-server/src"
+  printf '{"name":"@cstk-panel/state-server-fixture","version":"0.0.1"}\n' \
+    > "$_root/catalog/mcp/state-server/package.json"
+  printf '// fixture index\n' > "$_root/catalog/mcp/state-server/src/index.ts"
+  (cd "$_r" && tar -czf cstk-test-v0.1.0.tar.gz cstk-test-v0.1.0) || return 1
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$_r" && sha256sum cstk-test-v0.1.0.tar.gz > cstk-test-v0.1.0.tar.gz.sha256) || return 1
+  else
+    (cd "$_r" && shasum -a 256 cstk-test-v0.1.0.tar.gz > cstk-test-v0.1.0.tar.gz.sha256) || return 1
+  fi
+
+  _run_install "$_h" --from "file://$_r/cstk-test-v0.1.0.tar.gz"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "install exit" "obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  [ -f "$_h/.claude/mcp/state-server/package.json" ] \
+    || { _fail "mcp/state-server nao espelhado no HOME" "$(ls -R "$_h/.claude" 2>/dev/null | head -20)"; return 1; }
+  [ -f "$_h/.claude/mcp/state-server/src/index.ts" ] \
+    || { _fail "src/ do state-server ausente no espelho" ""; return 1; }
+}
+
+scenario_install_catalogo_sem_mcp_e_noop() {
+  _h="$TMPDIR_TEST/home-semcp"
+  _r="$TMPDIR_TEST/release-semcp"
+  _make_fixture_release "$_r" || { _error "fixture" "tarball build falhou"; return 2; }
+  _run_install "$_h" --from "file://$_r/cstk-test-v0.1.0.tar.gz"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "install exit" "obtido $_CAPTURED_EXIT"; return 1; }
+  [ ! -e "$_h/.claude/mcp" ] || { _fail "mcp/ criado sem fonte no catalogo" ""; return 1; }
+}
+
 run_all_scenarios

--- a/tests/cstk/test_mcp.sh
+++ b/tests/cstk/test_mcp.sh
@@ -553,7 +553,11 @@ scenario_start_contexto_ausente_bash_fallback_exit_3() {
   capture sh "$CSTK_BIN" mcp start --state-dir "$_SF_STATE_DIR"
   unset CSTK_LIB
   [ "$_CAPTURED_EXIT" = 3 ] || { _fail "start contexto ausente exit" "esperado 3, obtido $_CAPTURED_EXIT ($_CAPTURED_STDERR)"; return 1; }
-  assert_stdout_contains "reason=image-build-failed" || return 1
+  # Reason DISTINTO de image-build-failed (fix pos-6.2.1): fonte do servidor
+  # nao instalada => server-source-missing (aponta `cstk update`), nunca o
+  # reason de build que mascarava o gap de distribuicao.
+  assert_stdout_contains "reason=server-source-missing" || return 1
+  assert_stderr_contains "cstk update" || return 1
 }
 
 # ---------- start: caminho feliz (mode=docker) ----------

--- a/tests/cstk/test_update.sh
+++ b/tests/cstk/test_update.sh
@@ -319,4 +319,39 @@ scenario_update_help_exit0() {
   assert_stderr_contains "cstk update" || return 1
 }
 
+# ==== mcp/state-server: update espelha e substitui a fonte (fix pos-6.2.1) ====
+
+scenario_update_espelha_mcp_state_server() {
+  _h="$TMPDIR_TEST/home-mcpup"
+  _r1="$TMPDIR_TEST/rel-mcpup-1"
+  _r2="$TMPDIR_TEST/rel-mcpup-2"
+  _make_release "$_r1" "v1.0" "alpha" || return 2
+  _install_release "$_h" "file://$_r1/cstk-v1.0.tar.gz"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _error "seed install" "$_CAPTURED_STDERR"; return 2; }
+
+  # v2.0 traz catalog/mcp/state-server; o update deve espelhar no HOME.
+  _make_release "$_r2" "v2.0" "alpha" || return 2
+  _root2="$_r2/cstk-v2.0"
+  mkdir -p "$_root2/catalog/mcp/state-server/src"
+  printf '{"version":"0.9.9"}\n' > "$_root2/catalog/mcp/state-server/package.json"
+  printf '// v2 index\n' > "$_root2/catalog/mcp/state-server/src/index.ts"
+  (cd "$_r2" && tar -czf cstk-v2.0.tar.gz cstk-v2.0) || return 2
+  if command -v sha256sum >/dev/null 2>&1; then
+    (cd "$_r2" && sha256sum cstk-v2.0.tar.gz > cstk-v2.0.tar.gz.sha256) || return 2
+  else
+    (cd "$_r2" && shasum -a 256 cstk-v2.0.tar.gz > cstk-v2.0.tar.gz.sha256) || return 2
+  fi
+
+  # Sujeira pre-existente no destino prova o replace atomico (rm+cp).
+  mkdir -p "$_h/.claude/mcp/state-server"
+  printf 'stale\n' > "$_h/.claude/mcp/state-server/stale-file.txt"
+
+  _run_update "$_h" --from "file://$_r2/cstk-v2.0.tar.gz"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "update exit" "obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  grep -q '"version":"0.9.9"' "$_h/.claude/mcp/state-server/package.json" 2>/dev/null \
+    || { _fail "fonte do state-server nao atualizada" ""; return 1; }
+  [ ! -e "$_h/.claude/mcp/state-server/stale-file.txt" ] \
+    || { _fail "replace nao removeu conteudo stale" ""; return 1; }
+}
+
 run_all_scenarios

--- a/tests/test_feature-00c-preflight.sh
+++ b/tests/test_feature-00c-preflight.sh
@@ -9,6 +9,7 @@ REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
 . "$TESTS_ROOT/lib/harness.sh"
 
 SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/scripts/feature-00c-preflight.sh"
+SCRIPTS_DIR="$REPO_ROOT/global/skills/agente-00c-runtime/scripts"
 
 # Helper: cria fixture de projeto-alvo + state.json com hashes corretos.
 # Imprime path do state-dir em stdout.
@@ -198,7 +199,61 @@ scenario_check_sem_state_json_falha() {
     _fail "exit" "esperado 2, obtido $_CAPTURED_EXIT"
     return 1
   fi
-  assert_stderr_contains "state.json ausente" || return 1
+  assert_stderr_contains "estado ausente" || return 1
+}
+
+# ==== backend sqlite (fix pos-6.2.1): check NAO pode ser inerte ====
+# Bug de campo (meta-gob-ms): com state.db o preflight reportava
+# "state.json ausente" e a validacao de drift FR-PRE-004 nunca rodava.
+
+_fp_make_sqlite_state() {
+  # $1=home sandbox  $2=state-dir  $3=projeto (com briefing/constitution)
+  mkdir -p "$1/.claude/cstk"
+  printf 'state_backend=sqlite\n' > "$1/.claude/cstk/config"
+  mkdir -p "$3/docs/01-briefing-discovery"
+  printf '# briefing de teste com conteudo suficiente\n' > "$3/docs/01-briefing-discovery/briefing.md"
+  printf '# constitution de teste\n\n**Version**: 1.0.0\n' > "$3/docs/constitution.md"
+  if command -v sha256sum >/dev/null 2>&1; then
+    _fpms_br=$(sha256sum "$3/docs/01-briefing-discovery/briefing.md" | awk '{print $1}')
+    _fpms_ct=$(sha256sum "$3/docs/constitution.md" | awk '{print $1}')
+  else
+    _fpms_br=$(shasum -a 256 "$3/docs/01-briefing-discovery/briefing.md" | awk '{print $1}')
+    _fpms_ct=$(shasum -a 256 "$3/docs/constitution.md" | awk '{print $1}')
+  fi
+  env HOME="$1" sh "$SCRIPTS_DIR/state-rw.sh" init --state-dir "$2" \
+    --short-name "sqlite-preflight" \
+    --projeto-alvo-path "$3" \
+    --descricao "descricao de teste com tamanho suficiente para validacao" \
+    --briefing-path "$3/docs/01-briefing-discovery/briefing.md" --briefing-sha256 "$_fpms_br" \
+    --constitution-path "$3/docs/constitution.md" --constitution-sha256 "$_fpms_ct" \
+    --constitution-version "1.0.0" >/dev/null 2>&1
+}
+
+scenario_check_backend_sqlite_valida_ok() {
+  command -v sqlite3 >/dev/null 2>&1 || { printf '# skip: sqlite3 indisponivel\n'; return 0; }
+  _h="$TMPDIR_TEST/home-sq1"
+  _sd="$TMPDIR_TEST/sq1-state"
+  _pj="$TMPDIR_TEST/sq1-proj"
+  _fp_make_sqlite_state "$_h" "$_sd" "$_pj" || { _error "fixture" "init sqlite falhou"; return 2; }
+  [ -f "$_sd/state.db" ] || { _error "fixture" "state.db nao criado (config nao aplicou?)"; return 2; }
+  [ ! -f "$_sd/state.json" ] || { _error "fixture" "state.json presente — cenario invalido"; return 2; }
+  capture env HOME="$_h" "$SCRIPT" check --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit sqlite ok" "esperado 0, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains '"ok": true' || return 1
+}
+
+scenario_check_backend_sqlite_detecta_drift() {
+  command -v sqlite3 >/dev/null 2>&1 || { printf '# skip: sqlite3 indisponivel\n'; return 0; }
+  _h="$TMPDIR_TEST/home-sq2"
+  _sd="$TMPDIR_TEST/sq2-state"
+  _pj="$TMPDIR_TEST/sq2-proj"
+  _fp_make_sqlite_state "$_h" "$_sd" "$_pj" || { _error "fixture" "init sqlite falhou"; return 2; }
+  # Muta o briefing DEPOIS do init: o check deve reportar drift (a prova de
+  # que a validacao deixou de ser inerte sob sqlite).
+  printf '\nconteudo novo pos-init\n' >> "$_pj/docs/01-briefing-discovery/briefing.md"
+  capture env HOME="$_h" "$SCRIPT" check --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit sqlite drift" "esperado 1 (findings), obtido $_CAPTURED_EXIT: $_CAPTURED_STDOUT"; return 1; }
+  assert_stdout_contains 'briefing' || return 1
 }
 
 scenario_uso_sem_argumentos() {

--- a/tests/test_report.sh
+++ b/tests/test_report.sh
@@ -431,4 +431,27 @@ scenario_stack_final_condicional_ao_status() {
   assert_stdout_contains "herdada do projeto" || return 1
 }
 
+# ==== backend sqlite (fix pos-6.2.1): report NAO pode mascarar falha ====
+# Bug de campo (meta-gob-ms, abort de document-templates): com state.db o
+# emit reclamava "state.json ausente" e NENHUM relatorio era gerado.
+
+scenario_generate_backend_sqlite_produz_relatorio() {
+  command -v sqlite3 >/dev/null 2>&1 || { printf '# skip: sqlite3 indisponivel\n'; return 0; }
+  _h="$TMPDIR_TEST/home-rpsq"
+  mkdir -p "$_h/.claude/cstk"
+  printf 'state_backend=sqlite\n' > "$_h/.claude/cstk/config"
+  _sd="$TMPDIR_TEST/rpsq-state"
+  env HOME="$_h" sh "$REPO_ROOT/global/skills/agente-00c-runtime/scripts/state-rw.sh" init \
+    --state-dir "$_sd" --execucao-id "exec-rpsq-1" --projeto-alvo-path "/tmp/rpsq" \
+    --descricao "descricao de teste com tamanho suficiente para validacao" >/dev/null 2>&1 \
+    || { _error "fixture" "init sqlite falhou"; return 2; }
+  [ -f "$_sd/state.db" ] || { _error "fixture" "state.db nao criado"; return 2; }
+  [ ! -f "$_sd/state.json" ] || { _error "fixture" "state.json presente — cenario invalido"; return 2; }
+
+  capture env HOME="$_h" "$SCRIPT" generate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "generate sqlite exit" "esperado 0, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "Relatorio do Agente-00C" || return 1
+  assert_stdout_contains "exec-rpsq-1" || return 1
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Resumo

Dois bugs de campo do backend/MCP em ambientes instalados (observados no meta-gob-ms, primeiro projeto real em sqlite):

1. **Modo docker do `cstk mcp` nunca funcionou fora do repo** — a fonte `mcp/state-server` não era empacotada nem instalada; `_mcp_context_dir` falhava nos 3 caminhos e todo start degradava para `bash-fallback` (mascarado como `image-build-failed`). Fix: tarball empacota `catalog/mcp/state-server` (sem node_modules/dist/test), `install`/`update` espelham em `~/.claude/mcp/state-server` (replace atômico), e contexto ausente ganha reason honesto `server-source-missing` com dica de `cstk update`.
2. **`feature-00c-preflight.sh` e `report.sh` inertes sob SQLite** — drift FR-PRE-004 nunca rodava nas retomadas e nenhum relatório de auditoria era gerado no abort. Fix mínimo: ambos materializam o estado via `state-rw.sh read` (cross-backend) + fallback. O porte completo da classe (~16 leitores restantes, `set` multi-campo vs CHECK, `acquire --force`) fica registrado como feature `state-db-runtime-parity`.

Bônus: o guard endurecido de confinamento docker pegou uma menção nova em comentário de `install.sh` — reword aplicado (o guard funciona).

## Testado

- Suite completa `LC_ALL=C ./tests/run.sh`: **2326/2326 PASS** (1089s); coverage zero órfãos; fixtures regeneradas; shellcheck sem erros.
- Prova viva contra o `state.db` real do meta-gob-ms: preflight `{"ok":true}` e relatório renderizado (`Status: abortada`).
- Cenários novos: tarball layout (+5 asserts), install (+2), update (+1 replace atômico), mcp reason novo, preflight sqlite (+2, drift detectado), report sqlite (+1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa