### PR TITLE
fix(guard-hooks): detecta copia stale e rebaixa tick-mode por cegueira de backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,56 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [6.5.0] - 2026-08-04
+
+`tool_calls` estava zerado em TODAS as ondas desde o cutover
+`state.json` → `state.db` (03/ago). As cópias dos hooks em
+`<projeto>/.claude/hooks/` são snapshots do dia do provisionamento e nada
+as reconcilia com o catálogo: os projetos seguiram com o
+`posttooluse-tool-call-tick.sh` de julho, que só sabe detectar execução
+ativa lendo `state.json`. Sob backend SQLite o hook não enxerga a
+execução, sai mudo, e o sidecar `tool-call-ticks.log` nunca é criado. As
+duas guardas que deveriam pegar isso falharam juntas: `check` só olhava
+*present + registered* (cópia stale passava como saudável) e `tick-mode`
+respondia `hook`, então o orquestrador também não tickava na mão. Esta
+release torna a cópia stale visível e faz a métrica sobreviver até o
+reprovisionamento.
+
+### Added
+
+- **`guard-hooks-status.sh check`: 4ª coluna `current|stale|unknown`.** A
+  cópia do projeto é comparada byte-a-byte (`cmp`) com a do catálogo
+  (`CSTK_HOOKS_CATALOG_DIR` > sibling `../hooks` > `$HOME`). `stale`
+  reprova com exit 1 e diagnóstico próprio; a guarda stale
+  (`pretooluse-bash-guard.sh`) ganha alerta destacado, em paridade com o
+  alerta de guarda inativa — copia stale roda regras de uma versão
+  anterior, o que é problema de segurança, não só de métrica.
+- **Invariantes INV-6 e INV-7 em `tests/test_guard-hooks-status.sh`** — 8
+  cenários novos (28 no total), incluindo o anti-contagem-dupla e a
+  reprodução do bug de campo (3 hooks present+registered porém stale).
+
+### Changed
+
+- **`guard-hooks-status.sh tick-mode` rebaixa para `manual` por cegueira de
+  backend.** No par exato *cópia que não referencia `_hook-active-exec.sh`*
+  + *projeto com `state.db`*, o hook nunca ticka: o orquestrador volta a
+  tickar na mão e a métrica sobrevive sem reprovisionar. Fora desse par a
+  resposta segue `hook` — rebaixar uma cópia cega sobre backend JSON, onde
+  ela funciona, produziria contagem DUPLA.
+- **Diagnóstico dos commands `/agente-00c` e `/feature-00c`** trata `stale`
+  como ausente (mesma remediação, `cstk hooks install`); `unknown` nunca é
+  veredito.
+- **Prosa do `tick-mode` nos dois orquestradores** cobre o caso de cegueira
+  de backend, não só o de hook ausente.
+- **README**: documenta a 4ª coluna e por que reprovisionar após todo
+  upgrade que toque os hooks.
+
+### Fixed
+
+- **`freshness` degrada para `unknown` — nunca `stale` — quando não há com
+  que comparar** (`cmp` fora do PATH, catálogo irresolvível, hook ausente
+  no projeto): acusar drift sem ter comparado seria inventar veredito.
+
 ## [6.4.1] - 2026-08-03
 
 Arquivamento das 5 features do ciclo v6.x (cutover `state.json` →
@@ -4951,6 +5001,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[6.5.0]: https://github.com/JotJunior/cstk/releases/tag/v6.5.0
 [6.4.1]: https://github.com/JotJunior/cstk/releases/tag/v6.4.1
 [6.4.0]: https://github.com/JotJunior/cstk/releases/tag/v6.4.0
 [6.3.0]: https://github.com/JotJunior/cstk/releases/tag/v6.3.0

--- a/README.md
+++ b/README.md
@@ -276,7 +276,19 @@ anything:
 
 ```bash
 guard-hooks-status.sh check --projeto-alvo-path .
+# <hook>  present|missing  registered|unregistered  current|stale|unknown
 ```
+
+Re-run `cstk hooks install` after every cstk upgrade that touches the hooks:
+the copies under `.claude/hooks/` are snapshots and nothing reconciles them
+with the catalog. A **stale** copy is as harmful as a missing one — it runs
+an older ruleset. That is a real regression, not a hypothetical: after the
+`state.json` → `state.db` cutover, projects kept a tick hook that only knew
+how to read `state.json`, so `tool_calls` was 0 for every wave while the
+check still reported "3/3 hooks active". The fourth column exists to make
+that visible, and `tick-mode` falls back to `manual` in exactly that pairing
+(backend-blind copy + `state.db`) so the metric survives until you
+re-provision.
 
 ### Real per-wave cost (`otel-usage.sh`)
 

--- a/global/agents/agente-00c-feature-orchestrator.md
+++ b/global/agents/agente-00c-feature-orchestrator.md
@@ -284,8 +284,10 @@ Sequencia da onda corrente. Cada iteracao:
      pula os hooks). NAO assuma que esta ativo; consulte
      `guard-hooks-status.sh tick-mode --projeto-alvo-path <PAP>`:
        - "hook"   → NAO chamar state-ondas.sh tool-call-tick (dobraria)
-       - "manual" → chamar tool-call-tick a cada tool call relevante,
-         senao tool_calls fica 0 na onda inteira (observado em campo)
+       - "manual" → hook ausente OU cego ao backend (copia anterior a
+         hooks-db-parity, que so le state.json, com state.db em uso);
+         chamar tool-call-tick a cada tool call relevante, senao
+         tool_calls fica 0 na onda inteira (observado em campo)
      wallclock/state_size seguem cobrindo o orcamento nos dois modos.
 4.ter (best-effort, ADITIVO — dica de onda, US4 — FR-006):
     Exibir dica da skill correspondente a fase corrente. Fail-silent absoluto:

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -297,10 +297,14 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
 
    - `MODO_TICK=hook` → o sidecar `tool-call-ticks.log` e alimentado
      sozinho; NAO chame `state-ondas.sh tool-call-tick` (contaria em dobro).
-   - `MODO_TICK=manual` → o hook NAO esta ativo; chame
+   - `MODO_TICK=manual` → o hook NAO esta ativo **ou esta cego ao backend
+     em uso** (copia anterior a `hooks-db-parity`, que so le `state.json`,
+     num projeto que ja usa `state.db`); chame
      `state-ondas.sh tool-call-tick --state-dir <SD>` a cada tool call
      relevante, senao `tool_calls` fica 0 na onda inteira e o proxy de
-     orcamento vira letra morta (observado em campo: 35 ondas, todas 0).
+     orcamento vira letra morta (observado em campo duas vezes: 35 ondas
+     por hook ausente; 15 ondas por copia stale apos o cutover
+     `state.json`->`state.db`).
 
    Em qualquer dos modos os proxies wallclock/state_size seguem gateando a
    onda normalmente.

--- a/global/commands/agente-00c.md
+++ b/global/commands/agente-00c.md
@@ -161,10 +161,17 @@ Se o preflight imprimir `status=port-conflict` (porta do exporter presa por
 OUTRO processo — `owner_pid`/`owner_cwd` na saida) ou `status=exporter-down`,
 REPASSE o aviso ao operador antes de seguir: a execucao inteira sairia com
 `otel_usage` null em toda onda. `ok`/`disabled`/`unverified` seguem sem
-mencao. Se os tres hooks ja estao ativos, siga para o passo 3 sem incomodar
-o operador.
+mencao. Se os tres hooks ja estao ativos E `current`, siga para o passo 3 sem
+incomodar o operador.
 
-**Se faltar algum, PECA a instalacao explicitamente** — nao instale por
+A 4a coluna do TSV (`current|stale|unknown`) diz se a copia do projeto ainda
+bate com a do catalogo. `stale` reprova igual a ausente e pede a MESMA
+remediacao (`cstk hooks install`): copia stale roda codigo de uma versao
+anterior — foi assim que o cutover `state.json`->`state.db` zerou
+`tool_calls` em projetos que exibiam "3/3 hooks ativos". `unknown` (catalogo
+irresolvivel) nao e veredito: siga.
+
+**Se faltar algum OU algum estiver `stale`, PECA a instalacao explicitamente** — nao instale por
 conta propria e nao siga em silencio. Apresente os tres pontos abaixo e
 espere a resposta:
 

--- a/global/commands/feature-00c.md
+++ b/global/commands/feature-00c.md
@@ -148,13 +148,19 @@ Exporte: `AGENTE_00C_STATE_DIR=<projeto>/.claude/feature-00c-state/<short_name>`
 8. coleta de consumo: PEDIR instalacao ao operador (nunca instalar sozinho)
    guard-hooks-status.sh check --projeto-alvo-path "$_proj" || :
    otel-usage.sh preflight || :
-   - READ-ONLY: diagnosticam, nunca instalam. Os tres hooks ativos => siga
-     sem incomodar o operador.
+   - READ-ONLY: diagnosticam, nunca instalam. Os tres hooks ativos E
+     `current` (4a coluna do TSV) => siga sem incomodar o operador.
+   - 4a coluna `stale` = copia do projeto diverge da do catalogo: reprova
+     igual a ausente, MESMA remediacao (`cstk hooks install`). Copia stale
+     roda codigo de versao anterior — foi assim que o cutover
+     `state.json`->`state.db` zerou `tool_calls` em projetos que exibiam
+     "3/3 hooks ativos". `unknown` nao e veredito: siga.
    - preflight com `status=port-conflict` (porta do exporter presa por
      OUTRO processo; owner_pid/owner_cwd na saida) ou `status=exporter-down`
      => REPASSE o aviso ao operador antes de seguir (execucao sairia com
      otel_usage null em toda onda). ok/disabled/unverified => siga.
-   - Faltando algum => PECA a instalacao, apresentando os 3 pontos:
+   - Faltando algum OU algum `stale` => PECA a instalacao, apresentando os
+     3 pontos:
 
      (1) O que instala e para que serve — nenhum e redundante:
          . pretooluse-bash-guard.sh  -> guarda fail-closed de Bash.

--- a/global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
+++ b/global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
@@ -24,27 +24,65 @@
 # o inicio da execucao 00c, que ja esta DENTRO do projeto-alvo — dai este
 # script, consumido pelos commands /agente-00c e /feature-00c.
 #
+# SEGUNDO MODO DE FALHA DE CAMPO: a copia STALE
+# ---------------------------------------------
+# `present + registered` NAO implica funcional. A copia em
+# <PAP>/.claude/hooks/ e um SNAPSHOT tirado no dia do provisionamento; o
+# catalogo (~/.claude/skills/agente-00c-runtime/hooks/) segue evoluindo e
+# NADA reconcilia os dois — `cstk update` so reprovisiona quando invocado
+# com `--scope project` E com agente-00c-runtime na selecao (default e
+# global), e roda no repo do cstk, nao no projeto-alvo.
+#
+# Consequencia observada em campo (03/ago/2026): apos o cutover
+# state.json -> state.db (features state-db-runtime-parity/hooks-db-parity),
+# projetos seguiram com a copia de jul/2026 do posttooluse-tool-call-tick.sh,
+# que detectava execucao ativa lendo SO `state.json`. Com backend sqlite o
+# hook nao enxerga mais a execucao, sai 0 mudo, e o sidecar
+# tool-call-ticks.log nunca e criado => tool_calls=0 em TODAS as ondas de
+# 2 projetos. Falha dupla: `check` dizia "3/3 ativos" e `tick-mode` dizia
+# "hook", entao o orquestrador tambem nao tickava na mao.
+#
+# Dai a 3a dimensao (`current|stale|unknown`) e o rebaixamento do tick-mode
+# quando a copia e cega ao backend em uso.
+#
 # Subcomandos:
 #   guard-hooks-status.sh check --projeto-alvo-path PATH [--quiet]
 #       — stdout: uma linha TSV por hook:
-#             <arquivo>\t<present|missing>\t<registered|unregistered>
+#             <arquivo>\t<present|missing>\t<registered|unregistered>\t<current|stale|unknown>
 #         "registered" = o basename aparece em <PAP>/.claude/settings.json
 #         (o hook so roda de fato se estiver copiado E registrado).
+#         "current"/"stale" = comparacao byte-a-byte (cmp) da copia do
+#         projeto com a do catalogo; "unknown" = hook ausente ou catalogo
+#         irresolvivel (nao e veredito, nao reprova).
 #       — stderr: diagnostico + comando de remediacao (suprimido por --quiet).
-#       — exit 0 se os 3 estao present+registered; 1 caso contrario.
+#       — exit 0 se os 3 estao present+registered+(current|unknown);
+#         1 caso contrario (inclui stale).
 #
 #   guard-hooks-status.sh tick-mode --projeto-alvo-path PATH
 #       — stdout: "hook" se posttooluse-tool-call-tick.sh esta ativo
-#         (present+registered), senao "manual".
+#         (present+registered) E capaz de enxergar o backend em uso; senao
+#         "manual".
 #         Consumido pelo orquestrador para decidir se chama
 #         `state-ondas.sh tool-call-tick` na mao. A regra "NAO tickar
 #         manualmente" so vale quando o hook existe — sem esta checagem o
 #         default virava "nao ticka" e a metrica zerava em silencio.
+#         Rebaixa para "manual" quando a copia do projeto e CEGA A BACKEND
+#         (nao referencia _hook-active-exec.sh, i.e. anterior a
+#         hooks-db-parity) E ha `state.db` num state-dir do projeto: nesse
+#         par exato o hook nunca ticka, entao o orquestrador precisa tickar.
+#         O rebaixamento e condicionado ao par (cego + sqlite) de proposito:
+#         copia cega sobre backend JSON SEGUE funcionando, e devolver
+#         "manual" ali produziria contagem DUPLA (hook + tick manual).
 #       — exit 0 sempre (0 = consulta respondida, nao veredito).
 #
+# Override do catalogo (so para teste/diagnostico):
+#   CSTK_HOOKS_CATALOG_DIR=<dir> — diretorio com as copias de referencia.
+#   Sem ele: sibling `<script_dir>/../hooks` e depois
+#   `$HOME/.claude/skills/agente-00c-runtime/hooks`.
+#
 # Exit codes:
-#   0  check: tudo provisionado | tick-mode: consulta respondida
-#   1  check: pelo menos um hook ausente ou nao-registrado
+#   0  check: tudo provisionado e atual | tick-mode: consulta respondida
+#   1  check: pelo menos um hook ausente, nao-registrado ou stale
 #   2  uso incorreto
 #
 # READ-ONLY por construcao: nao copia hook, nao edita settings.json, nao
@@ -85,6 +123,77 @@ _gh_registered() {
   grep -Fq -- "$2" "$_gh_settings" 2>/dev/null
 }
 
+# _gh_self_dir -> diretorio do proprio script (vazio se irresolvivel).
+_gh_self_dir() {
+  (CDPATH='' cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || printf ''
+}
+
+# _gh_catalog_hook HOOK -> ecoa o path da copia de referencia do catalogo,
+# ou nada (exit 1) se irresolvivel. Ordem: override de teste, sibling do
+# proprio script (<catalog>/skills/agente-00c-runtime/scripts/..), $HOME.
+_gh_catalog_hook() {
+  _gh_ch_h=$1
+  if [ -n "${CSTK_HOOKS_CATALOG_DIR:-}" ] && [ -r "$CSTK_HOOKS_CATALOG_DIR/$_gh_ch_h" ]; then
+    printf '%s' "$CSTK_HOOKS_CATALOG_DIR/$_gh_ch_h"
+    return 0
+  fi
+  _gh_ch_self=$(_gh_self_dir)
+  if [ -n "$_gh_ch_self" ] && [ -r "$_gh_ch_self/../hooks/$_gh_ch_h" ]; then
+    printf '%s' "$_gh_ch_self/../hooks/$_gh_ch_h"
+    return 0
+  fi
+  if [ -n "${HOME:-}" ] && [ -r "$HOME/.claude/skills/agente-00c-runtime/hooks/$_gh_ch_h" ]; then
+    printf '%s' "$HOME/.claude/skills/agente-00c-runtime/hooks/$_gh_ch_h"
+    return 0
+  fi
+  return 1
+}
+
+# _gh_freshness PAP HOOK -> "current" | "stale" | "unknown".
+# "unknown" (nao reprova) quando o hook nao esta no projeto ou quando nao
+# ha copia de catalogo com que comparar — na duvida NAO se acusa drift.
+_gh_freshness() {
+  _gh_fr_proj="$1/.claude/hooks/$2"
+  [ -f "$_gh_fr_proj" ] || { printf 'unknown'; return 0; }
+  # Sem `cmp` no PATH nao ha como comparar — "unknown", nunca "stale"
+  # (acusar drift sem ter comparado seria inventar veredito).
+  command -v cmp >/dev/null 2>&1 || { printf 'unknown'; return 0; }
+  if _gh_fr_cat=$(_gh_catalog_hook "$2"); then
+    if cmp -s -- "$_gh_fr_proj" "$_gh_fr_cat"; then
+      printf 'current'
+    else
+      printf 'stale'
+    fi
+  else
+    printf 'unknown'
+  fi
+  return 0
+}
+
+# _gh_has_state_db PAP -> 0 se existe `state.db` em algum state-dir 00c do
+# projeto (agente-00c-state/ ou feature-00c-state/*/). Builtins puros.
+_gh_has_state_db() {
+  [ -f "$1/.claude/agente-00c-state/state.db" ] && return 0
+  _gh_sd_root="$1/.claude/feature-00c-state"
+  if [ -d "$_gh_sd_root" ]; then
+    for _gh_sd_d in "$_gh_sd_root"/*/; do
+      [ -d "$_gh_sd_d" ] || continue
+      [ -f "${_gh_sd_d}state.db" ] && return 0
+    done
+  fi
+  return 1
+}
+
+# _gh_backend_blind PAP HOOK -> 0 se a copia do projeto NAO referencia
+# _hook-active-exec.sh, i.e. e anterior a hooks-db-parity e so sabe ler
+# `state.json` (cega ao backend sqlite).
+_gh_backend_blind() {
+  _gh_bb_f="$1/.claude/hooks/$2"
+  [ -f "$_gh_bb_f" ] || return 1
+  grep -Fq -- "_hook-active-exec.sh" "$_gh_bb_f" 2>/dev/null && return 1
+  return 0
+}
+
 _gh_cmd_check() {
   _pap=""
   _quiet=0
@@ -99,7 +208,9 @@ _gh_cmd_check() {
   [ -d "$_pap" ] || _gh_die_usage "check: --projeto-alvo-path nao e diretorio: $_pap"
 
   _missing=0
+  _stale=0
   _guard_missing=0
+  _guard_stale=0
   for _h in $_GH_HOOKS; do
     if _gh_present "$_pap" "$_h"; then
       _st_file="present"
@@ -111,21 +222,37 @@ _gh_cmd_check() {
     else
       _st_reg="unregistered"
     fi
-    printf '%s\t%s\t%s\n' "$_h" "$_st_file" "$_st_reg"
+    _st_fresh=$(_gh_freshness "$_pap" "$_h")
+    printf '%s\t%s\t%s\t%s\n' "$_h" "$_st_file" "$_st_reg" "$_st_fresh"
     if [ "$_st_file" != "present" ] || [ "$_st_reg" != "registered" ]; then
       _missing=$((_missing + 1))
       [ "$_h" = "pretooluse-bash-guard.sh" ] && _guard_missing=1
+    elif [ "$_st_fresh" = stale ]; then
+      # So conta como stale o hook que de fato rodaria (present+registered);
+      # hook ausente ja esta contabilizado em _missing.
+      _stale=$((_stale + 1))
+      [ "$_h" = "pretooluse-bash-guard.sh" ] && _guard_stale=1
     fi
   done
 
-  [ "$_missing" -eq 0 ] && return 0
+  [ "$_missing" -eq 0 ] && [ "$_stale" -eq 0 ] && return 0
 
   if [ "$_quiet" = 0 ]; then
-    _gh_err "$_missing de 3 hooks 00c NAO estao ativos em $_pap/.claude/"
+    if [ "$_missing" -gt 0 ]; then
+      _gh_err "$_missing de 3 hooks 00c NAO estao ativos em $_pap/.claude/"
+    fi
+    if [ "$_stale" -gt 0 ]; then
+      _gh_err "$_stale de 3 hooks 00c estao STALE em $_pap/.claude/hooks/ (copia diverge do catalogo)"
+    fi
     if [ "$_guard_missing" = 1 ]; then
       _gh_err "ATENCAO: pretooluse-bash-guard.sh inativo — a guarda fail-closed de Bash NAO esta enforced nesta execucao."
     fi
-    _gh_err "Remediacao (rode NO PROJETO-ALVO, uma vez):"
+    if [ "$_guard_stale" = 1 ]; then
+      _gh_err "ATENCAO: pretooluse-bash-guard.sh STALE — a guarda roda com regras de uma versao anterior do catalogo."
+    fi
+    _gh_err "Remediacao (so os hooks; rode uma vez):"
+    _gh_err "  cstk hooks install --project-path $_pap"
+    _gh_err "Alternativa (tambem duplica skill+commands+agents no repo):"
     _gh_err "  cd $_pap && cstk install --scope project agente-00c-runtime"
     _gh_err "Sem isso: tool_calls fica 0 e agent_usage fica null em todas as ondas."
   fi
@@ -142,12 +269,24 @@ _gh_cmd_tick_mode() {
   done
   [ -n "$_pap" ] || _gh_die_usage "tick-mode: --projeto-alvo-path obrigatorio"
 
-  if _gh_present "$_pap" "posttooluse-tool-call-tick.sh" \
-     && _gh_registered "$_pap" "posttooluse-tool-call-tick.sh"; then
-    printf 'hook\n'
-  else
+  if ! _gh_present "$_pap" "posttooluse-tool-call-tick.sh" \
+     || ! _gh_registered "$_pap" "posttooluse-tool-call-tick.sh"; then
     printf 'manual\n'
+    return 0
   fi
+
+  # Ativo mas CEGO ao backend em uso: copia anterior a hooks-db-parity (so
+  # le state.json) num projeto que ja tem state.db. Nesse par o hook nunca
+  # ticka — rebaixa para manual em vez de zerar a metrica em silencio.
+  # Fora desse par (copia cega + backend JSON) o hook funciona: devolver
+  # "manual" ali produziria contagem DUPLA.
+  if _gh_backend_blind "$_pap" "posttooluse-tool-call-tick.sh" \
+     && _gh_has_state_db "$_pap"; then
+    printf 'manual\n'
+    return 0
+  fi
+
+  printf 'hook\n'
   return 0
 }
 
@@ -168,12 +307,14 @@ USO:
   guard-hooks-status.sh check     --projeto-alvo-path PATH [--quiet]
   guard-hooks-status.sh tick-mode --projeto-alvo-path PATH
 
-check     TSV <hook>\t<present|missing>\t<registered|unregistered>;
-          exit 0 se os 3 ativos, 1 caso contrario.
+check     TSV <hook>\t<present|missing>\t<registered|unregistered>\t<current|stale|unknown>;
+          exit 0 se os 3 ativos E atuais, 1 caso contrario.
 tick-mode "hook" ou "manual" — o orquestrador so ticka na mao em "manual".
+          "manual" tambem quando a copia do hook e cega a backend (pre
+          hooks-db-parity) e o projeto ja usa state.db.
 
-Remediacao quando faltam: rodar NO PROJETO-ALVO
-  cstk install --scope project agente-00c-runtime
+Remediacao quando faltam ou estao stale:
+  cstk hooks install --project-path PATH
 HELP
     exit 2
     ;;

--- a/tests/test_guard-hooks-status.sh
+++ b/tests/test_guard-hooks-status.sh
@@ -14,6 +14,16 @@
 #          metrica em silencio).
 #   INV-5: remediacao citada em stderr aponta `--scope project` (a causa
 #          raiz e o default `--scope global` do cstk install/update).
+#   INV-6: 3a dimensao `current|stale|unknown` — copia do projeto que
+#          diverge do catalogo reprova (exit 1). Foi o 2o modo de falha de
+#          campo: apos o cutover state.json->state.db os projetos ficaram
+#          com a copia de jul/2026 do tick-hook (que so le state.json),
+#          `check` dizia "3/3 ativos" e tool_calls zerou em todas as ondas.
+#          "unknown" (hook ausente, catalogo irresolvivel, `cmp` ausente)
+#          NUNCA reprova — na duvida nao se acusa drift.
+#   INV-7: tick-mode rebaixa para "manual" no par exato
+#          (copia cega a backend + projeto com state.db). Copia cega sobre
+#          backend JSON SEGUE "hook" — rebaixar ali daria contagem DUPLA.
 
 TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
@@ -32,11 +42,40 @@ _mkproj() {
   printf '%s' "$_p"
 }
 
-# _put_hook PAP HOOK -> materializa o arquivo do hook, executavel.
+# Catalogo de referencia dos cenarios: `_put_hook` materializa a MESMA
+# copia no projeto e no catalogo, entao o default de todo cenario e
+# "current". Cenarios de drift divergem uma das duas pontas de proposito.
+# Sem este override o catalogo resolveria para o sibling do script (os
+# hooks reais do repo) e todo stub viraria "stale".
+# Define e EXPORTA CSTK_HOOKS_CATALOG_DIR, deixando o path em $_CATALOG.
+# Nao pode ecoar via $(...): o export morreria no subshell e o catalogo
+# cairia no sibling (hooks reais do repo), tornando todo stub "stale".
+_catalog_dir() {
+  _CATALOG="$TMPDIR_TEST/catalog-hooks"
+  mkdir -p "$_CATALOG"
+  CSTK_HOOKS_CATALOG_DIR="$_CATALOG"
+  export CSTK_HOOKS_CATALOG_DIR
+}
+
+# _put_hook PAP HOOK [BODY] -> materializa o arquivo do hook (executavel)
+# no projeto E no catalogo, com o mesmo conteudo.
 _put_hook() {
+  _ph_body=${3:-'#!/bin/sh
+exit 0'}
+  _catalog_dir
   mkdir -p "$1/.claude/hooks"
-  printf '#!/bin/sh\nexit 0\n' > "$1/.claude/hooks/$2"
+  printf '%s\n' "$_ph_body" > "$1/.claude/hooks/$2"
   chmod +x "$1/.claude/hooks/$2"
+  printf '%s\n' "$_ph_body" > "$_CATALOG/$2"
+}
+
+# _put_hook_stale PAP HOOK -> copia do projeto DIVERGE da do catalogo.
+_put_hook_stale() {
+  _catalog_dir
+  mkdir -p "$1/.claude/hooks"
+  printf '#!/bin/sh\n# versao antiga (so le state.json)\nexit 0\n' > "$1/.claude/hooks/$2"
+  chmod +x "$1/.claude/hooks/$2"
+  printf '#!/bin/sh\n# versao nova\n. _hook-active-exec.sh\nexit 0\n' > "$_CATALOG/$2"
 }
 
 # _register PAP HOOK... -> settings.json citando os hooks passados.
@@ -70,8 +109,8 @@ scenario_check_completo_exit0() {
   capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
   for _h in $_HOOKS; do
-    printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered$" \
-      || { _fail "TSV" "esperado '$_h present registered'"; return 1; }
+    printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered	current$" \
+      || { _fail "TSV" "esperado '$_h present registered current'"; return 1; }
   done
   return 0
 }
@@ -134,8 +173,8 @@ scenario_check_parcial_exit1_com_alerta_da_guarda() {
   _register "$_p" "posttooluse-tool-call-tick.sh"
   capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
-  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-tool-call-tick.sh	present	registered$' \
-    || { _fail "TSV" "tick-hook ativo deveria aparecer como present/registered"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-tool-call-tick.sh	present	registered	current$' \
+    || { _fail "TSV" "tick-hook ativo deveria aparecer como present/registered/current"; return 1; }
   # A ausencia da guarda e o item grave: precisa vir destacada em stderr.
   printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'pretooluse-bash-guard.sh inativo' \
     || { _fail "stderr" "faltou alerta destacado da guarda inativa"; return 1; }
@@ -211,6 +250,128 @@ scenario_tick_mode_manual_sem_registro() {
   capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
   [ "$_CAPTURED_STDOUT" = "manual" ] \
     || { _fail "stdout" "hook nao-registrado deve dar 'manual'"; return 1; }
+  return 0
+}
+
+# ==== INV-6: copia stale (o 2o modo de falha de campo) ====
+
+# Reproduz o bug de 03/ago/2026: os 3 hooks present+registered, mas a copia
+# do projeto e a de jul/2026. Antes desta dimensao, `check` dizia 3/3 ativos
+# e tool_calls zerava em silencio.
+scenario_check_stale_exit1() {
+  _p=$(_mkproj proj-stale)
+  for _h in $_HOOKS; do _put_hook_stale "$_p" "$_h"; done
+  # shellcheck disable=SC2086
+  _register "$_p" $_HOOKS
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "copia stale deve reprovar (esperado 1, obtido $_CAPTURED_EXIT)"; return 1; }
+  _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c '	present	registered	stale$')
+  [ "$_n" = 3 ] || { _fail "TSV" "esperado 3 linhas present/registered/stale, obtido $_n"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'STALE' \
+    || { _fail "stderr" "faltou diagnostico de stale"; return 1; }
+  return 0
+}
+
+# A guarda stale e o item grave (roda com regras de versao anterior) —
+# precisa de alerta destacado, paridade com o alerta de guarda inativa.
+scenario_check_stale_da_guarda_tem_alerta_destacado() {
+  _p=$(_mkproj proj-stale-guarda)
+  _fully_provisioned "$_p"
+  _put_hook_stale "$_p" "pretooluse-bash-guard.sh"
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'pretooluse-bash-guard.sh STALE' \
+    || { _fail "stderr" "faltou alerta destacado da guarda stale"; return 1; }
+  return 0
+}
+
+# INV-6: catalogo irresolvivel => "unknown", nunca "stale" (nao se acusa
+# drift sem ter com que comparar).
+scenario_check_catalogo_ausente_da_unknown_e_nao_reprova() {
+  _p=$(_mkproj proj-sem-catalogo)
+  _fully_provisioned "$_p"
+  _vazio="$TMPDIR_TEST/catalogo-vazio"
+  mkdir -p "$_vazio"
+  # As TRES pontas da cadeia precisam falhar para valer como "irresolvivel":
+  # override vazio, script copiado para fora do catalogo (sem sibling
+  # ../hooks) e HOME falso. Neutralizar so o override deixaria o sibling do
+  # repo responder — e o veredito seria "stale", nao "unknown".
+  _solto="$TMPDIR_TEST/script-solto"
+  mkdir -p "$_solto"
+  cp "$SCRIPT" "$_solto/guard-hooks-status.sh"
+  capture env HOME="$_vazio" CSTK_HOOKS_CATALOG_DIR="$_vazio" \
+    sh "$_solto/guard-hooks-status.sh" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "exit" "catalogo irresolvivel nao pode reprovar (obtido $_CAPTURED_EXIT)"; return 1; }
+  _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c '	unknown$')
+  [ "$_n" = 3 ] || { _fail "TSV" "esperado 3 linhas unknown, obtido $_n"; return 1; }
+  return 0
+}
+
+# Hook ausente => freshness "unknown" (nao ha copia do projeto p/ comparar);
+# o que reprova ali e o missing, nao o drift.
+scenario_check_hook_ausente_da_unknown() {
+  _p=$(_mkproj proj-unknown-missing)
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c '	missing	unregistered	unknown$')
+  [ "$_n" = 3 ] || { _fail "TSV" "hook ausente deve dar freshness unknown, obtido $_n linhas"; return 1; }
+  return 0
+}
+
+# ==== INV-7: rebaixamento do tick-mode por cegueira de backend ====
+
+# Copia cega (pre hooks-db-parity) + state.db no projeto = o par exato em
+# que o hook nunca ticka. Sem o rebaixamento, tool_calls fica 0.
+scenario_tick_mode_manual_com_copia_cega_e_state_db() {
+  _p=$(_mkproj proj-cego-sqlite)
+  _fully_provisioned "$_p"
+  mkdir -p "$_p/.claude/feature-00c-state/demo"
+  : > "$_p/.claude/feature-00c-state/demo/state.db"
+  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_STDOUT" = "manual" ] \
+    || { _fail "stdout" "copia cega + state.db deve dar 'manual', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+# Mesma cegueira em agente-00c-state/ (nao so feature-00c-state/*/).
+scenario_tick_mode_manual_com_copia_cega_e_state_db_agente() {
+  _p=$(_mkproj proj-cego-sqlite-agente)
+  _fully_provisioned "$_p"
+  mkdir -p "$_p/.claude/agente-00c-state"
+  : > "$_p/.claude/agente-00c-state/state.db"
+  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_STDOUT" = "manual" ] \
+    || { _fail "stdout" "copia cega + state.db (agente) deve dar 'manual', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+# ANTI-CONTAGEM-DUPLA: copia cega sobre backend JSON SEGUE funcionando —
+# devolver "manual" ali somaria tick do hook + tick manual.
+scenario_tick_mode_hook_com_copia_cega_e_backend_json() {
+  _p=$(_mkproj proj-cego-json)
+  _fully_provisioned "$_p"
+  mkdir -p "$_p/.claude/feature-00c-state/demo"
+  printf '{}\n' > "$_p/.claude/feature-00c-state/demo/state.json"
+  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_STDOUT" = "hook" ] \
+    || { _fail "stdout" "copia cega + backend JSON deve seguir 'hook', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+# Copia ATUAL (referencia _hook-active-exec.sh) + state.db => "hook":
+# o rebaixamento e por cegueira, nao pela mera presenca de sqlite.
+scenario_tick_mode_hook_com_copia_atual_e_state_db() {
+  _p=$(_mkproj proj-atual-sqlite)
+  _fully_provisioned "$_p"
+  _put_hook "$_p" "posttooluse-tool-call-tick.sh" '#!/bin/sh
+# versao pos hooks-db-parity
+. _hook-active-exec.sh
+exit 0'
+  mkdir -p "$_p/.claude/feature-00c-state/demo"
+  : > "$_p/.claude/feature-00c-state/demo/state.db"
+  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_STDOUT" = "hook" ] \
+    || { _fail "stdout" "copia atual + state.db deve dar 'hook', obtido '$_CAPTURED_STDOUT'"; return 1; }
   return 0
 }
 


### PR DESCRIPTION
## Problema

`tool_calls` estava **0 em todas as ondas** desde o cutover `state.json` → `state.db` (03/ago). Último valor não-zero: `state-mcp-server` onda-021 (02/ago, backend JSON). Atingiu o cstk (15 ondas) e o `meta-gob-ms` (4 ondas).

**Causa**: as cópias dos hooks em `<projeto>/.claude/hooks/` são snapshots do dia do provisionamento e nada as reconcilia com o catálogo — `cstk update` só reprovisiona com `--scope project` + `agente-00c-runtime` na seleção, e roda no repo do cstk, não no projeto-alvo. Os projetos seguiram com o `posttooluse-tool-call-tick.sh` de julho, que detecta execução ativa lendo **só `state.json`**: sob backend SQLite o hook não enxerga a execução, sai mudo, e o sidecar `tool-call-ticks.log` nunca é criado.

As duas guardas que deveriam pegar isso falharam juntas — `check` só olhava *present + registered* (cópia stale passava como saudável) e `tick-mode` respondia `hook`, então o orquestrador também não tickava na mão.

## Mudanças

- **`check`: 4ª coluna `current|stale|unknown`** — `cmp` contra o catálogo (`CSTK_HOOKS_CATALOG_DIR` > sibling `../hooks` > `$HOME`). `stale` reprova com exit 1; guarda stale ganha alerta destacado (roda regras de versão anterior — é segurança, não só métrica).
- **`freshness` degrada para `unknown`, nunca `stale`**, sem `cmp` no PATH / catálogo irresolvível / hook ausente: acusar drift sem ter comparado seria inventar veredito.
- **`tick-mode` → `manual`** no par exato *cópia cega (sem `_hook-active-exec.sh`)* + *`state.db`*, onde o hook nunca ticka. Fora desse par segue `hook`: rebaixar cópia cega sobre backend JSON, onde ela funciona, daria **contagem dupla**.
- Commands, orquestradores e README alinhados: `stale` tem a mesma remediação de ausente (`cstk hooks install`); `unknown` nunca é veredito.

## Testado

- Suite completa: `LC_ALL=C ./tests/run.sh` → **PASS 2452 · FAIL 0 · ERROR 0 · ORPHANS 0** (704s)
- `tests/test_guard-hooks-status.sh`: 28/28 (8 cenários novos — INV-6/INV-7, incluindo a reprodução do bug de campo e o anti-contagem-dupla)
- `cstk doctor`: drift zero · `./tests/run.sh --check-coverage`: zero órfãos · shellcheck limpo no script tocado
- Fixture com `state.db` ativo: hook stale → sem sidecar; hook atual → tick gravado

## Não recuperável

As 19 ondas já fechadas com `0` não têm sidecar — não há de onde fazer backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVpPJKqBQbuJEGZBDCyiN7