### PR TITLE
fix(tests): G7 do hook-active-exec exclui sidecars WAL da comparacao

### DIFF
--- a/tests/test__hook-active-exec.sh
+++ b/tests/test__hook-active-exec.sh
@@ -241,11 +241,17 @@ scenario_stderr_sempre_vazio_uso_incorreto_cwd_vazio() {
 
 scenario_g7_helper_nao_escreve_nenhum_arquivo() {
   _sqlite_state_db "$TMPDIR_TEST" "demo" "em_andamento"
-  _before=$(find "$TMPDIR_TEST" -type f | LC_ALL=C sort)
+  # Sidecars -shm/-wal ficam FORA da comparacao: sao artefatos legitimos
+  # do motor no fallback rw sobre um db WAL em repouso (nota de escopo do
+  # contrato hook-active-exec.md / cabecalho do helper, research Decision
+  # 1.a). A persistencia deles pos-fixture varia por plataforma (macOS os
+  # mantem; Linux os remove no close), o que tornava este cenario
+  # plataforma-dependente — vide FAIL do release v6.4.0 no CI Ubuntu.
+  _before=$(find "$TMPDIR_TEST" -type f | grep -v -E -- '-(shm|wal)$' | LC_ALL=C sort)
   _run_helper "$TMPDIR_TEST"
-  _after=$(find "$TMPDIR_TEST" -type f | LC_ALL=C sort)
+  _after=$(find "$TMPDIR_TEST" -type f | grep -v -E -- '-(shm|wal)$' | LC_ALL=C sort)
   [ "$_before" = "$_after" ] || {
-    _fail "G7" "conjunto de arquivos mudou apos a chamada (antes/depois):
+    _fail "G7" "conjunto de arquivos (excluindo sidecars -shm/-wal) mudou apos a chamada (antes/depois):
 before: $_before
 after:  $_after"
     return 1


### PR DESCRIPTION
O cenario G7 falhava no CI Ubuntu (release v6.4.0, run 30841029872) por diferenca de plataforma na persistencia dos sidecars WAL apos o fixture. Sidecars -shm/-wal sao artefatos legitimos do motor no fallback rw (contrato hook-active-exec.md) e saem da comparacao; qualquer outro arquivo criado segue detectado.

Testado: tests/run.sh test__hook-active-exec 22/22 + simulacao da condicao do CI (sidecars removidos em repouso) passando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa