### PR TITLE
fix(agente-00c-runtime): path Windows no preflight (#77) + baseline stale e collation no wave-commit (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [6.5.1] - 2026-08-05
+
+Fecha as issues #77 e #49, ambas do runtime dos orquestradores. A #77
+bloqueava o gate FR-010A (clarify→plan) em qualquer execução feature-00c
+sobre projeto com path Windows (drive-letter): `C:/Users/...` não era
+reconhecido como absoluto e virava `<projeto>/C:/Users/...`, produzindo
+`briefing_missing`/`constitution_missing` falsos com hash correto no
+disco. A #49 (wave-commit staged ~45 untracked pré-existentes) já tinha o
+fix proposto na issue implementado desde a v5.23.0 (`--untracked-files=all`
+nos dois lados) — a análise achou as duas brechas residuais que explicam o
+incidente: baseline stale sobrevivendo a uma captura best-effort falha, e
+collation de locale divergente entre `sort` (snapshot) e `comm`
+(stage-derived).
+
+### Fixed
+
+- **`feature-00c-preflight.sh` reconhece path absoluto Windows (#77).** O
+  resolve de `prerequisites.briefing.path`/`constitution.path` agora casa
+  `/*` E `[A-Za-z]:[/\\]*` — path com drive-letter deixa de ser
+  concatenado ao `target_project_path`. Cenário novo
+  `scenario_check_path_windows_drive_letter_nao_concatena` prova que o
+  finding cita o path original sem prefixo do projeto.
+- **`state-ondas.sh start` invalida o baseline da onda anterior (#49).**
+  `commit-baseline.txt` é removido ANTES de qualquer early-return da
+  captura best-effort: se a captura falhar, o arquivo fica ausente e
+  `stage-derived` cai no fail-closed existente (untracked fora do
+  staging), em vez de reusar baseline stale e vazar untracked
+  pré-existente para o wave-commit. Cenário novo
+  `scenario_issue49_start_invalida_baseline_stale_quando_captura_falha`.
+- **`commit-mode.sh` fixa `LC_ALL=C` em todos os `sort`/`comm` (#49).**
+  `snapshot` e `stage-derived` comparavam via `comm` listas ordenadas sob
+  o locale herdado de cada invocação — collation divergente (ex.: pt_BR
+  ordena `a.txt` antes de `Z.txt`) fazia linhas do baseline não casarem e
+  untracked pré-existente "vazar" como novo. Cenário novo
+  `scenario_issue49_collation_c_entre_snapshot_e_stagederived` roda
+  snapshot sob `en_US.UTF-8` e stage-derived sob `C` e prova o roundtrip
+  limpo.
+
 ## [6.5.0] - 2026-08-04
 
 `tool_calls` estava zerado em TODAS as ondas desde o cutover
@@ -5001,6 +5039,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[6.5.1]: https://github.com/JotJunior/cstk/releases/tag/v6.5.1
 [6.5.0]: https://github.com/JotJunior/cstk/releases/tag/v6.5.0
 [6.4.1]: https://github.com/JotJunior/cstk/releases/tag/v6.4.1
 [6.4.0]: https://github.com/JotJunior/cstk/releases/tag/v6.4.0

--- a/global/skills/agente-00c-runtime/scripts/commit-mode.sh
+++ b/global/skills/agente-00c-runtime/scripts/commit-mode.sh
@@ -411,8 +411,11 @@ _cm_cmd_snapshot() {
   # para uma linha por entrada via tr (paths nao contem NUL; newline
   # literal em nome de arquivo e fora de escopo, mesma limitacao aceita
   # pelo restante do runtime POSIX).
+  # LC_ALL=C: baseline e comparado via `comm` em stage-derived, que exige
+  # ordenacao IDENTICA — collation de locale (pt_BR etc.) divergente entre
+  # as duas invocacoes faz untracked pre-existente "vazar" como novo.
   if ! git -C "$_pap" status --porcelain -z --untracked-files=all 2>/dev/null \
-      | tr '\0' '\n' | sed -n 's/^?? //p' | sort > "$_tmp"; then
+      | tr '\0' '\n' | sed -n 's/^?? //p' | LC_ALL=C sort > "$_tmp"; then
     rm -f "$_tmp" 2>/dev/null || :
     _cm_err "snapshot: 'git status --porcelain' falhou em $_pap"
     _cm_diag "error" "git-status-failed" "git status --porcelain falhou em $_pap" "confirme que $_pap e um repositorio git valido"
@@ -554,19 +557,21 @@ _cm_cmd_stage_derived() {
     fi
   done < "$_raw"
 
-  sort -u -o "$_tracked" "$_tracked"
-  sort -u -o "$_untracked_cur" "$_untracked_cur"
+  # LC_ALL=C em sort/comm: mesma collation do snapshot (baseline) — `comm`
+  # exige ordenacao identica dos dois lados (issue #49).
+  LC_ALL=C sort -u -o "$_tracked" "$_tracked"
+  LC_ALL=C sort -u -o "$_untracked_cur" "$_untracked_cur"
 
   _baseline="$_sdir/commit-baseline.txt"
   if [ -f "$_baseline" ]; then
-    comm -13 "$_baseline" "$_untracked_cur" > "$_untracked_new" 2>/dev/null || : > "$_untracked_new"
+    LC_ALL=C comm -13 "$_baseline" "$_untracked_cur" > "$_untracked_new" 2>/dev/null || : > "$_untracked_new"
   else
     _cm_err "stage-derived: baseline ausente ($_baseline) — untracked ficam FORA do staging (fail-closed, nunca fallback amplo)"
     _cm_diag "warning" "baseline-missing" "commit-baseline.txt ausente em $_sdir" "chame 'commit-mode.sh snapshot' antes de stage-derived para incluir untracked novos"
     : > "$_untracked_new"
   fi
 
-  cat "$_tracked" "$_untracked_new" | sort -u > "$_allowlist"
+  cat "$_tracked" "$_untracked_new" | LC_ALL=C sort -u > "$_allowlist"
 
   if [ "$_has_scope" = 1 ]; then
     : > "$_filtered"
@@ -582,7 +587,7 @@ _cm_cmd_stage_derived() {
         esac
       done < "$_scope_file"
     done < "$_allowlist"
-    sort -u -o "$_filtered" "$_filtered"
+    LC_ALL=C sort -u -o "$_filtered" "$_filtered"
     cp "$_filtered" "$_allowlist" 2>/dev/null || :
   fi
 

--- a/global/skills/agente-00c-runtime/scripts/feature-00c-preflight.sh
+++ b/global/skills/agente-00c-runtime/scripts/feature-00c-preflight.sh
@@ -98,9 +98,12 @@ _fp_cmd_check() {
   fi
   [ -n "$_projeto" ] || _fp_die_io "check: state.json sem execution.target_project_path"
 
-  # Resolver paths absolutos relativos ao projeto-alvo
-  case "$_br_path" in /*) _br_abs="$_br_path" ;; *) _br_abs="$_projeto/$_br_path" ;; esac
-  case "$_ct_path" in /*) _ct_abs="$_ct_path" ;; *) _ct_abs="$_projeto/$_ct_path" ;; esac
+  # Resolver paths absolutos relativos ao projeto-alvo. Alem de absoluto
+  # POSIX (/*), reconhece drive-letter Windows (C:/..., execucao sob Git
+  # Bash) — sem isso o path vira "relativo", concatena com _projeto e o
+  # gate FR-010A reporta briefing/constitution_missing falso (issue #77).
+  case "$_br_path" in /*|[A-Za-z]:[/\\]*) _br_abs="$_br_path" ;; *) _br_abs="$_projeto/$_br_path" ;; esac
+  case "$_ct_path" in /*|[A-Za-z]:[/\\]*) _ct_abs="$_ct_path" ;; *) _ct_abs="$_projeto/$_ct_path" ;; esac
 
   # Coletar findings em arquivos temporarios (linhas JSON)
   _findings_file=$(mktemp)

--- a/global/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/global/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -645,6 +645,12 @@ _so_cmd_start() {
 # fluxo principal de start com `set -e` (toda falha aqui e silenciosa).
 _so_start_snapshot_baseline() {
   _ssb_sdir="$1"
+  # Invalida o baseline da onda ANTERIOR antes de qualquer early-return:
+  # se a captura desta onda falhar (best-effort), o arquivo fica AUSENTE e
+  # stage-derived cai no fail-closed (untracked fora do staging). Sem isso,
+  # um baseline stale sobrevive e tudo que ficou untracked desde aquela
+  # onda antiga "vaza" como novo e e staged no wave-commit (issue #49).
+  rm -f "$_ssb_sdir/commit-baseline.txt" 2>/dev/null || :
   command -v git >/dev/null 2>&1 || return 0
 
   # Le via state-rw.sh get (backend-safe: funciona sob JSON e SQLite sem

--- a/tests/test_commit-mode.sh
+++ b/tests/test_commit-mode.sh
@@ -523,6 +523,49 @@ beta.txt"
   [ "$_got" = "$_expected" ] || { _fail "baseline ordenado" "esperado '$_expected' obtido '$_got'"; return 1; }
 }
 
+# ==== issue #49: collation estavel (LC_ALL=C) entre snapshot e stage-derived ====
+# Incidente real: ~45 untracked PRE-EXISTENTES staged no wave-commit. Uma
+# das causas: baseline ordenado sob collation de locale (en_US/pt_BR poem
+# "a.txt" antes de "Z.txt") e `comm` comparando sob outra — linhas do
+# baseline nao casam e o pre-existente "vaza" como novo. Com o fix, sort e
+# comm rodam SEMPRE em LC_ALL=C nos dois subcomandos, independente do
+# locale herdado da invocacao.
+
+scenario_issue49_collation_c_entre_snapshot_e_stagederived() {
+  _loc=$(locale -a 2>/dev/null | grep -i '^en_US\.utf-*8$' | head -1)
+  [ -n "$_loc" ] || { printf '# skip: locale en_US.UTF-8 indisponivel\n'; return 0; }
+  _gdir="$TMPDIR_TEST/repo-collation"
+  _sd="$TMPDIR_TEST/sd-collation"
+  _init_git_repo "$_gdir" "feat/collation"
+  # Em C, "Z.txt" < "a.txt"; em en_US, "a.txt" < "Z.txt" — o par detecta
+  # qualquer sort fora de LC_ALL=C.
+  printf 'z\n' > "$_gdir/Z.txt"
+  printf 'a\n' > "$_gdir/a.txt"
+
+  # snapshot herda locale UTF-8 (sessao tipica do operador nao-C)
+  capture env LC_ALL="$_loc" "$SCRIPT" snapshot --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "snapshot exit" "obtido $_CAPTURED_EXIT"; return 1; }
+  _expected="Z.txt
+a.txt"
+  _got=$(cat "$_sd/commit-baseline.txt")
+  [ "$_got" = "$_expected" ] \
+    || { _fail "baseline deve ser C-sorted mesmo sob $_loc" "obtido '$_got'"; return 1; }
+
+  # stage-derived herda OUTRO locale (C): os pre-existentes continuam fora,
+  # so a mudanca tracked entra.
+  printf 'r2\n' >> "$_gdir/README.md"
+  capture env LC_ALL=C "$SCRIPT" stage-derived --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "stage-derived exit" "obtido $_CAPTURED_EXIT stderr='$_CAPTURED_STDERR'"; return 1; }
+  _staged=$(git -C "$_gdir" diff --cached --name-only)
+  case "$_staged" in
+    *Z.txt*|*a.txt*) _fail "pre-existentes vazaram para o staging" "obtido: $_staged"; return 1 ;;
+  esac
+  case "$_staged" in
+    *README.md*) : ;;
+    *) _fail "README.md deveria estar staged" "obtido: $_staged"; return 1 ;;
+  esac
+}
+
 # ==== snapshot: uso incorreto sem --state-dir/--projeto-alvo-path => exit 2 ====
 
 scenario_snapshot_uso_incorreto_exit2() {

--- a/tests/test_feature-00c-preflight.sh
+++ b/tests/test_feature-00c-preflight.sh
@@ -182,6 +182,28 @@ CT
   assert_stdout_contains '"ok": false' || return 1
 }
 
+# ==== issue #77: path Windows drive-letter tratado como ABSOLUTO ====
+# Execucao sob Git Bash grava prerequisites.*.path como "C:/Users/...".
+# O case pattern antigo (/*) nao reconhecia esse formato como absoluto e
+# concatenava com target_project_path ("<proj>/C:/Users/..."), gerando
+# false-positive briefing_missing/constitution_missing que bloqueia o gate
+# FR-010A em toda execucao. O path drive-letter nao existe no runner (o
+# arquivo segue missing), mas o finding DEVE citar o path original SEM o
+# prefixo do projeto — prova de que nao houve concatenacao.
+scenario_check_path_windows_drive_letter_nao_concatena() {
+  _sdir=$(_setup_fixture)
+  _proj=$(dirname -- "$(dirname -- "$(dirname -- "$_sdir")")")
+  _tmp=$(mktemp)
+  jq '.prerequisites.briefing.path = "C:/Users/Op/proj/docs/01-briefing-discovery/briefing.md"
+      | .prerequisites.constitution.path = "C:/Users/Op/proj/docs/constitution.md"' \
+    "$_sdir/state.json" > "$_tmp" && mv "$_tmp" "$_sdir/state.json"
+  capture "$SCRIPT" check --state-dir "$_sdir"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1 (missing), obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains 'briefing_missing' || return 1
+  assert_stdout_contains 'C:/Users/Op/proj' || return 1
+  assert_stdout_not_contains "$_proj/C:" || return 1
+}
+
 scenario_check_state_dir_inexistente_falha() {
   capture "$SCRIPT" check --state-dir "/path/que/nao/existe"
   if [ "$_CAPTURED_EXIT" != 2 ]; then

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -1046,6 +1046,24 @@ scenario_5_5_wave_commit_endurecido_exclui_alien() {
   esac
 }
 
+# ==== issue #49: baseline stale invalidado no start ====
+# A captura do baseline e best-effort e silenciosa. Se ela falha numa onda
+# nova, o commit-baseline.txt da onda ANTERIOR nao pode sobreviver:
+# stage-derived o trataria como valido e tudo que ficou untracked desde
+# aquela onda antiga "vazaria" como novo no wave-commit (o incidente dos
+# ~45 arquivos .claude/). start remove o baseline ANTES de qualquer
+# early-return: falha de captura => arquivo AUSENTE => fail-closed.
+scenario_issue49_start_invalida_baseline_stale_quando_captura_falha() {
+  _sd="$TMPDIR_TEST/state-stale-baseline"
+  # projeto-alvo inexistente: a captura early-returns sem gravar baseline
+  _init_state "$_sd" "$TMPDIR_TEST/projeto-que-nao-existe"
+  printf 'stale-da-onda-anterior.txt\n' > "$_sd/commit-baseline.txt"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start exit" "$_CAPTURED_STDERR"; return 1; }
+  [ ! -f "$_sd/commit-baseline.txt" ] \
+    || { _fail "baseline stale sobreviveu ao start" "$(cat "$_sd/commit-baseline.txt")"; return 1; }
+}
+
 # ==== Sidecar de ticks do hook PostToolUse (tool-call-ticks.log) ====
 
 scenario_end_soma_sidecar_ao_campo_do_state() {


### PR DESCRIPTION
## Resumo

Fecha #77 e corrige as causas-raiz residuais de #49 (release 6.5.1).

### #77 — `feature-00c-preflight.sh` falhava com paths Windows
O resolve de `prerequisites.*.path` só reconhecia absoluto POSIX (`/*`); `C:/Users/...` era concatenado ao `target_project_path`, gerando `briefing_missing`/`constitution_missing` falsos que bloqueavam o gate FR-010A (clarify→plan). Agora o case casa `/*|[A-Za-z]:[/\\]*`.

### #49 — wave-commit staged ~45 untracked pré-existentes
O fix proposto na issue (`--untracked-files=all`) já existia desde a v5.23.0. A análise identificou as duas brechas residuais que explicam o incidente:

1. **Baseline stale**: a captura em `state-ondas.sh start` é best-effort e silenciosa, e nada removia o `commit-baseline.txt` da onda anterior — captura falha ⇒ `stage-derived` tratava o baseline velho como válido e tudo untracked desde então vazava para o commit. Agora o `start` invalida o baseline ANTES de qualquer early-return (falha ⇒ ausente ⇒ fail-closed).
2. **Collation**: `sort` (snapshot) e `comm` (stage-derived) rodavam sob o locale herdado de cada invocação; collation divergente quebrava o `comm` e vazava pré-existente como novo. Agora todos os `sort`/`comm` fixam `LC_ALL=C`.

## Testado

- 3 cenários novos de regressão (`test_feature-00c-preflight.sh`, `test_commit-mode.sh`, `test_state-ondas.sh`)
- Suíte completa local: **2455 PASS / 0 FAIL** (739s)
- `--check-coverage`: zero órfãos · shellcheck: sem finding novo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa