### PR TITLE
feat: cstk usage (consumo avulso) + briefing canonico + deprecation initialize-docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [6.6.0] - 2026-08-07
+
+Duas frentes: (1) rastreio de consumo avulso — tokens/custo das sessões
+interativas comuns do Claude Code, que ficavam invisíveis porque o
+`cstk recall` só cobre ondas de orquestrador — via hook opt-in + subcomando
+`cstk usage`; (2) oficialização do briefing canônico em `docs/briefing.md`
+e deprecation formal do `initialize-docs` (remoção na v7).
+
+### Added
+
+- **`cstk usage` / `usage compare` / `usage prune`** (`cli/lib/usage.sh`,
+  novo). `usage` lista consumo avulso por projeto/modelo (`--project`,
+  `--since ISO`, `--json`); `compare` põe avulso vs pipeline lado a lado;
+  `prune` remove segmentos fechados do sidecar + linhas `loose_usage` acima
+  do TTL (`CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`; `--dry-run`;
+  segmentos abertos nunca são elegíveis). Campo sem medição imprime
+  `nao medido` / `null` no `--json` — nunca `0` fabricado (Princípio VI).
+  `usage.sh` nunca chama `sqlite3` direto: delega a `cli/lib/recall.sh`,
+  único arquivo autorizado (mesma regra do `cstk recall`).
+- **Hook de captura opt-in `posttooluse-loose-usage.sh`** +
+  `cstk hooks install --with-loose-usage`. Registrado em snippet SEPARADO
+  (`settings.loose-usage.snippet.json`) do dos 3 hooks obrigatórios —
+  nunca bundlado sem a flag (default DESLIGADO). Throttle O(1) via
+  `meta.tsv` (`CSTK_LOOSE_USAGE_INTERVAL_S`, default `300`); detecta
+  execução 00c ativa (polaridade invertida de `_hook-active-exec.sh`) para
+  não contar duas vezes o mesmo consumo; contrato de saída stdout/stderr
+  sempre vazios, exit sempre `0`. Sidecar TSV em
+  `~/.claude/cstk/loose-usage/<process_key>/seg-*/` com permissões
+  restritivas (`700` diretórios, `600` arquivos).
+- **`knowledge.db` schema v13** (migração `12 → 13`, aditiva): tabela
+  `loose_usage` + `recall_prune_loose_usage` em `cli/lib/recall.sh`.
+- **Docs e testes.** `docs/cstk-usage.md` (+ pt-BR), spec completa em
+  `docs/specs/loose-usage-capture/`; `tests/cstk/test_usage.sh` e
+  `tests/test_posttooluse-loose-usage.sh` novos, extensões em
+  `tests/cstk/test_recall.sh` + `tests/cstk/test_hooks.sh`.
+
+### Changed
+
+- **Briefing canônico em `docs/briefing.md`.** Todos os leitores checam o
+  caminho canônico primeiro e caem no legado
+  `docs/01-briefing-discovery/briefing.md` só em fallback:
+  `pipeline.sh detect-completion` (inclusive fallback `--projeto-alvo-path`),
+  skills `briefing`/`clarify`/`plan`/`specify`/`execute-task`, orquestrador
+  `agente-00c` e command `feature-00c`, docs e READMEs. A skill `briefing`
+  passa a salvar no canônico e registra aviso quando encontra briefing
+  apenas no caminho legado. Cenários novos em `tests/test_pipeline.sh`.
+
+### Deprecated
+
+- **`initialize-docs` (remoção planejada na v7).** A hierarquia numerada
+  01-09 foi superada pelo layout SDD (`docs/briefing.md` +
+  `docs/constitution.md` + `docs/specs/`), criado pelas próprias skills
+  `briefing`/`constitution`/`specify` sem scaffold prévio. Marcação de
+  deprecated no frontmatter/description da skill, READMEs, help do
+  `cstk install` (profile `complementary`) e `tips/catalog.md`; a skill
+  permanece instalável apenas para projetos legados. O pipeline aceita os
+  dois layouts até a remoção.
+
 ## [6.5.1] - 2026-08-05
 
 Fecha as issues #77 e #49, ambas do runtime dos orquestradores. A #77
@@ -5039,6 +5097,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[6.6.0]: https://github.com/JotJunior/cstk/releases/tag/v6.6.0
 [6.5.1]: https://github.com/JotJunior/cstk/releases/tag/v6.5.1
 [6.5.0]: https://github.com/JotJunior/cstk/releases/tag/v6.5.0
 [6.4.1]: https://github.com/JotJunior/cstk/releases/tag/v6.4.1

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Details, flow diagram and shortcuts in
 | **bugfix** | "bugfix", "fix bug", "debug" | Structured multi-layer bug-fixing protocol |
 | **converge** | "converge", "o código bate com a spec?" | Reconciles spec/plan/tasks against the CURRENT code and appends gaps as a new task phase. Unconditional gate between execute-task and review-task in the orchestrators |
 | **e2e-integration-flow** | "e2e", "playwright", "validar fluxo completo" | Full-stack E2E integration tests (UI → API → database → queue → side effects) |
-| **initialize-docs** | "inicializar docs", "setup documentação" | Creates the standard documentation hierarchy with 9 levels |
+| **initialize-docs** | *(deprecated — removal in v7)* | Creates the legacy 9-level documentation hierarchy. Superseded by the SDD layout (`docs/briefing.md` + `docs/constitution.md` + `docs/specs/`); kept only for legacy projects |
 | **apply-insights** | "aplicar insights", "melhorar claude.md" | Applies proven usage insights to CLAUDE.md, hooks and workflows — see [Usage insights](#usage-insights) |
 | **owasp-security** | When reviewing security | Checklist-guided review (OWASP Top 10:2025, ASVS 5.0, LLM/Agentic, NIST, OAuth 2.1...). Does not replace audit/pentest |
 | **review-features** | "status global", "comparar features" | Cross-feature report suggesting archive/abandon/prioritize; the archive action applies deltas to the living-specs corpus |
@@ -185,6 +185,7 @@ before deciding.
 | `/agente-00c` + `/feature-00c` orchestrators, model-routing, atomic-commit, guards | [docs/agente-00c.md](./docs/agente-00c.md) |
 | Parallel sessions (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.md) |
 | Knowledge memory (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.md) |
+| Loose usage tracking (`cstk usage`) | [docs/cstk-usage.md](./docs/cstk-usage.md) |
 | Web metrics panel (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.md) |
 
 ## Usage insights
@@ -413,6 +414,7 @@ Default profile when none is given: `sdd`. Details in `cstk install --help`.
 | Autonomous orchestrator (agente-00c / feature-00c) | [docs/agente-00c.md](./docs/agente-00c.md) |
 | Parallel sessions (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.md) |
 | Knowledge memory (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.md) |
+| Loose usage tracking (`cstk usage`) | [docs/cstk-usage.md](./docs/cstk-usage.md) |
 | Web panel (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.md) |
 | Go skills and hooks | [docs/go-toolkit.md](./docs/go-toolkit.md) |
 | Naming conventions and docs hierarchy | [docs/conventions.md](./docs/conventions.md) |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -161,7 +161,7 @@ Detalhes, diagrama do fluxo e atalhos em
 | **bugfix** | "bugfix", "fix bug", "debug" | Protocolo estruturado de correção de bugs multi-camada |
 | **converge** | "converge", "o código bate com a spec?" | Reconcilia spec/plan/tasks contra o código ATUAL e apenda gaps como nova fase de tasks. Gate incondicional entre execute-task e review-task nos orquestradores |
 | **e2e-integration-flow** | "e2e", "playwright", "validar fluxo completo" | Testes E2E de integração full-stack (UI → API → banco → fila → efeitos colaterais) |
-| **initialize-docs** | "inicializar docs", "setup documentação" | Cria hierarquia padrão de documentação com 9 níveis |
+| **initialize-docs** | *(deprecated — remoção na v7)* | Cria a hierarquia legada de 9 níveis. Superada pelo layout SDD (`docs/briefing.md` + `docs/constitution.md` + `docs/specs/`); mantida só para projetos legados |
 | **apply-insights** | "aplicar insights", "melhorar claude.md" | Aplica insights de uso comprovados ao CLAUDE.md, hooks e workflows — ver [Insights de uso](#insights-de-uso) |
 | **owasp-security** | Ao revisar segurança | Revisão guiada por checklist (OWASP Top 10:2025, ASVS 5.0, LLM/Agentic, NIST, OAuth 2.1...). Não substitui auditoria/pentest |
 | **review-features** | "status global", "comparar features" | Relatório cross-feature com sugestão de arquivar/abandonar/priorizar; a ação de archive aplica os deltas ao corpus de specs vivas |
@@ -185,6 +185,7 @@ cross-feature consultada antes de decidir.
 | Orquestradores `/agente-00c` + `/feature-00c`, model-routing, atomic-commit, guardas | [docs/agente-00c.md](./docs/agente-00c.pt-BR.md) |
 | Sessões paralelas (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.pt-BR.md) |
 | Memória de conhecimento (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.pt-BR.md) |
+| Consumo avulso (`cstk usage`) | [docs/cstk-usage.md](./docs/cstk-usage.pt-BR.md) |
 | Painel web de métricas (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.pt-BR.md) |
 
 ## Insights de uso
@@ -403,6 +404,7 @@ Profile padrão quando nada é informado: `sdd`. Detalhes em `cstk install --hel
 | Orquestrador autônomo (agente-00c / feature-00c) | [docs/agente-00c.md](./docs/agente-00c.pt-BR.md) |
 | Sessões paralelas (`cstk session`) | [docs/cstk-session.md](./docs/cstk-session.pt-BR.md) |
 | Memória de conhecimento (`cstk recall`) | [docs/cstk-recall.md](./docs/cstk-recall.pt-BR.md) |
+| Consumo avulso (`cstk usage`) | [docs/cstk-usage.md](./docs/cstk-usage.pt-BR.md) |
 | Painel web (`cstk serve`) | [docs/cstk-serve.md](./docs/cstk-serve.pt-BR.md) |
 | Skills e hooks para Go | [docs/go-toolkit.md](./docs/go-toolkit.pt-BR.md) |
 | Convenções de nomenclatura e hierarquia de docs | [docs/conventions.md](./docs/conventions.pt-BR.md) |

--- a/cli/cstk
+++ b/cli/cstk
@@ -147,6 +147,8 @@ COMANDOS:
   mcp           Servidor MCP de estado das execucoes 00c (mcp status)
   hooks         Provisiona os hooks do runtime 00c num projeto-alvo
                 (so hooks + settings.json; nao duplica skill/commands/agents)
+  usage         Consulta o consumo avulso (fora de execucoes 00c); tambem
+                `usage compare` (avulso vs pipeline) e `usage prune` (TTL)
   00c <path>    Bootstrap interativo de projeto-alvo do agente-00C
                 (cria diretorio, coleta parametros e invoca claude)
 
@@ -197,6 +199,11 @@ HELP
       printf 'Para help inline, rode: cstk show-tip --help\n'
       exit "$CSTK_EXIT_OK"
       ;;
+    usage)
+      printf 'cstk help usage: consulte docs/specs/loose-usage-capture/contracts/cli-usage.md\n'
+      printf 'Para help inline, rode: cstk usage --help\n'
+      exit "$CSTK_EXIT_OK"
+      ;;
     00c)
       printf 'cstk help 00c: consulte docs/specs/cstk-cli/contracts/cstk-00c.md\n'
       printf 'Para help inline, rode: cstk 00c --help\n'
@@ -207,7 +214,7 @@ HELP
       ;;
     *)
       printf 'cstk: comando desconhecido para help: %s\n' "$_sub" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, 00c\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, 00c\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac
@@ -240,7 +247,7 @@ _dispatch() {
       . "$_lib_file"
       serve_main "$@"
       ;;
-    install|update|self-update|list|doctor|session|recall|show-tip|hooks|state|mcp)
+    install|update|self-update|list|doctor|session|recall|show-tip|hooks|state|mcp|usage)
       # Boot-check para todos exceto self-update (que e o caminho de recovery
       # da janela transiente — bloquea-lo aqui causaria deadlock).
       case "$_cmd" in
@@ -289,7 +296,7 @@ _dispatch() {
       ;;
     *)
       printf 'cstk: comando desconhecido: %s\n' "$_cmd" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, 00c, help, --version\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, 00c, help, --version\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac

--- a/cli/lib/hooks.sh
+++ b/cli/lib/hooks.sh
@@ -22,7 +22,13 @@
 #                                       — fallback sem jq: imprime bloco
 #                                         JSON em stderr com instrucoes
 #                                         para o usuario mesclar manualmente.
-#   apply_guard_hooks <src_dir> <dest_claude_root> <dry_run>
+#   merge_settings_loose_usage <target> <source>
+#                                       — append idempotente (NAO jq '*')
+#                                         do hook opt-in de consumo avulso
+#                                         no array .hooks.PostToolUse[]
+#                                         ja populado pelo merge_settings
+#                                         base (loose-usage-capture task 3.3).
+#   apply_guard_hooks <src_dir> <dest_claude_root> <dry_run> [with_loose_usage]
 #                                       — provisiona o hook PreToolUse/Bash
 #                                         de enforced-guards (US1): copia
 #                                         pretooluse-bash-guard.sh para
@@ -30,6 +36,9 @@
 #                                         settings.snippet.json. Reusa
 #                                         merge_settings/print_paste_block
 #                                         (Decision 9 — nenhum mecanismo novo).
+#                                         with_loose_usage=1 (opt-in, default
+#                                         0) tambem provisiona
+#                                         posttooluse-loose-usage.sh.
 #                                         Imprime em stdout uma palavra de
 #                                         estado: merged | paste-instructed |
 #                                         hooks-only | not-applicable | error.
@@ -130,6 +139,110 @@ merge_settings() {
   return 0
 }
 
+# merge_settings_loose_usage TARGET SOURCE
+#
+# Merge ADITIVO especializado para o hook OPT-IN de captura de consumo
+# avulso (posttooluse-loose-usage.sh, feature loose-usage-capture task
+# 3.3). NAO reusa merge_settings (jq '*' generico): jq's `*` NAO faz merge
+# recursivo de ARRAYS — quando os dois lados tem `.hooks.PostToolUse` como
+# array, o SEGUNDO operando vence POR INTEIRO, descartando o primeiro
+# (verificado empiricamente: `jq -s '.[0]*.[1]'` com dois arrays sempre
+# devolve o array do segundo operando, nunca uma uniao). Como o snippet
+# base (settings.snippet.json) ja populou target.hooks.PostToolUse com as
+# 2 entradas obrigatorias (tick + agent-usage) ANTES deste merge rodar,
+# aplicar merge_settings aqui perderia o hook opt-in silenciosamente.
+#
+# Estrategia: acha (ou cria) a entrada de matcher "*" dentro de
+# .hooks.PostToolUse e APPENDA o comando do SOURCE ao array .hooks[] dessa
+# entrada, dedup por `.command` (idempotente — reinstalar nao duplica).
+# jq obrigatorio (mesmo carve-out de merge_settings); target inexistente
+# apenas copia o source (source ja e um settings.json valido e minimo).
+merge_settings_loose_usage() {
+  if [ "$#" -ne 2 ]; then
+    log_error "hooks: merge_settings_loose_usage espera 2 argumentos (target, source)"
+    return 2
+  fi
+  _hooks_target=$1
+  _hooks_source=$2
+
+  if ! detect_jq; then
+    log_error "hooks: merge_settings_loose_usage exige jq (carve-out 1.1.0); use print_paste_block como fallback"
+    return 1
+  fi
+  if [ ! -f "$_hooks_source" ]; then
+    log_error "hooks: source JSON nao encontrado: $_hooks_source"
+    return 1
+  fi
+
+  _hooks_target_dir=$(dirname -- "$_hooks_target")
+  if [ ! -d "$_hooks_target_dir" ]; then
+    if ! mkdir -p -- "$_hooks_target_dir"; then
+      log_error "hooks: nao consegui criar dir pai de $_hooks_target"
+      return 1
+    fi
+  fi
+
+  # Caso 1: target nao existe -> apenas copia source (ja e um settings.json
+  # minimo valido, mesmo caso 1 de merge_settings).
+  if [ ! -f "$_hooks_target" ]; then
+    if ! cp -- "$_hooks_source" "$_hooks_target"; then
+      log_error "hooks: cp inicial falhou para $_hooks_target"
+      return 1
+    fi
+    log_info "hooks: $_hooks_target criado a partir de $_hooks_source"
+    return 0
+  fi
+
+  _hooks_cmd=$(jq -r '.hooks.PostToolUse[0].hooks[0].command // empty' -- "$_hooks_source" 2>/dev/null)
+  _hooks_timeout=$(jq -r '.hooks.PostToolUse[0].hooks[0].timeout // 5' -- "$_hooks_source" 2>/dev/null)
+  if [ -z "$_hooks_cmd" ]; then
+    log_error "hooks: source $_hooks_source nao tem o formato esperado (hooks.PostToolUse[0].hooks[0].command)"
+    return 1
+  fi
+
+  # Caso 2: target existe -> backup defensivo + append idempotente.
+  if ! cp -- "$_hooks_target" "${_hooks_target}.bak"; then
+    log_error "hooks: backup de $_hooks_target falhou — abortando sem merge"
+    return 1
+  fi
+
+  _hooks_tmp=$(mktemp -- "${_hooks_target_dir}/.cstk-merge.XXXXXX") || {
+    log_error "hooks: mktemp em $_hooks_target_dir falhou"
+    return 1
+  }
+
+  if ! jq --arg cmd "$_hooks_cmd" --argjson timeout "$_hooks_timeout" '
+    .hooks.PostToolUse = ((.hooks.PostToolUse // [])
+      | if any(.[]; .matcher == "*") then
+          map(
+            if .matcher == "*" then
+              .hooks = (
+                (.hooks // []) as $eh
+                | if ($eh | map(.command) | index($cmd)) then $eh
+                  else $eh + [{"type":"command","command":$cmd,"timeout":$timeout}]
+                  end
+              )
+            else . end
+          )
+        else
+          . + [{"matcher":"*","hooks":[{"type":"command","command":$cmd,"timeout":$timeout}]}]
+        end)
+  ' -- "$_hooks_target" > "$_hooks_tmp" 2>/dev/null; then
+    log_error "hooks: jq append falhou (JSON invalido em target?)"
+    rm -f -- "$_hooks_tmp"
+    return 1
+  fi
+
+  if ! mv -f -- "$_hooks_tmp" "$_hooks_target"; then
+    log_error "hooks: mv atomico falhou para $_hooks_target"
+    rm -f -- "$_hooks_tmp"
+    return 1
+  fi
+
+  log_info "hooks: $_hooks_target mesclado com hook opt-in de consumo avulso (backup em ${_hooks_target}.bak)"
+  return 0
+}
+
 # print_paste_block: fallback quando jq ausente. Imprime em stderr o JSON
 # do source com instrucao clara de onde colar. NUNCA modifica o filesystem.
 print_paste_block() {
@@ -175,6 +288,12 @@ print_paste_block() {
 #      <dest_claude_root>/settings.json via merge_settings (jq) ou
 #      print_paste_block (fallback sem jq) — mesma mecanica ja testada dos
 #      hooks language-*, nenhum mecanismo de distribuicao novo (FR-017).
+#   3. SOMENTE quando <with_loose_usage>=1 (opt-in, default 0 — feature
+#      loose-usage-capture task 3.3): copia
+#      <src_dir>/posttooluse-loose-usage.sh e mescla (append idempotente,
+#      via merge_settings_loose_usage) <src_dir>/settings.loose-usage.snippet.json.
+#      Best-effort — falha aqui NUNCA muda a palavra de estado nem os
+#      3 hooks obrigatorios (dec-008/FR-006).
 #
 # <src_dir> = diretorio contendo pretooluse-bash-guard.sh +
 # settings.snippet.json (tipicamente <catalog>/skills/agente-00c-runtime/hooks,
@@ -187,7 +306,9 @@ print_paste_block() {
 # resolvida para instalacao/atualizacao E escopo=project — Decision 9 diz
 # que --scope global sempre pula, mesma regra ja aplicada a language-*).
 #
-# Retorno: imprime em stdout UMA palavra de estado (sem newline extra):
+# Retorno: imprime em stdout UMA palavra de estado (sem newline extra),
+# SEMPRE derivada dos 3 hooks OBRIGATORIOS (o opt-in de item 3 nunca altera
+# esta palavra — best-effort separado):
 #   merged           — settings.json mesclado via jq
 #   paste-instructed — jq ausente, bloco impresso em stderr p/ colar manual
 #   hooks-only       — script copiado mas settings.snippet.json ausente
@@ -195,14 +316,15 @@ print_paste_block() {
 #                      trouxe hooks/ nesta instalacao — nao e erro)
 #   error            — falha de I/O (mkdir/cp/merge)
 apply_guard_hooks() {
-  if [ "$#" -ne 3 ]; then
-    log_error "hooks: apply_guard_hooks espera 3 argumentos (src_dir, dest_claude_root, dry_run)"
+  if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+    log_error "hooks: apply_guard_hooks espera 3 ou 4 argumentos (src_dir, dest_claude_root, dry_run, [with_loose_usage])"
     printf '%s' "error"
     return 2
   fi
   _agh_src=$1
   _agh_dest_root=$2
   _agh_dry_run=$3
+  _agh_with_loose=${4:-0}
 
   if [ ! -d "$_agh_src" ]; then
     log_warn "hooks: guard-hooks source ausente: $_agh_src"
@@ -223,6 +345,8 @@ apply_guard_hooks() {
 
   _agh_tick_script="$_agh_src/posttooluse-tool-call-tick.sh"
   _agh_usage_script="$_agh_src/posttooluse-agent-usage.sh"
+  _agh_loose_script="$_agh_src/posttooluse-loose-usage.sh"
+  _agh_loose_snippet="$_agh_src/settings.loose-usage.snippet.json"
 
   if [ "$_agh_dry_run" = 1 ]; then
     log_info "[dry-run] guard-hooks: copiaria $_agh_hook_script -> $_agh_hooks_dst/pretooluse-bash-guard.sh"
@@ -231,6 +355,18 @@ apply_guard_hooks() {
     fi
     if [ -f "$_agh_usage_script" ]; then
       log_info "[dry-run] guard-hooks: copiaria $_agh_usage_script -> $_agh_hooks_dst/posttooluse-agent-usage.sh"
+    fi
+    if [ "$_agh_with_loose" = 1 ]; then
+      if [ -f "$_agh_loose_script" ]; then
+        log_info "[dry-run] guard-hooks: copiaria $_agh_loose_script -> $_agh_hooks_dst/posttooluse-loose-usage.sh (opt-in --with-loose-usage)"
+      fi
+      if [ -f "$_agh_loose_snippet" ]; then
+        if detect_jq; then
+          log_info "[dry-run] guard-hooks: mesclaria (append) $_agh_loose_snippet -> $_agh_settings_dst"
+        else
+          log_info "[dry-run] guard-hooks: imprimiria paste-block do hook opt-in (jq ausente)"
+        fi
+      fi
     fi
     if [ -f "$_agh_snippet" ]; then
       if detect_jq; then
@@ -281,22 +417,63 @@ apply_guard_hooks() {
     fi
   fi
 
-  if [ ! -f "$_agh_snippet" ]; then
-    log_info "hooks: settings.snippet.json ausente em $_agh_src — so hook copiado"
-    printf '%s' "hooks-only"
-    return 0
+  # Hook OPT-IN de consumo avulso: copia do script e best-effort, independe
+  # do settings.json e por isso pode rodar aqui. So o MERGE do snippet
+  # precisa acontecer DEPOIS do merge base (bloco abaixo) — ver nota la.
+  if [ "$_agh_with_loose" = 1 ]; then
+    if [ -f "$_agh_loose_script" ]; then
+      if cp -- "$_agh_loose_script" "$_agh_hooks_dst/posttooluse-loose-usage.sh" 2>/dev/null; then
+        chmod +x -- "$_agh_hooks_dst/posttooluse-loose-usage.sh" 2>/dev/null || :
+        log_info "hooks: posttooluse-loose-usage.sh provisionado em $_agh_hooks_dst (opt-in --with-loose-usage)"
+      else
+        log_warn "hooks: cp de posttooluse-loose-usage.sh falhou — captura de consumo avulso indisponivel (demais hooks intactos)"
+      fi
+    else
+      log_warn "hooks: posttooluse-loose-usage.sh ausente no catalogo — --with-loose-usage sem efeito"
+    fi
   fi
 
-  if detect_jq; then
-    if merge_settings "$_agh_settings_dst" "$_agh_snippet"; then
-      printf '%s' "merged"
+  _agh_state="hooks-only"
+  if [ -f "$_agh_snippet" ]; then
+    if detect_jq; then
+      if merge_settings "$_agh_settings_dst" "$_agh_snippet"; then
+        _agh_state="merged"
+      else
+        _agh_state="error"
+      fi
     else
-      printf '%s' "error"
+      print_paste_block "$_agh_settings_dst" "$_agh_snippet"
+      _agh_state="paste-instructed"
     fi
   else
-    print_paste_block "$_agh_settings_dst" "$_agh_snippet"
-    printf '%s' "paste-instructed"
+    log_info "hooks: settings.snippet.json ausente em $_agh_src — so hook copiado"
   fi
+
+  # Merge do snippet OPT-IN: OBRIGATORIAMENTE depois do merge base acima.
+  # jq's `*` NAO faz merge recursivo de arrays — se este bloco rodasse
+  # ANTES do merge base (ordem tentada originalmente), com settings.json
+  # ainda inexistente, `merge_settings_loose_usage` criaria settings.json
+  # SO com o snippet opt-in; o merge base seguinte entao veria
+  # target.hooks.PostToolUse ja populado (so com o comando opt-in) e o
+  # `jq -s '.[0]*.[1]'` do merge_settings faria TARGET vencer o array
+  # inteiro — descartando o comando do tick/agent-usage. Rodar o append
+  # DEPOIS garante que o array PostToolUse ja tem as entradas obrigatorias
+  # quando o append (idempotente, por comando) acontece.
+  if [ "$_agh_with_loose" = 1 ] && [ -f "$_agh_loose_snippet" ]; then
+    if detect_jq; then
+      if merge_settings_loose_usage "$_agh_settings_dst" "$_agh_loose_snippet"; then
+        log_info "hooks: hook opt-in de consumo avulso registrado em $_agh_settings_dst"
+      else
+        log_warn "hooks: merge do hook opt-in de consumo avulso falhou (demais hooks intactos)"
+      fi
+    else
+      print_paste_block "$_agh_settings_dst" "$_agh_loose_snippet"
+    fi
+  elif [ "$_agh_with_loose" = 1 ]; then
+    log_warn "hooks: settings.loose-usage.snippet.json ausente no catalogo — --with-loose-usage sem registro automatico"
+  fi
+
+  printf '%s' "$_agh_state"
   return 0
 }
 
@@ -324,6 +501,7 @@ apply_guard_hooks() {
 #
 # Sintaxe:
 #   cstk hooks install [--project-path PATH] [--catalog DIR] [--dry-run]
+#                       [--with-loose-usage]
 #
 #   --project-path PATH  Raiz do projeto-alvo (default: diretorio corrente).
 #                        Os hooks vao para <PATH>/.claude/hooks/ e o merge
@@ -332,6 +510,12 @@ apply_guard_hooks() {
 #                        hooks sao lidos de
 #                        <DIR>/skills/agente-00c-runtime/hooks/.
 #   --dry-run            Reporta o plano sem escrever.
+#   --with-loose-usage   OPT-IN (default DESLIGADA — feature
+#                        loose-usage-capture task 3.3.2): tambem provisiona
+#                        posttooluse-loose-usage.sh (captura de consumo
+#                        avulso fora de execucoes 00c). Sem esta flag,
+#                        apply_guard_hooks() se comporta EXATAMENTE como
+#                        antes (3 hooks obrigatorios, zero regressao).
 #
 # Escopo de PROJETO apenas, por construcao: os hooks so fazem sentido
 # registrados no settings.json de um projeto (FR-009c — `--scope global`
@@ -349,11 +533,17 @@ cstk hooks — provisiona os hooks do runtime 00c num projeto-alvo.
 
 USO:
   cstk hooks install [--project-path PATH] [--catalog DIR] [--dry-run]
+                      [--with-loose-usage]
 
 Copia pretooluse-bash-guard.sh + posttooluse-tool-call-tick.sh +
 posttooluse-agent-usage.sh para <PATH>/.claude/hooks/ e mescla o bloco de
 registro em <PATH>/.claude/settings.json (via jq; sem jq, imprime o bloco
 para colagem manual).
+
+--with-loose-usage (opt-in, default DESLIGADA): tambem provisiona
+posttooluse-loose-usage.sh, hook que captura consumo avulso (fora de
+execucoes agente-00c/feature-00c) num sidecar local. Sem a flag,
+comportamento identico a antes desta opcao existir.
 
 Diferenca para `cstk install --scope project agente-00c-runtime`: aquele
 comando tambem duplica skill+commands+agents dentro do repo; este toca
@@ -384,6 +574,7 @@ hooks_main() {
   _hooks_project_path="."
   _hooks_catalog="${HOME:?HOME nao setado}/.claude"
   _hooks_dry_run=0
+  _hooks_with_loose=0
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -396,6 +587,7 @@ hooks_main() {
         _hooks_catalog=$2; shift 2 ;;
       --catalog=*) _hooks_catalog=${1#--catalog=}; shift ;;
       --dry-run) _hooks_dry_run=1; shift ;;
+      --with-loose-usage) _hooks_with_loose=1; shift ;;
       -h|--help) _hooks_print_help; return 0 ;;
       *) log_error "hooks install: flag desconhecida: $1"; return 2 ;;
     esac
@@ -426,7 +618,7 @@ hooks_main() {
 
   _hooks_dest="$_hooks_abs/.claude"
 
-  _hooks_state=$(apply_guard_hooks "$_hooks_src" "$_hooks_dest" "$_hooks_dry_run")
+  _hooks_state=$(apply_guard_hooks "$_hooks_src" "$_hooks_dest" "$_hooks_dry_run" "$_hooks_with_loose")
 
   case "$_hooks_state" in
     merged)

--- a/cli/lib/install.sh
+++ b/cli/lib/install.sh
@@ -93,7 +93,7 @@ PROFILES DISPONIVEIS:
   complementary  Skills de uso pontual (sem sequencia): advisor, bugfix,
                  apply-insights, owasp-security,
                  validate-documentation, validate-docs-rendered,
-                 initialize-docs.
+                 initialize-docs (deprecated, remocao na v7).
   all            Todas as skills do catalog (uniao de sdd + complementary
                  + qualquer skill nova em global/skills/).
 

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -125,7 +125,15 @@ RECALL_EXIT_USAGE=2
 # table_info (mesmo padrao v2/v5/v8/v9/v10); tabela nova via CREATE TABLE IF
 # NOT EXISTS (sem ALTER necessario). Onda antiga ou sem by_source -> as 8
 # colunas ficam NULL, nunca 0 (Principio VI).
-RECALL_SCHEMA_VERSION=12
+# v13 (loose-usage-capture): tabela nova `loose_usage` (grao processo x
+# segmento x modelo; origem: ingest-on-read do hook posttooluse-loose-usage
+# via `cstk usage`, fora do fluxo state.json/onda — consumo AVULSO do
+# Claude Code, nao pipeline agente-00c/feature-00c). Migracao v12->v13 e
+# puramente aditiva: sem ALTER TABLE, sem DROP — mesmo precedente literal
+# de `wave_model_usage` na v11->v12 (linhas 810-811 acima), CREATE TABLE IF
+# NOT EXISTS coberto pelo DDL. `cost_usd`/`total_tokens`/`model` NULL quando
+# nao medido, nunca 0 (Principio VI; data-model.md §Entity LooseUsageRecord).
+RECALL_SCHEMA_VERSION=13
 # Enum interno (canonico): valores EN. 'bloqueio' permanece aceito como ALIAS
 # DEPRECADO em --type (normalizado para 'block' com aviso) — ver recall_normalize_type.
 RECALL_TYPE_ENUM="decision block retro skill memory suggestion"
@@ -635,6 +643,20 @@ CREATE TABLE IF NOT EXISTS wave_model_usage (
   total_tokens INTEGER,
   ingested_at TEXT NOT NULL,
   UNIQUE(project, feature, wave, source_id)
+);
+CREATE TABLE IF NOT EXISTS loose_usage (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project TEXT NOT NULL,
+  project_path TEXT,
+  process_key TEXT NOT NULL,
+  segment_id TEXT NOT NULL,
+  model TEXT,
+  cost_usd REAL,
+  total_tokens INTEGER,
+  segment_open INTEGER,
+  captured_at TEXT NOT NULL,
+  ingested_at TEXT NOT NULL,
+  UNIQUE(process_key, segment_id, model)
 );
 CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5 (
   body,
@@ -2387,6 +2409,52 @@ recall_apply_sql_with_retry() {
     esac
   done
   return 1
+}
+
+# recall_prune_loose_usage DB_PATH DAYS [--dry-run] -> poda linhas `loose_usage`
+# com `captured_at` mais antigo que DAYS dias (camada de indice — task 2.2,
+# CHK002/CHK029, data-model.md §Retencao). Imprime a contagem de linhas
+# elegiveis em stdout (dry-run: contagem sem remover; real: contagem removida)
+# e retorna 0. So retorna 1 em falha de infra (DB ausente ao tentar escrever,
+# `date` sem suporte a aritmetica relativa em NENHUMA das duas variantes
+# GNU/BSD, ou retries de escrita esgotados) — nunca por "zero elegiveis"
+# (isso e sucesso com contagem 0). `cli/lib/usage.sh` (FASE 4) delega a
+# remocao da camada de indice a este helper — nunca chama `sqlite3`
+# diretamente (Constitution II, contracts/cli-usage.md §Restricao de
+# arquitetura).
+recall_prune_loose_usage() {
+  _plu_db="$1"
+  _plu_days="$2"
+  _plu_dry=0
+  [ "$3" = "--dry-run" ] && _plu_dry=1
+  case "$_plu_days" in
+    ''|*[!0-9]*)
+      log_warn "recall: recall_prune_loose_usage: DAYS invalido: '$_plu_days'"
+      return 1
+      ;;
+  esac
+  # DB ausente: nada a podar (mesma semantica de recall_normalize_db_perms
+  # para arquivo inexistente — no-op de sucesso, contagem 0).
+  if [ ! -f "$_plu_db" ]; then
+    printf '0\n'
+    return 0
+  fi
+  # GNU (-d) primeiro, fallback BSD (-v-Nd) — mesmo padrao GNU-first de
+  # recall_normalize_db_perms (stat -c antes de -f).
+  _plu_cutoff=$(date -u -d "-${_plu_days} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+    || _plu_cutoff=$(date -u -v-"${_plu_days}"d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) \
+    || { log_warn "recall: recall_prune_loose_usage: 'date' sem suporte a aritmetica relativa (GNU -d / BSD -v)"; return 1; }
+  _plu_n=$(recall_query_sql "$_plu_db" "SELECT count(*) FROM loose_usage WHERE captured_at < '$_plu_cutoff';")
+  _plu_n=${_plu_n:-0}
+  if [ "$_plu_dry" = 1 ]; then
+    printf '%s\n' "$_plu_n"
+    return 0
+  fi
+  [ "$_plu_n" = "0" ] && { printf '0\n'; return 0; }
+  recall_apply_sql_with_retry "$_plu_db" "DELETE FROM loose_usage WHERE captured_at < '$_plu_cutoff';" || return 1
+  recall_normalize_db_perms "$_plu_db"
+  printf '%s\n' "$_plu_n"
+  return 0
 }
 
 # ==========================================================================

--- a/cli/lib/usage.sh
+++ b/cli/lib/usage.sh
@@ -1,0 +1,691 @@
+#!/bin/sh
+# usage.sh — subcomando `cstk usage` (feature loose-usage-capture, FASE 4).
+#
+# Consulta o consumo AVULSO (fora de execucoes agente-00c/feature-00c)
+# capturado pelo hook `posttooluse-loose-usage.sh` no sidecar
+# `~/.claude/cstk/loose-usage/<process_key>/seg-*/`. Este arquivo e o UNICO
+# tradutor sidecar->DB (plan.md §Convencoes de Borda "Mapper layer"):
+#
+#   - `usage_map_sidecar_to_db` (task 4.1): varre os segmentos, invoca
+#     `otel-usage.sh delta --state-dir <segmento>` por segmento, converte o
+#     JSON `by_model` em linhas `loose_usage` e faz UPSERT pela chave
+#     natural (process_key, segment_id, model). Chamado ingest-on-read por
+#     `cstk usage`/`cstk usage compare` — best-effort, nunca aborta a
+#     listagem.
+#   - `usage_cmd_list` (task 4.2): `cstk usage` — listagem por projeto.
+#   - `usage_cmd_compare` (task 4.3): `cstk usage compare` — avulso vs
+#     pipeline (`loose_usage` vs `wave_model_usage`), agregacao lado a
+#     lado, NUNCA JOIN linha a linha (granularidades diferentes).
+#   - `usage_cmd_prune` (task 4.4): `cstk usage prune` — poda os segmentos
+#     fechados do sidecar mais antigos que o TTL (camada de captura) e as
+#     linhas `loose_usage` correspondentes (camada de indice, delegado a
+#     `recall_prune_loose_usage` de `cli/lib/recall.sh`).
+#
+# RESTRICAO DE ARQUITETURA (Constitution II, contracts/cli-usage.md
+# §Restricao de arquitetura): este arquivo NUNCA invoca `sqlite3`
+# diretamente — toda operacao de banco delega aos helpers ja existentes de
+# `cli/lib/recall.sh` (unico arquivo autorizado a `sqlite3`).
+#
+# Campo nao medido vira NULL/`null`/"nao medido", NUNCA 0 fabricado
+# (Principio VI / FR-005 / SC-004) — mesma politica de `wave_model_usage`.
+#
+# Despachado por cli/cstk: `cstk usage ...` -> usage_main "$@".
+#
+# POSIX sh puro. Deps OPCIONAIS: sqlite3, jq (ausencia degrada gracioso
+# conforme contracts/cli-usage.md §Comportamento sem dados).
+
+if [ -n "${_CSTK_USAGE_LOADED:-}" ]; then
+  return 0 2>/dev/null
+fi
+_CSTK_USAGE_LOADED=1
+
+if [ -n "${CSTK_LIB:-}" ] && [ -f "$CSTK_LIB/common.sh" ]; then
+  # shellcheck source=./common.sh
+  . "$CSTK_LIB/common.sh"
+fi
+
+# recall.sh concentra sql_escape/validate_limit/value_has_nul/strip_nul,
+# a camada de conexao (recall_have_sqlite3/recall_have_jq/recall_resolve_db/
+# recall_ensure_db_dir/recall_apply_schema/recall_normalize_db_perms/
+# recall_query_sql/recall_apply_sql_with_retry), recall_real_or_null/
+# recall_int_or_null e recall_prune_loose_usage (task 2.2.1) — usage.sh
+# reusa tudo isso em vez de reimplementar (Constitution II).
+if [ -n "${CSTK_LIB:-}" ] && [ -f "$CSTK_LIB/recall.sh" ]; then
+  # shellcheck source=./recall.sh
+  . "$CSTK_LIB/recall.sh"
+fi
+
+if ! command -v log_warn >/dev/null 2>&1; then
+  log_info() { printf '[info] %s\n' "$*" >&2; }
+  log_warn() { printf '[warn] %s\n' "$*" >&2; }
+  log_error() { printf '[error] %s\n' "$*" >&2; }
+fi
+
+# Locale pinado: este arquivo formata float (awk printf de share_pct/blended
+# em _usage_share_pct_text/_usage_blended). Sob locale pt_BR o printf de
+# float produz virgula decimal ("50,000000") em vez de ponto — mesmo bug
+# real ja corrigido em otel-usage.sh (linha 120/114-118: 2 cenarios de
+# test_otel-usage falhavam para operadores com LANG=pt_BR.UTF-8). Pinar aqui
+# protege PRODUCAO (CLI rodando no shell do operador), nao so os testes.
+LC_ALL=C
+export LC_ALL
+
+# ==== Exit codes (contracts/cli-usage.md) ====
+USAGE_EXIT_OK=0
+USAGE_EXIT_ERROR=1
+USAGE_EXIT_USAGE=2
+
+# ==== Usage text ====
+_usage_usage_text() {
+  cat <<'USAGETXT'
+cstk usage — consumo avulso (fora de execucoes agente-00c/feature-00c)
+
+USO:
+  cstk usage [--project P] [--since ISO] [--limit N] [--json] [--db PATH]
+  cstk usage compare [--project P] [--since ISO] [--json] [--db PATH]
+  cstk usage prune [--dry-run] [--older-than-days N] [--db PATH]
+
+LISTAGEM (default): uma secao por projeto, uma linha por modelo (modelo,
+  tokens, custo, participacao). Campo sem medicao imprime "nao medido".
+  --project P        default: projeto do diretorio corrente
+  --since ISO        filtra por captured_at >= ISO
+  --limit N          maximo de modelos (default 20; inteiro positivo)
+  --json             saida maquina-legivel
+  --db PATH          indice (default $CSTK_KNOWLEDGE_DB ou ~/.claude/cstk/knowledge.db)
+
+COMPARE: mix de modelos e custo blended (avulso vs pipeline), lado a lado.
+  Mesmas flags de listagem, exceto --limit (nao aplicavel).
+
+PRUNE: poda segmentos fechados do sidecar + linhas de indice acima do TTL.
+  --dry-run              reporta sem remover
+  --older-than-days N    default $CSTK_LOOSE_USAGE_RETENTION_DAYS ou 90
+  --db PATH              indice
+
+Documentacao: docs/specs/loose-usage-capture/contracts/cli-usage.md
+USAGETXT
+}
+
+# ==========================================================================
+# Helpers de filesystem (sidecar) — task 4.1
+# ==========================================================================
+
+# _usage_sidecar_root -> imprime a raiz do sidecar de captura avulsa.
+_usage_sidecar_root() {
+  printf '%s/.claude/cstk/loose-usage\n' "${HOME:-/tmp}"
+}
+
+# _usage_project_from_cwd -> imprime o basename do diretorio corrente
+# (default de --project, contracts/cli-usage.md).
+_usage_project_from_cwd() {
+  basename -- "$(pwd)" 2>/dev/null
+}
+
+# _usage_runtime_script_path NAME -> imprime o path do script NAME do
+# runtime agente-00c-runtime. Mesmo padrao de _mcp_runtime_script_path
+# (cli/lib/mcp.sh): (1) PATH; (2) layout de repo relativo a CSTK_LIB;
+# (3) layout instalado em ~/.claude.
+_usage_runtime_script_path() {
+  _urs_name=$1
+  if command -v "$_urs_name" >/dev/null 2>&1; then
+    command -v "$_urs_name"
+    return 0
+  fi
+  if [ -n "${CSTK_LIB:-}" ]; then
+    _urs_repo="$CSTK_LIB/../../global/skills/agente-00c-runtime/scripts/$_urs_name"
+    if [ -f "$_urs_repo" ]; then
+      printf '%s\n' "$_urs_repo"
+      return 0
+    fi
+  fi
+  _urs_default="${HOME:-/tmp}/.claude/skills/agente-00c-runtime/scripts/$_urs_name"
+  if [ -f "$_urs_default" ]; then
+    printf '%s\n' "$_urs_default"
+    return 0
+  fi
+  return 1
+}
+
+# _usage_file_mtime_epoch FILE -> epoch da ultima modificacao, ou vazio.
+# GNU (-c '%Y') primeiro, fallback BSD (-f '%m') — mesmo padrao GNU-first
+# de recall_normalize_db_perms.
+_usage_file_mtime_epoch() {
+  stat -c '%Y' -- "$1" 2>/dev/null || stat -f '%m' -- "$1" 2>/dev/null || return 1
+}
+
+# _usage_epoch_to_iso EPOCH -> ISO 8601 UTC. GNU (-d @EPOCH) primeiro,
+# fallback BSD (-r EPOCH) — mesma tecnica de _plu_iso_to_epoch invertida.
+_usage_epoch_to_iso() {
+  date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null
+}
+
+# _usage_segment_latest_epoch SEG_DIR -> epoch do arquivo mais recente entre
+# closed/otel-end.tsv/otel-start.tsv (nao existe timestamp per-segmento
+# persistido no sidecar: meta.tsv so guarda o current_segment do processo).
+# Deriva de um fato observavel do filesystem (mtime real), nunca fabrica.
+_usage_segment_latest_epoch() {
+  _usle_dir="$1"
+  _usle_latest=0
+  for _usle_f in "$_usle_dir/closed" "$_usle_dir/otel-end.tsv" "$_usle_dir/otel-start.tsv"; do
+    [ -f "$_usle_f" ] || continue
+    _usle_e=$(_usage_file_mtime_epoch "$_usle_f") || continue
+    case "$_usle_e" in ''|*[!0-9]*) continue ;; esac
+    if [ "$_usle_e" -gt "$_usle_latest" ]; then _usle_latest=$_usle_e; fi
+  done
+  [ "$_usle_latest" -gt 0 ] || return 1
+  printf '%s\n' "$_usle_latest"
+}
+
+# _usage_segment_captured_at SEG_DIR -> ISO 8601 UTC (data-model.md
+# §Entity LooseUsageRecord campo captured_at).
+_usage_segment_captured_at() {
+  _usca_epoch=$(_usage_segment_latest_epoch "$1") || return 1
+  _usage_epoch_to_iso "$_usca_epoch"
+}
+
+# _usage_meta_get META_FILE FIELD -> valor da chave em meta.tsv (formato
+# chave<TAB>valor) — mesmo padrao de _plu_meta_get do hook.
+_usage_meta_get() {
+  [ -f "$1" ] || return 1
+  awk -F '\t' -v k="$2" '$1==k {print $2; found=1} END {exit !found}' "$1" 2>/dev/null
+}
+
+# ==========================================================================
+# Task 4.1 — Mapper sidecar -> DB
+# ==========================================================================
+
+# usage_map_sidecar_to_db DB_PATH -> varre `~/.claude/cstk/loose-usage/*/
+# seg-*/`, invoca `otel-usage.sh delta` por segmento e faz UPSERT das linhas
+# `loose_usage` correspondentes. Best-effort/ingest-on-read: qualquer
+# degradacao (sidecar ausente, otel-usage.sh irresolvivel, jq ausente,
+# delta null) e no-op silencioso, NUNCA aborta o caller. Assume que o DB
+# JA tem o schema aplicado (caller chama recall_apply_schema antes).
+usage_map_sidecar_to_db() {
+  _umd_db="$1"
+  _umd_root=$(_usage_sidecar_root)
+  [ -d "$_umd_root" ] || return 0
+
+  _umd_otel=$(_usage_runtime_script_path otel-usage.sh) || {
+    log_warn "cstk usage: otel-usage.sh nao resolvido; mapeamento sidecar->DB pulado"
+    return 0
+  }
+  recall_have_jq || return 0
+
+  _umd_now=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || return 0
+
+  for _umd_proc_dir in "$_umd_root"/*/; do
+    [ -d "$_umd_proc_dir" ] || continue
+    _umd_process_key=$(basename -- "${_umd_proc_dir%/}")
+    _umd_meta="${_umd_proc_dir}meta.tsv"
+    _umd_proj_path=$(_usage_meta_get "$_umd_meta" project_path) || _umd_proj_path=""
+    _umd_proj_path=$(printf '%s' "$_umd_proj_path" | strip_nul)
+    [ -n "$_umd_proj_path" ] || continue
+    _umd_project=$(basename -- "$_umd_proj_path")
+    [ -n "$_umd_project" ] || continue
+
+    for _umd_seg_dir in "${_umd_proc_dir}"seg-*/; do
+      [ -d "$_umd_seg_dir" ] || continue
+      _umd_seg_id=$(basename -- "${_umd_seg_dir%/}")
+      _umd_open=1
+      [ -f "${_umd_seg_dir}closed" ] && _umd_open=0
+
+      _umd_captured=$(_usage_segment_captured_at "$_umd_seg_dir") || continue
+
+      _umd_delta=$("$_umd_otel" delta --state-dir "${_umd_seg_dir%/}" 2>/dev/null) || _umd_delta="null"
+      [ -n "$_umd_delta" ] || _umd_delta="null"
+      [ "$_umd_delta" != "null" ] || continue
+
+      _umd_models=$(printf '%s' "$_umd_delta" | jq -r '(.by_model // {}) | keys[]' 2>/dev/null) || _umd_models=""
+      [ -n "$_umd_models" ] || continue
+
+      _umd_sql=""
+      _umd_OLDIFS="$IFS"
+      IFS='
+'
+      for _umd_model in $_umd_models; do
+        _umd_model=$(printf '%s' "$_umd_model" | strip_nul)
+        [ -n "$_umd_model" ] || continue
+        _umd_cost=$(printf '%s' "$_umd_delta" | jq -r --arg m "$_umd_model" '.by_model[$m].cost_usd // ""' 2>/dev/null) || _umd_cost=""
+        _umd_tok=$(printf '%s' "$_umd_delta" | jq -r --arg m "$_umd_model" '.by_model[$m].total_tokens // ""' 2>/dev/null) || _umd_tok=""
+        _umd_cost=$(printf '%s' "$_umd_cost" | strip_nul)
+        _umd_tok=$(printf '%s' "$_umd_tok" | strip_nul)
+        _umd_cost_sql=$(recall_real_or_null "$_umd_cost")
+        _umd_tok_sql=$(recall_int_or_null "$_umd_tok")
+        _umd_sql="$_umd_sql
+INSERT INTO loose_usage(project,project_path,process_key,segment_id,model,cost_usd,total_tokens,segment_open,captured_at,ingested_at)
+VALUES('$(sql_escape "$_umd_project")','$(sql_escape "$_umd_proj_path")','$(sql_escape "$_umd_process_key")','$(sql_escape "$_umd_seg_id")','$(sql_escape "$_umd_model")',$_umd_cost_sql,$_umd_tok_sql,$_umd_open,'$(sql_escape "$_umd_captured")','$(sql_escape "$_umd_now")')
+ON CONFLICT(process_key,segment_id,model) DO UPDATE SET project=excluded.project,project_path=excluded.project_path,cost_usd=excluded.cost_usd,total_tokens=excluded.total_tokens,segment_open=excluded.segment_open,captured_at=excluded.captured_at,ingested_at=excluded.ingested_at;"
+      done
+      IFS="$_umd_OLDIFS"
+      [ -n "$_umd_sql" ] && recall_apply_sql_with_retry "$_umd_db" "$_umd_sql" >/dev/null 2>&1
+    done
+  done
+  return 0
+}
+
+# _usage_prepare_db DB_FLAG -> resolve o DB, garante schema+permissao e roda
+# o mapper ingest-on-read. Best-effort: falha de schema/dir nao aborta —
+# a listagem segue com o DB no estado em que estiver (possivelmente vazio).
+# Imprime o path resolvido em stdout.
+_usage_prepare_db() {
+  _upd_db=$(recall_resolve_db "$1")
+  if recall_ensure_db_dir "$_upd_db" && recall_apply_schema "$_upd_db" >/dev/null 2>&1; then
+    recall_normalize_db_perms "$_upd_db"
+    usage_map_sidecar_to_db "$_upd_db"
+  fi
+  printf '%s\n' "$_upd_db"
+}
+
+# ==========================================================================
+# Renderizacao compartilhada (texto + --json)
+# ==========================================================================
+
+# _usage_share_pct MODEL_TOKENS TOTAL_TOKENS -> "NN.N%" ou "nao medido".
+_usage_share_pct_text() {
+  _uspt_m="$1"; _uspt_t="$2"
+  if [ -n "$_uspt_m" ] && [ -n "$_uspt_t" ] && [ "$_uspt_t" != "0" ]; then
+    awk -v m="$_uspt_m" -v t="$_uspt_t" 'BEGIN{printf "%.1f%%", (m/t)*100}'
+  else
+    printf 'nao medido'
+  fi
+}
+
+# _usage_render_text_rows PROJECT ROWS TOTAL_TOKENS -> texto por modelo.
+# ROWS: linhas "model|@|cost|@|tokens" (recall_query_sql .separator |@|).
+_usage_render_text_rows() {
+  _urtr_project="$1"; _urtr_rows="$2"; _urtr_total="$3"
+  printf 'projeto: %s\n' "$_urtr_project"
+  if [ -z "$_urtr_rows" ]; then
+    printf '  nao medido — sem cobertura de captura\n'
+    return 0
+  fi
+  printf '%s\n' "$_urtr_rows" | while IFS= read -r _urtr_line; do
+    [ -n "$_urtr_line" ] || continue
+    _urtr_m=$(printf '%s' "$_urtr_line" | awk -F '\\|@\\|' '{print $1}')
+    _urtr_c=$(printf '%s' "$_urtr_line" | awk -F '\\|@\\|' '{print $2}')
+    _urtr_t=$(printf '%s' "$_urtr_line" | awk -F '\\|@\\|' '{print $3}')
+    [ -n "$_urtr_m" ] || _urtr_m="(desconhecido)"
+    _urtr_c_disp="nao medido"
+    [ -n "$_urtr_c" ] && _urtr_c_disp=$(printf '$%s' "$_urtr_c")
+    _urtr_t_disp="nao medido"
+    [ -n "$_urtr_t" ] && _urtr_t_disp="$_urtr_t"
+    _urtr_share=$(_usage_share_pct_text "$_urtr_t" "$_urtr_total")
+    printf '  %-24s tokens=%-12s custo=%-12s participacao=%s\n' \
+      "$_urtr_m" "$_urtr_t_disp" "$_urtr_c_disp" "$_urtr_share"
+  done
+}
+
+# _usage_rows_to_json_models ROWS TOTAL_TOKENS -> array JSON [{model,
+# total_tokens, cost_usd[, share_pct]}]. share_pct so entra quando
+# TOTAL_TOKENS != "" (contrato: `cstk usage --json` nao inclui share_pct,
+# `cstk usage compare --json` inclui via chamada com TOTAL_TOKENS).
+_usage_rows_to_json_models() {
+  _urtjm_rows="$1"
+  _urtjm_total="${2:-}"
+  if [ -z "$_urtjm_rows" ]; then
+    printf '[]'
+    return 0
+  fi
+  _urtjm_tot_json="null"
+  [ -n "$_urtjm_total" ] && _urtjm_tot_json="$_urtjm_total"
+  printf '%s\n' "$_urtjm_rows" \
+    | awk -F '\\|@\\|' '{print $1"\t"$2"\t"$3}' \
+    | jq -R -s --argjson tot "$_urtjm_tot_json" '
+        [ split("\n")[] | select(length>0) | split("\t")
+          | {model: .[0],
+             cost_usd: (if .[1]=="" then null else (.[1]|tonumber) end),
+             total_tokens: (if .[2]=="" then null else (.[2]|tonumber) end)}
+          | if $tot != null then
+              . + {share_pct: (if (.total_tokens != null and ($tot|tonumber) != 0)
+                                then ((.total_tokens / ($tot|tonumber)) * 100) else null end)}
+            else . end
+        ]
+      ' 2>/dev/null
+}
+
+# ==========================================================================
+# Task 4.2 — `cstk usage` (listagem por projeto)
+# ==========================================================================
+
+usage_cmd_list() {
+  _ul_project=""
+  _ul_since=""
+  _ul_limit="20"
+  _ul_json=0
+  _ul_db_flag=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --project) shift; _ul_project="${1:-}" ;;
+      --since) shift; _ul_since="${1:-}" ;;
+      --limit) shift; _ul_limit="${1:-}" ;;
+      --json) _ul_json=1 ;;
+      --db) shift; _ul_db_flag="${1:-}" ;;
+      -h|--help) _usage_usage_text; return "$USAGE_EXIT_OK" ;;
+      *) log_error "cstk usage: flag invalida: $1"; return "$USAGE_EXIT_USAGE" ;;
+    esac
+    shift || break
+  done
+
+  for _ul_in in "$_ul_project" "$_ul_since" "$_ul_db_flag"; do
+    if value_has_nul "$_ul_in"; then
+      log_error "cstk usage: byte NUL em input rejeitado"
+      return "$USAGE_EXIT_USAGE"
+    fi
+  done
+
+  if ! validate_limit "$_ul_limit"; then
+    log_error "cstk usage: --limit deve ser inteiro positivo (recebido: '$_ul_limit')"
+    return "$USAGE_EXIT_USAGE"
+  fi
+
+  [ -n "$_ul_project" ] || _ul_project=$(_usage_project_from_cwd)
+
+  if ! recall_have_sqlite3; then
+    log_warn "cstk usage: sqlite3 nao instalado; consumo avulso indisponivel"
+    return "$USAGE_EXIT_ERROR"
+  fi
+
+  # Ingest-on-read (best-effort): tenta preparar/popular o indice a partir
+  # do sidecar ANTES de checar ausencia — cobre o caso "primeira consulta
+  # nunca houve execucao 00c anterior", quando knowledge.db ainda nao
+  # existe. Se apos a tentativa o arquivo continuar ausente (sqlite3 OK mas
+  # dir nao-gravavel, por exemplo), degrada para "nao medido" (FR-005).
+  _ul_db=$(_usage_prepare_db "$_ul_db_flag")
+  if [ ! -f "$_ul_db" ]; then
+    log_warn "cstk usage: indice ausente ($_ul_db); rode com telemetria ativa para popular"
+    if [ "$_ul_json" -eq 1 ] && recall_have_jq; then
+      jq -n --arg proj "$_ul_project" '{project: $proj, category: "loose", models: []}'
+    else
+      printf 'projeto: %s\n' "$_ul_project"
+      printf '  nao medido\n'
+    fi
+    return "$USAGE_EXIT_OK"
+  fi
+
+  _ul_where="WHERE project = '$(sql_escape "$_ul_project")'"
+  [ -n "$_ul_since" ] && _ul_where="$_ul_where AND captured_at >= '$(sql_escape "$_ul_since")'"
+
+  _ul_rows=$(recall_query_sql "$_ul_db" ".mode list
+.separator |@|
+SELECT model, SUM(cost_usd), SUM(total_tokens)
+FROM loose_usage
+$_ul_where
+GROUP BY model
+ORDER BY SUM(total_tokens) DESC
+LIMIT $_ul_limit;") || _ul_rows=""
+
+  _ul_total=$(recall_query_sql "$_ul_db" "SELECT SUM(total_tokens) FROM loose_usage $_ul_where;") || _ul_total=""
+
+  if [ "$_ul_json" -eq 1 ]; then
+    if recall_have_jq; then
+      _ul_models_json=$(_usage_rows_to_json_models "$_ul_rows")
+      [ -n "$_ul_models_json" ] || _ul_models_json="[]"
+      jq -n --arg proj "$_ul_project" --argjson models "$_ul_models_json" \
+        '{project: $proj, category: "loose", models: $models}'
+    else
+      log_warn "cstk usage: jq ausente; --json indisponivel, usando texto"
+      _usage_render_text_rows "$_ul_project" "$_ul_rows" "$_ul_total"
+    fi
+  else
+    _usage_render_text_rows "$_ul_project" "$_ul_rows" "$_ul_total"
+  fi
+  return "$USAGE_EXIT_OK"
+}
+
+# ==========================================================================
+# Task 4.3 — `cstk usage compare` (avulso vs pipeline)
+# ==========================================================================
+
+usage_cmd_compare() {
+  _uc_project=""
+  _uc_since=""
+  _uc_json=0
+  _uc_db_flag=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --project) shift; _uc_project="${1:-}" ;;
+      --since) shift; _uc_since="${1:-}" ;;
+      --json) _uc_json=1 ;;
+      --db) shift; _uc_db_flag="${1:-}" ;;
+      -h|--help) _usage_usage_text; return "$USAGE_EXIT_OK" ;;
+      *) log_error "cstk usage compare: flag invalida: $1"; return "$USAGE_EXIT_USAGE" ;;
+    esac
+    shift || break
+  done
+
+  for _uc_in in "$_uc_project" "$_uc_since" "$_uc_db_flag"; do
+    if value_has_nul "$_uc_in"; then
+      log_error "cstk usage compare: byte NUL em input rejeitado"
+      return "$USAGE_EXIT_USAGE"
+    fi
+  done
+
+  [ -n "$_uc_project" ] || _uc_project=$(_usage_project_from_cwd)
+
+  if ! recall_have_sqlite3; then
+    log_warn "cstk usage compare: sqlite3 nao instalado; consumo indisponivel"
+    return "$USAGE_EXIT_ERROR"
+  fi
+
+  # Ingest-on-read (best-effort), mesma logica de usage_cmd_list: sempre
+  # tenta preparar/popular o indice antes de consultar (cobre o caso
+  # "primeira consulta, knowledge.db ainda nao existe").
+  _uc_db=$(_usage_prepare_db "$_uc_db_flag")
+
+  _uc_loose_where="WHERE project = '$(sql_escape "$_uc_project")'"
+  [ -n "$_uc_since" ] && _uc_loose_where="$_uc_loose_where AND captured_at >= '$(sql_escape "$_uc_since")'"
+  _uc_pipe_where="WHERE project = '$(sql_escape "$_uc_project")'"
+  [ -n "$_uc_since" ] && _uc_pipe_where="$_uc_pipe_where AND source_ts >= '$(sql_escape "$_uc_since")'"
+
+  _uc_loose_rows=""
+  _uc_pipe_rows=""
+  _uc_loose_total=""
+  _uc_pipe_total=""
+  _uc_loose_cost=""
+  _uc_pipe_cost=""
+  if [ -f "$_uc_db" ]; then
+    _uc_loose_rows=$(recall_query_sql "$_uc_db" ".mode list
+.separator |@|
+SELECT model, SUM(cost_usd), SUM(total_tokens) FROM loose_usage $_uc_loose_where GROUP BY model ORDER BY model;") || _uc_loose_rows=""
+    _uc_pipe_rows=$(recall_query_sql "$_uc_db" ".mode list
+.separator |@|
+SELECT model, SUM(cost_usd), SUM(total_tokens) FROM wave_model_usage $_uc_pipe_where GROUP BY model ORDER BY model;") || _uc_pipe_rows=""
+    _uc_loose_totals_raw=$(recall_query_sql "$_uc_db" ".mode list
+.separator |@|
+SELECT SUM(cost_usd), SUM(total_tokens) FROM loose_usage $_uc_loose_where;") || _uc_loose_totals_raw=""
+    _uc_pipe_totals_raw=$(recall_query_sql "$_uc_db" ".mode list
+.separator |@|
+SELECT SUM(cost_usd), SUM(total_tokens) FROM wave_model_usage $_uc_pipe_where;") || _uc_pipe_totals_raw=""
+    _uc_loose_cost=$(printf '%s' "$_uc_loose_totals_raw" | awk -F '\\|@\\|' '{print $1}')
+    _uc_loose_total=$(printf '%s' "$_uc_loose_totals_raw" | awk -F '\\|@\\|' '{print $2}')
+    _uc_pipe_cost=$(printf '%s' "$_uc_pipe_totals_raw" | awk -F '\\|@\\|' '{print $1}')
+    _uc_pipe_total=$(printf '%s' "$_uc_pipe_totals_raw" | awk -F '\\|@\\|' '{print $2}')
+  fi
+
+  _uc_loose_blended=$(_usage_blended "$_uc_loose_cost" "$_uc_loose_total")
+  _uc_pipe_blended=$(_usage_blended "$_uc_pipe_cost" "$_uc_pipe_total")
+
+  if [ "$_uc_json" -eq 1 ] && recall_have_jq; then
+    _uc_loose_models=$(_usage_rows_to_json_models "$_uc_loose_rows" "${_uc_loose_total:-}")
+    _uc_pipe_models=$(_usage_rows_to_json_models "$_uc_pipe_rows" "${_uc_pipe_total:-}")
+    [ -n "$_uc_loose_models" ] || _uc_loose_models="[]"
+    [ -n "$_uc_pipe_models" ] || _uc_pipe_models="[]"
+    jq -n \
+      --arg proj "$_uc_project" \
+      --argjson loose_models "$_uc_loose_models" \
+      --argjson pipe_models "$_uc_pipe_models" \
+      --arg loose_blended "$_uc_loose_blended" \
+      --arg pipe_blended "$_uc_pipe_blended" \
+      '{
+        project: $proj,
+        categories: [
+          { category: "loose", models: $loose_models,
+            blended_cost_per_mtok: (if $loose_blended == "" then null else ($loose_blended | tonumber) end) },
+          { category: "pipeline", models: $pipe_models,
+            blended_cost_per_mtok: (if $pipe_blended == "" then null else ($pipe_blended | tonumber) end) }
+        ]
+      }'
+  else
+    [ "$_uc_json" -eq 1 ] && log_warn "cstk usage compare: jq ausente; --json indisponivel, usando texto"
+    printf 'projeto: %s\n' "$_uc_project"
+    printf '== loose ==\n'
+    _usage_render_text_rows "$_uc_project" "$_uc_loose_rows" "$_uc_loose_total" | tail -n +2
+    printf '  blended_cost_per_mtok=%s\n' "${_uc_loose_blended:-nao medido}"
+    printf '== pipeline ==\n'
+    _usage_render_text_rows "$_uc_project" "$_uc_pipe_rows" "$_uc_pipe_total" | tail -n +2
+    printf '  blended_cost_per_mtok=%s\n' "${_uc_pipe_blended:-nao medido}"
+  fi
+  return "$USAGE_EXIT_OK"
+}
+
+# _usage_blended COST TOKENS -> "SUM(cost)/SUM(tokens)*1e6" ou "" quando
+# TOKENS ausente/0 (divisao indefinida nunca vira 0 — Principio VI).
+_usage_blended() {
+  _ub_cost="$1"; _ub_tok="$2"
+  if [ -z "$_ub_cost" ] || [ -z "$_ub_tok" ] || [ "$_ub_tok" = "0" ]; then
+    printf ''
+    return 0
+  fi
+  awk -v c="$_ub_cost" -v t="$_ub_tok" 'BEGIN{printf "%.6f", (c/t)*1000000}'
+}
+
+# ==========================================================================
+# Task 4.4 — `cstk usage prune` (retencao/expurgo)
+# ==========================================================================
+
+usage_cmd_prune() {
+  _up_dry=0
+  _up_days_flag=""
+  _up_db_flag=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --dry-run) _up_dry=1 ;;
+      --older-than-days) shift; _up_days_flag="${1:-}" ;;
+      --db) shift; _up_db_flag="${1:-}" ;;
+      -h|--help) _usage_usage_text; return "$USAGE_EXIT_OK" ;;
+      *) log_error "cstk usage prune: flag invalida: $1"; return "$USAGE_EXIT_USAGE" ;;
+    esac
+    shift || break
+  done
+
+  _up_days="$_up_days_flag"
+  [ -n "$_up_days" ] || _up_days="${CSTK_LOOSE_USAGE_RETENTION_DAYS:-90}"
+  case "$_up_days" in
+    ''|*[!0-9]*)
+      log_error "cstk usage prune: --older-than-days deve ser inteiro (recebido: '$_up_days')"
+      return "$USAGE_EXIT_USAGE"
+      ;;
+  esac
+
+  if value_has_nul "$_up_db_flag"; then
+    log_error "cstk usage prune: byte NUL em input rejeitado"
+    return "$USAGE_EXIT_USAGE"
+  fi
+
+  if ! recall_have_sqlite3; then
+    log_warn "cstk usage prune: sqlite3 nao instalado; poda da camada de indice indisponivel"
+    return "$USAGE_EXIT_ERROR"
+  fi
+
+  _up_root=$(_usage_sidecar_root)
+  if [ ! -d "$_up_root" ]; then
+    log_warn "cstk usage prune: sidecar ausente ($_up_root)"
+    printf 'nada a podar\n'
+    return "$USAGE_EXIT_OK"
+  fi
+
+  _up_now_epoch=$(date -u +%s 2>/dev/null) || _up_now_epoch=""
+  _up_cutoff_epoch=""
+  if [ -n "$_up_now_epoch" ]; then
+    _up_cutoff_epoch=$((_up_now_epoch - _up_days * 86400))
+  fi
+
+  _up_list=$(mktemp 2>/dev/null) || {
+    log_error "cstk usage prune: mktemp falhou"
+    return "$USAGE_EXIT_ERROR"
+  }
+  _up_eligible=0
+
+  for _up_proc_dir in "$_up_root"/*/; do
+    [ -d "$_up_proc_dir" ] || continue
+    _up_process_key=$(basename -- "${_up_proc_dir%/}")
+    for _up_seg_dir in "${_up_proc_dir}"seg-*/; do
+      [ -d "$_up_seg_dir" ] || continue
+      [ -f "${_up_seg_dir}closed" ] || continue
+      _up_seg_id=$(basename -- "${_up_seg_dir%/}")
+      _up_seg_epoch=$(_usage_segment_latest_epoch "$_up_seg_dir") || continue
+      if [ -n "$_up_cutoff_epoch" ] && [ "$_up_seg_epoch" -lt "$_up_cutoff_epoch" ] 2>/dev/null; then
+        printf '%s\t%s\t%s\n' "$_up_process_key" "$_up_seg_id" "${_up_seg_dir%/}" >> "$_up_list"
+        _up_eligible=$((_up_eligible + 1))
+      fi
+    done
+  done
+
+  if [ "$_up_eligible" -eq 0 ]; then
+    rm -f -- "$_up_list"
+    printf 'nada a podar — sem segmentos alem do TTL\n'
+    return "$USAGE_EXIT_OK"
+  fi
+
+  _up_db=$(recall_resolve_db "$_up_db_flag")
+  _up_tab=$(printf '\t')
+
+  while IFS="$_up_tab" read -r _up_pk _up_sid _up_dir; do
+    [ -n "$_up_pk" ] || continue
+    if [ "$_up_dry" -eq 1 ]; then
+      printf 'action=would-remove process_key=%s segment=%s\n' "$_up_pk" "$_up_sid"
+    else
+      if rm -rf -- "$_up_dir" 2>/dev/null; then
+        printf 'action=removed process_key=%s segment=%s\n' "$_up_pk" "$_up_sid"
+      else
+        printf 'action=remove-failed process_key=%s segment=%s\n' "$_up_pk" "$_up_sid"
+      fi
+    fi
+  done < "$_up_list"
+  rm -f -- "$_up_list"
+
+  if [ "$_up_dry" -eq 1 ]; then
+    _up_db_n=$(recall_prune_loose_usage "$_up_db" "$_up_days" --dry-run) || _up_db_n="0"
+    printf 'total: %d segmentos elegiveis (dry-run), %s linhas de indice elegiveis\n' "$_up_eligible" "$_up_db_n"
+  else
+    _up_db_n=$(recall_prune_loose_usage "$_up_db" "$_up_days") || _up_db_n="0"
+    printf 'total: %d segmentos removidos, %s linhas de indice removidas\n' "$_up_eligible" "$_up_db_n"
+  fi
+  return "$USAGE_EXIT_OK"
+}
+
+# ==========================================================================
+# Task 4.5 — Dispatcher
+# ==========================================================================
+
+usage_main() {
+  _um_sub="${1:-}"
+  case "$_um_sub" in
+    compare)
+      shift
+      usage_cmd_compare "$@"
+      return $?
+      ;;
+    prune)
+      shift
+      usage_cmd_prune "$@"
+      return $?
+      ;;
+    -h|--help)
+      _usage_usage_text
+      return "$USAGE_EXIT_OK"
+      ;;
+    ''|--*)
+      usage_cmd_list "$@"
+      return $?
+      ;;
+    *)
+      log_error "cstk usage: subcomando/flag desconhecido: $_um_sub"
+      _usage_usage_text
+      return "$USAGE_EXIT_USAGE"
+      ;;
+  esac
+}

--- a/docs-site/manual/fluxo-sdd.md
+++ b/docs-site/manual/fluxo-sdd.md
@@ -16,7 +16,7 @@ command.
    ideia
      |
      v
-[1] briefing ----------> docs/01-briefing-discovery/briefing.md
+[1] briefing ----------> docs/briefing.md
      |                   (discovery por entrevista estruturada)
      v
 [2] constitution ------> docs/constitution.md
@@ -54,7 +54,9 @@ command.
 ### 1. [`briefing`](../skills/briefing/) — Discovery
 
 Entrevista estruturada que captura visao, usuarios, restricoes, prioridades,
-stack e qualidade. Saida: `docs/01-briefing-discovery/briefing.md`. Esse
+stack e qualidade. Saida: `docs/briefing.md` (projetos antigos usam o
+caminho legado `docs/01-briefing-discovery/briefing.md`, ainda aceito por
+todo o pipeline). Esse
 documento alimenta TODAS as etapas seguintes — pular esta etapa significa
 inventar premissas no meio do pipeline.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -27,7 +27,10 @@ your domain.
 
 ## Documentation Hierarchy
 
-The `initialize-docs` skill creates the following structure:
+**LEGACY** — the `initialize-docs` skill (deprecated, removal in v7) creates
+the numbered structure below. New projects use the SDD layout instead:
+`docs/briefing.md` + `docs/constitution.md` + `docs/specs/<feature>/`. The
+pipeline accepts both layouts.
 
 ```
 docs/

--- a/docs/conventions.pt-BR.md
+++ b/docs/conventions.pt-BR.md
@@ -27,7 +27,10 @@ seu domínio.
 
 ## Hierarquia de Documentação
 
-O skill `initialize-docs` cria a seguinte estrutura:
+**LEGADO** — a skill `initialize-docs` (deprecated, remoção na v7) cria a
+estrutura numerada abaixo. Projetos novos usam o layout SDD:
+`docs/briefing.md` + `docs/constitution.md` + `docs/specs/<feature>/`. O
+pipeline aceita os dois layouts.
 
 ```
 docs/

--- a/docs/cstk-usage.md
+++ b/docs/cstk-usage.md
@@ -1,0 +1,66 @@
+**English** · [Português (pt-BR)](./cstk-usage.pt-BR.md)
+
+# Loose usage tracking (`cstk usage`)
+
+> **Advanced track** — opt-in, complements [Knowledge memory](./cstk-recall.md).
+
+Tracks Claude Code token/cost consumption that happens **outside** any
+`agente-00c`/`feature-00c` execution — regular interactive sessions. Opt-in via
+the same native local telemetry configuration Claude Code already uses (no
+second toggle): a `PostToolUse` hook writes a local TSV sidecar per
+process/segment, throttled and silent by design (never blocks or slows down
+the session). `cstk usage` reads that sidecar plus the `loose_usage` table in
+`knowledge.db` to report consumption by project/model, and to compare it
+against pipeline (orchestrator) consumption.
+
+```bash
+# Enable the capture hook (opt-in, default OFF)
+cstk hooks install --with-loose-usage
+
+# List loose consumption by project/model
+cstk usage
+cstk usage --project my-project --since 2026-08-01 --json
+
+# Compare loose vs pipeline consumption for a project (mix + blended cost/Mtok)
+cstk usage compare --project my-project
+
+# Prune sidecar segments + indexed rows past the retention TTL
+cstk usage prune --dry-run
+cstk usage prune --older-than-days 30
+```
+
+## Subcommands
+
+- `usage [--project P] [--since ISO] [--limit N] [--json] [--db PATH]` —
+  one section per project, one line per model (model, tokens, cost, share).
+  A field with no measurement prints `nao medido` (text) / `null` (`--json`),
+  never `0`.
+- `usage compare [--project P] [--since ISO] [--json] [--db PATH]` —
+  `loose` (from `loose_usage`) vs `pipeline` (from `wave_model_usage`)
+  side by side; aggregated per category, never joined row-by-row (different
+  granularities). Includes `blended_cost_per_mtok`
+  (`SUM(cost_usd)/SUM(total_tokens)*1e6`; `null` when the sum is zero/absent).
+- `usage prune [--dry-run] [--older-than-days N] [--db PATH]` — removes
+  **closed** sidecar segments older than the TTL
+  (`CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`) plus the corresponding
+  `loose_usage` rows. Open segments are never eligible. `--dry-run` reports
+  the same selection without any side effect.
+
+**Requirements**: `sqlite3`, `jq`. Capture requires the hook to be installed
+(`cstk hooks install --with-loose-usage`, opt-in, default OFF — never bundled
+with the mandatory guard hooks).
+
+## Data captured
+
+Only cost/token/model metadata — `project`, `project_path`, `process_key`,
+`segment_id`, `model`, `cost_usd`, `total_tokens`, `segment_open`,
+`captured_at`, `ingested_at`. No prompt/conversation content field exists in
+the schema. Sidecar directory/files use restrictive permissions (`chmod 700`
+on directories, `chmod 600` on files), same posture as `knowledge.db`.
+
+## Full documentation
+
+- [`specs/loose-usage-capture/spec.md`](./specs/loose-usage-capture/spec.md) — user stories, FRs, success criteria
+- [`specs/loose-usage-capture/contracts/cli-usage.md`](./specs/loose-usage-capture/contracts/cli-usage.md) — flags, exit codes, output formats
+- [`specs/loose-usage-capture/contracts/hook-loose-usage.md`](./specs/loose-usage-capture/contracts/hook-loose-usage.md) — capture hook contract
+- [`specs/loose-usage-capture/data-model.md`](./specs/loose-usage-capture/data-model.md) — schema + retention policy

--- a/docs/cstk-usage.pt-BR.md
+++ b/docs/cstk-usage.pt-BR.md
@@ -1,0 +1,67 @@
+[English](./cstk-usage.md) · **Português (pt-BR)**
+
+# Consumo avulso (`cstk usage`)
+
+> **Trilha avançada** — opt-in, complementa a [Memória de conhecimento](./cstk-recall.pt-BR.md).
+
+Rastreia o consumo de tokens/custo do Claude Code que acontece **fora** de
+qualquer execução `agente-00c`/`feature-00c` — sessões interativas comuns.
+Opt-in via a mesma configuração nativa de telemetria local que o Claude Code
+já usa (sem um segundo toggle): um hook `PostToolUse` escreve um sidecar TSV
+local por processo/segmento, com throttle e silencioso por design (nunca
+bloqueia nem atrasa a sessão). O `cstk usage` lê esse sidecar mais a tabela
+`loose_usage` do `knowledge.db` para reportar consumo por projeto/modelo, e
+para comparar com o consumo de pipeline (orquestrador).
+
+```bash
+# Habilitar o hook de captura (opt-in, default DESLIGADO)
+cstk hooks install --with-loose-usage
+
+# Listar consumo avulso por projeto/modelo
+cstk usage
+cstk usage --project meu-projeto --since 2026-08-01 --json
+
+# Comparar consumo avulso vs pipeline para um projeto (mix + custo blended/Mtok)
+cstk usage compare --project meu-projeto
+
+# Podar segmentos do sidecar + linhas indexadas acima do TTL de retencao
+cstk usage prune --dry-run
+cstk usage prune --older-than-days 30
+```
+
+## Subcomandos
+
+- `usage [--project P] [--since ISO] [--limit N] [--json] [--db PATH]` —
+  uma seção por projeto, uma linha por modelo (modelo, tokens, custo,
+  participação). Campo sem medição imprime `nao medido` (texto) / `null`
+  (`--json`), nunca `0`.
+- `usage compare [--project P] [--since ISO] [--json] [--db PATH]` —
+  `loose` (de `loose_usage`) vs `pipeline` (de `wave_model_usage`) lado a
+  lado; agregado por categoria, nunca via JOIN linha a linha (granularidades
+  diferentes). Inclui `blended_cost_per_mtok`
+  (`SUM(cost_usd)/SUM(total_tokens)*1e6`; `null` quando a soma é zero/ausente).
+- `usage prune [--dry-run] [--older-than-days N] [--db PATH]` — remove
+  segmentos **fechados** do sidecar mais antigos que o TTL
+  (`CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`) mais as linhas
+  `loose_usage` correspondentes. Segmentos abertos nunca são elegíveis.
+  `--dry-run` reporta a mesma seleção sem nenhum efeito colateral.
+
+**Requisitos**: `sqlite3`, `jq`. A captura exige o hook instalado
+(`cstk hooks install --with-loose-usage`, opt-in, default DESLIGADO — nunca
+empacotado junto dos guard hooks obrigatórios).
+
+## Dados capturados
+
+Apenas metadados de custo/token/modelo — `project`, `project_path`,
+`process_key`, `segment_id`, `model`, `cost_usd`, `total_tokens`,
+`segment_open`, `captured_at`, `ingested_at`. Não existe campo de conteúdo
+de prompt/conversa no schema. Diretório/arquivos do sidecar usam permissão
+restritiva (`chmod 700` em diretórios, `chmod 600` em arquivos), mesma
+postura do `knowledge.db`.
+
+## Documentação completa
+
+- [`specs/loose-usage-capture/spec.md`](./specs/loose-usage-capture/spec.md) — user stories, FRs, success criteria
+- [`specs/loose-usage-capture/contracts/cli-usage.md`](./specs/loose-usage-capture/contracts/cli-usage.md) — flags, exit codes, formatos de saída
+- [`specs/loose-usage-capture/contracts/hook-loose-usage.md`](./specs/loose-usage-capture/contracts/hook-loose-usage.md) — contrato do hook de captura
+- [`specs/loose-usage-capture/data-model.md`](./specs/loose-usage-capture/data-model.md) — schema + política de retenção

--- a/docs/sdd-pipeline.md
+++ b/docs/sdd-pipeline.md
@@ -14,7 +14,7 @@ feeds the next.
  │  DISCOVERY   │
  └──────┬───────┘
         │
-   ① briefing          Discovery interview → docs/01-briefing-discovery/briefing.md
+   ① briefing          Discovery interview → docs/briefing.md
         │                Gathers vision, users, scope, constraints and stack.
         │                Asks ONE question at a time (max 10).
         ▼
@@ -93,7 +93,7 @@ feeds the next.
 
 - **Simple feature**: `specify` → `plan` → `create-tasks` → `execute-task`
 - **Bug fix**: `bugfix` (standalone skill, no pipeline required)
-- **Existing project without docs**: `initialize-docs` → `briefing` → `constitution`
+- **Existing project without docs**: `briefing` → `constitution` (no scaffold needed — the skills create `docs/briefing.md` and `docs/constitution.md` themselves)
 - **Only need tasks**: `create-tasks` directly (if you already have enough context)
 
 `specify` also brings a triage guide "update an existing spec vs. open a new

--- a/docs/sdd-pipeline.pt-BR.md
+++ b/docs/sdd-pipeline.pt-BR.md
@@ -14,7 +14,7 @@ próximo.
  │  DISCOVERY   │
  └──────┬───────┘
         │
-   ① briefing          Entrevista de discovery → docs/01-briefing-discovery/briefing.md
+   ① briefing          Entrevista de discovery → docs/briefing.md
         │                Coleta visão, usuários, escopo, restrições e stack.
         │                Pergunta UMA pergunta por vez (max 10).
         ▼
@@ -93,7 +93,7 @@ próximo.
 
 - **Feature simples**: `specify` → `plan` → `create-tasks` → `execute-task`
 - **Bug fix**: `bugfix` (skill independente, não requer pipeline)
-- **Projeto existente sem docs**: `initialize-docs` → `briefing` → `constitution`
+- **Projeto existente sem docs**: `briefing` → `constitution` (sem scaffold — as proprias skills criam `docs/briefing.md` e `docs/constitution.md`)
 - **Só precisa de tasks**: `create-tasks` direto (se já tem contexto suficiente)
 
 A `specify` também traz um guia de triagem "atualizar spec existente vs abrir

--- a/docs/specs/loose-usage-capture/checklists/requirements.md
+++ b/docs/specs/loose-usage-capture/checklists/requirements.md
@@ -1,0 +1,148 @@
+# Requirements Checklist: loose-usage-capture
+
+**Purpose**: validar a QUALIDADE dos requisitos de `spec.md` (completude,
+clareza, consistencia, mensurabilidade, cobertura de cenarios) antes de
+`create-tasks` — nao valida implementacao (ainda nao existe codigo desta
+feature).
+**Created**: 2026-08-06
+**Feature**: [spec.md](../spec.md) | [plan.md](../plan.md) | [research.md](../research.md)
+**Numeracao**: CHK001–CHK018 (IDs unicos por feature; continuam em `security.md`)
+
+## Completude
+
+- [x] CHK001 - O requisito de opt-in (FR-006) amarra a captura avulsa a um
+  mecanismo de configuracao ja existente, sem introduzir um segundo opt-in
+  paralelo e potencialmente inconsistente? [Completude, Spec §FR-006] {auto}
+  — FR-006: "habilitada pela mesma configuracao nativa de telemetria local
+  do Claude Code".
+- [ ] CHK002 - Existe requisito de retencao/expurgo para os artefatos
+  persistidos (sidecar TSV por processo/segmento + linhas em
+  `loose_usage`), dado que a captura e continua e sem limite superior de
+  volume declarado? [Completude, Gap] {auto} — nao encontrado: `grep -rniE
+  "retenc|limpeza|expira|cleanup|purge|ttl|delete"
+  docs/specs/loose-usage-capture/` so retorna spec.md linha 215, que trata
+  apenas de "TTL de token externo" como N/A ("a feature ... nao depende de
+  token externo com TTL") — nao aborda o ciclo de vida dos proprios dados
+  de consumo capturados. `plan.md` §Scale/Scope estima "dezenas por dia"
+  mas nao projeta acumulo de longo prazo nem define poda.
+- [x] CHK003 - O requisito de nao-degradacao da sessao do operador (NFR de
+  performance/resiliencia) esta coberto explicitamente, e nao apenas
+  implicito no design? [Completude, Spec §FR-007] {auto} — FR-007: "MUST
+  NUNCA interromper, atrasar ou degradar a sessao avulsa do operador — a
+  captura e estritamente melhor-esforco".
+- [x] CHK004 - O fora-de-escopo (exposicao da comparacao no painel web) esta
+  declarado explicitamente, evitando expansao implicita de escopo?
+  [Completude, Spec §Clarifications Q3] {auto} — "exposicao no painel web
+  fica fora do escopo desta feature", tambem repetido em FR-009.
+
+## Clareza
+
+- [x] CHK005 - A unidade de atribuicao "processo" (FR-002) tem definicao
+  operacional citavel, ou fica so como rotulo sem criterio? [Clareza, Spec
+  §FR-002 + research.md Decision 2] {auto} — a spec define o CONTRATO
+  ("processo e projeto, nunca session_id"); o algoritmo de identidade
+  (`process_key` = endpoint + project_path + owner_pid opcional) e
+  deliberadamente deferido a `data-model.md` (`[PROPOSTA]`, "detalhe de
+  implementacao") — divisao de camada SDD apropriada (spec = WHAT, plan/
+  data-model = HOW), nao uma lacuna de clareza da spec.
+- [x] CHK006 - O valor concreto do intervalo de captura periodica (FR-003)
+  e deixado deliberadamente fora da spec (nao e dado factual, e policy de
+  implementacao), em vez de ser uma omissao nao-intencional? [Clareza,
+  Spec §FR-003 + research.md Decision 4] {auto} — research.md Decision 4:
+  "O default de 300 s e **politica de design**, nao dado factual ...
+  Ajustavel sem mudanca de contrato" — FR-003 exige a CAPACIDADE
+  (capturar em intervalos periodicos), nao o valor.
+- [x] CHK007 - "Melhor-esforco"/"nunca interromper" (FR-007) tem criterio
+  operacional verificavel, em vez de ser um adjetivo vago sem contraparte
+  testavel? [Clareza, Spec §FR-007] {auto} — o Independent Test/Acceptance
+  Scenario da User Story 1 e a propria Edge Case "porta fechada, processo
+  reiniciado" (linha 146-150: "a captura falha de forma silenciosa ...
+  nunca bloqueia a sessao") tornam o criterio verificavel: falha =
+  no-op silencioso, sessao sempre segue.
+
+## Consistencia
+
+- [x] CHK008 - O termo "consumo avulso" e usado de forma consistente em
+  todo o `spec.md`, sem sinonimos concorrentes que fragmentem a
+  terminologia? [Consistencia] {auto} — termo usado uniformemente nas 3
+  User Stories, Edge Cases, FRs e Success Criteria; nenhuma ocorrencia de
+  termo alternativo ("uso solto", "uso livre" etc.) encontrada na leitura
+  integral do documento.
+- [x] CHK009 - Os requisitos de nunca-fabricar-dado (FR-005 + Edge Case 1)
+  sao consistentes entre si e com o Principio VI da constitution do
+  projeto? [Constitution Alignment, Spec §FR-005 + Edge Cases item 1]
+  {auto} — FR-005: "MUST reportar 'consumo nao medido' (nunca um valor
+  zero)"; Edge Case 1 repete o mesmo criterio para o caso de opt-in
+  ausente ("nunca um valor zero fabricado (Principio VI)") — mesma regra,
+  duas superficies, sem contradicao.
+- [x] CHK010 - Ha conflito entre a proibicao de usar `session_id` como
+  identidade (FR-002) e alguma outra parte da spec que reintroduza
+  `session_id` como chave de agregacao? [Conflict check, Spec §FR-002 +
+  §Key Entities] {auto} — nenhuma das 3 Key Entities ("Registro de
+  Consumo Avulso", "Janela de Consumo de Pipeline", "Comparativo de Uso
+  do Projeto") referencia `session_id`; sem conflito dentro do proprio
+  `spec.md`.
+
+## Mensurabilidade (Success Criteria)
+
+- [x] CHK011 - SC-002 e SC-004 usam threshold quantificado (100%) em vez
+  de linguagem qualitativa ("a maioria", "quase todo")? [Mensurabilidade,
+  Spec §SC-002, §SC-004] {auto} — ambos literalmente "100%".
+- [x] CHK012 - SC-005 (comparacao avulso vs pipeline) e objetivamente
+  verificavel apesar de nao ter um numero-alvo, por depender de uma
+  condicao binaria testavel? [Mensurabilidade, Spec §SC-005] {auto} —
+  criterio e "sem precisar cruzar manualmente dados de fontes separadas":
+  testavel como pass/fail (existe um unico comando que apresenta as duas
+  categorias lado a lado, ou nao existe).
+
+## Cobertura de Cenarios
+
+- [x] CHK013 - O gate deterministico de cobertura de requisitos confirma
+  que TODAS as FRs tem pelo menos um cenario associado? [Gap-check via
+  script] {auto} — `requirement-coverage.sh docs/specs/loose-usage-capture/spec.md`
+  retornou `RESULT|docs/specs/loose-usage-capture/spec.md|requirements=10|covered=10|errors=0`
+  (exit 0, zero `FINDING`).
+- [x] CHK014 - O Edge Case de concorrencia (duas sessoes avulsas
+  simultaneas no mesmo projeto) esta coberto, incluindo a regra de
+  desambiguacao? [Cobertura, Spec §Edge Cases item 2] {auto} — "Cada
+  processo e atribuido e contabilizado separadamente; a agregacao do
+  projeto soma os processos, sem misturar identificadores de sessao".
+- [x] CHK015 - Ha cenario cobrindo a transicao avulso→pipeline→avulso no
+  MESMO processo (FR-010), nao apenas o caso avulso-puro ou
+  pipeline-puro? [Cobertura, Spec §User Story 2 Acceptance Scenario 2]
+  {auto} — Acceptance Scenario 2 da US2 cobre exatamente esse ciclo:
+  "sessao avulsa que, no meio de sua execucao, da origem a uma execucao
+  de pipeline ... quando a onda se encerra e a sessao avulsa continua,
+  somente a janela fora da onda ativa volta a contar".
+
+## Dependencias e Premissas
+
+- [x] CHK016 - As premissas de ambiente (telemetria nativa habilitada,
+  hooks provisionados) estao explicitadas como pre-condicao verificavel,
+  em vez de implicitas? [Completude, Spec §FR-005 + Edge Cases itens 1 e
+  3] {auto} — Edge Case 3 cobre explicitamente "hooks de captura nao
+  estao provisionados no projeto (escopo `project` nunca instalado)" como
+  premissa de cobertura distinta da premissa de opt-in (Edge Case 1).
+
+## Itens de julgamento humano
+
+- [ ] CHK017 - A janela de perda tolerada em encerramentos abruptos
+  (implicita no intervalo de captura periodica — default proposto 300s em
+  research.md Decision 4, nao fixado na spec) reflete o apetite de risco
+  aceitavel do produto para consumo nao-capturado, ou deveria ser um
+  requisito explicito de spec (ex.: "perda maxima tolerada de N minutos")
+  antes de seguir para `create-tasks`? [Risco, Spec §SC-003 + research.md
+  Decision 4] {humano}
+- [ ] CHK018 - A ausencia de politica de retencao/expurgo (CHK002) e
+  aceitavel como decisao consciente de escopo desta feature (ficando para
+  uma iteracao futura), ou deve virar requisito obrigatorio nesta rodada
+  antes de `create-tasks`? [Risco, CHK002] {humano}
+
+## Notes
+
+- Items `{auto}` ja vem resolvidos pelo agente (`[x]` com citacao, ou
+  marcador `[Gap]` quando a checagem em si e verificavel mas revela
+  ausencia).
+- Items `{humano}` ficam `[ ]` aguardando decisao do dono do produto.
+- CHK002 (retencao) e CHK017 (janela de perda tolerada) sao achados
+  centrais desta rodada — ver `## Follow-up` no relatorio da onda.

--- a/docs/specs/loose-usage-capture/checklists/requirements.md
+++ b/docs/specs/loose-usage-capture/checklists/requirements.md
@@ -18,12 +18,14 @@ feature).
 - [x] CHK002 - Existe requisito de retencao/expurgo para os artefatos
   persistidos (sidecar TSV por processo/segmento + linhas em
   `loose_usage`), dado que a captura e continua e sem limite superior de
-  volume declarado? [Completude, Gap] {auto} — RESOLVIDO pela task 1.1:
-  data-model.md §Retencao (CHK002/CHK029) documenta `CSTK_LOOSE_USAGE_RETENTION_DAYS`
-  (default `90`) e o subcomando `cstk usage prune [--dry-run] [--older-than-days N]`
-  (contracts/cli-usage.md §`cstk usage prune`)
-  de consumo capturados. `plan.md` §Scale/Scope estima "dezenas por dia"
-  mas nao projeta acumulo de longo prazo nem define poda.
+  volume declarado? [Completude, Gap] {auto} — RESOLVIDO pelas tasks 1.1
+  (data-model.md §Retencao (CHK002/CHK029) documenta
+  `CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`), 2.2 (rotina de poda
+  na camada de indice, `recall_prune_loose_usage` em `cli/lib/recall.sh`)
+  e 4.4 (subcomando `cstk usage prune [--dry-run] [--older-than-days N]`,
+  contracts/cli-usage.md §`cstk usage prune`). `plan.md` §Scale/Scope
+  estimava "dezenas por dia" sem projetar acumulo de longo prazo; a poda
+  implementada cobre a lacuna.
 - [x] CHK003 - O requisito de nao-degradacao da sessao do operador (NFR de
   performance/resiliencia) esta coberto explicitamente, e nao apenas
   implicito no design? [Completude, Spec §FR-007] {auto} — FR-007: "MUST

--- a/docs/specs/loose-usage-capture/checklists/requirements.md
+++ b/docs/specs/loose-usage-capture/checklists/requirements.md
@@ -15,14 +15,13 @@ feature).
   paralelo e potencialmente inconsistente? [Completude, Spec §FR-006] {auto}
   — FR-006: "habilitada pela mesma configuracao nativa de telemetria local
   do Claude Code".
-- [ ] CHK002 - Existe requisito de retencao/expurgo para os artefatos
+- [x] CHK002 - Existe requisito de retencao/expurgo para os artefatos
   persistidos (sidecar TSV por processo/segmento + linhas em
   `loose_usage`), dado que a captura e continua e sem limite superior de
-  volume declarado? [Completude, Gap] {auto} — nao encontrado: `grep -rniE
-  "retenc|limpeza|expira|cleanup|purge|ttl|delete"
-  docs/specs/loose-usage-capture/` so retorna spec.md linha 215, que trata
-  apenas de "TTL de token externo" como N/A ("a feature ... nao depende de
-  token externo com TTL") — nao aborda o ciclo de vida dos proprios dados
+  volume declarado? [Completude, Gap] {auto} — RESOLVIDO pela task 1.1:
+  data-model.md §Retencao (CHK002/CHK029) documenta `CSTK_LOOSE_USAGE_RETENTION_DAYS`
+  (default `90`) e o subcomando `cstk usage prune [--dry-run] [--older-than-days N]`
+  (contracts/cli-usage.md §`cstk usage prune`)
   de consumo capturados. `plan.md` §Scale/Scope estima "dezenas por dia"
   mas nao projeta acumulo de longo prazo nem define poda.
 - [x] CHK003 - O requisito de nao-degradacao da sessao do operador (NFR de

--- a/docs/specs/loose-usage-capture/checklists/security.md
+++ b/docs/specs/loose-usage-capture/checklists/security.md
@@ -36,10 +36,12 @@ repositorio versionado.
   e seus arquivos, no MESMO padrao ja aplicado ao `knowledge.db`
   (`chmod 600`, `recall_normalize_db_perms`)? [Gap, cli/lib/recall.sh
   linhas ~669-685 vs spec.md/plan.md/data-model.md/contracts/*] {auto} —
-  RESOLVIDO pela task 1.2: data-model.md §Permissao (CHK021) documenta
+  RESOLVIDO pelas tasks 1.2 (data-model.md §Permissao (CHK021) documenta
   `chmod 700` nos diretorios (raiz, `<process_key>/`, `seg-*/`) e
   `chmod 600` nos arquivos (`meta.tsv`, `otel-start.tsv`, `otel-end.tsv`),
-  paridade com `recall_normalize_db_perms`.
+  paridade com `recall_normalize_db_perms`) e 3.2 (permissao aplicada de
+  fato no hook `posttooluse-loose-usage.sh`, funcoes
+  `_plu_secure_dir`/`_plu_secure_file`).
   Precedente direto ja existe no proprio codebase para o arquivo irmao
   (`knowledge.db`) — a ausencia de requisito equivalente para o
   diretorio de sidecar (que tambem contem `project_path` — path absoluto
@@ -110,9 +112,10 @@ repositorio versionado.
   angulo de seguranca de dados: crescimento local ilimitado de um
   diretorio que contem `project_path` (path absoluto do operador) e um
   risco de superficie de dados que cresce sem controle declarado, nao
-  apenas uma questao de completude funcional. RESOLVIDO pela task 1.1:
-  data-model.md §Retencao (CHK002/CHK029) + contracts/cli-usage.md
-  §`cstk usage prune`.
+  apenas uma questao de completude funcional. RESOLVIDO pelas tasks 1.1
+  (data-model.md §Retencao (CHK002/CHK029)), 2.2 (rotina de poda na
+  camada de indice, `recall_prune_loose_usage` em `cli/lib/recall.sh`) e
+  4.4 (`cstk usage prune`, contracts/cli-usage.md §`cstk usage prune`).
 
 ## Itens de julgamento humano
 

--- a/docs/specs/loose-usage-capture/checklists/security.md
+++ b/docs/specs/loose-usage-capture/checklists/security.md
@@ -31,13 +31,15 @@ repositorio versionado.
   `project`, `project_path`, `process_key`, `segment_id`, `model`,
   `cost_usd`, `total_tokens`, `segment_open`, `captured_at`,
   `ingested_at`; nenhum campo de texto livre de conteudo de sessao.
-- [ ] CHK021 - Existe requisito de permissao de arquivo restritiva
+- [x] CHK021 - Existe requisito de permissao de arquivo restritiva
   (least privilege) para o diretorio novo `~/.claude/cstk/loose-usage/`
   e seus arquivos, no MESMO padrao ja aplicado ao `knowledge.db`
   (`chmod 600`, `recall_normalize_db_perms`)? [Gap, cli/lib/recall.sh
   linhas ~669-685 vs spec.md/plan.md/data-model.md/contracts/*] {auto} —
-  nao encontrado: `grep -rniE "chmod|0700|0600|permiss|umask"
-  docs/specs/loose-usage-capture/` nao retorna nenhuma ocorrencia.
+  RESOLVIDO pela task 1.2: data-model.md §Permissao (CHK021) documenta
+  `chmod 700` nos diretorios (raiz, `<process_key>/`, `seg-*/`) e
+  `chmod 600` nos arquivos (`meta.tsv`, `otel-start.tsv`, `otel-end.tsv`),
+  paridade com `recall_normalize_db_perms`.
   Precedente direto ja existe no proprio codebase para o arquivo irmao
   (`knowledge.db`) — a ausencia de requisito equivalente para o
   diretorio de sidecar (que tambem contem `project_path` — path absoluto
@@ -100,7 +102,7 @@ repositorio versionado.
 
 ## Ciclo de Vida dos Dados (retencao/compliance)
 
-- [ ] CHK029 - Existe politica declarada de retencao/expurgo para os
+- [x] CHK029 - Existe politica declarada de retencao/expurgo para os
   segmentos do sidecar (`~/.claude/cstk/loose-usage/<process_key>/seg-*/`)
   e para as linhas correspondentes em `loose_usage`, dado que a captura
   roda continuamente sem limite superior de volume declarado? [Gap,
@@ -108,7 +110,9 @@ repositorio versionado.
   angulo de seguranca de dados: crescimento local ilimitado de um
   diretorio que contem `project_path` (path absoluto do operador) e um
   risco de superficie de dados que cresce sem controle declarado, nao
-  apenas uma questao de completude funcional.
+  apenas uma questao de completude funcional. RESOLVIDO pela task 1.1:
+  data-model.md §Retencao (CHK002/CHK029) + contracts/cli-usage.md
+  §`cstk usage prune`.
 
 ## Itens de julgamento humano
 

--- a/docs/specs/loose-usage-capture/checklists/security.md
+++ b/docs/specs/loose-usage-capture/checklists/security.md
@@ -1,0 +1,134 @@
+# Security Checklist: loose-usage-capture
+
+**Purpose**: validar a QUALIDADE dos requisitos de seguranca/privacidade da
+captura de consumo avulso — protecao de dados, opt-in/consentimento,
+superficie de rede, auditabilidade e ciclo de vida dos dados locais
+persistidos. Dominio adicional (nao-primario) justificado pelo design: hook
+que le telemetria e escreve um sidecar local novo fora de qualquer
+repositorio versionado.
+**Created**: 2026-08-06
+**Feature**: [spec.md](../spec.md) | [plan.md](../plan.md) |
+[research.md](../research.md) | [data-model.md](../data-model.md) |
+[contracts/hook-loose-usage.md](../contracts/hook-loose-usage.md)
+**Numeracao**: CHK019–CHK031 (IDs unicos por feature; continuam de
+`requirements.md`)
+
+## Protecao de Dados / Privacidade
+
+- [x] CHK019 - O vazamento de PII (`user_id`, `user_email`,
+  `user_account_uuid`, `user_account_id`, `organization_id`) e impedido
+  por construcao antes de qualquer dado alcancar o sidecar local, com
+  defesa em profundidade (nao apenas um unico ponto de filtro)? [Protecao
+  de Dados, contracts/hook-loose-usage.md §Privacidade] {auto} — "Os
+  labels de PII ... sao descartados por construcao no parse do
+  `otel-usage.sh` (allowlist de 4 labels) e reconferidos por defesa em
+  profundidade antes de o snapshot ser publicado (linhas 276-281, que
+  APAGAM o arquivo e falham alto se algum vazar)".
+- [x] CHK020 - Os artefatos persistidos (sidecar TSV, tabela
+  `loose_usage`) contem apenas metadados de custo/token/modelo, sem campo
+  de conteudo de prompt/conversa? [Protecao de Dados, data-model.md
+  §LooseUsageRecord] {auto} — schema de `LooseUsageRecord` lista apenas
+  `project`, `project_path`, `process_key`, `segment_id`, `model`,
+  `cost_usd`, `total_tokens`, `segment_open`, `captured_at`,
+  `ingested_at`; nenhum campo de texto livre de conteudo de sessao.
+- [ ] CHK021 - Existe requisito de permissao de arquivo restritiva
+  (least privilege) para o diretorio novo `~/.claude/cstk/loose-usage/`
+  e seus arquivos, no MESMO padrao ja aplicado ao `knowledge.db`
+  (`chmod 600`, `recall_normalize_db_perms`)? [Gap, cli/lib/recall.sh
+  linhas ~669-685 vs spec.md/plan.md/data-model.md/contracts/*] {auto} —
+  nao encontrado: `grep -rniE "chmod|0700|0600|permiss|umask"
+  docs/specs/loose-usage-capture/` nao retorna nenhuma ocorrencia.
+  Precedente direto ja existe no proprio codebase para o arquivo irmao
+  (`knowledge.db`) — a ausencia de requisito equivalente para o
+  diretorio de sidecar (que tambem contem `project_path` — path absoluto
+  do projeto do operador) e uma lacuna, nao uma decisao explicita.
+
+## Opt-in / Consentimento (FR-006)
+
+- [x] CHK022 - O requisito de opt-in e enforced por um mecanismo
+  estrutural verificavel (provisionamento separado), nao apenas por
+  documentacao/convencao? [Autorizacao, research.md Decision 10 +
+  contracts/hook-loose-usage.md §Registro no harness] {auto} — "flag nova
+  `cstk hooks install --with-loose-usage` `[PROPOSTA]`, default
+  DESLIGADA, com snippet de registro em arquivo SEPARADO" — o hook so
+  existe no harness se o operador rodar o comando explicito.
+- [x] CHK023 - Ha garantia de que o hook de captura NUNCA e bundlado
+  silenciosamente junto dos guard hooks obrigatorios (risco de opt-in
+  implicito via `cstk hooks install` default)? [Autorizacao, plan.md
+  §Project Structure + research.md Decision 10] {auto} — plan.md lista o
+  novo `settings.loose-usage.snippet.json` como arquivo SEPARADO de
+  `settings.snippet.json` (que registra os 3 hooks obrigatorios);
+  research.md Decision 10: "O hook de captura NUNCA entra em
+  `apply_guard_hooks()` por default".
+
+## Superficie de Rede / Threat Modeling
+
+- [x] CHK024 - A superficie de rede da feature esta confinada a loopback
+  (`127.0.0.1`), sem introduzir nenhum destino remoto novo em relacao ao
+  que ja esta em producao? [Threat Modeling, plan.md §Principio IV +
+  contracts/hook-loose-usage.md §Privacidade] {auto} — plan.md: "Destino:
+  `127.0.0.1` (loopback), servidor do proprio processo ... Nenhum pacote
+  deixa a maquina"; reusa exatamente `otel-usage.sh`, sem endpoint novo.
+- [x] CHK025 - Ha requisito cobrindo indisponibilidade temporaria do
+  endpoint de telemetria durante uma janela de captura, com
+  comportamento fail-open explicito (nunca bloqueia a sessao)? [Cobertura,
+  Spec §Edge Cases item 4 + FR-007] {auto} — Edge Case 4: "a captura falha
+  de forma silenciosa para aquela janela (nunca bloqueia a sessao do
+  operador) e a lacuna fica visivel como dado ausente, nao como zero".
+- [x] CHK026 - O design evita atribuicao cruzada de consumo entre
+  processos/sessoes concorrentes (um processo sendo creditado com o
+  consumo de outro)? [Threat Modeling / Integridade, research.md
+  Decision 2 + Decision 5] {auto} — Decision 2 rejeita `session_id` como
+  identidade justamente por esse risco documentado ("label ja observado
+  apontando para outra sessao/projeto"); Decision 5 resolve estados
+  indeterminados sempre para "nao captura" (subconta, nunca superconta).
+
+## Logging e Auditabilidade
+
+- [x] CHK027 - O contrato do hook garante que nenhum dado de consumo
+  vaza para stdout/stderr/logs do harness? [Logging, contracts/hook-loose-usage.md
+  §Saida] {auto} — "stdout: SEMPRE vazio | stderr: SEMPRE vazio (nenhuma
+  falha e reportada ao operador) | exit: SEMPRE 0".
+- [x] CHK028 - O trade-off de "falha sempre silenciosa, zero
+  auditabilidade de falhas sistemicas do hook" e uma decisao deliberada e
+  consistente com o precedente ja aceito no codebase (nao uma omissao
+  desta feature)? [Consistencia / Risco aceito, contracts/hook-loose-usage.md
+  §Saida "REGRA DURA (herdada do molde)"] {auto} — herda literalmente a
+  mesma regra de `posttooluse-tool-call-tick.sh` (hook `PostToolUse` ja
+  em producao com o mesmo contrato de silencio total); nao e um padrao
+  novo introduzido por esta feature.
+
+## Ciclo de Vida dos Dados (retencao/compliance)
+
+- [ ] CHK029 - Existe politica declarada de retencao/expurgo para os
+  segmentos do sidecar (`~/.claude/cstk/loose-usage/<process_key>/seg-*/`)
+  e para as linhas correspondentes em `loose_usage`, dado que a captura
+  roda continuamente sem limite superior de volume declarado? [Gap,
+  Compliance] {auto} — mesma raiz de CHK002 (requirements.md), vista pelo
+  angulo de seguranca de dados: crescimento local ilimitado de um
+  diretorio que contem `project_path` (path absoluto do operador) e um
+  risco de superficie de dados que cresce sem controle declarado, nao
+  apenas uma questao de completude funcional.
+
+## Itens de julgamento humano
+
+- [ ] CHK030 - E aceitavel, em ambiente multi-usuario (ex.: maquina
+  compartilhada), que `~/.claude/cstk/loose-usage/` fique sem permissao
+  restritiva explicita (ver CHK021), dado que o conteudo e limitado a
+  paths de projeto + metricas de custo/token (sem PII, ja garantido por
+  CHK019), ou isso deve virar requisito obrigatorio antes de
+  `create-tasks`? [Risco, CHK021] {humano}
+- [ ] CHK031 - A politica de retencao ausente (CHK002/CHK029) deve ser
+  definida AGORA nesta feature (ex.: poda por idade/tamanho no proprio
+  `cstk usage`/hook), ou aceita conscientemente como divida tecnica para
+  uma iteracao futura, dado o volume estimado baixo ("dezenas por dia",
+  plan.md §Scale/Scope)? [Risco, CHK002, CHK029] {humano}
+
+## Notes
+
+- Items `{auto}` ja vem resolvidos pelo agente (`[x]` com citacao, ou
+  marcador `[Gap]` quando a checagem em si e verificavel mas revela
+  ausencia).
+- Items `{humano}` ficam `[ ]` aguardando decisao do dono do produto.
+- CHK021/CHK029/CHK030/CHK031 sao os achados de seguranca centrais desta
+  rodada — ver `## Follow-up` no relatorio da onda.

--- a/docs/specs/loose-usage-capture/contracts/cli-usage.md
+++ b/docs/specs/loose-usage-capture/contracts/cli-usage.md
@@ -88,6 +88,47 @@ linha a linha.
 
 ---
 
+## `cstk usage prune` (retencao/expurgo — CHK002/CHK029) `[PROPOSTA]`
+
+**Comando**: `cstk usage prune [--dry-run] [--older-than-days N] [--db PATH]`
+
+Paridade estrutural com `cstk mcp gc [--dry-run]` (`cli/lib/mcp.sh`).
+Politica detalhada em [data-model.md §Retencao](../data-model.md#retencao-chk002--chk029).
+
+### Parametros
+
+| Flag | Type | Required | Validation |
+|------|------|----------|------------|
+| `--dry-run` | flag | nao | Reporta o que seria removido sem remover |
+| `--older-than-days` | int | nao | Override do TTL; default `CSTK_LOOSE_USAGE_RETENTION_DAYS` (env), ou `90` se a env tambem estiver ausente |
+| `--db` | path | nao | Override do `knowledge.db` (paridade com `cstk usage`/`cstk recall --db`) |
+
+### Comportamento
+
+1. Varre `~/.claude/cstk/loose-usage/*/seg-*/` e seleciona segmentos com
+   marcador `closed` cujo `updated_at` (de `meta.tsv`) e mais antigo que o
+   TTL efetivo. Segmentos **abertos** nunca sao elegiveis.
+2. Remove os diretorios `seg-*` elegiveis (camada de captura).
+3. Remove as linhas `loose_usage` correspondentes via o helper de poda de
+   `cli/lib/recall.sh` (task 2.2 — `usage.sh` nunca chama `sqlite3`
+   diretamente, mesma restricao da secao abaixo).
+
+### Saida
+
+| Situacao | Saida | Exit |
+|----------|-------|------|
+| Itens elegiveis removidos (ou listados em `--dry-run`) | Uma linha por `process_key/segment_id` afetado + contagem total | 0 |
+| Nenhum item elegivel | `nada a podar — sem segmentos alem do TTL` | 0 |
+| Sidecar (`~/.claude/cstk/loose-usage/`) ausente | Aviso em stderr + `nada a podar` | 0 |
+| `sqlite3` ausente (impede poda da camada de indice) | Aviso em stderr explicando a dep | 1 |
+| Flag desconhecida / `--older-than-days` nao-numerico | Uso em stderr | 2 |
+
+`--dry-run` nunca produz efeito colateral em nenhuma das duas camadas
+(sidecar ou `knowledge.db`) — apenas reporta a mesma selecao que a execucao
+real removeria.
+
+---
+
 ## Restricao de arquitetura (Constitution II)
 
 `cli/lib/usage.sh` `[PROPOSTA]` **nao invoca `sqlite3` diretamente**: delega

--- a/docs/specs/loose-usage-capture/contracts/cli-usage.md
+++ b/docs/specs/loose-usage-capture/contracts/cli-usage.md
@@ -1,0 +1,116 @@
+# Contracts: `cstk usage` `[PROPOSTA — a validar na implementacao]`
+
+Superficie de consulta do consumo avulso (FR-009 / SC-005). Subcomando NOVO —
+**nao existe hoje**. A lista atual de subcomandos do dispatch em `cli/cstk` e
+`install | update | self-update | list | doctor | session | serve | recall |
+show-tip | hooks | state | mcp`; `usage` esta livre.
+
+Convencoes herdadas do CLI existente: mensagens de erro em stderr, dados em
+stdout, exit `0` sucesso / `1` erro geral / `2` uso incorreto (Constitution II).
+
+---
+
+## `cstk usage` (listagem por projeto)
+
+**Comando**: `cstk usage [--project P] [--since ISO] [--limit N] [--json] [--db PATH]`
+**Auth**: N/A (local, sem rede)
+
+### Parametros
+
+| Flag | Type | Required | Validation |
+|------|------|----------|------------|
+| `--project` | string | nao | Default: projeto do diretorio corrente |
+| `--since` | ISO 8601 | nao | Filtra por `captured_at >= valor` |
+| `--limit` | int | nao | Inteiro positivo; default `20` (paridade com `cstk recall`) |
+| `--json` | flag | nao | Saida maquina-legivel em vez de texto |
+| `--db` | path | nao | Override do `knowledge.db` (paridade com `cstk recall --db`) |
+
+### Saida (texto, exit 0)
+
+Uma secao por projeto com uma linha por modelo: modelo, tokens, custo e
+participacao. Campo sem medicao imprime **`nao medido`**, nunca `0`
+(FR-005 / SC-004).
+
+### Saida (`--json`, exit 0)
+
+Objeto com `project`, `category: "loose"` e `models[]`, onde cada item traz
+`model`, `total_tokens`, `cost_usd`. Campos nao medidos sao `null` JSON —
+a ausencia e representada por `null`, nunca por `0`.
+
+### Comportamento sem dados
+
+| Situacao | Saida | Exit |
+|----------|-------|------|
+| `knowledge.db` ausente | Aviso em stderr + `nao medido` | 0 |
+| Tabela `loose_usage` vazia p/ o projeto | `nao medido — sem cobertura de captura` | 0 |
+| `sqlite3` ausente | Aviso em stderr explicando a dep | 1 |
+| Flag desconhecida | Uso em stderr | 2 |
+
+> "Sem cobertura" e "medido e zero" sao mensagens DISTINTAS (FR-005). A
+> distincao vem da existencia de linhas em `loose_usage`, nao do valor.
+
+---
+
+## `cstk usage compare` (avulso vs pipeline)
+
+**Comando**: `cstk usage compare [--project P] [--since ISO] [--json] [--db PATH]`
+
+Atende FR-009 e SC-005: mix de modelos e custo blended por milhao de tokens,
+das duas categorias lado a lado, para o mesmo projeto.
+
+### Fontes
+
+| Categoria | Tabela | Situacao |
+|-----------|--------|----------|
+| `loose` | `loose_usage` | NOVA (`[PROPOSTA]`, schema v13) |
+| `pipeline` | `wave_model_usage` | JA EXISTE — `cli/lib/recall.sh` linhas 625-637 (`project`, `model`, `cost_usd`, `total_tokens`) |
+
+### Saida (por categoria)
+
+| Campo | Type | Descricao |
+|-------|------|-----------|
+| `category` | enum `loose`\|`pipeline` | Conjunto fechado |
+| `models[]` | array | `{model, total_tokens, cost_usd, share_pct}` |
+| `blended_cost_per_mtok` | number \| null | `SUM(cost_usd)/SUM(total_tokens)*1e6` |
+
+**Agregacao, nao JOIN**: as duas tabelas tem granularidades diferentes
+(processo x segmento x modelo vs onda x modelo). A comparacao soma cada
+categoria separadamente e as apresenta lado a lado — nunca correlaciona
+linha a linha.
+
+### Regras de ausencia
+
+| Situacao | Resultado |
+|----------|-----------|
+| Categoria sem nenhuma linha | `nao medido` / `null`; a outra categoria ainda e exibida |
+| `SUM(total_tokens)` = 0 ou NULL | `blended_cost_per_mtok = null` (divisao indefinida nao vira 0) |
+| Ambas vazias | `nao medido` nas duas; exit 0 |
+
+---
+
+## Restricao de arquitetura (Constitution II)
+
+`cli/lib/usage.sh` `[PROPOSTA]` **nao invoca `sqlite3` diretamente**: delega
+aos helpers ja existentes de `cli/lib/recall.sh` (que hoje concentram
+`recall_apply_schema`, `recall_run_sql`, `recall_query_sql`).
+
+A regra ja esta escrita no codigo — `cli/lib/serve-docker.sh` linhas 11-13:
+*"`cli/lib/recall.sh` (unico arquivo autorizado a `sqlite3`)"*.
+
+Invariante verificavel na revisao (o `grep -l 'sqlite3'` simples NAO serve:
+retorna 5 arquivos hoje, por casar comentarios, `sqlite3 --version` de
+diagnostico em `doctor.sh` e o pacote npm `better-sqlite3` em
+`serve-docker.sh`):
+
+```sh
+# Arquivos que ABREM banco via sqlite3 — deve continuar sendo so recall.sh
+grep -nE '(^|[^-[:alnum:]_])sqlite3[[:space:]]+(-cmd[[:space:]]|--[[:space:]])' cli/lib/*.sh
+```
+
+(O espaco exigido apos `--` e o que exclui o `sqlite3 --version` de
+diagnostico do `cli/lib/doctor.sh` linha 438, que nunca abre banco.)
+
+Isso preserva a condicao (b) do carve-out de dep opcional (Constitution
+Principio II, amendment 1.1.0): "codigo que referencia a dep confinado em UM
+unico arquivo identificavel". Ver tambem `plan.md` §Principio II para o
+detalhamento por arquivo.

--- a/docs/specs/loose-usage-capture/contracts/hook-loose-usage.md
+++ b/docs/specs/loose-usage-capture/contracts/hook-loose-usage.md
@@ -1,0 +1,138 @@
+# Contracts: hook `posttooluse-loose-usage.sh` `[PROPOSTA — a validar na implementacao]`
+
+Hook `PostToolUse` dedicado a captura de consumo avulso (dec-006). **Nao
+existe hoje**; o molde e `global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh`
+(EXISTENTE, 159 linhas), cujas invariantes sao herdadas integralmente.
+
+---
+
+## Registro no harness `[PROPOSTA]`
+
+Bloco em arquivo SEPARADO do `settings.snippet.json` atual (dec-008 / FR-006).
+O snippet existente registra os tres hooks obrigatorios
+(`pretooluse-bash-guard` em `PreToolUse`/`Bash`, `posttooluse-tool-call-tick`
+em `PostToolUse`/`*`, `posttooluse-agent-usage` em `PostToolUse`/`Agent`) —
+o hook de captura avulsa NAO entra ali.
+
+| Campo | Valor |
+|-------|-------|
+| Evento | `PostToolUse` |
+| `matcher` | `*` |
+| `command` | `"$CLAUDE_PROJECT_DIR"/.claude/hooks/posttooluse-loose-usage.sh` |
+| `timeout` | `5` (mesmo teto dos hooks existentes) |
+
+Provisionado por `cstk hooks install --with-loose-usage` `[PROPOSTA]` —
+flag nova, default DESLIGADA. Sem a flag, `apply_guard_hooks()` mantem
+exatamente o comportamento atual.
+
+---
+
+## Entrada
+
+STDIN: payload JSON do harness. Campos consumidos (os mesmos ja consumidos
+pelo molde, linhas 73-78):
+
+| Campo | Uso |
+|-------|-----|
+| `.cwd` | Projeto ao qual o consumo e atribuido (FR-002). Vazio ⇒ no-op |
+| `.tool_name` | Sanidade do payload. Vazio ⇒ no-op (nao inventa captura) |
+
+Ambiente consumido:
+
+| Variavel | Uso | Fonte |
+|----------|-----|-------|
+| `CSTK_OTEL_ENDPOINT` | Endpoint por processo; **ancora de identidade** | Observada presente no subprocesso do harness (research.md Decision 3) |
+| `CSTK_LOOSE_USAGE_INTERVAL_S` | Override do intervalo de throttle `[PROPOSTA]` | Default `300` |
+
+**NAO consumidas**: `OTEL_METRICS_EXPORTER` e `OTEL_EXPORTER_PROMETHEUS_PORT`
+— observadas AUSENTES no ambiente do subprocesso (research.md Decision 3).
+Gatear por elas produziria zero captura.
+
+---
+
+## Saida
+
+| Canal | Contrato |
+|-------|----------|
+| stdout | SEMPRE vazio |
+| stderr | SEMPRE vazio (nenhuma falha e reportada ao operador) |
+| exit | SEMPRE `0` |
+| Efeito | No maximo: escrita sob `~/.claude/cstk/loose-usage/<process_key>/` |
+
+**REGRA DURA (herdada do molde, linhas 22-35)**: o hook NUNCA le nem escreve
+`state.json`/`state.db`, e NUNCA abre o `knowledge.db`. `PostToolUse` dispara
+concorrente as tool calls; qualquer read-modify-write de estado compartilhado
+poderia clobberar uma escrita transacional.
+
+---
+
+## Sequencia (ordem obrigatoria — barato antes de caro)
+
+| # | Passo | Falha ⇒ |
+|---|-------|---------|
+| 1 | `CSTK_OTEL_ENDPOINT` presente? | no-op |
+| 2 | `jq` disponivel? | no-op (dep opcional, fail-open — igual ao molde linha 68) |
+| 3 | Parse do stdin; `.cwd` e `.tool_name` nao-vazios? | no-op |
+| 4 | Throttle: `now - meta.updated_at >= intervalo`? | no-op (caminho O(1), sem rede) |
+| 5 | Deteccao de execucao ativa (invertida — abaixo) | conforme tabela |
+| 6 | `otel-usage.sh snapshot` no diretorio do segmento | no-op (o proprio snapshot ja degrada) |
+| 7 | Atualiza `meta.tsv` (`updated_at`, `current_segment`) | no-op |
+
+O passo 4 antes do 5 e deliberado: o throttle e a checagem mais barata que
+descarta a maioria esmagadora dos ticks; so depois vale sondar estado.
+
+---
+
+## Polaridade da deteccao de execucao ativa (INVERTIDA — dec-006)
+
+Helper `_hook-active-exec.sh` (EXISTENTE; contrato no cabecalho, linhas 31-36):
+
+| Exit do helper | Significado | Acao do hook de captura | Acao do hook de tick (molde) |
+|----------------|-------------|--------------------------|------------------------------|
+| `0` | ativa | **fecha o segmento**, nao captura | grava tick |
+| `1` | inativa | **captura** | no-op |
+| `2` | indeterminada | no-op | no-op |
+| `3` | uso incorreto | no-op | no-op |
+
+`indeterminada` NAO e tratada como `inativa`: capturar sob incerteza
+fabricaria consumo avulso (Constitution VI). A assimetria e intencional —
+SC-002 exige 100% de exclusao das janelas de pipeline; nao ha requisito
+simetrico de 100% de captura do avulso.
+
+**Pre-check inline**: o molde sai barato quando NAO ha nenhum
+`state.json`/`state.db` sob `.claude/agente-00c-state/` ou
+`.claude/feature-00c-state/*/` (linhas 85-106). Sob polaridade invertida esse
+mesmo teste conclui `inativa` — e o hook segue para a captura sem sourcear o
+helper. Mantem-se o requisito SEC-H1 do molde: o pre-check usa
+EXCLUSIVAMENTE builtins do shell, antes de qualquer resolucao de dependencia.
+
+`HAE_BUSY_TIMEOUT_MS`: `50` (mesma politica de hook de metrica do molde,
+linhas 137-140) — sob contencao do SQLite o helper devolve `indeterminada` e
+o tick e pulado, nunca esperado.
+
+---
+
+## Resolucao de dependencias
+
+Mesma cadeia do molde (`_ptt_resolve_dep_hae`, linhas 115-130), com `$HOME`
+antes de `<cwd>` e teste `-r` (helpers `_*.sh` do runtime nao sao
+executaveis):
+
+1. `<dir do hook>/../scripts/<rel>`
+2. `$HOME/.claude/skills/agente-00c-runtime/scripts/<rel>`
+3. `<cwd>/.claude/skills/agente-00c-runtime/scripts/<rel>`
+
+Dependencias resolvidas por essa cadeia: `_hook-active-exec.sh` (sourceado) e
+`otel-usage.sh` (executado). Qualquer uma irresolvivel ⇒ no-op silencioso.
+
+---
+
+## Privacidade (Constitution IV)
+
+- Toda leitura e de `127.0.0.1` (loopback). Nada e transmitido para fora.
+- Os labels de PII (`user_id`, `user_email`, `user_account_uuid`,
+  `user_account_id`, `organization_id`) sao descartados por construcao no
+  parse do `otel-usage.sh` (allowlist de 4 labels, linhas 170-197) e
+  reconferidos por defesa em profundidade antes de o snapshot ser publicado
+  (linhas 276-281, que APAGAM o arquivo e falham alto se algum vazar).
+- Nenhum artefato desta feature sai do filesystem local do operador.

--- a/docs/specs/loose-usage-capture/data-model.md
+++ b/docs/specs/loose-usage-capture/data-model.md
@@ -54,6 +54,27 @@ projeto (Edge Case "duas janelas/terminais abertos").
 > **Constitution VI**: `owner_pid` ausente e gravado como `unknown`, jamais
 > como `0` ou PID chutado.
 
+### Permissao (CHK021)
+
+Paridade com `recall_normalize_db_perms` (`cli/lib/recall.sh` ~669-689,
+que fecha o mesmo gap para `knowledge.db`): o hook aplica permissao
+restritiva no sidecar apos cada escrita, best-effort (nunca bloqueia o
+caller — ausencia de `stat` portavel ou `chmod` negado degrada para
+no-op silencioso, mesmo padrao fail-open do proprio hook).
+
+| Alvo | Modo |
+|------|------|
+| `~/.claude/cstk/loose-usage/` (raiz) | `chmod 700` |
+| `<process_key>/` | `chmod 700` |
+| `seg-*/` | `chmod 700` |
+| `meta.tsv` | `chmod 600` |
+| `otel-start.tsv` | `chmod 600` |
+| `otel-end.tsv` | `chmod 600` |
+
+Motivo: os arquivos carregam `project_path` e trechos de metricas de
+consumo por processo — conteudo local sensivel o suficiente para restringir
+ao dono do processo, mesma logica ja aplicada ao indice SQLite irmao.
+
 ### Formato de `otel-start.tsv` / `otel-end.tsv` (JA EXISTENTE)
 
 Escrito por `otel-usage.sh snapshot`. Cabecalho `# session_id<TAB><valor>`
@@ -130,6 +151,26 @@ e sem `DROP` (precedente literal da v11->v12 para tabela nova —
 `cli/lib/recall.sh` linhas 810-811). Base v12 existente do operador ganha a
 tabela vazia na proxima escrita; bases pre-v12 seguem o caminho de migracao
 ja existente sem interferencia.
+
+### Retencao (CHK002 / CHK029)
+
+Politica de design explicita — nao dado factual (mesma natureza do default
+de intervalo tratado em research.md Decision 4). Mecanismo: subcomando
+dedicado `cstk usage prune [--dry-run] [--older-than-days N]`, paridade
+estrutural com `cstk mcp gc [--dry-run]` ja existente em `cli/lib/mcp.sh`.
+
+| Aspecto | Valor |
+|---------|-------|
+| Variavel de TTL | `CSTK_LOOSE_USAGE_RETENTION_DAYS` |
+| Default | `90` (dias) |
+| Override | `--older-than-days N` no subcomando `cstk usage prune` |
+| Alvo da poda (camada de captura) | Segmentos `seg-*` **fechados** (marcador `closed` presente) sob `~/.claude/cstk/loose-usage/<process_key>/` |
+| Alvo da poda (camada de indice) | Linhas de `loose_usage` correspondentes aos segmentos podados |
+| Criterio de elegibilidade | Idade de `updated_at` (`meta.tsv`) / `captured_at` (`loose_usage`) acima do TTL — segmentos **abertos** nunca sao elegiveis, mesmo com `updated_at` antigo (evita truncar captura em andamento) |
+| Modo dry-run | `--dry-run` reporta o que seria removido sem remover (paridade com `cstk mcp gc --dry-run`) |
+
+A poda e best-effort e idempotente: rodar `cstk usage prune` sobre um
+diretorio ja podado nao produz erro, apenas relata zero itens elegiveis.
 
 ---
 

--- a/docs/specs/loose-usage-capture/data-model.md
+++ b/docs/specs/loose-usage-capture/data-model.md
@@ -1,0 +1,155 @@
+# Data Model: Loose Usage Capture
+
+Duas camadas de persistencia (research.md Decision 7):
+
+- **Camada de captura (fonte)**: arquivos sob `~/.claude/cstk/loose-usage/`,
+  escritos exclusivamente pelo hook. Sobrevivem ao processo (FR-008).
+- **Camada de indice (derivada)**: tabela nova no `knowledge.db`
+  (`~/.claude/cstk/knowledge.db`), populada por ingest-on-read do CLI.
+  Reconstruivel a partir da camada de captura.
+
+Todos os schemas marcados `[PROPOSTA — a validar na implementacao]` ainda nao
+existem no codigo. O que ja existe esta citado com arquivo e linha.
+
+---
+
+## Entity: LooseUsageProcess (camada de captura) `[PROPOSTA]`
+
+Um processo local do Claude Code observado num projeto. Grao: processo x
+projeto (FR-002). Materializado como um diretorio:
+
+```
+~/.claude/cstk/loose-usage/<process_key>/
+├── meta.tsv                    # metadados do processo
+└── seg-<NNN>/                  # um diretorio por segmento avulso
+    ├── otel-start.tsv          # snapshot inicial do segmento
+    ├── otel-end.tsv            # snapshot mais recente do segmento
+    └── closed                  # marcador; presente = segmento encerrado
+```
+
+Os nomes `otel-start.tsv` / `otel-end.tsv` **nao sao escolha desta feature**:
+sao os nomes que `otel-usage.sh` escreve e le (`snapshot` linha 265,
+`delta` linhas 296-297). Mante-los permite reusar os dois subcomandos sem
+alteracao.
+
+### Campos de `meta.tsv` (formato `chave<TAB>valor`, uma linha por chave)
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| `schema` | int | NOT NULL | Versao do layout do sidecar; inicia em `1` |
+| `project_path` | string | NOT NULL | `cwd` recebido do payload do hook |
+| `endpoint` | string | NOT NULL | Valor de `CSTK_OTEL_ENDPOINT` do processo |
+| `owner_pid` | int \| `unknown` | — | PID dono da porta; `unknown` quando indeterminavel (nunca 0) |
+| `created_at` | ISO 8601 UTC | NOT NULL | Primeira captura do processo |
+| `updated_at` | ISO 8601 UTC | NOT NULL | Ultima captura bem-sucedida; base do throttle |
+| `current_segment` | string | NOT NULL | Id do segmento aberto (ex: `seg-002`) |
+
+**Derivacao de `process_key`**: funcao estavel do par
+(`endpoint`, `project_path`), com `owner_pid` como componente adicional
+quando obtenivel. `[PROPOSTA]` — o algoritmo exato (hash vs composicao
+literal saneada) e detalhe de implementacao; o requisito e ser deterministico
+dentro de um processo e nao colidir entre processos simultaneos no mesmo
+projeto (Edge Case "duas janelas/terminais abertos").
+
+> **Constitution VI**: `owner_pid` ausente e gravado como `unknown`, jamais
+> como `0` ou PID chutado.
+
+### Formato de `otel-start.tsv` / `otel-end.tsv` (JA EXISTENTE)
+
+Escrito por `otel-usage.sh snapshot`. Cabecalho `# session_id<TAB><valor>`
+seguido de linhas de 5 colunas separadas por TAB
+(`_ou_parse`, linhas 170-197):
+
+| Coluna | Conteudo |
+|--------|----------|
+| 1 | `session_id` (informativo; NAO usado como identidade — Decision 2) |
+| 2 | `query_source` (`main` \| `subagent` \| `auxiliary` \| `sdk`) |
+| 3 | `model` |
+| 4 | `type` (`cost` na linha de custo; senao `input`/`output`/`cacheRead`/`cacheCreation`) |
+| 5 | `value` (numerico) |
+
+Labels de PII (`user_id`, `user_email`, `user_account_uuid`,
+`user_account_id`, `organization_id`) sao descartados por construcao no parse
+e reconferidos por defesa em profundidade (linhas 276-281) — nunca alcancam
+estes arquivos.
+
+### State Transitions — segmento avulso
+
+```
+(sem segmento) --tick com execucao INATIVA--> aberto
+aberto --tick com execucao INATIVA--> aberto (otel-end.tsv reescrito)
+aberto --tick com execucao ATIVA--> fechado (marcador `closed`; trecho nao persistido e descartado)
+fechado --tick com execucao INATIVA--> novo segmento aberto (seg-N+1)
+```
+
+Estados `indeterminada` (exit 2) e `uso incorreto` (exit 3) do helper NAO
+provocam transicao: o tick e ignorado por completo (Decision 5).
+
+---
+
+## Entity: LooseUsageRecord (camada de indice — tabela `loose_usage`) `[PROPOSTA]`
+
+Grao: processo x segmento x modelo. Uma linha por modelo usado num segmento.
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| `id` | INTEGER | PK AUTOINCREMENT | Padrao das demais tabelas do `knowledge.db` |
+| `project` | TEXT | NOT NULL | Nome canonico do projeto (basename de `project_path`) |
+| `project_path` | TEXT | — | Path absoluto; paridade com `executions.target_project_path` (v9) |
+| `process_key` | TEXT | NOT NULL | Ver LooseUsageProcess |
+| `segment_id` | TEXT | NOT NULL | Ex: `seg-002` |
+| `model` | TEXT | — | Rotulo de modelo vindo do exporter; NULL se ausente |
+| `cost_usd` | REAL | — | **NULL quando nao medido** — jamais 0 fabricado |
+| `total_tokens` | INTEGER | — | **NULL quando nao medido** — jamais 0 fabricado |
+| `segment_open` | INTEGER | — | `1` segmento aberto, `0` fechado |
+| `captured_at` | TEXT | NOT NULL | `updated_at` do segmento (ultima captura) |
+| `ingested_at` | TEXT | NOT NULL | Momento da ingestao |
+| — | — | `UNIQUE(process_key, segment_id, model)` | Chave natural; ingestao e UPSERT idempotente |
+
+**Colunas deliberadamente AUSENTES** (fundamento de dec-005): `feature`,
+`wave`, `execution_id`. Nao existem para consumo avulso; preenche-las com
+sentinela seria fabricar dado (Constitution VI). E exatamente por serem
+`NOT NULL` em `wave_model_usage` (`cli/lib/recall.sh` linhas 625-637) que
+aquela tabela nao pode ser reusada.
+
+### Relationships
+
+- `LooseUsageProcess` 1:N `LooseUsageRecord` via `process_key`.
+- `loose_usage` N:1 (logico) `executions.target_project_path` via
+  `project_path` — **sem FK declarada**: as duas tabelas sao indices
+  derivados independentes e uma FK quebraria `--reindex` parcial.
+- `loose_usage` x `wave_model_usage`: sem relacao de chave; a comparacao de
+  FR-009 e uma agregacao lado a lado por `project`, nunca um JOIN linha a
+  linha (granularidades diferentes por construcao).
+
+### Migracao
+
+`RECALL_SCHEMA_VERSION`: `12` -> `13`. Aditiva pura: `CREATE TABLE IF NOT
+EXISTS loose_usage (...)` no corpo de `recall_schema_ddl`, sem `ALTER TABLE`
+e sem `DROP` (precedente literal da v11->v12 para tabela nova —
+`cli/lib/recall.sh` linhas 810-811). Base v12 existente do operador ganha a
+tabela vazia na proxima escrita; bases pre-v12 seguem o caminho de migracao
+ja existente sem interferencia.
+
+---
+
+## Entity: ProjectUsageComparison (derivada, sem persistencia)
+
+Visao calculada em tempo de consulta por `cstk usage compare` `[PROPOSTA]`.
+Nao e tabela.
+
+| Field | Type | Origem |
+|-------|------|--------|
+| `project` | string | Parametro/agrupador |
+| `category` | enum `loose` \| `pipeline` | Conjunto fechado |
+| `model` | string | `loose_usage.model` / `wave_model_usage.model` |
+| `total_tokens` | integer \| `null` | SUM por categoria+modelo; `null` se nao medido |
+| `cost_usd` | number \| `null` | SUM por categoria+modelo; `null` se nao medido |
+| `share_pct` | number \| `null` | Participacao do modelo no total da categoria |
+| `blended_cost_per_mtok` | number \| `null` | `SUM(cost_usd) / SUM(total_tokens) * 1e6` |
+
+**Regra de ausencia (FR-005 / SC-004)**: quando uma categoria nao tem
+nenhuma linha para o projeto, o campo e `null` e a renderizacao textual e
+`nao medido`. Zero so aparece se houver linha com valor `0` de fato medido.
+`blended_cost_per_mtok` e `null` quando `SUM(total_tokens)` e `0` ou `NULL`
+(divisao indefinida nunca vira `0`).

--- a/docs/specs/loose-usage-capture/plan.md
+++ b/docs/specs/loose-usage-capture/plan.md
@@ -1,0 +1,284 @@
+# Implementation Plan: Captura de Consumo Avulso de Uso (Loose Usage Capture)
+
+**Feature**: `loose-usage-capture` | **Date**: 2026-08-06 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Dar ao operador visibilidade do consumo de tokens/custo por modelo das sessoes
+**avulsas** do Claude Code — as que acontecem fora de qualquer execucao das
+pipelines SDD `agente-00c`/`feature-00c` — para poder compara-lo, no mesmo
+projeto, com o consumo ja medido das pipelines (mix de modelos + custo blended
+por milhao de tokens).
+
+Abordagem tecnica, em tres camadas, cada uma reusando um padrao ja em producao
+no toolkit:
+
+1. **Captura**: hook `PostToolUse` dedicado (`posttooluse-loose-usage.sh`),
+   moldado em `posttooluse-tool-call-tick.sh`, com throttle por intervalo e
+   com a deteccao de execucao ativa de `_hook-active-exec.sh` usada em
+   **polaridade invertida** — captura quando NAO ha pipeline ativa, o que
+   implementa simultaneamente o gatilho periodico (FR-003) e a exclusao de
+   dupla contagem (FR-004).
+2. **Persistencia**: snapshots TSV por processo/segmento sob
+   `~/.claude/cstk/loose-usage/`, escritos por `otel-usage.sh snapshot` **sem
+   nenhuma alteracao no script** (os nomes de arquivo e o formato ja batem);
+   ingestao posterior numa tabela NOVA do `knowledge.db` (migracao aditiva
+   v12 -> v13).
+3. **Consulta**: subcomando novo `cstk usage` (+ `cstk usage compare`), com a
+   camada SQL delegada aos helpers de `cli/lib/recall.sh` para preservar o
+   confinamento de dependencia.
+
+Fio condutor de toda a feature: **ausencia de metrica e `null`/"nao medido",
+nunca zero** (Constitution VI) — e cada ponta degrada em no-op silencioso,
+jamais bloqueando a sessao do operador (FR-007).
+
+## Technical Context
+
+**Language/Version**: POSIX `sh` (shebang `#!/bin/sh`), conforme Constitution
+Principio II. Sem Bash-isms.
+**Primary Dependencies**:
+- `curl` — ja usado por `otel-usage.sh` (`_ou_have_curl`, linha 136), com
+  degradacao se ausente;
+- `awk`, `sed`, `sort`, `mktemp` — POSIX canonicos;
+- `jq` — dep OPCIONAL com fail-open no hook (mesmo carve-out do molde,
+  linha 68) e ja presente em `cli/lib/recall.sh`;
+- `sqlite3` — confinado a `cli/lib/recall.sh` (nao adicionar novo arquivo que
+  o invoque);
+- `lsof` — OPCIONAL, so para `owner_pid`; ja confinado a `otel-usage.sh`
+  (`_ou_port_owner`, linha 443, com `command -v lsof || return 1`).
+
+**Storage**: (a) arquivos TSV sob `~/.claude/cstk/loose-usage/` (fonte);
+(b) `~/.claude/cstk/knowledge.db` (SQLite, indice derivado) — versao real
+verificada nesta onda: `schema_version = 12`.
+**Testing**: harness POSIX proprio (`tests/run.sh`). Convencao de mapeamento:
+script em `global/skills/<X>/scripts/` -> `tests/test_<n>.sh`; lib em
+`cli/lib/` -> `tests/cstk/test_<n>.sh`. Hooks seguem `tests/test_<n>.sh`
+(precedente: `tests/test_pretooluse-bash-guard.sh`).
+**Target Platform**: macOS e Linux, ambiente local do operador. Sem servidor,
+sem container, sem rede externa.
+**Project Type**: CLI + runtime de hooks (single-process, local).
+**Performance Goals**: caminho quente do hook (tick fora do intervalo de
+throttle) sem I/O de rede e sem sourcing de dependencia; teto de execucao do
+hook e o `timeout: 5` do registro no harness, e o pior caso de scrape e
+`--max-time 3` (`otel-usage.sh` linha 150).
+**Constraints**: o hook NUNCA escreve `state.json`/`state.db` nem abre o
+`knowledge.db`; stdout/stderr sempre vazios; exit sempre `0`.
+**Scale/Scope**: um operador, N projetos, ate poucas sessoes simultaneas por
+projeto. Volume de linhas em `loose_usage` proporcional a
+(processos x segmentos x modelos) — ordem de grandeza de dezenas por dia.
+
+Nenhum `NEEDS CLARIFICATION` remanescente: os quatro pontos abertos foram
+fechados na etapa clarify (dec-005..dec-008, registrados em `spec.md`
+§Clarifications) e os demais foram resolvidos no Phase 0
+([research.md](./research.md), Decisions 1-11).
+
+## Constitution Check
+
+*GATE: Deve passar antes do Phase 0. Re-checado apos Phase 1 — ver §Re-check.*
+
+Constitution: `docs/constitution.md` **v1.3.0**.
+
+| Principio | Status | Notas |
+|-----------|--------|-------|
+| I. SDD recursivo (MUST) | PASS | Feature nao-trivial entrando pela pipeline completa: `spec.md` + `clarify` + este `plan.md`; `tasks.md` na proxima etapa. Contrato de CLI novo (`cstk usage`) exige nota no CHANGELOG (MINOR — capacidade nova, nada removido/renomeado). |
+| II. POSIX sh puro, zero dep externa (MUST) | PASS **com carve-outs declarados** | Ver bloco dedicado abaixo. |
+| III. Formato canonico de skill | N/A (com dever de doc) | A feature nao cria skill nova. Toca a skill interna `agente-00c-runtime` (hook novo) — a documentacao do runtime deve mencionar o hook, mas nao ha novo `SKILL.md` a produzir. |
+| IV. Zero coleta remota (MUST) | PASS **apos analise explicita** | Ver bloco dedicado abaixo. |
+| V. Profundidade sobre adocao (SHOULD) | PASS | Fecha um ponto cego real de custo do operador; nenhum requisito de visibilidade externa. |
+| VI. Veracidade de dados / zero fabricacao (MUST) | PASS | Toda ausencia e `null`/"nao medido"; as guardas de ambiguidade do `delta` (mais de uma sessao cresceu, exporter trocou, formato antigo) sao herdadas e imprimem `null`; `owner_pid` indeterminavel grava `unknown`; `indeterminada` do helper nunca vira captura. |
+
+### Principio II — carve-outs aplicaveis (condicoes declaradas aqui, cumprindo (c))
+
+Duas subsecoes da Constitution sao invocadas:
+
+**(1) Optional dependencies with graceful fallback (amendment 1.1.0)** — para
+`jq` e `lsof`:
+
+| Condicao | Como e satisfeita |
+|----------|-------------------|
+| (a) opcional com fallback verificavel | `jq` ausente ⇒ hook faz no-op (exit 0) e a captura simplesmente nao ocorre; `lsof` ausente ⇒ `owner_pid=unknown`, captura segue. Ambos cobertos por cenario de teste. |
+| (b) confinada a um arquivo identificavel | `jq` no hook novo (arquivo unico) e em `cli/lib/recall.sh` (ja existente); `lsof` permanece exclusivamente em `otel-usage.sh`. |
+| (c) declarada na doc da feature | Este bloco + [research.md](./research.md) Decisions 3 e 7. |
+
+**(2) `sqlite3`** permanece sob o confinamento ja vigente: `cli/lib/usage.sh`
+`[PROPOSTA]` **nao** invoca `sqlite3` — delega aos helpers de
+`cli/lib/recall.sh`.
+
+A disciplina esta escrita no proprio codigo — `cli/lib/serve-docker.sh`
+linhas 11-13: *"Mesma disciplina de `cli/lib/hooks.sh` (unico arquivo
+autorizado a `jq`) e `cli/lib/recall.sh` (unico arquivo autorizado a
+`sqlite3`)"*.
+
+**Estado real medido nesta onda** (para nao inventar um invariante mais limpo
+do que a realidade): `grep -l 'sqlite3' cli/lib/*.sh` retorna **5** arquivos —
+`recall.sh`, `doctor.sh`, `mcp-docker.sh`, `serve-docker.sh`, `state.sh`. A
+leitura linha a linha separa os casos:
+
+| Arquivo | Natureza das ocorrencias |
+|---------|--------------------------|
+| `recall.sh` | Unico que **abre um banco** (`sqlite3 -- "$db"`, `-cmd '.timeout 5000'`, etc.) |
+| `doctor.sh` | So diagnostico de dependencia: `command -v sqlite3` e `sqlite3 --version` — nunca abre banco |
+| `state.sh`, `mcp-docker.sh` | Apenas comentario/texto de ajuda |
+| `serve-docker.sh` | Comentario + o nome do pacote npm `better-sqlite3` (outro binario) |
+
+Invariante correto a preservar (e o que a revisao deve checar), ja que o
+`grep -l` simples produz falsos positivos. A forma abaixo foi **executada
+nesta onda** e retorna exatamente `cli/lib/recall.sh` — exigir espaco depois
+de `--` e o que exclui o `sqlite3 --version` de diagnostico do `doctor.sh`
+(linha 438):
+
+```sh
+# Arquivos que ABREM banco via sqlite3 — deve continuar sendo so recall.sh
+grep -nE '(^|[^-[:alnum:]_])sqlite3[[:space:]]+(-cmd[[:space:]]|--[[:space:]])' cli/lib/*.sh
+```
+
+Sem a delegacao de `usage.sh` a `recall.sh`, esse conjunto cresceria e a
+condicao (b) seria violada.
+
+### Principio IV — analise explicita (nao e carimbo)
+
+O Principio IV proibe requisicao de rede "para endpoint de telemetria,
+analytics, feature-flag remoto, ou servico de erro". Esta feature **le** um
+endpoint de telemetria. A analise, item a item:
+
+- **Destino**: `127.0.0.1` (loopback), servidor do proprio processo do Claude
+  Code do operador. Nenhum pacote deixa a maquina.
+- **Direcao**: leitura do proprio consumo; nao ha envio de dado a terceiros.
+- **Beneficiario**: o operador, sobre a propria sessao. O rationale do
+  Principio IV protege o usuario de coleta pelo AUTOR do toolkit ("cegueira
+  operacional do autor sobre adocao" e o custo aceito) — aqui nao ha autor no
+  circuito.
+- **Artefatos**: permanecem no filesystem local (`~/.claude/cstk/`), sem
+  upload automatico — o bullet literal do Principio IV sobre artefatos e
+  satisfeito.
+- **Precedente vigente**: `otel-usage.sh` faz exatamente esse scrape desde a
+  linha v5.28+ e a whitelist do proprio `bash-guard`
+  (`.claude/agente-00c-whitelist`, linhas 1-7) documenta o endpoint loopback
+  como permitido com a justificativa "Nada sai da maquina".
+
+**Veredito**: PASS. Esta feature nao amplia a superficie de rede existente —
+consome a mesma fonte local ja consumida. Um FAIL exigiria envio para fora do
+ambiente local, que nao ocorre em nenhum caminho do design.
+
+**GATE**: nenhum FAIL em principio MUST. Prosseguir autorizado.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+docs/specs/loose-usage-capture/
+├── spec.md
+├── plan.md          # This file
+├── research.md      # Phase 0 output
+├── data-model.md    # Phase 1 output
+├── quickstart.md    # Phase 1 output
+└── contracts/       # Phase 1 output
+    ├── cli-usage.md
+    └── hook-loose-usage.md
+```
+
+### Source Code (repository root)
+
+Arvore real do repositorio, com marcacao do que muda:
+
+```
+cli/
+├── cstk                                   # MODIFICA: dispatch + help do subcomando `usage`
+└── lib/
+    ├── recall.sh                          # MODIFICA: RECALL_SCHEMA_VERSION 12->13 + DDL da tabela nova
+    ├── hooks.sh                           # MODIFICA: flag opt-in --with-loose-usage
+    └── usage.sh                           # NOVO: logica de `cstk usage` (SQL delegado a recall.sh)
+global/skills/agente-00c-runtime/
+├── hooks/
+│   ├── posttooluse-tool-call-tick.sh      # INTACTO (molde de referencia)
+│   ├── posttooluse-agent-usage.sh         # INTACTO
+│   ├── pretooluse-bash-guard.sh           # INTACTO
+│   ├── settings.snippet.json              # INTACTO (guard hooks obrigatorios)
+│   ├── posttooluse-loose-usage.sh         # NOVO: hook de captura avulsa
+│   └── settings.loose-usage.snippet.json  # NOVO: registro opt-in, separado
+└── scripts/
+    ├── otel-usage.sh                      # INTACTO no caminho principal (snapshot/delta reusados como estao)
+    └── _hook-active-exec.sh               # INTACTO (consumido com polaridade invertida)
+tests/
+├── test_posttooluse-loose-usage.sh        # NOVO (convencao de hooks)
+└── cstk/
+    ├── test_usage.sh                      # NOVO (convencao cli/lib)
+    ├── test_recall.sh                     # ESTENDE: migracao v13
+    └── test_hooks.sh                      # ESTENDE: flag opt-in
+```
+
+**Structure Decision**: nenhum diretorio novo de topo. A feature se encaixa
+nas tres superficies existentes — hooks do runtime, libs do CLI e o indice
+`knowledge.db` — porque cada uma ja tem um precedente direto do que precisa
+ser feito (hook de metrica fail-open; subcomando de consulta; migracao aditiva
+de schema). Criar uma superficie nova custaria mais em manutencao do que
+resolve. O unico caminho novo de dados e o diretorio de sidecar
+`~/.claude/cstk/loose-usage/`, deliberadamente fora de qualquer repositorio:
+uso avulso nao pertence a nenhum projeto versionado.
+
+## Convencoes de Borda
+
+A feature atravessa 3 fronteiras (exporter -> hook -> sidecar -> CLI/DB), logo
+a secao se aplica (nao e single-layer).
+
+| Camada | Case style | Validacao | Fonte da verdade |
+|--------|------------|-----------|------------------|
+| Labels do exporter Prometheus | `snake_case` (`session_id`, `query_source`) + valores `camelCase` em `type` (`cacheRead`, `cacheCreation`) | Allowlist de 4 labels no parse | Parse: `otel-usage.sh` `_ou_parse`, linhas 170-197. Os literais `cacheRead`/`cacheCreation` aparecem no consumidor, linhas 387-388 (bloco `jq` de `_ou_cmd_delta`) — o parse nao enumera valores de `type`, so extrai o label |
+| Sidecar TSV do segmento | 5 colunas TAB-separadas, sem cabecalho de nomes (so `# session_id`) | Guarda `NF != 5` ⇒ `legacy` ⇒ exit 3 ⇒ `null` | `otel-usage.sh` linhas 317-331 |
+| Sidecar `meta.tsv` | `snake_case` nas chaves | Leitura tolerante a chave desconhecida (ignora) | `data-model.md` §LooseUsageProcess |
+| Colunas SQLite (`loose_usage`) | `snake_case` | DDL + `UNIQUE(process_key, segment_id, model)` | `cli/lib/recall.sh` (DDL), `data-model.md` |
+| Flags de CLI | `kebab-case` (`--project`, `--since`, `--with-loose-usage`) | Parser explicito com `*)` ⇒ exit 2 | `contracts/cli-usage.md` |
+| Saida `--json` | `snake_case` nas chaves | — | `contracts/cli-usage.md` |
+| Variaveis de ambiente | `SCREAMING_SNAKE_CASE` com prefixo `CSTK_` | — | `CSTK_OTEL_ENDPOINT` (existente), `CSTK_LOOSE_USAGE_INTERVAL_S` `[PROPOSTA]` |
+
+**Mapper layer (sidecar ↔ DB)**: `cli/lib/usage.sh` `[PROPOSTA]` e o unico
+tradutor. Responsabilidades: varrer `~/.claude/cstk/loose-usage/*/seg-*/`,
+invocar `otel-usage.sh delta --state-dir <segmento>`, converter o JSON
+`by_model` em linhas de `loose_usage` e fazer UPSERT pela chave natural.
+ORM auto-mapping: **NAO** (SQL escrito a mao, como todo o `recall.sh`).
+
+**Validacao de payload**: nao ha Zod (projeto shell). O equivalente e a guarda
+estrutural do `delta`: `NF != 5` ⇒ formato antigo ⇒ `null`. O contrato de
+saida do `delta` (`session_id`, `total_cost_usd`, `total_tokens`, `by_source`,
+`by_model`) esta em `otel-usage.sh` linhas 370-405 e e consumido literalmente,
+sem renomear campo — evitando por construcao o drift de nomes que a secao de
+Convencoes de Borda existe para prevenir.
+
+**Prefixo `CSTK_` e proposital** (research.md Decision 3): variaveis com
+prefixo `OTEL_` foram observadas AUSENTES no ambiente do subprocesso do
+harness, enquanto `CSTK_OTEL_ENDPOINT` estava presente. Qualquer configuracao
+nova desta feature usa o prefixo `CSTK_`.
+
+## Re-check de Constitution (pos-Phase 1)
+
+Revalidacao apos o design estar fechado:
+
+| Pergunta | Resposta |
+|----------|----------|
+| O design introduziu complexidade nao justificada? | Nao. Zero servico novo, zero daemon, zero diretorio de topo. Os dois artefatos novos (1 hook + 1 lib) sao o minimo para separar captura de consulta. |
+| Algum MUST deixou de ser respeitado apos o design? | Nao. O ponto de risco era `sqlite3` escapar do confinamento — resolvido pela delegacao de `usage.sh` a `recall.sh` (invariante grep-avel). |
+| O design criou caminho que fabrica dado? | Nao. Foram identificados 4 pontos de ausencia (endpoint fora do ar, atribuicao ambigua, `owner_pid` indeterminavel, categoria sem linhas) e todos resolvem em `null`/`unknown`/"nao medido". |
+| O design mantem a sessao do operador intocada (FR-007)? | Sim. Hook com exit sempre `0`, stdout/stderr vazios, throttle O(1) no caminho quente e teto de 3 s no scrape. |
+
+**Veredito do re-check**: PASS. Nenhuma linha de Complexity Tracking
+necessaria.
+
+## Complexity Tracking
+
+> Preencher APENAS se Constitution Check tem violacoes que precisam justificativa
+
+Nao aplicavel — Constitution Check e re-check passaram sem violacao. Os dois
+carve-outs invocados (deps opcionais `jq`/`lsof`; confinamento de `sqlite3`)
+sao mecanismos previstos pela propria Constitution (Decision Framework item 4:
+"subsecoes de carve-out ... sao mecanismo valido de conformidade"), nao
+excecoes que exijam sunset.
+
+## Riscos conhecidos (herdados, nao introduzidos)
+
+| Risco | Origem | Mitigacao no design |
+|-------|--------|---------------------|
+| Disputa da porta fixa `9464` entre processos | `otel-usage.sh` linhas 40-52 (caso real 2026-07-29) | A ancora e `CSTK_OTEL_ENDPOINT` com porta dinamica por processo; sem essa variavel o hook faz no-op em vez de medir a sessao errada |
+| Exporter com multiplas sessoes ⇒ atribuicao ambigua | `otel-usage.sh` linhas 81-103 (caso real 2026-07-28) | Guarda de `delta` herdada: mais de uma sessao cresceu ⇒ `null`, nunca chute |
+| Subcontagem do avulso na transicao para pipeline ativa | Decisao de design (research.md Decision 6) | Aceita e documentada: erro sempre no sentido conservador, limitado a 1 intervalo por transicao. SC-002 tem prioridade sobre completude do avulso |
+| Verificacao manual via `Bash` bloqueada pelo `bash-guard` | Observado nesta onda (research.md Decision 11) | Cenarios do quickstart usam `--endpoint file://...`; runtime da feature nao e afetado (hooks nao passam por `PreToolUse`) |

--- a/docs/specs/loose-usage-capture/quickstart.md
+++ b/docs/specs/loose-usage-capture/quickstart.md
@@ -15,19 +15,35 @@ Isso tambem torna os cenarios deterministicos e reproduziveis em CI.
 
 ## Scenario 1: Happy path — captura avulsa com dois modelos (US1)
 
-1. Preparar fixture `A` com linhas `claude_code_cost_usage_total{...}` e
-   `claude_code_token_usage_total{...}` para DOIS modelos distintos, e uma
-   fixture `B` identica porem com os contadores incrementados.
+1. Preparar um UNICO arquivo de fixture (ex: `fixture-live.prom`) com linhas
+   `claude_code_cost_usage_total{...}` e `claude_code_token_usage_total{...}`
+   para DOIS modelos distintos — conteudo `A` (baseline).
 2. Provisionar o hook num projeto de teste:
-   `cstk hooks install --with-loose-usage --project-path <tmp>` `[PROPOSTA]`
+   `cstk hooks install --with-loose-usage --project-path <tmp>`
 3. Disparar o hook com payload de `PostToolUse` (`.cwd` = projeto de teste,
-   `.tool_name` preenchido) e `CSTK_OTEL_ENDPOINT=file://.../A`.
-4. Avancar o relogio do throttle (tocar `meta.tsv` com `updated_at` antigo) e
-   disparar o hook de novo, agora apontando para a fixture `B`.
-5. `cstk usage --project <projeto de teste> --json` `[PROPOSTA]`
+   `.tool_name` preenchido) e `CSTK_OTEL_ENDPOINT=file:///.../fixture-live.prom`.
+4. Avancar o relogio do throttle (tocar `meta.tsv` com `updated_at` antigo),
+   **sobrescrever o MESMO arquivo `fixture-live.prom`** com os contadores
+   incrementados (conteudo `B`) e disparar o hook de novo — **sem trocar o
+   valor de `CSTK_OTEL_ENDPOINT`**.
+   > **Validado empiricamente (onda execute-task FASE 5)**: `process_key` e
+   > uma funcao estavel de `(endpoint, project_path)` (hash de
+   > `"${CSTK_OTEL_ENDPOINT}|${cwd}"` — hook linhas ~99-100). Apontar o
+   > `CSTK_OTEL_ENDPOINT` para um path de arquivo DIFERENTE entre os dois
+   > disparos (ex.: `.../A` depois `.../B`) muda o `process_key` e cria um
+   > **processo/segmento novo e independente** em vez de reabrir o mesmo
+   > segmento — confirmado reproduzindo os dois disparos e observando dois
+   > diretorios `<project>-<hash>` distintos sob
+   > `~/.claude/cstk/loose-usage/`. Em producao o endpoint (URL do exporter
+   > Prometheus local) e estavel durante a sessao; quem muda ao longo do
+   > tempo e o VALOR lido daquele mesmo endpoint — a fixture deve simular
+   > isso reescrevendo o conteudo do mesmo path, nao trocando de path.
+5. `cstk usage --project <projeto de teste> --json`
 6. **Expected**: duas entradas em `models[]`, uma por modelo, com
    `total_tokens` e `cost_usd` iguais a `B - A` **por modelo**; nenhum campo
-   `null`; exit 0.
+   `null`; exit 0. Reproduzido empiricamente com fixtures sinteticas
+   (`claude-opus-5[1m]`: cost `0.25`, tokens `750`; `claude-sonnet-5`: cost
+   `0.05`, tokens `150`).
 
 ---
 
@@ -37,11 +53,19 @@ Isso tambem torna os cenarios deterministicos e reproduziveis em CI.
 2. Disparar o hook com `CSTK_OTEL_ENDPOINT` apontando para um caminho
    inexistente.
 3. **Expected**:
-   - hook: exit `0`, stdout vazio, stderr vazio, nenhum diretorio de captura
-     criado;
-   - `cstk usage --project <p>` responde **`nao medido`** (mensagem de
-     ausencia de cobertura), exit 0;
+   - hook: exit `0`, stdout vazio, stderr vazio;
+   - `cstk usage --project <p>` responde **`nao medido — sem cobertura de
+     captura`** (mensagem de ausencia de cobertura), exit 0;
    - a saida NAO contem `0` como valor de tokens nem de custo.
+   > **Correcao empirica (onda execute-task FASE 5)**: o diretorio de
+   > processo + `meta.tsv` + o diretorio do segmento SAO criados mesmo
+   > quando o scrape falha (o hook faz `mkdir -p` antes de tentar o scrape,
+   > e a falha do `otel-usage.sh snapshot` e engolida via `|| :`) — o que
+   > NAO existe e o arquivo `otel-start.tsv`/dado de consumo em si. Por
+   > isso `cstk usage` ainda reporta corretamente "nao medido" (a ausencia
+   > de LINHA em `loose_usage`, nao a ausencia do diretorio, e o que
+   > importa para FR-005/SC-004); a formulacao original ("nenhum diretorio
+   > ... criado") nao correspondia ao comportamento real.
 
 ---
 
@@ -82,7 +106,7 @@ Isso tambem torna os cenarios deterministicos e reproduziveis em CI.
 1. Popular `wave_model_usage` com ao menos uma linha para o projeto (via
    execucao 00c real ou `cstk recall --ingest` de um state-dir de teste).
 2. Popular `loose_usage` pelos Scenarios 1/3.
-3. `cstk usage compare --project <p>` `[PROPOSTA]`
+3. `cstk usage compare --project <p>`
 4. **Expected**: duas categorias (`loose` e `pipeline`) lado a lado, cada uma
    com mix por modelo (`share_pct`) e `blended_cost_per_mtok`; sem
    cruzamento manual de fontes pelo operador.

--- a/docs/specs/loose-usage-capture/quickstart.md
+++ b/docs/specs/loose-usage-capture/quickstart.md
@@ -1,0 +1,127 @@
+# Quickstart: Loose Usage Capture
+
+Cenarios que validam a implementacao end-to-end. Todos rodam localmente, sem
+rede externa.
+
+**Nota de ambiente (research.md Decision 11)**: durante uma execucao 00c
+ativa, o `pretooluse-bash-guard` bloqueia comandos de rede cuja URL nao esteja
+na whitelist do projeto, e a whitelist atual so contem a porta fixa `9464`.
+Por isso os cenarios abaixo usam **fixture local** via `--endpoint file://...`
+— caminho ja previsto pelo comentario de `_OU_DEFAULT_ENDPOINT`
+(`otel-usage.sh` linhas 125-127: "ou para apontar a um arquivo em teste").
+Isso tambem torna os cenarios deterministicos e reproduziveis em CI.
+
+---
+
+## Scenario 1: Happy path — captura avulsa com dois modelos (US1)
+
+1. Preparar fixture `A` com linhas `claude_code_cost_usage_total{...}` e
+   `claude_code_token_usage_total{...}` para DOIS modelos distintos, e uma
+   fixture `B` identica porem com os contadores incrementados.
+2. Provisionar o hook num projeto de teste:
+   `cstk hooks install --with-loose-usage --project-path <tmp>` `[PROPOSTA]`
+3. Disparar o hook com payload de `PostToolUse` (`.cwd` = projeto de teste,
+   `.tool_name` preenchido) e `CSTK_OTEL_ENDPOINT=file://.../A`.
+4. Avancar o relogio do throttle (tocar `meta.tsv` com `updated_at` antigo) e
+   disparar o hook de novo, agora apontando para a fixture `B`.
+5. `cstk usage --project <projeto de teste> --json` `[PROPOSTA]`
+6. **Expected**: duas entradas em `models[]`, uma por modelo, com
+   `total_tokens` e `cost_usd` iguais a `B - A` **por modelo**; nenhum campo
+   `null`; exit 0.
+
+---
+
+## Scenario 2: Error case — endpoint indisponivel nao vira zero (FR-005 / SC-004)
+
+1. Estado inicial: nenhum dado de captura para o projeto.
+2. Disparar o hook com `CSTK_OTEL_ENDPOINT` apontando para um caminho
+   inexistente.
+3. **Expected**:
+   - hook: exit `0`, stdout vazio, stderr vazio, nenhum diretorio de captura
+     criado;
+   - `cstk usage --project <p>` responde **`nao medido`** (mensagem de
+     ausencia de cobertura), exit 0;
+   - a saida NAO contem `0` como valor de tokens nem de custo.
+
+---
+
+## Scenario 3: Exclusao de janela de pipeline (US2 / SC-002)
+
+1. No projeto de teste, criar um estado 00c com `status: em_andamento`
+   (state-dir sob `.claude/feature-00c-state/<short>/`), de modo que
+   `_hook-active-exec.sh` retorne `0` (ativa) para aquele `cwd`.
+2. Disparar o hook com fixture `C` (contadores maiores que os do segmento
+   aberto).
+3. **Expected**: o segmento corrente e marcado como fechado; o valor
+   registrado permanece o do ultimo tick de execucao INATIVA; nenhum
+   incremento de `C` entra em `loose_usage`.
+4. Promover o estado 00c para terminal (`status: concluida`), avancar o
+   throttle e disparar o hook com fixture `D`.
+5. **Expected** (FR-010): um segmento NOVO e aberto; capturas voltam a
+   ocorrer sem reiniciar o processo; o total do projeto = segmento anterior +
+   novo segmento, e o consumo do trecho de execucao ativa nao aparece em
+   nenhum dos dois.
+
+---
+
+## Scenario 4: Sobrevivencia a encerramento abrupto (US3 / SC-003)
+
+1. Disparar duas capturas periodicas bem-sucedidas para um processo.
+2. Simular encerramento abrupto: **nao** disparar nenhum evento de fim de
+   sessao; simplesmente parar de invocar o hook (o segmento fica sem marcador
+   `closed`).
+3. Consultar `cstk usage --project <p>`.
+4. **Expected**: o consumo acumulado ate a ultima captura permanece
+   disponivel e integro; o segmento aparece como aberto (`segment_open = 1`);
+   nenhum dado e perdido pela ausencia do evento de encerramento.
+
+---
+
+## Scenario 5: Comparacao avulso vs pipeline (US1 cenario 2 / FR-009 / SC-005)
+
+1. Popular `wave_model_usage` com ao menos uma linha para o projeto (via
+   execucao 00c real ou `cstk recall --ingest` de um state-dir de teste).
+2. Popular `loose_usage` pelos Scenarios 1/3.
+3. `cstk usage compare --project <p>` `[PROPOSTA]`
+4. **Expected**: duas categorias (`loose` e `pipeline`) lado a lado, cada uma
+   com mix por modelo (`share_pct`) e `blended_cost_per_mtok`; sem
+   cruzamento manual de fontes pelo operador.
+5. Repetir com um projeto que tenha SO uma das categorias.
+6. **Expected**: a categoria ausente aparece como `nao medido` (nao `0`), e a
+   categoria presente continua sendo exibida normalmente.
+
+---
+
+## Scenario 6: Roundtrip End-to-End produtor↔consumidor (obrigatorio)
+
+Adaptacao do cenario de roundtrip para a borda desta feature. Nao ha borda
+backend↔frontend; a borda real e **hook (produtor de TSV) ↔ CLI (consumidor)**,
+e o modo de falha analogo ao drift de case style e o **drift de formato de
+snapshot** — o `delta` ja possui uma guarda que descarta snapshot "em formato
+antigo" com 4 colunas em vez de 5 (`otel-usage.sh` linhas 320-331, exit 3).
+
+1. Executar o hook de verdade (nao fixture de TSV pre-fabricado): ele deve
+   produzir os arquivos chamando `otel-usage.sh snapshot`.
+2. Inspecionar `otel-start.tsv` / `otel-end.tsv` produzidos e comparar o shape
+   contra o contrato declarado em `data-model.md`:
+   - numero de colunas por linha = 5, separadas por TAB;
+   - ordem `session_id, query_source, model, type, value`;
+   - presenca do cabecalho `# session_id<TAB>...`.
+3. Rodar o consumidor real (`cstk usage`) sobre esses arquivos — sem mock,
+   sem fixture intermediaria.
+4. Verificar que nenhum label de PII (`user_email`, `user_id`,
+   `user_account_uuid`, `user_account_id`, `organization_id`) aparece nos
+   arquivos gerados.
+5. **Expected**: zero divergencia entre o arquivo realmente escrito pelo hook,
+   o formato documentado e o que o consumidor parseia; `delta` NAO retorna
+   `null` por formato antigo; zero PII em disco.
+
+---
+
+## Scenario 7: Opt-out preservado (FR-006 / dec-008)
+
+1. Rodar `cstk hooks install --project-path <tmp>` **sem** `--with-loose-usage`.
+2. **Expected**: `.claude/hooks/` contem os tres hooks obrigatorios atuais e
+   **nao** contem `posttooluse-loose-usage.sh`; o `settings.json` nao registra
+   o hook de captura; nenhum diretorio sob `~/.claude/cstk/loose-usage/` e
+   criado durante uma sessao subsequente.

--- a/docs/specs/loose-usage-capture/research.md
+++ b/docs/specs/loose-usage-capture/research.md
@@ -1,0 +1,357 @@
+# Research: Loose Usage Capture
+
+Documento produzido no Phase 0 do `/plan`. Resolve os `NEEDS CLARIFICATION` do
+Technical Context antes do design.
+
+**Regra de veracidade (Constitution VI)**: cada decisao abaixo cita a fonte
+real consultada (arquivo + linha, ou saida de comando de fato executada).
+Interfaces que ainda NAO existem estao marcadas `[PROPOSTA — a validar na
+implementacao]`. Inferencias estao rotuladas como inferencia, nunca como fato.
+
+---
+
+## Decision 1: Fonte da metrica de consumo avulso
+
+**Decision**: reusar a telemetria OTel nativa do Claude Code (exporter
+Prometheus local) pelo MESMO caminho ja usado por
+`global/skills/agente-00c-runtime/scripts/otel-usage.sh` — sem nova fonte,
+sem nova dependencia de rede, sem API remota.
+
+**Rationale**: a fonte ja esta em producao e documentada no cabecalho do
+proprio script (linhas 31-38): pre-requisito `CLAUDE_CODE_ENABLE_TELEMETRY=1`
++ `OTEL_METRICS_EXPORTER=prometheus`; o exporter sobe um HTTP local em
+`127.0.0.1:9464/metrics` (override por `CSTK_OTEL_ENDPOINT`, linha 127) e
+"nada trafega para fora da maquina". O formato das linhas consumidas
+(`claude_code_cost_usage_total{...}` / `claude_code_token_usage_total{...}`)
+esta declarado como "verificado empiricamente contra Claude Code 2.1.220"
+(linhas 159-161).
+
+**Alternatives considered**:
+- *Usage & Cost Admin API da Anthropic*: rejeitada — o cabecalho do
+  `otel-usage.sh` (linhas 16-19) registra que exige Admin key
+  (`sk-ant-admin01-...`), e indisponivel para contas individuais e nao tem
+  dimensao de sessao. Alem disso violaria o Principio IV (rede para fora).
+- *Parsing de transcripts JSONL de sessao*: rejeitada — e o caminho de
+  BACKFILL retroativo ja implementado em `wave-usage-report.sh backfill`
+  (cabecalho, subcomando `backfill --transcript PATH`), adequado a
+  reconstrucao historica, nao a captura periodica ao vivo exigida por FR-003.
+
+---
+
+## Decision 2: Ancora de identidade — processo + projeto, nunca `session_id`
+
+**Decision**: a chave de atribuicao e `(endpoint do exporter do processo,
+diretorio de trabalho do projeto)`, com o PID dono da porta como reforco
+quando obtenivel. O `session_id` emitido pelo exporter NAO e usado como
+identidade.
+
+**Rationale**: o bloco `MULTIPLAS SESSOES NO MESMO EXPORTER` do
+`otel-usage.sh` (linhas 81-103) registra o incidente real de 2026-07-28 e
+conclui textualmente: *"o session_id do OTel nao serve como IDENTIDADE da
+sessao corrente (label ja observado apontando para outra sessao/projeto), por
+isso NAO ha match contra env — apenas deteccao de crescimento por sessao"*.
+A spec ratificou isso em FR-002.
+
+Evidencia empirica coletada nesta onda (probe de ambiente executado no
+projeto-alvo): `CSTK_OTEL_ENDPOINT=http://127.0.0.1:55525/metrics` — porta
+DINAMICA por processo, atribuida pelo wrapper `claude()` de `~/.zshrc`
+(linhas 16-21: `OTEL_EXPORTER_PROMETHEUS_PORT=$_otel_port` +
+`CSTK_OTEL_ENDPOINT="http://127.0.0.1:${_otel_port}/metrics"`). Com porta por
+processo, o endpoint E um discriminador de processo estavel enquanto o
+processo vive.
+
+**Alternatives considered**:
+- *`session_id` do exporter*: rejeitada pela evidencia acima (FR-002).
+- *PID isolado como chave*: rejeitada — PID e reciclado pelo SO; sozinho nao
+  distingue sessoes sequenciais. Usado apenas como reforco/desempate.
+- *Somente o `cwd`*: rejeitada — nao separa duas sessoes simultaneas no mesmo
+  projeto (Edge Case explicito da spec: "duas janelas/terminais abertos").
+
+---
+
+## Decision 3: `OTEL_METRICS_EXPORTER` NAO e observavel no contexto do hook
+
+**Decision**: o hook de captura NAO pode gatear o opt-in por
+`OTEL_METRICS_EXPORTER`; deve gatear por presenca de `CSTK_OTEL_ENDPOINT` +
+probe do endpoint (`otel-usage.sh available`). Por consequencia,
+`otel-usage.sh preflight` NAO serve como gate no contexto de hook.
+
+**Rationale**: probe empirico executado nesta onda, em subprocesso do harness
+(mesmo tipo de contexto em que um hook roda):
+
+```
+CSTK_OTEL_ENDPOINT=[http://127.0.0.1:55525/metrics]
+CLAUDE_CODE_ENABLE_TELEMETRY=[1]
+OTEL_METRICS_EXPORTER=[<unset>]
+OTEL_EXPORTER_PROMETHEUS_PORT=[<unset>]
+```
+
+E, na sequencia, `otel-usage.sh preflight` respondeu
+`status=disabled endpoint=http://127.0.0.1:55525/metrics` (exit 0) — um
+falso "desabilitado", ja que `~/.zshrc` linhas 9-10 de fato exporta
+`CLAUDE_CODE_ENABLE_TELEMETRY=1` e `OTEL_METRICS_EXPORTER=prometheus`.
+O gate de `_ou_cmd_preflight` (otel-usage.sh linhas 479-483) exige as DUAS
+variaveis e retorna `disabled` quando qualquer uma falta.
+
+*Inferencia (rotulada como tal, nao afirmada como fato)*: as duas variaveis
+ausentes sao exatamente as de prefixo `OTEL_*`, enquanto as duas presentes
+nao tem esse prefixo — o padrao sugere que o harness remove variaveis
+`OTEL_*` do ambiente dos subprocessos de tool/hook. A CAUSA nao foi
+confirmada em fonte oficial; o que esta confirmado e a OBSERVACAO acima.
+Task de implementacao deve reconfirmar o probe no contexto real do hook
+(`PostToolUse`), nao apenas no de tool call.
+
+**Alternatives considered**:
+- *Gatear por `preflight`*: rejeitada pela evidencia — produziria zero
+  captura para operadores com telemetria de fato ligada.
+- *Gatear so por `CLAUDE_CODE_ENABLE_TELEMETRY`*: insuficiente — indica
+  intencao, nao disponibilidade do endpoint por processo (a spec exige nunca
+  fabricar; endpoint indisponivel = "nao medido", Edge Case explicito).
+
+---
+
+## Decision 4: Cadencia — throttle por intervalo dentro de um hook `PostToolUse`
+
+**Decision**: o hook dispara em `PostToolUse` com matcher `*` (dec-006), mas
+so executa scrape quando transcorreu o intervalo minimo desde a ultima
+captura do processo (default proposto: **300 s**, override por env
+`CSTK_LOOSE_USAGE_INTERVAL_S` `[PROPOSTA]`). Fora do intervalo: no-op de
+custo O(1) (um `stat`/teste de arquivo), sem rede.
+
+**Rationale**: o hook `posttooluse-tool-call-tick.sh` dispara a cada tool
+call (settings.snippet.json, matcher `*`). Um scrape HTTP por tool call seria
+custo desproporcional; `_ou_scrape` usa `--max-time 3` (otel-usage.sh linha
+150), logo o pior caso por tick e 3 s — inaceitavel a cada call. O throttle
+converte o gatilho "por tool call" no gatilho "periodico" que FR-003 pede,
+e a durabilidade de US3 vem de cada captura ja persistir em disco.
+
+O default de 300 s e **politica de design**, nao dado factual — escolhido
+por analogia ao granularidade util de custo (5 min) e por limitar a perda
+maxima por encerramento abrupto a um intervalo. Ajustavel sem mudanca de
+contrato.
+
+**Alternatives considered**:
+- *Hook `SessionEnd` apenas*: rejeitada pela spec (US3 / FR-003) — perde
+  exatamente as sessoes longas encerradas de forma abrupta.
+- *Agendador externo (cron/launchd)*: rejeitada por FR-003-INFRA-SCHED, que
+  determina cadencia por eventos do harness.
+- *Hook em matcher restrito (ex. so `Bash`)*: rejeitada — sessoes avulsas de
+  leitura/exploracao usariam poucas `Bash` e ficariam sub-amostradas.
+
+---
+
+## Decision 5: Polaridade invertida da deteccao de execucao ativa (FR-004)
+
+**Decision**: reusar `_hook-active-exec.sh` com a semantica INVERTIDA
+(dec-006): `exit 1` (inativa) e o unico caso que captura; `exit 0` (ativa),
+`exit 2` (indeterminada) e `exit 3` (uso incorreto) sao todos no-op.
+
+**Rationale**: o contrato do helper esta declarado no seu cabecalho (linhas
+31-36): `0 = ativa` com stdout `"<execution_kind>\t<state_dir>\t<backend>"`,
+`1 = inativa`, `2 = indeterminada`, `3 = uso incorreto`, com "stderr SEMPRE
+vazio". Tratar `indeterminada` como se fosse `inativa` fabricaria consumo
+avulso a partir de incerteza — violacao direta do Principio VI. A assimetria
+e deliberada: na duvida, **subconta**, nunca superconta (SC-002 exige 100% de
+exclusao das janelas de pipeline; nao exige 100% de captura do avulso).
+
+Consequencia sobre o pre-check inline do molde: em
+`posttooluse-tool-call-tick.sh` (linhas 85-106) o pre-check
+`_ptt_precheck_active_scope` existe para SAIR barato quando nao ha nenhum
+state dir. Sob polaridade invertida, "nenhum state dir" e justamente o caso
+que DEVE capturar — o pre-check nao pode ser copiado como esta. Ele vira o
+atalho oposto: ausencia total de `state.json`/`state.db` sob
+`.claude/agente-00c-state/` e `.claude/feature-00c-state/*/` conclui
+`inativa` sem sequer resolver/sourcear o helper (mais barato ainda que o
+molde).
+
+**Alternatives considered**:
+- *Filtro pos-hoc por janela de tempo* (comparar timestamps de onda contra
+  timestamps de captura): rejeitada na etapa clarify (registrada em
+  Clarifications da spec) — exigiria correlacao temporal entre relogios de
+  duas fontes e produziria zona cinzenta na fronteira; a checagem de execucao
+  ativa ja e o discriminador exato.
+- *Tratar `indeterminada` como `inativa`*: rejeitada por Constitution VI.
+
+---
+
+## Decision 6: Segmentacao — descartar o trecho aberto na transicao para "ativa"
+
+**Decision**: o consumo de um processo e modelado como uma sequencia de
+**segmentos avulsos**. Cada segmento tem um snapshot inicial e um snapshot
+corrente, e e persistido a cada tick. Ao detectar execucao de pipeline ativa,
+o segmento corrente e FECHADO no ultimo valor ja persistido e o trecho ainda
+nao persistido (do ultimo tick ate a deteccao) e **descartado**. Quando a
+execucao termina, o proximo tick abre um segmento novo (FR-010).
+
+**Rationale**: e a unica politica que satisfaz SC-002 literalmente ("100% do
+consumo que ocorreu durante janelas de execucao de pipeline ativa e excluido
+do total avulso"). Fechar o segmento COM um scrape no momento da deteccao
+seria mais preciso para o avulso, mas o primeiro tick com execucao ativa
+acontece necessariamente DEPOIS de a onda ja ter consumido tokens — parte do
+consumo de pipeline entraria no avulso e SC-002 falharia. O erro da politica
+escolhida e sempre no sentido seguro: subconta o avulso em no maximo um
+intervalo de captura por transicao.
+
+**Alternatives considered**:
+- *Fechar com scrape na deteccao*: rejeitada (viola SC-002, acima).
+- *Um unico segmento por processo, com subtracao posterior do consumo de
+  pipeline*: rejeitada — exigiria subtrair `wave_model_usage` do total do
+  processo, e as duas fontes tem granularidade e guardas de atribuicao
+  diferentes; subtracao entre bases heterogeneas produz numero sem fonte
+  unica rastreavel (Principio VI).
+
+---
+
+## Decision 7: Persistencia em duas camadas — sidecar de arquivo + indice SQLite
+
+**Decision**: o hook escreve APENAS arquivos (snapshots TSV + metadados) sob
+`~/.claude/cstk/loose-usage/`. A insercao no `knowledge.db` acontece na
+camada CLI (ingest-on-read), nunca no hook.
+
+**Rationale**: tres motivos, todos com fonte:
+1. **Confinamento de dependencia (Constitution II)**: `sqlite3` no CLI esta
+   confinado a `cli/lib/recall.sh` (condicao (b) do carve-out 1.1.0). Um hook
+   que abrisse o `knowledge.db` espalharia a dep para um segundo arquivo.
+2. **Nao-interferencia**: o cabecalho de `posttooluse-tool-call-tick.sh`
+   (linhas 22-35) impoe a REGRA DURA de o hook nunca fazer read-modify-write
+   de estado compartilhado, justamente porque `PostToolUse` dispara
+   concorrente as tool calls; o padrao prescrito e sidecar append-only e
+   agregacao posterior. Aqui vale o mesmo, com o `knowledge.db` global no
+   lugar do state.
+3. **Durabilidade (FR-008)**: arquivo em disco sobrevive ao processo por
+   construcao; a ingestao pode ocorrer arbitrariamente depois, inclusive
+   apos encerramento abrupto (US3).
+
+Reuso literal: `otel-usage.sh snapshot --state-dir DIR --phase start|end`
+grava `DIR/otel-<phase>.tsv` (linhas 265-270) e `delta --state-dir DIR` le
+`DIR/otel-start.tsv` + `DIR/otel-end.tsv` (linhas 296-297). Apontando
+`--state-dir` para o diretorio do segmento, os dois subcomandos servem a
+captura avulsa **sem nenhuma alteracao** — inclusive herdando as guardas de
+atribuicao (mais de uma sessao cresceu, processo do exporter trocou, formato
+antigo) que imprimem `null` em vez de numero duvidoso (linhas 355-366).
+
+**Alternatives considered**:
+- *Hook grava direto no `knowledge.db`*: rejeitada pelos 3 motivos acima.
+- *Sidecar JSONL append-only com deltas incrementais* (molde de
+  `wave-agent-usage.jsonl`): rejeitada — somar incrementos exige que nenhum
+  tick se perca; com snapshots cumulativos, um tick perdido nao corrompe o
+  acumulado (o proximo tick recupera).
+
+---
+
+## Decision 8: Migracao de schema v12 -> v13, aditiva, tabela nova
+
+**Decision**: bump de `RECALL_SCHEMA_VERSION` de 12 para 13 e uma tabela nova
+no DDL de `recall_schema_ddl`. Nenhum `ALTER TABLE`, nenhum `DROP`, nenhuma
+alteracao em tabela existente.
+
+**Rationale**: fontes diretas em `cli/lib/recall.sh` — `RECALL_SCHEMA_VERSION=12`
+(linha 128); o DDL usa `CREATE TABLE IF NOT EXISTS` para todas as tabelas
+(linhas 417-637) e grava a versao em `schema_meta` (linhas 648-653); as
+migracoes v7->v12 em `recall_apply_schema` (linhas 695-827) usam
+`ALTER TABLE ADD COLUMN` guardado por `PRAGMA table_info` apenas para colunas
+novas em tabela EXISTENTE. O precedente literal para tabela nova esta no
+comentario da v11->v12 (linhas 810-811): *"`wave_model_usage` NAO precisa de
+ALTER: e tabela nova, coberta pelo `CREATE TABLE IF NOT EXISTS` do DDL"* — a
+tabela de consumo avulso segue exatamente esse caminho.
+
+Estado real verificado nesta onda: `sqlite3 ~/.claude/cstk/knowledge.db
+"SELECT value FROM schema_meta WHERE key='schema_version';"` retornou `12`, e
+`.tables` listou `wave_model_usage` entre as tabelas existentes — a base do
+operador esta em v12, sem a tabela nova.
+
+**Alternatives considered**:
+- *Reusar `wave_model_usage`*: rejeitada na etapa clarify (dec-005). Fonte do
+  impedimento: DDL em `cli/lib/recall.sh` linhas 625-637 — `feature TEXT NOT
+  NULL`, `wave TEXT NOT NULL`, `execution_id TEXT NOT NULL` e
+  `UNIQUE(project, feature, wave, source_id)`. Consumo avulso nao tem
+  feature, onda nem execucao; preenche-los exigiria valores sentinela
+  inventados (Principio VI).
+- *Base SQLite separada so para uso avulso*: rejeitada — quebraria a
+  comparacao avulso-vs-pipeline (FR-009/SC-005), que precisa das duas
+  categorias na mesma base para um unico `SELECT`.
+
+---
+
+## Decision 9: Superficie de consulta — subcomando `cstk usage` `[PROPOSTA]`
+
+**Decision**: subcomando novo `cstk usage`, com lib propria em
+`cli/lib/usage.sh` que delega TODO acesso a SQLite aos helpers ja existentes
+de `cli/lib/recall.sh`.
+
+**Rationale**: dec-007 fixou "subcomando do `cstk` CLI"; a lista de
+subcomandos atuais (dispatch em `cli/cstk`) e `install|update|self-update|
+list|doctor|session|serve|recall|show-tip|hooks|state|mcp` — `usage` esta
+livre. A delegacao a `recall.sh` preserva a condicao (b) do carve-out do
+Principio II (dep confinada a um unico arquivo identificavel): `grep -l
+sqlite3 cli/lib/*.sh` deve continuar retornando apenas `recall.sh`.
+
+**Alternatives considered**:
+- *Flag nova em `cstk recall`*: rejeitada — `recall` e busca de conhecimento
+  (FTS sobre decisoes/bloqueios/memorias); consumo agregado e outra intencao
+  de uso e polui a superficie ja documentada em `contracts/cstk-recall.md`.
+- *Exposicao no painel web*: fora de escopo por decisao de clarify (dec-007).
+
+---
+
+## Decision 10: Provisionamento opt-in separado dos guard hooks
+
+**Decision**: flag nova `cstk hooks install --with-loose-usage` `[PROPOSTA]`,
+default DESLIGADA, com snippet de registro em arquivo separado. O hook de
+captura NUNCA entra em `apply_guard_hooks()` por default.
+
+**Rationale**: dec-008. Fonte do estado atual: `apply_guard_hooks()`
+(`cli/lib/hooks.sh` linha ~197) copia `pretooluse-bash-guard.sh` +
+`posttooluse-tool-call-tick.sh` + `posttooluse-agent-usage.sh` e mescla
+`global/skills/agente-00c-runtime/hooks/settings.snippet.json`, cujo conteudo
+registra exatamente esses tres hooks. Os tres sao obrigatorios/fail-closed ou
+metricas internas da pipeline; a captura avulsa observa a sessao do operador
+FORA da pipeline e por isso precisa de consentimento explicito (FR-006).
+
+**Alternatives considered**:
+- *Bundlar no snippet existente*: rejeitada por FR-006 + dec-008 — tornaria a
+  captura efeito colateral de instalar guardas de seguranca.
+- *Variavel de ambiente como unico gate*: insuficiente — sem o hook
+  provisionado nao ha gatilho; e a spec exige distinguir "sem cobertura" de
+  "medido e zero" (FR-005), o que pede um estado de provisionamento
+  inspecionavel.
+
+---
+
+## Decision 11: Restricao operacional conhecida — `bash-guard` bloqueia o scrape via tool `Bash`
+
+**Decision**: registrar como restricao de AMBIENTE DE IMPLEMENTACAO (nao de
+runtime da feature): durante uma execucao 00c ativa, o hook `PreToolUse`
+bloqueia comandos de rede cuja URL nao esteja na whitelist do projeto.
+
+**Rationale**: observado empiricamente nesta onda. Duas tentativas de scrape
+do endpoint dinamico via tool `Bash` foram bloqueadas:
+
+```
+REGRA_VIOLADA: bash-guard: BLOQUEADO — URL fora da whitelist: http://127.0.0.1:55525/metrics;
+  comando: [... linha do comando, elidida ...]
+  whitelist: /Users/jot/Projects/_lab/Jot/misc/cstk/.claude/agente-00c-whitelist
+```
+
+(Transcricao com a linha `comando:` elidida por concisao; o restante e
+literal.)
+
+O arquivo `.claude/agente-00c-whitelist` lista apenas a porta FIXA
+(`http://127.0.0.1:9464/metrics` e `http://localhost:9464/metrics`, linhas
+6-7), enquanto o endpoint real do operador usa porta dinamica.
+
+Escopo do impacto (importante nao exagerar): o guard e `PreToolUse`/`Bash` —
+avalia a STRING do comando da tool call. **Hooks nao sao tool calls**, e
+scripts que fazem o scrape internamente (como `otel-usage.sh`) passam pelo
+guard porque a URL nao aparece na linha de comando. Logo o runtime da feature
+NAO e afetado; o que e afetado e a verificacao manual/automatizada via `Bash`
+durante `execute-task`. Mitigacao para a fase de implementacao: exercitar o
+caminho por fixture local (`--endpoint file://...`, ja suportado pelo
+comentario de `_OU_DEFAULT_ENDPOINT`, linhas 125-127) ou acrescentar o
+endpoint dinamico a whitelist do projeto — decisao do operador, fora do
+escopo desta feature.
+
+**Alternatives considered**:
+- *Alterar a whitelist como parte desta feature*: rejeitada — mexer em
+  superficie de seguranca por conveniencia de teste e mudanca de escopo nao
+  especificada.

--- a/docs/specs/loose-usage-capture/spec.md
+++ b/docs/specs/loose-usage-capture/spec.md
@@ -1,0 +1,228 @@
+# Feature Specification: Captura de Consumo Avulso de Uso (Loose Usage Capture)
+
+**Feature**: `loose-usage-capture`
+**Created**: 2026-08-06
+**Status**: Draft
+
+## User Scenarios & Testing
+
+### User Story 1 - Visibilidade do consumo avulso por modelo (Priority: P1)
+
+Como operador que usa o Claude Code tanto em sessoes avulsas (fora de qualquer
+execucao das pipelines SDD `agente-00c`/`feature-00c`) quanto atraves dessas
+pipelines, eu quero enxergar quanto token/custo o uso avulso consumiu, com o
+mesmo recorte por modelo que ja existe para o uso dentro das pipelines, para
+poder comparar os dois de forma justa (mix de modelos e custo blended por
+milhao de tokens).
+
+**Why this priority**: sem essa visibilidade, o operador so conhece o custo
+do que passa pela pipeline SDD — a maior parte do uso diario (exploracao,
+debug, conversas avulsas) fica invisivel, mesmo ja sendo medido nativamente
+pela telemetria local do Claude Code. Esta e a capacidade minima que entrega
+valor sozinha.
+
+**Independent Test**: com telemetria local habilitada num projeto com os
+hooks provisionados, realizar uma sessao avulsa (sem iniciar nenhuma
+execucao de pipeline) e, ao final, obter um resumo do consumo dessa sessao
+por modelo (tokens e custo), sem qualquer intervencao manual de coleta.
+
+**Acceptance Scenarios**:
+
+1. **Given** um projeto com hooks provisionados e telemetria local
+   habilitada (opt-in do operador), **When** o operador conduz uma sessao
+   avulsa que usa dois modelos diferentes, **Then** o resumo de consumo
+   avulso do projeto reflete os dois modelos separadamente, com tokens e
+   custo correspondentes a cada um.
+2. **Given** um projeto ja com historico de execucoes de pipeline SDD
+   registrado, **When** o operador solicita a comparacao de mix de modelos
+   e custo blended entre uso avulso e uso de pipeline, **Then** o sistema
+   apresenta as duas categorias lado a lado para o mesmo projeto.
+
+---
+
+### User Story 2 - Nenhuma contagem dupla entre avulso e pipeline (Priority: P2)
+
+Como operador comparando gasto avulso com gasto de pipeline, eu quero que o
+consumo que ja aconteceu **dentro** de uma execucao de pipeline (onda de
+`agente-00c`/`feature-00c`) nunca apareca tambem como consumo avulso, para
+que a soma das duas categorias nao infle o total real gasto no projeto.
+
+**Why this priority**: sem essa discriminacao, a comparacao da Story 1 fica
+enviesada — o mesmo token pago uma vez apareceria contado duas vezes,
+tornando qualquer conclusao sobre mix de modelos ou custo blended nao
+confiavel. Depende da captura basica da Story 1 existir, mas e verificavel
+de forma isolada.
+
+**Independent Test**: com uma execucao de pipeline ativa (onda em
+andamento) rodando simultaneamente a uma sessao avulsa no mesmo projeto,
+verificar que o consumo da janela em que a onda esteve ativa e atribuido
+somente ao registro de pipeline ja existente, nunca somado ao total avulso.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma execucao de pipeline em andamento (onda aberta) num
+   projeto, **When** consumo de tokens acontece durante a janela de tempo
+   em que a onda esta ativa, **Then** esse consumo nao e somado ao total de
+   consumo avulso do mesmo projeto.
+2. **Given** uma sessao avulsa que, no meio de sua execucao, da origem a uma
+   execucao de pipeline (o operador inicia `agente-00c`/`feature-00c`
+   durante a sessao), **When** a onda de pipeline se encerra e a sessao
+   avulsa continua, **Then** somente a janela de tempo fora da onda ativa
+   volta a contar como consumo avulso.
+
+---
+
+### User Story 3 - Captura resiliente a encerramento abrupto (Priority: P3)
+
+Como operador de sessoes avulsas longas, eu quero que o consumo capturado
+sobreviva a um encerramento abrupto da sessao (crash, fechamento forcado do
+terminal, queda de energia), para que uma sessao que de fato consumiu
+orcamento nao fique com consumo zerado ou ausente so porque nao houve um
+encerramento limpo.
+
+**Why this priority**: encerramentos abruptos sao rotina em uso avulso
+(diferente das ondas de pipeline, que tem ciclo de vida controlado); depender
+apenas de um evento de fim de sessao limpo perderia dados exatamente nas
+sessoes mais longas e potencialmente mais caras. Refinamento sobre a Story 1,
+testavel isoladamente ao simular a ausencia do evento de encerramento.
+
+**Independent Test**: iniciar uma sessao avulsa, deixar transcorrer mais de
+um intervalo de captura periodica, e entao encerrar o processo de forma
+abrupta (sem o evento de fim de sessao ser disparado); verificar que o
+consumo ate a ultima captura periodica permanece registrado.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma sessao avulsa em andamento, **When** o intervalo de
+   captura periodica transcorre pelo menos uma vez, **Then** existe um
+   registro de consumo correspondente aquele intervalo, independente de a
+   sessao ainda estar aberta.
+2. **Given** uma sessao avulsa encerrada de forma abrupta (sem evento de
+   fim de sessao), **When** o operador consulta o consumo avulso do
+   projeto, **Then** o consumo capturado ate a ultima janela periodica
+   antes do encerramento abrupto esta presente no total.
+
+---
+
+### Edge Cases
+
+- O que acontece quando o operador nunca habilitou a telemetria local
+  (opt-in ausente)? O sistema MUST reportar "nao medido" para esse
+  projeto/sessao, nunca um valor zero fabricado (Principio VI).
+- Como o sistema se comporta quando duas sessoes avulsas rodam
+  simultaneamente no mesmo projeto (duas janelas/terminais abertos)? Cada
+  processo e atribuido e contabilizado separadamente; a agregacao do
+  projeto soma os processos, sem misturar identificadores de sessao entre
+  eles (label de sessao do OTel nao e confiavel para desambiguar).
+- O que acontece quando os hooks de captura nao estao provisionados no
+  projeto (escopo `project` nunca instalado)? Nenhum dado avulso e
+  capturado para esse projeto; o sistema MUST distinguir "nao medido por
+  falta de cobertura" de "medido e zero".
+- Como o sistema trata uma janela de captura em que o processo de
+  exportacao local de telemetria fica temporariamente inacessivel (porta
+  fechada, processo reiniciado)? A captura falha de forma silenciosa para
+  aquela janela (nunca bloqueia a sessao do operador) e a lacuna fica
+  visivel como dado ausente, nao como zero.
+- O que acontece se o evento de inicio de sessao nao disparar (ex.: hook
+  instalado no meio de uma sessao ja aberta)? A primeira captura periodica
+  disponivel assume o papel de baseline; consumo anterior a essa captura
+  nao e reconstruido retroativamente.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: O sistema MUST capturar, para sessoes avulsas (fora de
+  qualquer execucao de pipeline SDD) em projetos com cobertura habilitada,
+  o consumo de tokens e custo por modelo, usando a mesma fonte de
+  telemetria local ja emitida nativamente durante o uso do Claude Code.
+- **FR-002**: O sistema MUST atribuir cada registro de consumo avulso a um
+  processo e a um projeto (diretorio de trabalho), nunca a um identificador
+  de sessao — o identificador de sessao da telemetria nativa e conhecido
+  por nao representar a sessao de forma confiavel.
+- **FR-003**: O sistema MUST capturar o consumo em intervalos periodicos ao
+  longo da sessao avulsa, e nao apenas no encerramento dela, de modo que um
+  encerramento abrupto preserve o consumo ja acumulado ate a ultima
+  captura.
+- **FR-004**: O sistema MUST excluir do total de consumo avulso qualquer
+  janela de tempo em que uma execucao de pipeline SDD (`agente-00c` ou
+  `feature-00c`) esteve ativa no mesmo projeto, para que o mesmo consumo
+  nunca seja contado tanto como avulso quanto como pipeline.
+- **FR-005**: O sistema MUST reportar "consumo nao medido" (nunca um valor
+  zero) para qualquer projeto ou janela de tempo em que a captura de
+  telemetria nao estava habilitada ou nao estava coberta por hooks
+  provisionados.
+- **FR-006**: A captura de consumo avulso MUST ser opt-in do operador
+  (habilitada pela mesma configuracao nativa de telemetria local do Claude
+  Code) e MUST nunca transmitir dados para fora do ambiente local do
+  operador.
+- **FR-007**: A falha ou indisponibilidade temporaria do mecanismo de
+  captura (ex.: endpoint de telemetria local inacessivel numa janela)
+  MUST NUNCA interromper, atrasar ou degradar a sessao avulsa do operador
+  — a captura e estritamente melhor-esforco.
+- **FR-008**: O sistema MUST persistir o consumo avulso capturado de forma
+  que sobreviva ao encerramento do processo que o originou, permitindo
+  consulta posterior independente da sessao ainda estar ativa.
+- **FR-009**: Usuarios MUST ser capazes de obter, para um projeto, uma
+  comparacao entre o mix de modelos e o custo blended por milhao de tokens
+  do consumo avulso e do consumo de execucoes de pipeline SDD do mesmo
+  projeto.
+- **FR-010**: Quando o mesmo processo de sessao avulsa dá origem, no meio
+  de sua execucao, a uma execucao de pipeline SDD, o sistema MUST voltar a
+  contabilizar consumo avulso normalmente assim que a execucao de pipeline
+  se encerra, sem exigir reinicio da sessao avulsa.
+
+> Decisoes de infraestrutura: aplica-se apenas cadencia de captura (ver
+> FR-003) — **FR-003-INFRA-SCHED**: a cadencia de captura e determinada por
+> eventos do harness (inicio de sessao como baseline + capturas periodicas
+> subsequentes), nao por um agendador externo (cron); o sistema MUST
+> tolerar a ausencia do evento de fim de sessao, dependendo das capturas
+> periodicas como mecanismo de durabilidade. Demais itens do checklist
+> (rotacao de chave, refresh de token externo, mutex multi-pod, backup)
+> N/A — a feature nao persiste segredos, nao depende de token externo com
+> TTL, e roda em processo unico local por sessao.
+
+### Key Entities
+
+- **Registro de Consumo Avulso**: uma medicao (baseline ou periodica) do
+  consumo de tokens e custo de um processo local, por modelo, atribuida a
+  um projeto — nunca a um identificador de sessao.
+- **Janela de Consumo de Pipeline**: o intervalo de tempo em que uma
+  execucao de pipeline SDD esteve ativa para um projeto; usado para excluir
+  consumo ja contabilizado do total avulso (evita dupla contagem).
+- **Comparativo de Uso do Projeto**: visao agregada que contrasta mix de
+  modelos e custo blended por milhao de tokens entre consumo avulso e
+  consumo de pipeline, para o mesmo projeto.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Em um projeto com cobertura habilitada, apos o encerramento
+  (limpo ou abrupto) de uma sessao avulsa, o consumo por modelo dessa
+  sessao fica disponivel para consulta sem nenhuma acao manual de coleta
+  por parte do operador.
+- **SC-002**: 100% do consumo que ocorreu durante janelas de execucao de
+  pipeline ativa e excluido do total de consumo avulso do mesmo projeto —
+  nenhum token e contado nas duas categorias simultaneamente.
+- **SC-003**: Para uma sessao avulsa interrompida de forma abrupta apos
+  pelo menos um intervalo de captura periodica ter transcorrido, o consumo
+  acumulado ate essa ultima captura permanece disponivel — nenhuma sessao
+  com pelo menos uma captura periodica registrada fica com consumo
+  totalmente ausente.
+- **SC-004**: Para 100% dos projetos ou janelas sem cobertura de telemetria
+  habilitada, o consumo avulso reportado e explicitamente "nao medido",
+  nunca um valor numerico fabricado.
+- **SC-005**: Um operador consegue visualizar, para um projeto com
+  historico de ambas as categorias, o mix de modelos e o custo blended por
+  milhao de tokens do uso avulso lado a lado com o do uso em pipeline, sem
+  precisar cruzar manualmente dados de fontes separadas.
+
+## Delta Requirements
+
+**Skip**: feature adiciona uma capacidade inteiramente nova (captura de
+consumo avulso fora das execucoes de pipeline SDD); nao ha nenhuma
+capability documentada em `docs/specs/current/` referente a captura ou
+comparacao de telemetria de uso a ser alterada, removida ou renomeada — o
+corpus canonico atual cobre apenas atomic-commit-staging, guards e gates de
+delta/spec, sem sobreposicao com este escopo. — agente-00c-feature-orchestrator, 2026-08-06

--- a/docs/specs/loose-usage-capture/spec.md
+++ b/docs/specs/loose-usage-capture/spec.md
@@ -4,6 +4,31 @@
 **Created**: 2026-08-06
 **Status**: Draft
 
+## Clarifications
+
+### Session 2026-08-06
+
+- Q: Onde os registros de consumo avulso sao persistidos? → A: reusar o
+  `knowledge.db` global (`~/.claude/cstk/knowledge.db`, mesma base do `cstk
+  recall`), numa tabela nova de grao processo/projeto — distinta de
+  `wave_model_usage` (grao onda x modelo), conforme constraint ja registrada
+  na etapa specify.
+- Q: Qual mecanismo dispara a captura periodica e como o FR-004 exclui
+  janelas de pipeline ativas? → A: um hook `PostToolUse` dedicado (mesmo
+  padrao operacional do hook de tick ja existente), que so grava quando
+  NENHUMA execucao de pipeline `agente-00c`/`feature-00c` esta ativa no
+  projeto — a mesma checagem serve simultaneamente como gatilho periodico e
+  como exclusao do FR-004 (sem filtro pos-hoc separado por janela de tempo).
+- Q: Qual e a interface pela qual o operador obtem a comparacao avulso-vs-
+  pipeline (FR-009/SC-005)? → A: subcomando novo do `cstk` CLI (mesmo
+  padrao de superficie ja usado por `cstk recall`/`cstk session`); exposicao
+  no painel web fica fora do escopo desta feature.
+- Q: O hook de captura avulsa e provisionado junto dos hooks obrigatorios de
+  guarda (`pretooluse-bash-guard` etc.) ou por caminho de opt-in separado? →
+  A: caminho de opt-in separado — nunca bundlado automaticamente junto dos
+  guard hooks (que sao obrigatorios/fail-closed); a captura so e provisionada
+  quando o operador habilita explicitamente, preservando FR-006.
+
 ## User Scenarios & Testing
 
 ### User Story 1 - Visibilidade do consumo avulso por modelo (Priority: P1)
@@ -166,7 +191,8 @@ consumo ate a ultima captura periodica permanece registrado.
 - **FR-009**: Usuarios MUST ser capazes de obter, para um projeto, uma
   comparacao entre o mix de modelos e o custo blended por milhao de tokens
   do consumo avulso e do consumo de execucoes de pipeline SDD do mesmo
-  projeto.
+  projeto, via um subcomando do `cstk` CLI (exposicao em painel web fica
+  fora do escopo desta feature — ver Clarifications).
 - **FR-010**: Quando o mesmo processo de sessao avulsa dá origem, no meio
   de sua execucao, a uma execucao de pipeline SDD, o sistema MUST voltar a
   contabilizar consumo avulso normalmente assim que a execucao de pipeline
@@ -177,7 +203,13 @@ consumo ate a ultima captura periodica permanece registrado.
 > eventos do harness (inicio de sessao como baseline + capturas periodicas
 > subsequentes), nao por um agendador externo (cron); o sistema MUST
 > tolerar a ausencia do evento de fim de sessao, dependendo das capturas
-> periodicas como mecanismo de durabilidade. Demais itens do checklist
+> periodicas como mecanismo de durabilidade. O gatilho periodico e um hook
+> `PostToolUse` dedicado que so grava quando nenhuma execucao de pipeline
+> esta ativa no projeto — a mesma checagem serve como exclusao do FR-004
+> (ver Clarifications). Esse hook MUST ser provisionado por um caminho de
+> opt-in separado dos guard hooks obrigatorios (nunca bundlado junto de
+> `pretooluse-bash-guard`/`posttooluse-tool-call-tick`), preservando o
+> opt-in do operador exigido por FR-006. Demais itens do checklist
 > (rotacao de chave, refresh de token externo, mutex multi-pod, backup)
 > N/A — a feature nao persiste segredos, nao depende de token externo com
 > TTL, e roda em processo unico local por sessao.
@@ -186,7 +218,10 @@ consumo ate a ultima captura periodica permanece registrado.
 
 - **Registro de Consumo Avulso**: uma medicao (baseline ou periodica) do
   consumo de tokens e custo de um processo local, por modelo, atribuida a
-  um projeto — nunca a um identificador de sessao.
+  um projeto — nunca a um identificador de sessao. Persistido no mesmo
+  indice global de conhecimento (`knowledge.db`) ja usado pelo `cstk
+  recall`, numa tabela de grao processo/projeto — nao reutiliza o grao
+  onda x modelo da tabela de consumo de pipeline (ver Clarifications).
 - **Janela de Consumo de Pipeline**: o intervalo de tempo em que uma
   execucao de pipeline SDD esteve ativa para um projeto; usado para excluir
   consumo ja contabilizado do total avulso (evita dupla contagem).

--- a/docs/specs/loose-usage-capture/tasks.md
+++ b/docs/specs/loose-usage-capture/tasks.md
@@ -1,0 +1,217 @@
+# Tarefas loose-usage-capture - Captura de Consumo Avulso de Uso
+
+Escopo: implementar a visibilidade de consumo (tokens/custo por modelo) das
+sessoes avulsas do Claude Code fora das pipelines SDD `agente-00c`/`feature-00c`,
+em tres camadas — hook de captura opt-in, indice derivado no `knowledge.db`
+(migracao v13) e subcomando `cstk usage` (+ `compare`, `+ prune`) — conforme
+[plan.md](./plan.md), [data-model.md](./data-model.md) e
+[contracts/](./contracts/).
+
+**Legenda de status:**
+- `[ ]` Pendente
+- `[~]` Em andamento
+- `[x]` Concluido
+- `[!]` Bloqueado
+
+**Legenda de criticidade:**
+- `[C]` Critico - Impacto financeiro direto ou bloqueante
+- `[A]` Alto - Funcionalidade essencial
+- `[M]` Medio - Necessario mas sem urgencia imediata
+
+---
+
+## FASE 1 - Requisitos e Politica de Dados (Gaps do Checklist)
+
+### 1.1 Definir e documentar politica de retencao/expurgo do consumo avulso `[A]`
+
+Ref: checklists/requirements.md CHK002, checklists/security.md CHK029
+
+- [ ] 1.1.1 Decidir o mecanismo (subcomando dedicado `cstk usage prune [--dry-run] [--older-than-days N]`, paridade estrutural com `cstk mcp gc [--dry-run]` ja existente em `cli/lib/mcp.sh`) e o TTL default (`CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`) — politica de design explicita, nao dado factual (mesma natureza do default de intervalo tratado em research.md Decision 4)
+- [ ] 1.1.2 Adicionar secao "Retencao" em data-model.md descrevendo o TTL, o alvo da poda (segmentos `seg-*` fechados do sidecar + linhas de `loose_usage`) e o criterio de elegibilidade (idade de `captured_at`/`updated_at` acima do TTL)
+- [ ] 1.1.3 Atualizar contracts/cli-usage.md com a secao `cstk usage prune` (flags, saida, comportamento sem dados)
+- [ ] 1.1.4 Marcar CHK002 (requirements.md) e CHK029 (security.md) como `[x]` citando a secao nova de data-model.md
+
+### 1.2 Definir e documentar permissao restritiva do sidecar de captura avulsa `[A]`
+
+Ref: checklists/security.md CHK021
+
+- [ ] 1.2.1 Decidir o esquema de permissao (`chmod 700` no diretorio raiz `~/.claude/cstk/loose-usage/` e em cada `<process_key>/`/`seg-*/`; `chmod 600` em `meta.tsv`/`otel-start.tsv`/`otel-end.tsv`), paridade com `recall_normalize_db_perms` (`cli/lib/recall.sh` ~669-685)
+- [ ] 1.2.2 Adicionar nota de permissao em data-model.md §LooseUsageProcess
+- [ ] 1.2.3 Marcar CHK021 (security.md) como `[x]` citando a nota nova
+
+---
+
+## FASE 2 - Fundacao: Schema do knowledge.db (migracao v13)
+
+### 2.1 Migracao aditiva RECALL_SCHEMA_VERSION 12 -> 13 `[A]`
+
+Ref: data-model.md §Entity LooseUsageRecord, cli/lib/recall.sh (linha 128 `RECALL_SCHEMA_VERSION`, linha 652 `schema_meta`, precedente v11->v12 linhas 810-811)
+
+- [ ] 2.1.1 Bump `RECALL_SCHEMA_VERSION` para `13` em cli/lib/recall.sh
+- [ ] 2.1.2 Adicionar `CREATE TABLE IF NOT EXISTS loose_usage (...)` em `recall_schema_ddl`, colunas conforme data-model.md (`id`, `project`, `project_path`, `process_key`, `segment_id`, `model`, `cost_usd`, `total_tokens`, `segment_open`, `captured_at`, `ingested_at`) + `UNIQUE(process_key, segment_id, model)`
+- [ ] 2.1.3 Confirmar que a migracao e puramente aditiva (sem `ALTER TABLE`/`DROP`), seguindo o precedente literal da v11->v12 para tabela nova
+- [ ] 2.1.4 Escrever teste de migracao em tests/cstk/test_recall.sh: base v12 populada ganha `loose_usage` vazia na proxima escrita; base nova cria o schema direto em v13
+
+### 2.2 Rotina de poda (prune) na camada de indice `[A]`
+
+Ref: task 1.1 (politica de retencao), data-model.md §Retencao
+
+- [ ] 2.2.1 Adicionar helper de poda em cli/lib/recall.sh (`recall_prune_loose_usage` ou equivalente): `DELETE` de linhas `loose_usage` com `captured_at` mais antigo que o TTL recebido
+- [ ] 2.2.2 Aplicar `recall_normalize_db_perms` apos a poda, mesmo padrao das demais mutacoes do `knowledge.db`
+- [ ] 2.2.3 Escrever teste em tests/cstk/test_recall.sh: poda remove linhas expiradas e preserva linhas dentro do TTL
+
+---
+
+## FASE 3 - Captura: hook `posttooluse-loose-usage.sh` + sidecar
+
+### 3.1 Implementar hook posttooluse-loose-usage.sh `[A]`
+
+Ref: contracts/hook-loose-usage.md §Sequencia (7 passos), molde `global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh`
+
+- [ ] 3.1.1 Resolucao de dependencias (`_hook-active-exec.sh`, `otel-usage.sh`) pela cadeia de 3 niveis: `<dir do hook>/../scripts/`, `$HOME/.claude/skills/agente-00c-runtime/scripts/`, `<cwd>/.claude/skills/agente-00c-runtime/scripts/`
+- [ ] 3.1.2 Passos 1-3: checar `CSTK_OTEL_ENDPOINT` presente, `jq` disponivel, parse de stdin (`.cwd`/`.tool_name` nao-vazios) — no-op em qualquer ausencia
+- [ ] 3.1.3 Passo 4: throttle O(1) via `meta.tsv.updated_at` + `CSTK_LOOSE_USAGE_INTERVAL_S` (default `300`), executado ANTES do passo 5 (mais barato primeiro)
+- [ ] 3.1.4 Passo 5: deteccao de execucao ativa com polaridade INVERTIDA de `_hook-active-exec.sh` (exit `0`=ativa fecha segmento sem capturar; `1`=inativa captura; `2`/`3`=no-op) — pre-check inline usando exclusivamente builtins do shell (SEC-H1)
+- [ ] 3.1.5 Passos 6-7: `otel-usage.sh snapshot` no diretorio do segmento aberto + atualizacao de `meta.tsv` (`updated_at`, `current_segment`)
+- [ ] 3.1.6 Garantir o contrato de saida: stdout/stderr SEMPRE vazios, exit SEMPRE `0`, hook nunca toca `state.json`/`state.db`/`knowledge.db`
+- [ ] 3.1.7 Escrever tests/test_posttooluse-loose-usage.sh cobrindo: `CSTK_OTEL_ENDPOINT` ausente (no-op), `jq` ausente (no-op), throttle nao vencido (no-op), execucao ativa (fecha segmento), execucao inativa (captura), estados `indeterminada`/`uso incorreto` (no-op), payload sem `.cwd`/`.tool_name` (no-op)
+
+### 3.2 Aplicar permissao restritiva no sidecar (CHK021) `[A]`
+
+Ref: task 1.2
+
+- [ ] 3.2.1 `chmod 700` no diretorio raiz `~/.claude/cstk/loose-usage/` e em cada `<process_key>/`/`seg-*/` criado pelo hook
+- [ ] 3.2.2 `chmod 600` em `meta.tsv`, `otel-start.tsv`, `otel-end.tsv` apos cada escrita
+- [ ] 3.2.3 Estender tests/test_posttooluse-loose-usage.sh com cenario que confirma o modo de arquivo/diretorio apos uma captura bem-sucedida
+
+### 3.3 Registro opt-in do hook no harness `[A]`
+
+Ref: contracts/hook-loose-usage.md §Registro no harness, research.md Decision 10
+
+- [ ] 3.3.1 Criar `global/skills/agente-00c-runtime/hooks/settings.loose-usage.snippet.json` (evento `PostToolUse`, matcher `*`, `command` para `posttooluse-loose-usage.sh`, `timeout: 5`) em arquivo SEPARADO de `settings.snippet.json`
+- [ ] 3.3.2 Adicionar flag `--with-loose-usage` (default DESLIGADA) ao subcomando `hooks install` em cli/lib/hooks.sh, mesclando o snippet novo apenas quando a flag e passada
+- [ ] 3.3.3 Garantir que `apply_guard_hooks()` chamada sem a flag preserva exatamente o comportamento atual (3 hooks obrigatorios, zero regressao)
+- [ ] 3.3.4 Estender tests/cstk/test_hooks.sh: cenario com `--with-loose-usage` registra o hook novo; cenario sem a flag NAO o registra
+
+---
+
+## FASE 4 - Consulta: subcomando `cstk usage`
+
+### 4.1 Implementar cli/lib/usage.sh (mapper sidecar -> DB) `[A]`
+
+Ref: plan.md §Convencoes de Borda "Mapper layer (sidecar ↔ DB)", data-model.md
+
+- [ ] 4.1.1 Varredura de `~/.claude/cstk/loose-usage/*/seg-*/`, invocando `otel-usage.sh delta --state-dir <segmento>` por segmento
+- [ ] 4.1.2 Conversao do JSON `by_model` do `delta` em linhas `loose_usage`, UPSERT pela chave natural `(process_key, segment_id, model)`, delegando a `cli/lib/recall.sh` (usage.sh NUNCA invoca `sqlite3` diretamente — invariante grep-avel de plan.md/contracts/cli-usage.md)
+- [ ] 4.1.3 Tratamento de ausencia conforme Constitution VI: campo nao medido vira `null`/`NULL`, nunca `0` fabricado
+
+### 4.2 Implementar `cstk usage` (listagem por projeto) `[A]`
+
+Ref: contracts/cli-usage.md §`cstk usage`
+
+- [ ] 4.2.1 Parser de flags `--project`/`--since`/`--limit`/`--json`/`--db`; flag desconhecida ⇒ exit `2` com uso em stderr
+- [ ] 4.2.2 Saida texto: uma secao por projeto, uma linha por modelo (modelo, tokens, custo, participacao); campo sem medicao imprime `nao medido`
+- [ ] 4.2.3 Saida `--json`: objeto `{project, category: "loose", models[]}` com `model`/`total_tokens`/`cost_usd`; ausencia representada por `null` JSON
+- [ ] 4.2.4 Comportamento sem dados conforme tabela do contrato: `knowledge.db` ausente (aviso stderr + `nao medido`, exit 0), tabela vazia (`nao medido — sem cobertura de captura`, exit 0), `sqlite3` ausente (aviso stderr, exit 1)
+
+### 4.3 Implementar `cstk usage compare` `[A]`
+
+Ref: contracts/cli-usage.md §`cstk usage compare`, data-model.md §Entity ProjectUsageComparison
+
+- [ ] 4.3.1 Agregacao por categoria (`loose` via `loose_usage`, `pipeline` via `wave_model_usage` ja existente em cli/lib/recall.sh linhas 625-637) — soma lado a lado, NUNCA `JOIN` linha a linha (granularidades diferentes)
+- [ ] 4.3.2 Calculo de `share_pct` e `blended_cost_per_mtok` (`SUM(cost_usd)/SUM(total_tokens)*1e6`; `null` quando `SUM(total_tokens)` e `0` ou `NULL` — divisao indefinida nunca vira `0`)
+- [ ] 4.3.3 Regras de ausencia: categoria sem nenhuma linha ⇒ `nao medido`/`null`, a outra categoria segue exibida; ambas vazias ⇒ `nao medido` nas duas, exit `0`
+
+### 4.4 Implementar `cstk usage prune` `[A]`
+
+Ref: task 1.1/2.2 (politica de retencao)
+
+- [ ] 4.4.1 Poda dos segmentos fechados do sidecar (marcador `closed` presente) mais antigos que o TTL (`CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`, ou `--older-than-days N`)
+- [ ] 4.4.2 Poda das linhas correspondentes em `loose_usage` via o helper da task 2.2.1
+- [ ] 4.4.3 Flag `--dry-run` (paridade com `cstk mcp gc --dry-run`): reporta o que seria removido sem remover
+
+### 4.5 Wiring no dispatch + help do binario `[A]`
+
+Ref: contracts/cli-usage.md, cli/cstk (case dispatch e lista de subcomandos validos, linha ~243)
+
+- [ ] 4.5.1 Adicionar `usage)` ao `case "$1"` de cli/cstk, roteando para cli/lib/usage.sh
+- [ ] 4.5.2 Adicionar `usage` a lista de subcomandos validos (`install|update|...`) e ao texto de `--help`/uso
+- [ ] 4.5.3 Escrever tests/cstk/test_usage.sh cobrindo: listagem com/sem dados, `--json`, `compare`, `prune --dry-run`, flag desconhecida (exit 2), `sqlite3` ausente (exit 1)
+
+---
+
+## FASE 5 - Validacao, Testes de Integracao e Documentacao
+
+### 5.1 Fechar cobertura de testes e checklist `[A]`
+
+- [ ] 5.1.1 Rodar `./tests/run.sh --check-coverage` e confirmar zero script orfao para `posttooluse-loose-usage.sh` e `usage.sh`
+- [ ] 5.1.2 Rodar a suite relevante (`./tests/run.sh recall`, `./tests/run.sh hooks`, `./tests/run.sh usage`, `./tests/run.sh posttooluse-loose-usage`) e confirmar 100% verde
+- [ ] 5.1.3 Marcar CHK002/CHK021/CHK029 como `[x]` nos checklists com referencia as tasks que os fecharam (1.1, 1.2, 2.2, 3.2, 4.4)
+
+### 5.2 Atualizar documentacao do repositorio `[A]`
+
+Ref: CLAUDE.md secao "Memoria de conhecimento (cstk recall)" como precedente de formato
+
+- [ ] 5.2.1 Adicionar secao "Consumo avulso (cstk usage)" em CLAUDE.md descrevendo o hook opt-in, o sidecar, a migracao v13 e os 3 subcomandos (`usage`, `usage compare`, `usage prune`)
+- [ ] 5.2.2 Atualizar README.md se `cstk usage` entrar no texto de `--help`/lista de subcomandos documentados (paridade com as linhas ja existentes de `cstk hooks`/`cstk recall`)
+- [ ] 5.2.3 Adicionar entrada no CHANGELOG.md (proxima versao MINOR) descrevendo o subcomando novo — Constitution Principio I exige nota de release para contrato de CLI novo (plan.md §Constitution Check)
+
+### 5.3 Quickstart e validacao manual `[M]`
+
+Ref: quickstart.md
+
+- [ ] 5.3.1 Executar os cenarios de quickstart.md (manualmente ou via script) e confirmar que os passos descritos batem com a implementacao final
+- [ ] 5.3.2 Ajustar quickstart.md se algum passo tiver divergido durante a implementacao
+
+---
+
+## Matriz de Dependencias
+
+```mermaid
+flowchart TD
+    F1[Fase 1 - Requisitos e Politica de Dados]
+    F2[Fase 2 - Schema knowledge.db v13]
+    F3[Fase 3 - Hook + Sidecar]
+    F4[Fase 4 - CLI cstk usage]
+    F5[Fase 5 - Validacao e Documentacao]
+
+    F1 --> F2
+    F1 --> F3
+    F2 --> F4
+    F3 --> F4
+    F4 --> F5
+```
+
+## Resumo Quantitativo
+
+| Fase | Tarefas | Subtarefas | Criticidade |
+|------|---------|------------|-------------|
+| 1 - Requisitos e Politica de Dados | 2 | 7 | A |
+| 2 - Schema knowledge.db v13 | 2 | 7 | A |
+| 3 - Hook + Sidecar | 3 | 14 | A |
+| 4 - CLI `cstk usage` | 5 | 16 | A |
+| 5 - Validacao e Documentacao | 3 | 8 | A/M |
+| **Total** | **15** | **52** | - |
+
+## Escopo Coberto
+
+| Item | Descricao | Fase |
+|------|-----------|------|
+| FR-001/FR-002/FR-003 | Captura periodica de consumo avulso, atribuida por processo+projeto | 3 |
+| FR-004/FR-010 | Exclusao de dupla contagem via deteccao de execucao ativa (polaridade invertida) | 3 |
+| FR-005 | Ausencia sempre `null`/"nao medido", nunca `0` fabricado | 2, 4 |
+| FR-006 | Opt-in via `cstk hooks install --with-loose-usage`, snippet separado | 3.3 |
+| FR-007 | Hook fail-open, stdout/stderr vazios, exit sempre 0 | 3.1 |
+| FR-008 | Persistencia do sidecar sobrevive ao processo | 3.1 |
+| FR-009 | `cstk usage` / `cstk usage compare` (mix de modelos + custo blended) | 4.2, 4.3 |
+| CHK002/CHK029 | Politica de retencao/expurgo (gap do checklist) | 1.1, 2.2, 4.4 |
+| CHK021 | Permissao restritiva do sidecar (gap do checklist) | 1.2, 3.2 |
+
+## Escopo Excluido
+
+| Item | Descricao | Motivo |
+|------|-----------|--------|
+| Exposicao no painel web | Comparacao avulso vs pipeline no `cstk-panel` | Fora de escopo explicito da spec (Clarifications Q3, FR-009) |
+| Novo arquivo com acesso a `sqlite3` | `cli/lib/usage.sh` invocando `sqlite3` diretamente | Violaria o confinamento de dependencia (Constitution II); toda SQL delega a `cli/lib/recall.sh` |
+| Definicao numerica de "janela de perda tolerada" (CHK017) | Fixar um valor de SLA de perda maxima na spec | Item `{humano}` — aguarda decisao do dono do produto, fora do escopo de decomposicao automatica |
+| Decisao humana final sobre retencao/permissao (CHK018/CHK030/CHK031) | Ratificar formalmente as politicas definidas nas tasks 1.1/1.2 como requisito obrigatorio vs divida tecnica aceita | Itens `{humano}` dos checklists; as tasks 1.1/1.2 implementam uma politica razoavel, mas a ratificacao formal como requisito permanece decisao do operador |

--- a/docs/specs/loose-usage-capture/tasks.md
+++ b/docs/specs/loose-usage-capture/tasks.md
@@ -68,30 +68,30 @@ Ref: task 1.1 (politica de retencao), data-model.md §Retencao
 
 Ref: contracts/hook-loose-usage.md §Sequencia (7 passos), molde `global/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh`
 
-- [ ] 3.1.1 Resolucao de dependencias (`_hook-active-exec.sh`, `otel-usage.sh`) pela cadeia de 3 niveis: `<dir do hook>/../scripts/`, `$HOME/.claude/skills/agente-00c-runtime/scripts/`, `<cwd>/.claude/skills/agente-00c-runtime/scripts/`
-- [ ] 3.1.2 Passos 1-3: checar `CSTK_OTEL_ENDPOINT` presente, `jq` disponivel, parse de stdin (`.cwd`/`.tool_name` nao-vazios) — no-op em qualquer ausencia
-- [ ] 3.1.3 Passo 4: throttle O(1) via `meta.tsv.updated_at` + `CSTK_LOOSE_USAGE_INTERVAL_S` (default `300`), executado ANTES do passo 5 (mais barato primeiro)
-- [ ] 3.1.4 Passo 5: deteccao de execucao ativa com polaridade INVERTIDA de `_hook-active-exec.sh` (exit `0`=ativa fecha segmento sem capturar; `1`=inativa captura; `2`/`3`=no-op) — pre-check inline usando exclusivamente builtins do shell (SEC-H1)
-- [ ] 3.1.5 Passos 6-7: `otel-usage.sh snapshot` no diretorio do segmento aberto + atualizacao de `meta.tsv` (`updated_at`, `current_segment`)
-- [ ] 3.1.6 Garantir o contrato de saida: stdout/stderr SEMPRE vazios, exit SEMPRE `0`, hook nunca toca `state.json`/`state.db`/`knowledge.db`
-- [ ] 3.1.7 Escrever tests/test_posttooluse-loose-usage.sh cobrindo: `CSTK_OTEL_ENDPOINT` ausente (no-op), `jq` ausente (no-op), throttle nao vencido (no-op), execucao ativa (fecha segmento), execucao inativa (captura), estados `indeterminada`/`uso incorreto` (no-op), payload sem `.cwd`/`.tool_name` (no-op)
+- [x] 3.1.1 Resolucao de dependencias (`_hook-active-exec.sh`, `otel-usage.sh`) pela cadeia de 3 niveis: `<dir do hook>/../scripts/`, `$HOME/.claude/skills/agente-00c-runtime/scripts/`, `<cwd>/.claude/skills/agente-00c-runtime/scripts/`
+- [x] 3.1.2 Passos 1-3: checar `CSTK_OTEL_ENDPOINT` presente, `jq` disponivel, parse de stdin (`.cwd`/`.tool_name` nao-vazios) — no-op em qualquer ausencia
+- [x] 3.1.3 Passo 4: throttle O(1) via `meta.tsv.updated_at` + `CSTK_LOOSE_USAGE_INTERVAL_S` (default `300`), executado ANTES do passo 5 (mais barato primeiro)
+- [x] 3.1.4 Passo 5: deteccao de execucao ativa com polaridade INVERTIDA de `_hook-active-exec.sh` (exit `0`=ativa fecha segmento sem capturar; `1`=inativa captura; `2`/`3`=no-op) — pre-check inline usando exclusivamente builtins do shell (SEC-H1)
+- [x] 3.1.5 Passos 6-7: `otel-usage.sh snapshot` no diretorio do segmento aberto + atualizacao de `meta.tsv` (`updated_at`, `current_segment`)
+- [x] 3.1.6 Garantir o contrato de saida: stdout/stderr SEMPRE vazios, exit SEMPRE `0`, hook nunca toca `state.json`/`state.db`/`knowledge.db`
+- [x] 3.1.7 Escrever tests/test_posttooluse-loose-usage.sh cobrindo: `CSTK_OTEL_ENDPOINT` ausente (no-op), `jq` ausente (no-op), throttle nao vencido (no-op), execucao ativa (fecha segmento), execucao inativa (captura), estados `indeterminada`/`uso incorreto` (no-op), payload sem `.cwd`/`.tool_name` (no-op) — 10 scenarios, `./tests/run.sh test_posttooluse-loose-usage`: PASS 10 FAIL 0
 
 ### 3.2 Aplicar permissao restritiva no sidecar (CHK021) `[A]`
 
 Ref: task 1.2
 
-- [ ] 3.2.1 `chmod 700` no diretorio raiz `~/.claude/cstk/loose-usage/` e em cada `<process_key>/`/`seg-*/` criado pelo hook
-- [ ] 3.2.2 `chmod 600` em `meta.tsv`, `otel-start.tsv`, `otel-end.tsv` apos cada escrita
-- [ ] 3.2.3 Estender tests/test_posttooluse-loose-usage.sh com cenario que confirma o modo de arquivo/diretorio apos uma captura bem-sucedida
+- [x] 3.2.1 `chmod 700` no diretorio raiz `~/.claude/cstk/loose-usage/` e em cada `<process_key>/`/`seg-*/` criado pelo hook <!-- implementado junto com 3.1 (mesmo arquivo, funcoes _plu_secure_dir/_plu_secure_file) -->
+- [x] 3.2.2 `chmod 600` em `meta.tsv`, `otel-start.tsv`, `otel-end.tsv` apos cada escrita <!-- otel-start.tsv/otel-end.tsv ja recebem 600 do proprio otel-usage.sh snapshot; hook reforca via _plu_secure_file -->
+- [x] 3.2.3 Estender tests/test_posttooluse-loose-usage.sh com cenario que confirma o modo de arquivo/diretorio apos uma captura bem-sucedida — scenario_permissoes_apos_captura
 
 ### 3.3 Registro opt-in do hook no harness `[A]`
 
 Ref: contracts/hook-loose-usage.md §Registro no harness, research.md Decision 10
 
-- [ ] 3.3.1 Criar `global/skills/agente-00c-runtime/hooks/settings.loose-usage.snippet.json` (evento `PostToolUse`, matcher `*`, `command` para `posttooluse-loose-usage.sh`, `timeout: 5`) em arquivo SEPARADO de `settings.snippet.json`
-- [ ] 3.3.2 Adicionar flag `--with-loose-usage` (default DESLIGADA) ao subcomando `hooks install` em cli/lib/hooks.sh, mesclando o snippet novo apenas quando a flag e passada
-- [ ] 3.3.3 Garantir que `apply_guard_hooks()` chamada sem a flag preserva exatamente o comportamento atual (3 hooks obrigatorios, zero regressao)
-- [ ] 3.3.4 Estender tests/cstk/test_hooks.sh: cenario com `--with-loose-usage` registra o hook novo; cenario sem a flag NAO o registra
+- [x] 3.3.1 Criar `global/skills/agente-00c-runtime/hooks/settings.loose-usage.snippet.json` (evento `PostToolUse`, matcher `*`, `command` para `posttooluse-loose-usage.sh`, `timeout: 5`) em arquivo SEPARADO de `settings.snippet.json`
+- [x] 3.3.2 Adicionar flag `--with-loose-usage` (default DESLIGADA) ao subcomando `hooks install` em cli/lib/hooks.sh, mesclando o snippet novo apenas quando a flag e passada <!-- append idempotente via merge_settings_loose_usage (jq '*' generico NAO serve p/ arrays — descartaria o comando do tick; verificado empiricamente e corrigido durante a implementacao) -->
+- [x] 3.3.3 Garantir que `apply_guard_hooks()` chamada sem a flag preserva exatamente o comportamento atual (3 hooks obrigatorios, zero regressao) <!-- 4o parametro with_loose_usage e opcional (default 0); install.sh/update.sh chamam com 3 args, comportamento intacto; ./tests/run.sh test_install.sh + test_update.sh + test_hooks.sh: PASS -->
+- [x] 3.3.4 Estender tests/cstk/test_hooks.sh: cenario com `--with-loose-usage` registra o hook novo; cenario sem a flag NAO o registra — 6 scenarios novos (apply_guard_hooks com/sem flag, idempotencia, catalogo sem hook opt-in, hooks_main com/sem flag); `./tests/run.sh test_hooks.sh`: PASS 36 FAIL 0
 
 ---
 

--- a/docs/specs/loose-usage-capture/tasks.md
+++ b/docs/specs/loose-usage-capture/tasks.md
@@ -101,42 +101,42 @@ Ref: contracts/hook-loose-usage.md §Registro no harness, research.md Decision 1
 
 Ref: plan.md §Convencoes de Borda "Mapper layer (sidecar ↔ DB)", data-model.md
 
-- [ ] 4.1.1 Varredura de `~/.claude/cstk/loose-usage/*/seg-*/`, invocando `otel-usage.sh delta --state-dir <segmento>` por segmento
-- [ ] 4.1.2 Conversao do JSON `by_model` do `delta` em linhas `loose_usage`, UPSERT pela chave natural `(process_key, segment_id, model)`, delegando a `cli/lib/recall.sh` (usage.sh NUNCA invoca `sqlite3` diretamente — invariante grep-avel de plan.md/contracts/cli-usage.md)
-- [ ] 4.1.3 Tratamento de ausencia conforme Constitution VI: campo nao medido vira `null`/`NULL`, nunca `0` fabricado
+- [x] 4.1.1 Varredura de `~/.claude/cstk/loose-usage/*/seg-*/`, invocando `otel-usage.sh delta --state-dir <segmento>` por segmento
+- [x] 4.1.2 Conversao do JSON `by_model` do `delta` em linhas `loose_usage`, UPSERT pela chave natural `(process_key, segment_id, model)`, delegando a `cli/lib/recall.sh` (usage.sh NUNCA invoca `sqlite3` diretamente — invariante grep-avel de plan.md/contracts/cli-usage.md)
+- [x] 4.1.3 Tratamento de ausencia conforme Constitution VI: campo nao medido vira `null`/`NULL`, nunca `0` fabricado
 
 ### 4.2 Implementar `cstk usage` (listagem por projeto) `[A]`
 
 Ref: contracts/cli-usage.md §`cstk usage`
 
-- [ ] 4.2.1 Parser de flags `--project`/`--since`/`--limit`/`--json`/`--db`; flag desconhecida ⇒ exit `2` com uso em stderr
-- [ ] 4.2.2 Saida texto: uma secao por projeto, uma linha por modelo (modelo, tokens, custo, participacao); campo sem medicao imprime `nao medido`
-- [ ] 4.2.3 Saida `--json`: objeto `{project, category: "loose", models[]}` com `model`/`total_tokens`/`cost_usd`; ausencia representada por `null` JSON
-- [ ] 4.2.4 Comportamento sem dados conforme tabela do contrato: `knowledge.db` ausente (aviso stderr + `nao medido`, exit 0), tabela vazia (`nao medido — sem cobertura de captura`, exit 0), `sqlite3` ausente (aviso stderr, exit 1)
+- [x] 4.2.1 Parser de flags `--project`/`--since`/`--limit`/`--json`/`--db`; flag desconhecida ⇒ exit `2` com uso em stderr
+- [x] 4.2.2 Saida texto: uma secao por projeto, uma linha por modelo (modelo, tokens, custo, participacao); campo sem medicao imprime `nao medido`
+- [x] 4.2.3 Saida `--json`: objeto `{project, category: "loose", models[]}` com `model`/`total_tokens`/`cost_usd`; ausencia representada por `null` JSON
+- [x] 4.2.4 Comportamento sem dados conforme tabela do contrato: `knowledge.db` ausente (aviso stderr + `nao medido`, exit 0), tabela vazia (`nao medido — sem cobertura de captura`, exit 0), `sqlite3` ausente (aviso stderr, exit 1)
 
 ### 4.3 Implementar `cstk usage compare` `[A]`
 
 Ref: contracts/cli-usage.md §`cstk usage compare`, data-model.md §Entity ProjectUsageComparison
 
-- [ ] 4.3.1 Agregacao por categoria (`loose` via `loose_usage`, `pipeline` via `wave_model_usage` ja existente em cli/lib/recall.sh linhas 625-637) — soma lado a lado, NUNCA `JOIN` linha a linha (granularidades diferentes)
-- [ ] 4.3.2 Calculo de `share_pct` e `blended_cost_per_mtok` (`SUM(cost_usd)/SUM(total_tokens)*1e6`; `null` quando `SUM(total_tokens)` e `0` ou `NULL` — divisao indefinida nunca vira `0`)
-- [ ] 4.3.3 Regras de ausencia: categoria sem nenhuma linha ⇒ `nao medido`/`null`, a outra categoria segue exibida; ambas vazias ⇒ `nao medido` nas duas, exit `0`
+- [x] 4.3.1 Agregacao por categoria (`loose` via `loose_usage`, `pipeline` via `wave_model_usage` ja existente em cli/lib/recall.sh linhas 625-637) — soma lado a lado, NUNCA `JOIN` linha a linha (granularidades diferentes)
+- [x] 4.3.2 Calculo de `share_pct` e `blended_cost_per_mtok` (`SUM(cost_usd)/SUM(total_tokens)*1e6`; `null` quando `SUM(total_tokens)` e `0` ou `NULL` — divisao indefinida nunca vira `0`)
+- [x] 4.3.3 Regras de ausencia: categoria sem nenhuma linha ⇒ `nao medido`/`null`, a outra categoria segue exibida; ambas vazias ⇒ `nao medido` nas duas, exit `0`
 
 ### 4.4 Implementar `cstk usage prune` `[A]`
 
 Ref: task 1.1/2.2 (politica de retencao)
 
-- [ ] 4.4.1 Poda dos segmentos fechados do sidecar (marcador `closed` presente) mais antigos que o TTL (`CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`, ou `--older-than-days N`)
-- [ ] 4.4.2 Poda das linhas correspondentes em `loose_usage` via o helper da task 2.2.1
-- [ ] 4.4.3 Flag `--dry-run` (paridade com `cstk mcp gc --dry-run`): reporta o que seria removido sem remover
+- [x] 4.4.1 Poda dos segmentos fechados do sidecar (marcador `closed` presente) mais antigos que o TTL (`CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`, ou `--older-than-days N`)
+- [x] 4.4.2 Poda das linhas correspondentes em `loose_usage` via o helper da task 2.2.1
+- [x] 4.4.3 Flag `--dry-run` (paridade com `cstk mcp gc --dry-run`): reporta o que seria removido sem remover
 
 ### 4.5 Wiring no dispatch + help do binario `[A]`
 
 Ref: contracts/cli-usage.md, cli/cstk (case dispatch e lista de subcomandos validos, linha ~243)
 
-- [ ] 4.5.1 Adicionar `usage)` ao `case "$1"` de cli/cstk, roteando para cli/lib/usage.sh
-- [ ] 4.5.2 Adicionar `usage` a lista de subcomandos validos (`install|update|...`) e ao texto de `--help`/uso
-- [ ] 4.5.3 Escrever tests/cstk/test_usage.sh cobrindo: listagem com/sem dados, `--json`, `compare`, `prune --dry-run`, flag desconhecida (exit 2), `sqlite3` ausente (exit 1)
+- [x] 4.5.1 Adicionar `usage)` ao `case "$1"` de cli/cstk, roteando para cli/lib/usage.sh
+- [x] 4.5.2 Adicionar `usage` a lista de subcomandos validos (`install|update|...`) e ao texto de `--help`/uso
+- [x] 4.5.3 Escrever tests/cstk/test_usage.sh cobrindo: listagem com/sem dados, `--json`, `compare`, `prune --dry-run`, flag desconhecida (exit 2), `sqlite3` ausente (exit 1)
 
 ---
 

--- a/docs/specs/loose-usage-capture/tasks.md
+++ b/docs/specs/loose-usage-capture/tasks.md
@@ -144,24 +144,24 @@ Ref: contracts/cli-usage.md, cli/cstk (case dispatch e lista de subcomandos vali
 
 ### 5.1 Fechar cobertura de testes e checklist `[A]`
 
-- [ ] 5.1.1 Rodar `./tests/run.sh --check-coverage` e confirmar zero script orfao para `posttooluse-loose-usage.sh` e `usage.sh`
-- [ ] 5.1.2 Rodar a suite relevante (`./tests/run.sh recall`, `./tests/run.sh hooks`, `./tests/run.sh usage`, `./tests/run.sh posttooluse-loose-usage`) e confirmar 100% verde
-- [ ] 5.1.3 Marcar CHK002/CHK021/CHK029 como `[x]` nos checklists com referencia as tasks que os fecharam (1.1, 1.2, 2.2, 3.2, 4.4)
+- [x] 5.1.1 Rodar `./tests/run.sh --check-coverage` e confirmar zero script orfao para `posttooluse-loose-usage.sh` e `usage.sh` <!-- "Cobertura completa: zero orfaos." -->
+- [x] 5.1.2 Rodar a suite relevante (`./tests/run.sh recall`, `./tests/run.sh hooks`, `./tests/run.sh usage`, `./tests/run.sh posttooluse-loose-usage`) e confirmar 100% verde <!-- recall PASS 145/0, hooks PASS 75/0, usage (wave-usage-report PASS 113/0 + test_usage.sh PASS 15/0), posttooluse-loose-usage PASS 10/0 -->
+- [x] 5.1.3 Marcar CHK002/CHK021/CHK029 como `[x]` nos checklists com referencia as tasks que os fecharam (1.1, 1.2, 2.2, 3.2, 4.4) <!-- checklists/requirements.md (CHK002) e checklists/security.md (CHK021, CHK029) atualizados com referencias completas -->
 
 ### 5.2 Atualizar documentacao do repositorio `[A]`
 
 Ref: CLAUDE.md secao "Memoria de conhecimento (cstk recall)" como precedente de formato
 
-- [ ] 5.2.1 Adicionar secao "Consumo avulso (cstk usage)" em CLAUDE.md descrevendo o hook opt-in, o sidecar, a migracao v13 e os 3 subcomandos (`usage`, `usage compare`, `usage prune`)
-- [ ] 5.2.2 Atualizar README.md se `cstk usage` entrar no texto de `--help`/lista de subcomandos documentados (paridade com as linhas ja existentes de `cstk hooks`/`cstk recall`)
-- [ ] 5.2.3 Adicionar entrada no CHANGELOG.md (proxima versao MINOR) descrevendo o subcomando novo — Constitution Principio I exige nota de release para contrato de CLI novo (plan.md §Constitution Check)
+- [x] 5.2.1 Adicionar secao "Consumo avulso (cstk usage)" em CLAUDE.md descrevendo o hook opt-in, o sidecar, a migracao v13 e os 3 subcomandos (`usage`, `usage compare`, `usage prune`) <!-- CLAUDE.md e gitignored (per-usuario); secao adicionada localmente, nao entra em commit -->
+- [x] 5.2.2 Atualizar README.md se `cstk usage` entrar no texto de `--help`/lista de subcomandos documentados (paridade com as linhas ja existentes de `cstk hooks`/`cstk recall`) <!-- criados docs/cstk-usage.md + docs/cstk-usage.pt-BR.md; README.md/README.pt-BR.md ganharam 1 linha em cada uma das 2 tabelas de topicos. README* ja estavam dirty com conteudo NAO-relacionado de outra feature (deprecacao initialize-docs) -- edicao feita localmente mas EXCLUIDA do commit desta onda (ver dec-043 area e nota no relatorio da onda); operador consolida -->
+- [x] 5.2.3 Adicionar entrada no CHANGELOG.md (proxima versao MINOR) descrevendo o subcomando novo — Constitution Principio I exige nota de release para contrato de CLI novo (plan.md §Constitution Check) <!-- dec-043: este repo nao mantem secao Unreleased; headers de versao sao criados so pela skill local release-wave no momento do merge/release. Entrada adiada para a release-wave (conteudo ja preparado em CLAUDE.md/docs/cstk-usage.md) -->
 
 ### 5.3 Quickstart e validacao manual `[M]`
 
 Ref: quickstart.md
 
-- [ ] 5.3.1 Executar os cenarios de quickstart.md (manualmente ou via script) e confirmar que os passos descritos batem com a implementacao final
-- [ ] 5.3.2 Ajustar quickstart.md se algum passo tiver divergido durante a implementacao
+- [x] 5.3.1 Executar os cenarios de quickstart.md (manualmente ou via script) e confirmar que os passos descritos batem com a implementacao final <!-- Scenarios 1/2/5/6/7 rodados empiricamente com fixtures sinteticas file:// (OTel real desligado nesta sessao) em HOME/projeto isolados sob scratchpad; deltas por modelo, compare loose-vs-pipeline, permissoes 700/600, zero PII e opt-out todos conferidos contra a implementacao real -->
+- [x] 5.3.2 Ajustar quickstart.md se algum passo tiver divergido durante a implementacao <!-- 2 divergencias reais encontradas e corrigidas: (1) Scenario 1 -- trocar CSTK_OTEL_ENDPOINT de arquivo entre os dois disparos muda o process_key (hash inclui o endpoint) e cria processo/segmento novo em vez de acumular delta no mesmo segmento; corrigido para reescrever o MESMO arquivo. (2) Scenario 2 -- o hook cria diretorio de processo + meta.tsv + segmento vazio mesmo com scrape falho (mkdir antes do scrape, falha engolida); so o otel-start.tsv fica ausente. Removidos os 3 marcadores [PROPOSTA] remanescentes (subcomandos ja implementados) -->
 
 ---
 

--- a/docs/specs/loose-usage-capture/tasks.md
+++ b/docs/specs/loose-usage-capture/tasks.md
@@ -26,18 +26,18 @@ em tres camadas — hook de captura opt-in, indice derivado no `knowledge.db`
 
 Ref: checklists/requirements.md CHK002, checklists/security.md CHK029
 
-- [ ] 1.1.1 Decidir o mecanismo (subcomando dedicado `cstk usage prune [--dry-run] [--older-than-days N]`, paridade estrutural com `cstk mcp gc [--dry-run]` ja existente em `cli/lib/mcp.sh`) e o TTL default (`CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`) — politica de design explicita, nao dado factual (mesma natureza do default de intervalo tratado em research.md Decision 4)
-- [ ] 1.1.2 Adicionar secao "Retencao" em data-model.md descrevendo o TTL, o alvo da poda (segmentos `seg-*` fechados do sidecar + linhas de `loose_usage`) e o criterio de elegibilidade (idade de `captured_at`/`updated_at` acima do TTL)
-- [ ] 1.1.3 Atualizar contracts/cli-usage.md com a secao `cstk usage prune` (flags, saida, comportamento sem dados)
-- [ ] 1.1.4 Marcar CHK002 (requirements.md) e CHK029 (security.md) como `[x]` citando a secao nova de data-model.md
+- [x] 1.1.1 Decidir o mecanismo (subcomando dedicado `cstk usage prune [--dry-run] [--older-than-days N]`, paridade estrutural com `cstk mcp gc [--dry-run]` ja existente em `cli/lib/mcp.sh`) e o TTL default (`CSTK_LOOSE_USAGE_RETENTION_DAYS`, default `90`) — politica de design explicita, nao dado factual (mesma natureza do default de intervalo tratado em research.md Decision 4) — dec-029
+- [x] 1.1.2 Adicionar secao "Retencao" em data-model.md descrevendo o TTL, o alvo da poda (segmentos `seg-*` fechados do sidecar + linhas de `loose_usage`) e o criterio de elegibilidade (idade de `captured_at`/`updated_at` acima do TTL)
+- [x] 1.1.3 Atualizar contracts/cli-usage.md com a secao `cstk usage prune` (flags, saida, comportamento sem dados)
+- [x] 1.1.4 Marcar CHK002 (requirements.md) e CHK029 (security.md) como `[x]` citando a secao nova de data-model.md
 
 ### 1.2 Definir e documentar permissao restritiva do sidecar de captura avulsa `[A]`
 
 Ref: checklists/security.md CHK021
 
-- [ ] 1.2.1 Decidir o esquema de permissao (`chmod 700` no diretorio raiz `~/.claude/cstk/loose-usage/` e em cada `<process_key>/`/`seg-*/`; `chmod 600` em `meta.tsv`/`otel-start.tsv`/`otel-end.tsv`), paridade com `recall_normalize_db_perms` (`cli/lib/recall.sh` ~669-685)
-- [ ] 1.2.2 Adicionar nota de permissao em data-model.md §LooseUsageProcess
-- [ ] 1.2.3 Marcar CHK021 (security.md) como `[x]` citando a nota nova
+- [x] 1.2.1 Decidir o esquema de permissao (`chmod 700` no diretorio raiz `~/.claude/cstk/loose-usage/` e em cada `<process_key>/`/`seg-*/`; `chmod 600` em `meta.tsv`/`otel-start.tsv`/`otel-end.tsv`), paridade com `recall_normalize_db_perms` (`cli/lib/recall.sh` ~669-685) — dec-030
+- [x] 1.2.2 Adicionar nota de permissao em data-model.md §LooseUsageProcess
+- [x] 1.2.3 Marcar CHK021 (security.md) como `[x]` citando a nota nova
 
 ---
 
@@ -47,18 +47,18 @@ Ref: checklists/security.md CHK021
 
 Ref: data-model.md §Entity LooseUsageRecord, cli/lib/recall.sh (linha 128 `RECALL_SCHEMA_VERSION`, linha 652 `schema_meta`, precedente v11->v12 linhas 810-811)
 
-- [ ] 2.1.1 Bump `RECALL_SCHEMA_VERSION` para `13` em cli/lib/recall.sh
-- [ ] 2.1.2 Adicionar `CREATE TABLE IF NOT EXISTS loose_usage (...)` em `recall_schema_ddl`, colunas conforme data-model.md (`id`, `project`, `project_path`, `process_key`, `segment_id`, `model`, `cost_usd`, `total_tokens`, `segment_open`, `captured_at`, `ingested_at`) + `UNIQUE(process_key, segment_id, model)`
-- [ ] 2.1.3 Confirmar que a migracao e puramente aditiva (sem `ALTER TABLE`/`DROP`), seguindo o precedente literal da v11->v12 para tabela nova
-- [ ] 2.1.4 Escrever teste de migracao em tests/cstk/test_recall.sh: base v12 populada ganha `loose_usage` vazia na proxima escrita; base nova cria o schema direto em v13
+- [x] 2.1.1 Bump `RECALL_SCHEMA_VERSION` para `13` em cli/lib/recall.sh — dec-031
+- [x] 2.1.2 Adicionar `CREATE TABLE IF NOT EXISTS loose_usage (...)` em `recall_schema_ddl`, colunas conforme data-model.md (`id`, `project`, `project_path`, `process_key`, `segment_id`, `model`, `cost_usd`, `total_tokens`, `segment_open`, `captured_at`, `ingested_at`) + `UNIQUE(process_key, segment_id, model)`
+- [x] 2.1.3 Confirmar que a migracao e puramente aditiva (sem `ALTER TABLE`/`DROP`), seguindo o precedente literal da v11->v12 para tabela nova
+- [x] 2.1.4 Escrever teste de migracao em tests/cstk/test_recall.sh: base v12 populada ganha `loose_usage` vazia na proxima escrita; base nova cria o schema direto em v13 — scenario_lu1/scenario_lu2, `./tests/run.sh test_recall.sh`: PASS 145 FAIL 0 (145 scenarios, inclui as 14 pre-existentes que hardcodeavam schema_version=12 e foram atualizadas para 13)
 
 ### 2.2 Rotina de poda (prune) na camada de indice `[A]`
 
 Ref: task 1.1 (politica de retencao), data-model.md §Retencao
 
-- [ ] 2.2.1 Adicionar helper de poda em cli/lib/recall.sh (`recall_prune_loose_usage` ou equivalente): `DELETE` de linhas `loose_usage` com `captured_at` mais antigo que o TTL recebido
-- [ ] 2.2.2 Aplicar `recall_normalize_db_perms` apos a poda, mesmo padrao das demais mutacoes do `knowledge.db`
-- [ ] 2.2.3 Escrever teste em tests/cstk/test_recall.sh: poda remove linhas expiradas e preserva linhas dentro do TTL
+- [x] 2.2.1 Adicionar helper de poda em cli/lib/recall.sh (`recall_prune_loose_usage` ou equivalente): `DELETE` de linhas `loose_usage` com `captured_at` mais antigo que o TTL recebido
+- [x] 2.2.2 Aplicar `recall_normalize_db_perms` apos a poda, mesmo padrao das demais mutacoes do `knowledge.db`
+- [x] 2.2.3 Escrever teste em tests/cstk/test_recall.sh: poda remove linhas expiradas e preserva linhas dentro do TTL — scenario_lu3 (remove expirada/preserva recente), scenario_lu4 (--dry-run nao remove), scenario_lu5 (DAYS invalido), scenario_lu6 (DB ausente); `./tests/run.sh test_recall.sh`: PASS 145 FAIL 0
 
 ---
 

--- a/docs/templates/briefing-prompt-ideal.md
+++ b/docs/templates/briefing-prompt-ideal.md
@@ -139,7 +139,8 @@ As **§1–§5** são o mínimo irredutível — com elas o briefing já fecha s
 
 ## Mapeamento template → seções do briefing salvo
 
-Para auditoria (o briefing final é salvo em `docs/01-briefing-discovery/briefing.md`):
+Para auditoria (o briefing final é salvo em `docs/briefing.md`; projetos
+antigos usam o legado `docs/01-briefing-discovery/briefing.md`):
 
 | Seção deste prompt | Seção do `briefing.md` gerado |
 |---|---|

--- a/global/agents/agente-00c-orchestrator.md
+++ b/global/agents/agente-00c-orchestrator.md
@@ -1510,9 +1510,10 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
    --projeto-alvo-path <PAP>` — exit 0 indica artefato esperado presente.
    O flag `--projeto-alvo-path` e CRITICO para as etapas `briefing` e
    `constitution`: a skill `briefing` salva em
-   `<PAP>/docs/01-briefing-discovery/briefing.md` e a skill
-   `constitution` salva em `<PAP>/docs/constitution.md` (paths do
-   `/initialize-docs`, fora do feature-dir). Sem o flag, detect-completion
+   `<PAP>/docs/briefing.md` (canonico; o legado
+   `<PAP>/docs/01-briefing-discovery/briefing.md` tambem e aceito) e a skill
+   `constitution` salva em `<PAP>/docs/constitution.md` (paths
+   project-level, fora do feature-dir). Sem o flag, detect-completion
    so olha o feature-dir e a etapa nunca eh detectada como concluida —
    resultava no double-write workaround do issue #3.
 

--- a/global/commands/feature-00c.md
+++ b/global/commands/feature-00c.md
@@ -106,7 +106,8 @@ Exporte: `AGENTE_00C_STATE_DIR=<projeto>/.claude/feature-00c-state/<short_name>`
    - se >500 chars, truncar + warning (limit-length trunca e adiciona "...")
 
 3. validar briefing (FR-PRE-001):
-   _br="$_proj/docs/01-briefing-discovery/briefing.md"
+   _br="$_proj/docs/briefing.md"
+   [ -f "$_br" ] || _br="$_proj/docs/01-briefing-discovery/briefing.md"  # legado
    - existe + nao-vazio + seções mínimas (visão, usuários-alvo, restrições, prioridades)
    - sem placeholders [TBD]/[A definir]/[FILL]/TODO em seções minimas
    - se falha: stderr "/briefing antes ou /agente-00c para bootstrap"; exit 1

--- a/global/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh
+++ b/global/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh
@@ -1,0 +1,359 @@
+#!/bin/sh
+# posttooluse-loose-usage.sh — hook PostToolUse (todas as tools, opt-in):
+# captura consumo avulso (fora de execucoes agente-00c/feature-00c) via
+# segmentos otel-usage.sh persistidos em
+# ~/.claude/cstk/loose-usage/<process_key>/.
+#
+# Contrato: docs/specs/loose-usage-capture/contracts/hook-loose-usage.md
+# Data model: docs/specs/loose-usage-capture/data-model.md
+#
+# Molde: posttooluse-tool-call-tick.sh (EXISTENTE) — herda integralmente
+# as invariantes fail-open: sem `set -e`, cada passo trata a propria
+# falha com no-op, NUNCA toca state.json/state.db/knowledge.db, stdout e
+# stderr SEMPRE vazios, exit SEMPRE 0. PostToolUse dispara CONCORRENTE as
+# tool calls — nenhuma escrita compartilhada transacional acontece aqui.
+#
+# DIFERENCA de politica frente ao molde: gatilho por CSTK_OTEL_ENDPOINT
+# (nao por CLAUDE_CODE_ENABLE_TELEMETRY/OTEL_METRICS_EXPORTER — esses dois
+# NAO chegam ao subprocesso do harness, sug-001/research.md Decision 3).
+#
+# POLARIDADE INVERTIDA da deteccao de execucao ativa (dec-006): este hook
+# capura quando NAO ha execucao 00c ativa (o oposto do tick de metrica, que
+# so grava quando HA execucao ativa). Ver tabela de exit codes abaixo.
+#
+# Opt-in: registrado SOMENTE via `cstk hooks install --with-loose-usage`
+# (flag default DESLIGADA) — NUNCA pelo snippet obrigatorio dos 3 hooks
+# core (settings.snippet.json).
+
+set -u
+
+_PLU_SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || _PLU_SELF_DIR=""
+
+# ---------------------------------------------------------------------------
+# Passo 1: CSTK_OTEL_ENDPOINT presente? (ancora de identidade do processo)
+# ---------------------------------------------------------------------------
+_PLU_ENDPOINT="${CSTK_OTEL_ENDPOINT:-}"
+[ -n "$_PLU_ENDPOINT" ] || exit 0
+
+# ---------------------------------------------------------------------------
+# Passo 2: jq disponivel? (dep opcional, fail-open — igual ao molde)
+# ---------------------------------------------------------------------------
+command -v jq >/dev/null 2>&1 || exit 0
+
+# ---------------------------------------------------------------------------
+# Passo 3: parse do stdin; .cwd e .tool_name nao-vazios
+# ---------------------------------------------------------------------------
+_PLU_INPUT=$(cat 2>/dev/null) || exit 0
+[ -n "$_PLU_INPUT" ] || exit 0
+
+_PLU_CWD=$(printf '%s' "$_PLU_INPUT" | jq -r '.cwd // ""' 2>/dev/null) || exit 0
+_PLU_TOOL_NAME=$(printf '%s' "$_PLU_INPUT" | jq -r '.tool_name // ""' 2>/dev/null) || exit 0
+
+[ -n "$_PLU_CWD" ] || exit 0
+# tool_name vazio = payload anomalo do harness; nao inventa captura.
+[ -n "$_PLU_TOOL_NAME" ] || exit 0
+
+[ -n "${HOME:-}" ] || exit 0
+
+# ---------------------------------------------------------------------------
+# Derivacao de process_key: funcao estavel de (endpoint, project_path),
+# com owner_pid como componente adicional QUANDO obtenivel via lsof
+# (Constitution VI: indeterminavel grava "unknown", jamais PID chutado).
+# Reimplementado inline (nao sourceia otel-usage.sh — script nao projetado
+# para ser sourceado, so invocado por subcomando) mas confinado a mesma
+# logica de _ou_port_owner (otel-usage.sh linha 443).
+# ---------------------------------------------------------------------------
+_plu_sanitize() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '_'
+}
+
+_plu_hash() {
+  printf '%s' "$1" | cksum 2>/dev/null | awk '{print $1}'
+}
+
+_plu_ep_port() {
+  case "$1" in
+    http://127.0.0.1:[0-9]*|http://localhost:[0-9]*)
+      _plu_p=${1#http://*:}
+      _plu_p=${_plu_p%%/*}
+      printf '%s' "$_plu_p"
+      return 0 ;;
+  esac
+  return 1
+}
+
+_plu_port_owner() {
+  command -v lsof >/dev/null 2>&1 || return 1
+  _plu_own=$(lsof -nP -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null | head -n 1)
+  [ -n "$_plu_own" ] || return 1
+  printf '%s' "$_plu_own"
+}
+
+_PLU_OWNER_PID="unknown"
+if _PLU_EP_PORT=$(_plu_ep_port "$_PLU_ENDPOINT" 2>/dev/null); then
+  if _PLU_OWNER=$(_plu_port_owner "$_PLU_EP_PORT" 2>/dev/null); then
+    _PLU_OWNER_PID="$_PLU_OWNER"
+  fi
+fi
+
+_PLU_KEY_BASE=$(_plu_sanitize "$(basename "$_PLU_CWD" 2>/dev/null)")
+_PLU_KEY_HASH=$(_plu_hash "${_PLU_ENDPOINT}|${_PLU_CWD}")
+[ -n "$_PLU_KEY_HASH" ] || exit 0
+if [ "$_PLU_OWNER_PID" != "unknown" ]; then
+  _PLU_PROCESS_KEY="${_PLU_KEY_BASE}-${_PLU_KEY_HASH}-${_PLU_OWNER_PID}"
+else
+  _PLU_PROCESS_KEY="${_PLU_KEY_BASE}-${_PLU_KEY_HASH}"
+fi
+
+_PLU_ROOT="$HOME/.claude/cstk/loose-usage"
+_PLU_PROC_DIR="$_PLU_ROOT/$_PLU_PROCESS_KEY"
+_PLU_META="$_PLU_PROC_DIR/meta.tsv"
+
+# ---------------------------------------------------------------------------
+# Permissao restritiva (CHK021, paridade recall_normalize_db_perms):
+# best-effort, chamada apos cada mkdir/escrita. Nunca bloqueia o caller.
+# ---------------------------------------------------------------------------
+_plu_secure_dir() { chmod 700 -- "$1" 2>/dev/null || :; }
+_plu_secure_file() { chmod 600 -- "$1" 2>/dev/null || :; }
+
+# ---------------------------------------------------------------------------
+# Throttle: epoch helpers (BSD/GNU date), mesma tecnica de budget.sh
+# _bd_iso_to_epoch — reimplementada aqui pois a cadeia de dependencias do
+# contrato so autoriza _hook-active-exec.sh + otel-usage.sh.
+# ---------------------------------------------------------------------------
+_plu_iso_to_epoch() {
+  if _plu_e=$(date -u -d "$1" +%s 2>/dev/null); then
+    printf '%s' "$_plu_e"; return 0
+  fi
+  if _plu_e=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$1" +%s 2>/dev/null); then
+    printf '%s' "$_plu_e"; return 0
+  fi
+  return 1
+}
+
+_plu_now_epoch() { date -u +%s 2>/dev/null || printf '0'; }
+_plu_now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || printf ''; }
+
+# _plu_meta_get FIELD -> valor da chave em meta.tsv (formato chave<TAB>valor)
+_plu_meta_get() {
+  [ -f "$_PLU_META" ] || return 1
+  awk -F '\t' -v k="$1" '$1==k {print $2; found=1} END {exit !found}' "$_PLU_META" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Passo 4: throttle O(1) — mais barato antes de sondar estado (passo 5).
+# Sem meta.tsv (primeira captura do processo), NAO ha o que throttlear.
+# ---------------------------------------------------------------------------
+_PLU_INTERVAL="${CSTK_LOOSE_USAGE_INTERVAL_S:-300}"
+case "$_PLU_INTERVAL" in
+  ''|*[!0-9]*) _PLU_INTERVAL=300 ;;
+esac
+
+if [ -f "$_PLU_META" ]; then
+  _PLU_LAST_UPDATED=$(_plu_meta_get updated_at) || _PLU_LAST_UPDATED=""
+  if [ -n "$_PLU_LAST_UPDATED" ]; then
+    _PLU_LAST_EPOCH=$(_plu_iso_to_epoch "$_PLU_LAST_UPDATED") || _PLU_LAST_EPOCH=0
+    _PLU_NOW_EPOCH=$(_plu_now_epoch)
+    _PLU_DELTA=$(( _PLU_NOW_EPOCH - _PLU_LAST_EPOCH ))
+    if [ "$_PLU_DELTA" -lt "$_PLU_INTERVAL" ] 2>/dev/null; then
+      exit 0
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Passo 5: deteccao de execucao ativa, polaridade INVERTIDA (dec-006).
+#
+# Pre-check inline com builtins PUROS do shell (SEC-H1, paridade com
+# _ptt_precheck_active_scope do molde): se NAO ha nenhum state.json/
+# state.db sob agente-00c-state/ ou feature-00c-state/*/, conclui
+# "inativa" SEM resolver nem sourcear o helper — e segue direto para a
+# captura. So quando o pre-check acha algum state presente e que vale a
+# pena sondar de fato via _hook-active-exec.sh.
+# ---------------------------------------------------------------------------
+_plu_precheck_active_scope() {
+  _plu_pa_agente="$_PLU_CWD/.claude/agente-00c-state"
+  if [ -f "$_plu_pa_agente/state.json" ] || [ -f "$_plu_pa_agente/state.db" ]; then
+    return 0
+  fi
+
+  _plu_pa_froot="$_PLU_CWD/.claude/feature-00c-state"
+  if [ -d "$_plu_pa_froot" ]; then
+    for _plu_pa_d in "$_plu_pa_froot"/*/; do
+      [ -d "$_plu_pa_d" ] || continue
+      if [ -f "${_plu_pa_d}state.json" ] || [ -f "${_plu_pa_d}state.db" ]; then
+        return 0
+      fi
+    done
+  fi
+  return 1
+}
+
+_PLU_HAE_RC=1
+if _plu_precheck_active_scope; then
+  # _plu_resolve_dep_hae REL_PATH -> cadeia de resolucao para
+  # _hook-active-exec.sh, ordem $HOME ANTES de <cwd> (mesma ordem
+  # MODIFICADA do molde/contrato hook-active-exec.md), teste -r (helpers
+  # _*.sh nao sao executaveis).
+  _plu_resolve_dep_hae() {
+    _plu_rel=$1
+    if [ -n "$_PLU_SELF_DIR" ] && [ -r "$_PLU_SELF_DIR/../$_plu_rel" ]; then
+      printf '%s' "$_PLU_SELF_DIR/../$_plu_rel"
+      return 0
+    fi
+    if [ -n "${HOME:-}" ] && [ -r "$HOME/.claude/skills/agente-00c-runtime/$_plu_rel" ]; then
+      printf '%s' "$HOME/.claude/skills/agente-00c-runtime/$_plu_rel"
+      return 0
+    fi
+    if [ -n "${_PLU_CWD:-}" ] && [ -r "$_PLU_CWD/.claude/skills/agente-00c-runtime/$_plu_rel" ]; then
+      printf '%s' "$_PLU_CWD/.claude/skills/agente-00c-runtime/$_plu_rel"
+      return 0
+    fi
+    return 1
+  }
+
+  if _PLU_HAE_HELPER=$(_plu_resolve_dep_hae "scripts/_hook-active-exec.sh"); then
+    # shellcheck disable=SC1090 # caminho resolvido dinamicamente pela cadeia de candidatos acima
+    . "$_PLU_HAE_HELPER"
+
+    # SEC-M2: mesma politica de contencao dos hooks de metrica (50ms) —
+    # este hook NAO e uma guarda (fail-closed), e OK degradar sob contencao.
+    HAE_BUSY_TIMEOUT_MS=50
+    export HAE_BUSY_TIMEOUT_MS
+
+    if _PLU_HAE_OUT=$(hook_active_exec "$_PLU_CWD" 2>/dev/null); then
+      _PLU_HAE_RC=0
+    else
+      _PLU_HAE_RC=$?
+    fi
+  else
+    # Helper irresolvivel apesar do pre-check ter achado state: trata como
+    # indeterminada (nunca vira captura sob incerteza — Constitution VI).
+    _PLU_HAE_RC=2
+  fi
+fi
+
+# Resolucao de dependencia de otel-usage.sh (mesma cadeia, teste -x pois e
+# executado como subprocesso, nao sourceado).
+_plu_resolve_dep_otel() {
+  _plu_rel=$1
+  if [ -n "$_PLU_SELF_DIR" ] && [ -x "$_PLU_SELF_DIR/../$_plu_rel" ]; then
+    printf '%s' "$_PLU_SELF_DIR/../$_plu_rel"
+    return 0
+  fi
+  if [ -n "${HOME:-}" ] && [ -x "$HOME/.claude/skills/agente-00c-runtime/$_plu_rel" ]; then
+    printf '%s' "$HOME/.claude/skills/agente-00c-runtime/$_plu_rel"
+    return 0
+  fi
+  if [ -n "${_PLU_CWD:-}" ] && [ -x "$_PLU_CWD/.claude/skills/agente-00c-runtime/$_plu_rel" ]; then
+    printf '%s' "$_PLU_CWD/.claude/skills/agente-00c-runtime/$_plu_rel"
+    return 0
+  fi
+  return 1
+}
+
+# _plu_next_seg SEG_ID -> proximo id "seg-NNN" (zero-padded a 3 digitos).
+# awk trata "008" como decimal 8 (sem armadilha de octal do $(( )) puro).
+_plu_next_seg() {
+  _plu_n=${1#seg-}
+  awk -v n="$_plu_n" 'BEGIN{printf "seg-%03d", (n+0)+1}'
+}
+
+# _plu_write_meta SEGMENT CREATED_AT -> (re)escreve meta.tsv por completo,
+# atomico (tmp + mv), chmod 600. updated_at = agora.
+_plu_write_meta() {
+  _plu_seg=$1
+  _plu_created=$2
+  _plu_now=$(_plu_now_iso)
+  [ -n "$_plu_now" ] || return 1
+  _plu_tmp="$_PLU_META.tmp.$$"
+  {
+    printf 'schema\t1\n'
+    printf 'project_path\t%s\n' "$_PLU_CWD"
+    printf 'endpoint\t%s\n' "$_PLU_ENDPOINT"
+    printf 'owner_pid\t%s\n' "$_PLU_OWNER_PID"
+    printf 'created_at\t%s\n' "$_plu_created"
+    printf 'updated_at\t%s\n' "$_plu_now"
+    printf 'current_segment\t%s\n' "$_plu_seg"
+  } > "$_plu_tmp" 2>/dev/null || { rm -f -- "$_plu_tmp" 2>/dev/null; return 1; }
+  mv -- "$_plu_tmp" "$_PLU_META" 2>/dev/null || { rm -f -- "$_plu_tmp" 2>/dev/null; return 1; }
+  _plu_secure_file "$_PLU_META"
+  return 0
+}
+
+case "$_PLU_HAE_RC" in
+  0)
+    # ATIVA: fecha o segmento aberto (se existir), NAO captura. Trecho
+    # nao persistido e descartado (Decision 5 / state transition table).
+    if [ -f "$_PLU_META" ]; then
+      _PLU_CUR_SEG=$(_plu_meta_get current_segment) || _PLU_CUR_SEG=""
+      if [ -n "$_PLU_CUR_SEG" ]; then
+        _PLU_SEG_DIR="$_PLU_PROC_DIR/$_PLU_CUR_SEG"
+        if [ -d "$_PLU_SEG_DIR" ] && [ ! -f "$_PLU_SEG_DIR/closed" ]; then
+          : > "$_PLU_SEG_DIR/closed" 2>/dev/null || :
+        fi
+      fi
+    fi
+    ;;
+  1)
+    # INATIVA: captura (Passos 6-7).
+    _PLU_OTEL=$(_plu_resolve_dep_otel "scripts/otel-usage.sh") || exit 0
+
+    mkdir -p -- "$_PLU_ROOT" 2>/dev/null || exit 0
+    _plu_secure_dir "$_PLU_ROOT"
+    mkdir -p -- "$_PLU_PROC_DIR" 2>/dev/null || exit 0
+    _plu_secure_dir "$_PLU_PROC_DIR"
+
+    if [ ! -f "$_PLU_META" ]; then
+      # Processo novo: primeiro segmento.
+      _PLU_SEG="seg-001"
+      _PLU_SEG_DIR="$_PLU_PROC_DIR/$_PLU_SEG"
+      mkdir -p -- "$_PLU_SEG_DIR" 2>/dev/null || exit 0
+      _plu_secure_dir "$_PLU_SEG_DIR"
+
+      "$_PLU_OTEL" snapshot --state-dir "$_PLU_SEG_DIR" --phase start \
+        --endpoint "$_PLU_ENDPOINT" >/dev/null 2>&1 || :
+      _plu_secure_file "$_PLU_SEG_DIR/otel-start.tsv"
+
+      _PLU_NOW=$(_plu_now_iso)
+      [ -n "$_PLU_NOW" ] || exit 0
+      _plu_write_meta "$_PLU_SEG" "$_PLU_NOW" || :
+    else
+      _PLU_CUR_SEG=$(_plu_meta_get current_segment) || _PLU_CUR_SEG=""
+      _PLU_CREATED=$(_plu_meta_get created_at) || _PLU_CREATED=$(_plu_now_iso)
+      [ -n "$_PLU_CUR_SEG" ] || exit 0
+      _PLU_SEG_DIR="$_PLU_PROC_DIR/$_PLU_CUR_SEG"
+
+      if [ -f "$_PLU_SEG_DIR/closed" ]; then
+        # Segmento anterior fechado: abre um novo.
+        _PLU_SEG=$(_plu_next_seg "$_PLU_CUR_SEG")
+        _PLU_SEG_DIR="$_PLU_PROC_DIR/$_PLU_SEG"
+        mkdir -p -- "$_PLU_SEG_DIR" 2>/dev/null || exit 0
+        _plu_secure_dir "$_PLU_SEG_DIR"
+
+        "$_PLU_OTEL" snapshot --state-dir "$_PLU_SEG_DIR" --phase start \
+          --endpoint "$_PLU_ENDPOINT" >/dev/null 2>&1 || :
+        _plu_secure_file "$_PLU_SEG_DIR/otel-start.tsv"
+      else
+        # Segmento aberto: reescreve o snapshot mais recente.
+        mkdir -p -- "$_PLU_SEG_DIR" 2>/dev/null || exit 0
+        _plu_secure_dir "$_PLU_SEG_DIR"
+        _PLU_SEG="$_PLU_CUR_SEG"
+        _PLU_PHASE="end"
+        [ -f "$_PLU_SEG_DIR/otel-start.tsv" ] || _PLU_PHASE="start"
+
+        "$_PLU_OTEL" snapshot --state-dir "$_PLU_SEG_DIR" --phase "$_PLU_PHASE" \
+          --endpoint "$_PLU_ENDPOINT" >/dev/null 2>&1 || :
+        _plu_secure_file "$_PLU_SEG_DIR/otel-$_PLU_PHASE.tsv"
+      fi
+
+      _plu_write_meta "$_PLU_SEG" "$_PLU_CREATED" || :
+    fi
+    ;;
+  *)
+    # indeterminada (2) / uso incorreto (3): no-op total (Constitution VI —
+    # nunca captura sob incerteza).
+    ;;
+esac
+
+exit 0

--- a/global/skills/agente-00c-runtime/hooks/settings.loose-usage.snippet.json
+++ b/global/skills/agente-00c-runtime/hooks/settings.loose-usage.snippet.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/posttooluse-loose-usage.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/global/skills/agente-00c-runtime/scripts/pipeline.sh
+++ b/global/skills/agente-00c-runtime/scripts/pipeline.sh
@@ -28,8 +28,10 @@
 #           review-features -> sempre passa
 #       — `briefing` e `constitution` sao artefatos PROJECT-LEVEL (uma vez por
 #         projeto, nao por feature). As skills `briefing` e `constitution`
-#         salvam em paths do `/initialize-docs` (hierarquia numerada):
-#           briefing      -> docs/01-briefing-discovery/briefing.md
+#         salvam na raiz de docs/:
+#           briefing      -> docs/briefing.md (canonico)
+#                            docs/01-briefing-discovery/briefing.md (legado,
+#                            hierarquia numerada do /initialize-docs)
 #           constitution  -> docs/constitution.md
 #         Quando `--projeto-alvo-path PAP` e passado, esses paths sao
 #         aceitos como fallback alem do feature-dir convencional. Isso
@@ -266,8 +268,9 @@ _pl_validate_tasks() {
 #
 # Fallback PAP (issue #3): briefing e constitution sao project-level. Quando
 # `--projeto-alvo-path PAP` e passado, alem do feature-dir convencional, os
-# paths do /initialize-docs sao aceitos:
-#   briefing      -> $PAP/docs/01-briefing-discovery/briefing.md
+# paths project-level sao aceitos (canonico primeiro, legado depois):
+#   briefing      -> $PAP/docs/briefing.md (canonico)
+#                    $PAP/docs/01-briefing-discovery/briefing.md (legado)
 #   constitution  -> $PAP/docs/constitution.md
 _pl_cmd_detect_completion() {
   _fd=""
@@ -292,6 +295,9 @@ _pl_cmd_detect_completion() {
       # Valida estrutura: header + >=4 secoes nucleares.
       if [ -f "$_fd/briefing.md" ]; then
         _pl_validate_briefing "$_fd/briefing.md" || return 1
+        return 0
+      elif [ -n "$_pap" ] && [ -f "$_pap/docs/briefing.md" ]; then
+        _pl_validate_briefing "$_pap/docs/briefing.md" || return 1
         return 0
       elif [ -n "$_pap" ] && [ -f "$_pap/docs/01-briefing-discovery/briefing.md" ]; then
         _pl_validate_briefing "$_pap/docs/01-briefing-discovery/briefing.md" || return 1

--- a/global/skills/briefing/SKILL.md
+++ b/global/skills/briefing/SKILL.md
@@ -27,7 +27,6 @@ Apos salvar o briefing, o fluxo sugerido e:
 
 1. `/constitution` — derivar principios de governanca a partir do briefing
 2. `/specify` — especificar as features do MVP identificadas no briefing
-3. `/initialize-docs` (se ainda nao feito) — garantir estrutura padrao de docs/
 
 ## Argumentos
 
@@ -63,7 +62,8 @@ Leia os seguintes arquivos (se existirem) para entender o que ja se sabe:
 SEMPRE LER (se existirem):
 -- README.md
 -- CLAUDE.md
--- docs/01-briefing-discovery/*.md (briefings anteriores)
+-- docs/briefing.md (briefing atual, caminho canonico)
+-- docs/01-briefing-discovery/*.md (briefings legados)
 -- docs/constitution.md
 -- docs/specs/*/spec.md (specs existentes)
 -- package.json, go.mod, pyproject.toml, Cargo.toml (stack tecnica)
@@ -71,15 +71,18 @@ SEMPRE LER (se existirem):
 
 ### 1.2 Verificar Briefing Existente
 
-Procurar briefings existentes:
-1. `docs/01-briefing-discovery/briefing.md`
-2. `docs/01-briefing-discovery/BRIEFING-*.md`
-3. `docs/briefing.md`
+Procurar briefings existentes (canonico primeiro, legado depois):
+1. `docs/briefing.md` (caminho canonico)
+2. `docs/01-briefing-discovery/briefing.md` (legado)
+3. `docs/01-briefing-discovery/BRIEFING-*.md` (legado)
 
 Se encontrado:
 - Carregar conteudo atual
 - Identificar secoes incompletas ou marcadas com TODO
 - Perguntar ao usuario: "Encontrei um briefing existente. Deseja **atualizar** ou **criar um novo**?"
+- Se encontrado APENAS no caminho legado: registrar que o salvamento
+  continuara no caminho legado (ver Etapa 6.2) — nunca mover o arquivo
+  sem o usuario pedir
 
 Se nao encontrado:
 - Seguir para entrevista completa (Etapa 2)
@@ -208,22 +211,37 @@ Deseja que eu salve este briefing? Ou ha algo a corrigir/complementar?
 
 ### 6.1 Criar Diretorio
 
-Se `docs/01-briefing-discovery/` nao existir, criar.
+Se `docs/` nao existir, criar. O briefing vive na raiz de `docs/`, ao lado
+de `constitution.md` — nao depende mais da hierarquia numerada do
+`/initialize-docs`:
+
+```
+docs/
+-- briefing.md
+-- constitution.md
+-- specs/
+```
 
 ### 6.2 Salvar Briefing
 
-Salvar em `docs/01-briefing-discovery/briefing.md`.
+Caminho canonico: `docs/briefing.md`.
 
-Se ja existe um briefing:
-- Salvar como `docs/01-briefing-discovery/briefing-[DATE].md`
-- Ou sobrescrever se usuario pediu atualizacao
+**Excecao (legado preservado)**: se ja existe
+`docs/01-briefing-discovery/briefing.md` e NAO existe `docs/briefing.md`,
+atualizar o arquivo legado no lugar — nunca mover/duplicar sem o usuario
+pedir. Se o usuario pedir migracao explicitamente, mover o arquivo para
+`docs/briefing.md` (um unico briefing canonico; nao deixar copia para tras).
+
+Se ja existe um briefing e o usuario pediu **criar um novo** (nao atualizar):
+- Salvar o novo como `briefing-[DATE].md` no MESMO diretorio do briefing
+  em uso (canonico ou legado)
 
 ### 6.3 Reportar
 
 ```markdown
 ## Briefing Salvo
 
-**Arquivo**: docs/01-briefing-discovery/briefing.md
+**Arquivo**: docs/briefing.md  (ou o caminho legado, se foi o caso)
 **Dimensoes cobertas**: [N]/7
 **Itens a definir**: [N]
 
@@ -263,7 +281,7 @@ concluido:
    # bootstrap-deps.sh — pre-flight de dependencias para evitar bloqueios
    # cirurgicos npm install no meio da pipeline agente-00c.
    #
-   # Rode UMA VEZ antes de /agente-00c (ou apos /initialize-docs).
+   # Rode UMA VEZ antes de /agente-00c.
    #
    # Gerado por: briefing skill (pre-flight de bootstrap)
    # Data: <ISO>
@@ -342,7 +360,7 @@ do `/agente-00c` NAO encontra bloqueio `npm install`.
 | `clarify` | Pode refinar ambiguidades do briefing se necessario |
 | `advisor` | Pode criticar decisoes registradas no briefing |
 | `plan` | Usa briefing como contexto tecnico de alto nivel |
-| `initialize-docs` | Cria o diretorio onde o briefing e salvo |
+| `initialize-docs` | LEGADO: criava `docs/01-briefing-discovery/` onde o briefing era salvo; hoje o briefing vive em `docs/briefing.md` |
 
 ---
 
@@ -375,3 +393,12 @@ Se o projeto e uma biblioteca interna sem usuarios finais, remover a secao "Usua
 ### Nunca reescrever em jargao tecnico
 
 Usar as palavras do usuario. Se ele disse "app de caixa", nao trocar por "sistema de ponto-de-venda transacional". O briefing preserva linguagem; o `/plan` traduz em tecnico.
+
+### Caminho canonico vs legado — nunca migrar em silencio
+
+O canonico e `docs/briefing.md`. Projetos antigos tem
+`docs/01-briefing-discovery/briefing.md` (hierarquia do `/initialize-docs`) —
+esses continuam sendo atualizados NO LUGAR, e todos os leitores do pipeline
+(detect-completion, preflight do feature-00c) aceitam os dois caminhos.
+Migrar so com pedido explicito do usuario, movendo (nao copiando): dois
+briefings vivos = fonte de verdade ambigua para constitution/specify.

--- a/global/skills/clarify/SKILL.md
+++ b/global/skills/clarify/SKILL.md
@@ -55,7 +55,8 @@ $ARGUMENTS
 
 ## Leitura de artefatos foundational (briefing + constitution)
 
-Antes de ler `docs/01-briefing-discovery/briefing.md` ou `docs/constitution.md`
+Antes de ler `docs/briefing.md` (ou o legado
+`docs/01-briefing-discovery/briefing.md`) ou `docs/constitution.md`
 direto do disco, verifique se ha cache valido populado pelo agente-00c
 ou feature-00c. Aditivo — se nao houver cache, leia direto do disco
 conforme comportamento padrao (FR-CACHE-014).

--- a/global/skills/execute-task/SKILL.md
+++ b/global/skills/execute-task/SKILL.md
@@ -41,7 +41,8 @@ $ARGUMENTS
 
 ## Leitura de artefatos foundational (briefing + constitution)
 
-Quando a tarefa em execucao precisar consultar `docs/01-briefing-discovery/briefing.md`
+Quando a tarefa em execucao precisar consultar `docs/briefing.md` (ou o
+legado `docs/01-briefing-discovery/briefing.md`)
 ou `docs/constitution.md` (por exemplo, ETAPA 1 ANALISE ou ETAPA 6 VALIDACAO
 contra MUSTs), verifique se ha cache valido populado pelo agente-00c
 ou feature-00c. Aditivo — se nao houver cache, leia direto do disco

--- a/global/skills/initialize-docs/SKILL.md
+++ b/global/skills/initialize-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: initialize-docs
-description: 'Create standard docs hierarchy (01-09 dirs, READMEs, briefing/UCs/DER/ADRs/APIs/tests/ops). Triggers: "inicializar docs", "criar estrutura docs", "setup documentacao". Skip if structure exists and no --force.'
+description: 'DEPRECATED (remocao na v7) — a hierarquia numerada 01-09 nao faz mais sentido com o SDD; layout canonico e docs/briefing.md + docs/constitution.md + docs/specs/. NAO usar em projetos novos; mantida so para projetos legados que ja tem a hierarquia. Triggers legados: "inicializar docs", "criar estrutura docs", "setup documentacao".'
 argument-hint: "[--dry-run | --force | --no-move]"
 allowed-tools:
   - Read
@@ -12,6 +12,14 @@ allowed-tools:
 ---
 
 # Skill: Inicializar Estrutura de Documentacao
+
+> **DEPRECATED — remocao planejada na v7.** A hierarquia numerada 01-09
+> deixou de fazer sentido com o pipeline SDD: o layout canonico e
+> `docs/briefing.md` + `docs/constitution.md` + `docs/specs/` (criados pelas
+> proprias skills `briefing`, `constitution` e `specify`, sem scaffold
+> previo). Esta skill NAO deve ser usada em projetos novos; permanece
+> instalavel apenas para projetos legados que ja adotam a hierarquia
+> numerada. Todo o pipeline aceita os dois layouts ate a remocao.
 
 Inicializa a estrutura padrao de documentacao do projeto, criando diretorios e arquivos de template.
 

--- a/global/skills/plan/SKILL.md
+++ b/global/skills/plan/SKILL.md
@@ -39,7 +39,8 @@ $ARGUMENTS
 
 ## Leitura de artefatos foundational (briefing + constitution)
 
-Antes de ler `docs/01-briefing-discovery/briefing.md` ou `docs/constitution.md`
+Antes de ler `docs/briefing.md` (ou o legado
+`docs/01-briefing-discovery/briefing.md`) ou `docs/constitution.md`
 direto do disco, verifique se ha cache valido populado pelo agente-00c
 ou feature-00c. Aditivo — se nao houver cache, leia direto do disco
 conforme comportamento padrao (FR-CACHE-014).

--- a/global/skills/specify/SKILL.md
+++ b/global/skills/specify/SKILL.md
@@ -38,7 +38,8 @@ $ARGUMENTS
 
 ## Leitura de artefatos foundational (briefing + constitution)
 
-Antes de ler `docs/01-briefing-discovery/briefing.md` ou `docs/constitution.md`
+Antes de ler `docs/briefing.md` (ou o legado
+`docs/01-briefing-discovery/briefing.md`) ou `docs/constitution.md`
 direto do disco, verifique se ha cache valido populado pelo agente-00c
 ou feature-00c. Aditivo — se nao houver cache, leia direto do disco
 conforme comportamento padrao (FR-CACHE-014).

--- a/tests/cstk/test_hooks.sh
+++ b/tests/cstk/test_hooks.sh
@@ -211,6 +211,87 @@ _guard_src_fixture() {
   printf '%s' "$_gsf_dir"
 }
 
+# _guard_src_fixture_with_loose: mesma fixture base + posttooluse-loose-usage.sh
+# + settings.loose-usage.snippet.json (feature loose-usage-capture task 3.3.4).
+_guard_src_fixture_with_loose() {
+  _gsfl_dir=$(_guard_src_fixture)
+  printf '#!/bin/sh\nexit 0\n' > "$_gsfl_dir/posttooluse-loose-usage.sh"
+  chmod +x "$_gsfl_dir/posttooluse-loose-usage.sh"
+  printf '{"hooks":{"PostToolUse":[{"matcher":"*","hooks":[{"type":"command","command":"loose-usage-cmd","timeout":5}]}]}}\n' \
+    > "$_gsfl_dir/settings.loose-usage.snippet.json"
+  printf '%s' "$_gsfl_dir"
+}
+
+# ==== --with-loose-usage (loose-usage-capture task 3.3) ====
+
+# Sem a flag (default 0): zero regressao — hook opt-in NAO copiado, comando
+# opt-in NAO aparece em settings.json, mesmo quando o catalogo o traz.
+scenario_apply_guard_hooks_sem_flag_nao_provisiona_loose_usage() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _src=$(_guard_src_fixture_with_loose)
+  _dest="$TMPDIR_TEST/claude-root"
+  capture sh -c ". $CSTK_LIB/hooks.sh && apply_guard_hooks '$_src' '$_dest' 0"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "apply exit" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "merged" || return 1
+  [ -f "$_dest/hooks/posttooluse-loose-usage.sh" ] \
+    && { _fail "hook opt-in provisionado sem a flag" "regressao FR-006/3.3.3"; return 1; }
+  jq -e '[.hooks.PostToolUse[] | select(.matcher=="*") | .hooks[] | select(.command=="loose-usage-cmd")] | length == 0' \
+    "$_dest/settings.json" >/dev/null \
+    || { _fail "settings.json registrou o comando opt-in sem a flag" "$(cat "$_dest/settings.json")"; return 1; }
+  return 0
+}
+
+# Com a flag: hook copiado + comando ANEXADO ao array PostToolUse[matcher="*"]
+# SEM perder o comando do tick (regressao do bug jq '*' que descarta arrays).
+scenario_apply_guard_hooks_com_flag_provisiona_e_appenda() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _src=$(_guard_src_fixture_with_loose)
+  _dest="$TMPDIR_TEST/claude-root"
+  capture sh -c ". $CSTK_LIB/hooks.sh && apply_guard_hooks '$_src' '$_dest' 0 1"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "apply exit" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "merged" || return 1
+  [ -x "$_dest/hooks/posttooluse-loose-usage.sh" ] \
+    || { _fail "hook opt-in nao copiado/executavel" ""; return 1; }
+  jq -e '[.hooks.PostToolUse[] | select(.matcher=="*") | .hooks[] | select(.command=="loose-usage-cmd")] | length == 1' \
+    "$_dest/settings.json" >/dev/null \
+    || { _fail "comando opt-in nao registrado" "$(cat "$_dest/settings.json")"; return 1; }
+  # Regressao critica: o comando do tick (base snippet, mesmo matcher "*")
+  # tem de SOBREVIVER ao append do hook opt-in.
+  jq -e '[.hooks.PostToolUse[] | select(.matcher=="*") | .hooks[] | select(.command=="y")] | length == 1' \
+    "$_dest/settings.json" >/dev/null \
+    || { _fail "comando do tick (base) foi perdido pelo append do opt-in" "$(cat "$_dest/settings.json")"; return 1; }
+  # A entrada matcher="Agent" (posttooluse-agent-usage) tambem sobrevive.
+  jq -e '[.hooks.PostToolUse[] | select(.matcher=="Agent")] | length == 1' \
+    "$_dest/settings.json" >/dev/null \
+    || { _fail "entrada matcher=Agent foi perdida" "$(cat "$_dest/settings.json")"; return 1; }
+}
+
+# Idempotencia: reinstalar com a flag nao duplica o comando no array.
+scenario_apply_guard_hooks_com_flag_idempotente() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _src=$(_guard_src_fixture_with_loose)
+  _dest="$TMPDIR_TEST/claude-root"
+  capture sh -c ". $CSTK_LIB/hooks.sh && apply_guard_hooks '$_src' '$_dest' 0 1"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "1a chamada exit" "$_CAPTURED_EXIT"; return 1; }
+  capture sh -c ". $CSTK_LIB/hooks.sh && apply_guard_hooks '$_src' '$_dest' 0 1"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "2a chamada exit" "$_CAPTURED_EXIT"; return 1; }
+  jq -e '[.hooks.PostToolUse[] | select(.matcher=="*") | .hooks[] | select(.command=="loose-usage-cmd")] | length == 1' \
+    "$_dest/settings.json" >/dev/null \
+    || { _fail "comando opt-in duplicado apos reinstalar" "$(cat "$_dest/settings.json")"; return 1; }
+}
+
+# Catalogo SEM o hook opt-in mas flag passada: best-effort, nao quebra o
+# provisionamento dos 3 hooks obrigatorios.
+scenario_apply_guard_hooks_flag_sem_catalogo_best_effort() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _src=$(_guard_src_fixture)
+  _dest="$TMPDIR_TEST/claude-root"
+  capture sh -c ". $CSTK_LIB/hooks.sh && apply_guard_hooks '$_src' '$_dest' 0 1"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "apply exit" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "merged" || return 1
+  [ -x "$_dest/hooks/pretooluse-bash-guard.sh" ] || { _fail "guard obrigatorio nao provisionado" ""; return 1; }
+}
+
 scenario_apply_guard_hooks_merged_com_jq() {
   if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
   _src=$(_guard_src_fixture)
@@ -391,6 +472,47 @@ scenario_hooks_main_install_provisiona_so_hooks() {
       && { _fail "duplicou catalogo" "$_d nao deveria existir — hooks install toca so hooks+settings"; return 1; }
   done
   return 0
+}
+
+# _hooks_catalog_fixture_with_loose: catalogo com o hook opt-in incluido.
+_hooks_catalog_fixture_with_loose() {
+  _hcfl_cat="$TMPDIR_TEST/catalog-loose"
+  _hcfl_hooks="$_hcfl_cat/skills/agente-00c-runtime/hooks"
+  mkdir -p "$_hcfl_hooks"
+  _hcfl_src=$(_guard_src_fixture_with_loose)
+  cp "$_hcfl_src"/* "$_hcfl_hooks/" 2>/dev/null || :
+  chmod +x "$_hcfl_hooks"/*.sh 2>/dev/null || :
+  printf '%s' "$_hcfl_cat"
+}
+
+# `cstk hooks install --with-loose-usage` end-to-end: hook opt-in provisionado
+# e registrado; `cstk hooks install` (sem a flag) NAO o registra.
+scenario_hooks_main_with_loose_usage_registra() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_with_loose)
+  _proj="$TMPDIR_TEST/proj-hooks-loose"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --with-loose-usage
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  [ -x "$_proj/.claude/hooks/posttooluse-loose-usage.sh" ] \
+    || { _fail "hook opt-in ausente" ""; return 1; }
+  jq -e '[.hooks.PostToolUse[] | select(.matcher=="*") | .hooks[] | select(.command=="loose-usage-cmd")] | length == 1' \
+    "$_proj/.claude/settings.json" >/dev/null \
+    || { _fail "comando opt-in nao registrado" "$(cat "$_proj/.claude/settings.json")"; return 1; }
+}
+
+scenario_hooks_main_sem_with_loose_usage_nao_registra() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_with_loose)
+  _proj="$TMPDIR_TEST/proj-hooks-no-loose"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  [ -f "$_proj/.claude/hooks/posttooluse-loose-usage.sh" ] \
+    && { _fail "hook opt-in provisionado sem a flag" "regressao"; return 1; }
+  jq -e '[.hooks.PostToolUse[] | select(.matcher=="*") | .hooks[] | select(.command=="loose-usage-cmd")] | length == 0' \
+    "$_proj/.claude/settings.json" >/dev/null \
+    || { _fail "comando opt-in registrado sem a flag" "$(cat "$_proj/.claude/settings.json")"; return 1; }
 }
 
 scenario_hooks_main_dry_run_nao_escreve() {

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -606,9 +606,9 @@ SQL
   # Aplica schema v7 via funcao real (caminho de recall_apply_schema).
   sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_mdb" || {
     _fail "apply schema v7" "recall_apply_schema falhou"; return 1; }
-  # (a) schema_version virou a corrente (12 — v12 otel-model-breakdown).
+  # (a) schema_version virou a corrente (13 — v13 loose-usage-capture).
   _sv=$(sqlite3 "$_mdb" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "12" ] || { _fail "schema_version" "esperado 12, obtido $_sv"; return 1; }
+  [ "$_sv" = "13" ] || { _fail "schema_version" "esperado 13, obtido $_sv"; return 1; }
   # (b) tabela bloqueios DROPADA; blocks (EN) criada no lugar.
   _hasbloq=$(sqlite3 "$_mdb" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='bloqueios'")
   [ "$_hasbloq" = "0" ] || { _fail "bloqueios dropada" "tabela pt-BR bloqueios sobreviveu"; return 1; }
@@ -653,7 +653,7 @@ scenario_m11b_v7_reindex_repopula() {
   _v7db="$TMPDIR_TEST/v7.db"
   _rc --reindex --states-root "$TMPDIR_TEST/rxv7" --db "$_v7db" >/dev/null 2>&1
   _sv=$(sqlite3 "$_v7db" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "12" ] || { _fail "reindex schema corrente" "esperado schema_version 12, obtido $_sv"; return 1; }
+  [ "$_sv" = "13" ] || { _fail "reindex schema corrente" "esperado schema_version 13, obtido $_sv"; return 1; }
   # decisions repopuladas em EN (2 decisoes do _write_state).
   _n=$(sqlite3 "$_v7db" "SELECT count(*) FROM decisions WHERE feature='featV7'")
   [ "$_n" = "2" ] || { _fail "reindex repopula" "esperado 2 decisoes, obtido $_n"; return 1; }
@@ -675,7 +675,7 @@ scenario_m12_ddl_idempotente() {
   sqlite3 "$_mdb" "INSERT INTO decisions(project,feature,wave,execution_id,source_ts,source_id,choice,ingested_at) VALUES('p','f','w','e','t','dec-keep','keep','now')"
   assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_mdb" || return 1
   _sv=$(sqlite3 "$_mdb" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "12" ] || { _fail "schema estavel" "esperado 12 apos 2x, obtido $_sv"; return 1; }
+  [ "$_sv" = "13" ] || { _fail "schema estavel" "esperado 13 apos 2x, obtido $_sv"; return 1; }
   _keep=$(sqlite3 "$_mdb" "SELECT count(*) FROM decisions WHERE source_id='dec-keep'")
   [ "$_keep" = "1" ] || { _fail "idempotente sem re-drop" "linha sumiu: 2o apply re-dropou ($_keep)"; return 1; }
 }
@@ -1913,7 +1913,7 @@ scenario_b11_ddl_tasks_events() {
   # v9 executions-target-path: coluna target_project_path em executions; v8
   # recall-worktree-identity: coluna session em executions/waves).
   _sv=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "12" ] || { _fail "schema_version" "esperado 12, obtido $_sv"; return 1; }
+  [ "$_sv" = "13" ] || { _fail "schema_version" "esperado 13, obtido $_sv"; return 1; }
   # tasks tem a coluna title (EN, DDL fresco).
   _hascol=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT count(*) FROM pragma_table_info('tasks') WHERE name='title'")
   [ "$_hascol" = "1" ] || { _fail "coluna title" "esperado 1, obtido $_hascol"; return 1; }
@@ -2229,7 +2229,7 @@ scenario_m1_schema_memories_table_exists() {
   # schema_version deve ser 10 (wave-token-metrics: colunas agent_* em waves)
   _ver=$(sqlite3 "$TMPDIR_TEST/m1.db" \
     "SELECT value FROM schema_meta WHERE key='schema_version';" 2>/dev/null)
-  [ "$_ver" = "12" ] || { _fail "schema_version errado" "esperado 12, obtido '$_ver'"; return 1; }
+  [ "$_ver" = "13" ] || { _fail "schema_version errado" "esperado 13, obtido '$_ver'"; return 1; }
 }
 
 # M1-enum — RECALL_TYPE_ENUM inclui 'memory' apos bump.
@@ -2319,7 +2319,7 @@ scenario_m1_migration_v3_to_current() {
   # session/target_project_path de executions e agent_* de waves vem do DDL
   # fresco pos-drop v7)
   _ver=$(sqlite3 "$_v3db" "SELECT value FROM schema_meta WHERE key='schema_version';" 2>/dev/null)
-  [ "$_ver" = "12" ] || { _fail "migration: schema_version errado" "esperado 12, obtido '$_ver'"; return 1; }
+  [ "$_ver" = "13" ] || { _fail "migration: schema_version errado" "esperado 13, obtido '$_ver'"; return 1; }
   # decisions repopuladas pelo ingest (>=1; o derivado v3 foi descartado, o
   # state.json o reconstroi em EN).
   _n=$(sqlite3 "$_v3db" "SELECT count(*) FROM decisions;" 2>/dev/null)
@@ -3069,7 +3069,7 @@ INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,i
     *) _fail "W5 waves.session" "coluna session ausente em waves pos-migracao"; return 1 ;;
   esac
   _w5_ver=$(sqlite3 "$_w5_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_w5_ver" = "12" ] || { _fail "W5 schema_version" "esperado '12' (corrente pos-v12), obtido '$_w5_ver'"; return 1; }
+  [ "$_w5_ver" = "13" ] || { _fail "W5 schema_version" "esperado '13' (corrente pos-v13), obtido '$_w5_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/w5/sd" --db "$_w5_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "W5 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3195,7 +3195,7 @@ JSON
     *) _fail "TP1d shape v9" "coluna target_project_path ausente em executions"; return 1 ;;
   esac
   _tp1_ver=$(sqlite3 "$_tp1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_tp1_ver" = "12" ] || { _fail "TP1d schema_version" "esperado 12, obtido '$_tp1_ver'"; return 1; }
+  [ "$_tp1_ver" = "13" ] || { _fail "TP1d schema_version" "esperado 13, obtido '$_tp1_ver'"; return 1; }
 }
 
 # Cenario TP2 — re-ingestao idempotente + backfill: DB v8 preexistente com
@@ -3250,7 +3250,7 @@ INSERT INTO executions(project,feature,wave,execution_id,source_ts,source_id,ses
   _tp3_new=$(sqlite3 "$_tp3_db" "SELECT target_project_path FROM executions WHERE feature='feat-tp3';")
   [ "$_tp3_new" = "/nonexistent/tp3proj" ] || { _fail "TP3 linha nova" "esperado '/nonexistent/tp3proj', obtido '$_tp3_new'"; return 1; }
   _tp3_ver=$(sqlite3 "$_tp3_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_tp3_ver" = "12" ] || { _fail "TP3 schema_version" "esperado '12', obtido '$_tp3_ver'"; return 1; }
+  [ "$_tp3_ver" = "13" ] || { _fail "TP3 schema_version" "esperado '13', obtido '$_tp3_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada, sem duplicata)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/tp3/sd" --db "$_tp3_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "TP3 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3299,7 +3299,7 @@ JSON
     *) _fail "WT1 shape v10" "coluna agent_spawns_total ausente em waves"; return 1 ;;
   esac
   _wt1_ver=$(sqlite3 "$_wt1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wt1_ver" = "12" ] || { _fail "WT1 schema_version" "esperado 12, obtido '$_wt1_ver'"; return 1; }
+  [ "$_wt1_ver" = "13" ] || { _fail "WT1 schema_version" "esperado 13, obtido '$_wt1_ver'"; return 1; }
 }
 
 # Cenario WT2 — onda SEM .agent_usage: as 9 colunas ficam NULL, nunca 0
@@ -3371,7 +3371,7 @@ JSON
   _wt3_new=$(sqlite3 "$_wt3_db" "SELECT agent_spawns_total||'|'||agent_duration_ms FROM waves WHERE feature='feat-wt3';")
   [ "$_wt3_new" = "3|4321" ] || { _fail "WT3 linha nova" "esperado '3|4321', obtido '$_wt3_new'"; return 1; }
   _wt3_ver=$(sqlite3 "$_wt3_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wt3_ver" = "12" ] || { _fail "WT3 schema_version" "esperado '12', obtido '$_wt3_ver'"; return 1; }
+  [ "$_wt3_ver" = "13" ] || { _fail "WT3 schema_version" "esperado '13', obtido '$_wt3_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada, sem duplicata)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/wt3/sd" --db "$_wt3_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT3 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3508,7 +3508,7 @@ INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,session,
   capture _rc --ingest --state-dir "$_sd" --db "$_ot_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "ingest#1" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
   _v=$(sqlite3 "$_ot_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_v" = "12" ] || { _fail "schema_version" "esperado 12, obtido '$_v'"; return 1; }
+  [ "$_v" = "13" ] || { _fail "schema_version" "esperado 13, obtido '$_v'"; return 1; }
 
   # linha v10 intacta: session preservada, coluna nova NULL (nao 0)
   _leg=$(sqlite3 "$_ot_db" "SELECT session||'|'||COALESCE(otel_cost_usd,-999) FROM waves WHERE project='legacyp10';")
@@ -3558,13 +3558,13 @@ scenario_wmu1_fresh_db_colunas_e_tabela() {
   _wmu1_tbl=$(sqlite3 "$_wmu1_db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='wave_model_usage'")
   [ "$_wmu1_tbl" = "1" ] || { _fail "wmu1 tabela" "wave_model_usage ausente em banco novo"; return 1; }
   _wmu1_ver=$(sqlite3 "$_wmu1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wmu1_ver" = "12" ] || { _fail "wmu1 schema_version" "esperado 12, obtido '$_wmu1_ver'"; return 1; }
+  [ "$_wmu1_ver" = "13" ] || { _fail "wmu1 schema_version" "esperado 13, obtido '$_wmu1_ver'"; return 1; }
   return 0
 }
 
 # Tasks 2.2.3 (idempotencia do ALTER) + 2.3.1-2.3.4 (migracao sobre banco v11
 # REAL com dado pre-existente): fixture v11 com linhas em waves/decisions/
-# tasks; apos recall_apply_schema, schema_version=12, as 8 colunas novas
+# tasks; apos recall_apply_schema, schema_version=13, as 8 colunas novas
 # existem e ficam NULL para a linha v11 (ausente, nao 0 — Principio VI),
 # wave_model_usage existe vazia (nenhuma ingestao real ainda — FASE 3), e
 # TODAS as linhas/colunas pre-existentes continuam intactas. 2a rodada
@@ -3588,7 +3588,7 @@ INSERT INTO tasks(project,feature,wave,execution_id,source_ts,source_id,title,ou
   sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_wmu2_db" || {
     _fail "wmu2 apply#1" "recall_apply_schema falhou"; return 1; }
   _wmu2_ver=$(sqlite3 "$_wmu2_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wmu2_ver" = "12" ] || { _fail "wmu2 schema_version" "esperado 12, obtido '$_wmu2_ver'"; return 1; }
+  [ "$_wmu2_ver" = "13" ] || { _fail "wmu2 schema_version" "esperado 13, obtido '$_wmu2_ver'"; return 1; }
 
   # linha v11 intacta: session/otel_cost_usd preservados, colunas novas NULL (nao 0)
   _wmu2_leg=$(sqlite3 "$_wmu2_db" "SELECT session||'|'||otel_cost_usd||'|'||COALESCE(otel_main_input_tokens,-999) FROM waves WHERE project='p11';")
@@ -4213,6 +4213,153 @@ scenario_sqldb_json_path_preservado_sem_migracao() {
   assert_exit 0 _rc --ingest --state-dir "$_d" --db "$TMPDIR_TEST/no-migrate.db" || return 1
   assert_stdout_contains "3 decisions" || return 1
   [ ! -f "$_d/state.db" ] || { _fail "no-migrate: state.db nao deveria existir" ""; return 1; }
+  return 0
+}
+
+# =========================================================================
+# FASE 2 (loose-usage-capture, v12->v13): schema/DDL/migracao APENAS — a
+# ingestao real de loose_usage (mapper sidecar -> DB) e escopo de FASE 4
+# (cli/lib/usage.sh, ainda nao implementada). Cobre tasks 2.1.4: base v12
+# populada ganha `loose_usage` vazia na proxima escrita, base nova cria o
+# schema direto em v13. Mesmo padrao de scenario_wmu1/scenario_wmu2.
+# =========================================================================
+
+# Task 2.1.4 (banco novo) — banco criado do zero ja nasce em v13: sqlite_master
+# confirma a existencia da tabela loose_usage e schema_meta confirma v13.
+scenario_lu1_fresh_db_tabela_e_versao() {
+  _have_deps || return 0
+  _lu1_db="$TMPDIR_TEST/lu1/k.db"
+  mkdir -p "$TMPDIR_TEST/lu1"
+  sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_lu1_db" || {
+    _fail "lu1 apply" "recall_apply_schema falhou em banco novo"; return 1; }
+  _lu1_tbl=$(sqlite3 "$_lu1_db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='loose_usage'")
+  [ "$_lu1_tbl" = "1" ] || { _fail "lu1 tabela" "loose_usage ausente em banco novo"; return 1; }
+  _lu1_ver=$(sqlite3 "$_lu1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
+  [ "$_lu1_ver" = "13" ] || { _fail "lu1 schema_version" "esperado 13, obtido '$_lu1_ver'"; return 1; }
+  return 0
+}
+
+# Task 2.1.4 (base v12 populada) — fixture v12 real com linhas em
+# waves/decisions/tasks. Apos recall_apply_schema: schema_version=13,
+# loose_usage existe VAZIA (nenhuma ingestao real ainda — FASE 4), e TODAS as
+# linhas/colunas pre-existentes continuam intactas. 2a rodada confirma
+# idempotencia (sem erro de tabela duplicada, sem duplicar linha) — migracao
+# e puramente aditiva (sem ALTER TABLE, sem DROP; precedente literal de
+# wave_model_usage na v11->v12).
+scenario_lu2_migracao_v12_v13_real_idempotente() {
+  _have_deps || return 0
+  _lu2_db="$TMPDIR_TEST/lu2/k.db"
+  mkdir -p "$TMPDIR_TEST/lu2"
+  sqlite3 "$_lu2_db" "
+CREATE TABLE waves (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, stages TEXT, started_at TEXT, finished_at TEXT, wallclock_seconds INTEGER, tool_calls INTEGER, termination_reason TEXT, n_stages INTEGER, n_skills INTEGER, session TEXT, otel_cost_usd REAL, otel_cost_main_usd REAL, otel_cost_subagent_usd REAL, otel_total_tokens INTEGER, otel_subagent_tokens INTEGER, agent_spawns_total INTEGER, agent_spawns_with_usage INTEGER, agent_total_tokens INTEGER, agent_input_tokens INTEGER, agent_output_tokens INTEGER, agent_cache_read_tokens INTEGER, agent_cache_creation_tokens INTEGER, agent_tool_use_count INTEGER, agent_duration_ms INTEGER, otel_main_input_tokens INTEGER, otel_main_output_tokens INTEGER, otel_main_cache_read_tokens INTEGER, otel_main_cache_creation_tokens INTEGER, otel_subagent_input_tokens INTEGER, otel_subagent_output_tokens INTEGER, otel_subagent_cache_read_tokens INTEGER, otel_subagent_cache_creation_tokens INTEGER, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE decisions (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, agent TEXT, stage TEXT, choice TEXT, score INTEGER, context TEXT, rationale TEXT, evidence TEXT, options TEXT, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE tasks (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, title TEXT, outcome TEXT, tests_run INTEGER, tests_passed INTEGER, lint_ok INTEGER, touched_files INTEGER, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE wave_model_usage (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, model TEXT, cost_usd REAL, total_tokens INTEGER, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE schema_meta (key TEXT PRIMARY KEY, value TEXT);
+INSERT INTO schema_meta VALUES('schema_version','12');
+INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,session,otel_cost_usd,ingested_at) VALUES('p12','f12','onda-1','e12','t','onda-1','sess12',0.5,'t');
+INSERT INTO decisions(project,feature,wave,execution_id,source_ts,source_id,choice,ingested_at) VALUES('p12','f12','onda-1','e12','t','dec-1','keep','t');
+INSERT INTO tasks(project,feature,wave,execution_id,source_ts,source_id,title,outcome,ingested_at) VALUES('p12','f12','onda-1','e12','t','1.1','Task 1','pass','t');
+" || { _fail "lu2 fixture v12" "criacao do DB v12 falhou"; return 1; }
+
+  # 1a rodada: migra v12 -> v13
+  sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_lu2_db" || {
+    _fail "lu2 apply#1" "recall_apply_schema falhou"; return 1; }
+  _lu2_ver=$(sqlite3 "$_lu2_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
+  [ "$_lu2_ver" = "13" ] || { _fail "lu2 schema_version" "esperado 13, obtido '$_lu2_ver'"; return 1; }
+
+  # linha v12 intacta
+  _lu2_leg=$(sqlite3 "$_lu2_db" "SELECT session||'|'||otel_cost_usd FROM waves WHERE project='p12';")
+  [ "$_lu2_leg" = "sess12|0.5" ] || { _fail "lu2 linha v12" "esperado 'sess12|0.5', obtido '$_lu2_leg'"; return 1; }
+
+  # contagens pre-existentes intactas
+  _lu2_nw=$(sqlite3 "$_lu2_db" "SELECT count(*) FROM waves;")
+  [ "$_lu2_nw" = "1" ] || { _fail "lu2 waves count" "esperado 1, obtido $_lu2_nw"; return 1; }
+  _lu2_nd=$(sqlite3 "$_lu2_db" "SELECT count(*) FROM decisions;")
+  [ "$_lu2_nd" = "1" ] || { _fail "lu2 decisions count" "esperado 1, obtido $_lu2_nd"; return 1; }
+  _lu2_nt=$(sqlite3 "$_lu2_db" "SELECT count(*) FROM tasks;")
+  [ "$_lu2_nt" = "1" ] || { _fail "lu2 tasks count" "esperado 1, obtido $_lu2_nt"; return 1; }
+
+  # loose_usage existe e esta vazia (nenhuma ingestao real ainda — FASE 4)
+  _lu2_tbl=$(sqlite3 "$_lu2_db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='loose_usage';")
+  [ "$_lu2_tbl" = "1" ] || { _fail "lu2 tabela nova" "loose_usage ausente pos-migracao"; return 1; }
+  _lu2_lurows=$(sqlite3 "$_lu2_db" "SELECT count(*) FROM loose_usage;")
+  [ "$_lu2_lurows" = "0" ] || { _fail "lu2 tabela vazia" "esperado 0 linhas, obtido $_lu2_lurows"; return 1; }
+
+  # 2a rodada: idempotente — sem erro de tabela duplicada, sem duplicar linha
+  assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_lu2_db" || return 1
+  _lu2_nw2=$(sqlite3 "$_lu2_db" "SELECT count(*) FROM waves;")
+  [ "$_lu2_nw2" = "1" ] || { _fail "lu2 idempotencia waves" "linhas mudaram para $_lu2_nw2"; return 1; }
+  return 0
+}
+
+# Task 2.2.3 — recall_prune_loose_usage (poda da camada de indice, CHK002/
+# CHK029, data-model.md §Retencao). Semeia uma linha "expirada" (captured_at
+# em 2020, muito alem de qualquer TTL razoavel) e uma "recente" (captured_at
+# = agora). Poda com TTL=90 dias remove SO a expirada e preserva a recente.
+scenario_lu3_prune_remove_expirada_preserva_recente() {
+  _have_deps || return 0
+  _lu3_db="$TMPDIR_TEST/lu3/k.db"
+  mkdir -p "$TMPDIR_TEST/lu3"
+  sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_lu3_db" || {
+    _fail "lu3 apply" "recall_apply_schema falhou"; return 1; }
+  _lu3_now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  sqlite3 "$_lu3_db" "
+INSERT INTO loose_usage(project,project_path,process_key,segment_id,model,cost_usd,total_tokens,segment_open,captured_at,ingested_at) VALUES('p-lu3','/p','proc-old','seg-001','sonnet',0.1,100,0,'2020-01-01T00:00:00Z','$_lu3_now');
+INSERT INTO loose_usage(project,project_path,process_key,segment_id,model,cost_usd,total_tokens,segment_open,captured_at,ingested_at) VALUES('p-lu3','/p','proc-new','seg-001','sonnet',0.2,200,0,'$_lu3_now','$_lu3_now');
+" || { _fail "lu3 seed" "insercao de fixture falhou"; return 1; }
+
+  _lu3_out=$(sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_prune_loose_usage "$1" "$2"' _ "$_lu3_db" 90)
+  _lu3_rc=$?
+  [ "$_lu3_rc" = "0" ] || { _fail "lu3 exit" "esperado 0, obtido $_lu3_rc"; return 1; }
+  [ "$_lu3_out" = "1" ] || { _fail "lu3 contagem removida" "esperado 1, obtido '$_lu3_out'"; return 1; }
+
+  _lu3_left=$(sqlite3 "$_lu3_db" "SELECT count(*) FROM loose_usage;")
+  [ "$_lu3_left" = "1" ] || { _fail "lu3 linhas restantes" "esperado 1, obtido $_lu3_left"; return 1; }
+  _lu3_which=$(sqlite3 "$_lu3_db" "SELECT process_key FROM loose_usage;")
+  [ "$_lu3_which" = "proc-new" ] || { _fail "lu3 linha preservada" "esperado 'proc-new', obtido '$_lu3_which'"; return 1; }
+  return 0
+}
+
+# Task 4.4.3 (paridade --dry-run) coberta na camada de indice: --dry-run
+# reporta a mesma contagem elegivel SEM remover nenhuma linha.
+scenario_lu4_prune_dry_run_nao_remove() {
+  _have_deps || return 0
+  _lu4_db="$TMPDIR_TEST/lu4/k.db"
+  mkdir -p "$TMPDIR_TEST/lu4"
+  sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_lu4_db" || {
+    _fail "lu4 apply" "recall_apply_schema falhou"; return 1; }
+  _lu4_now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  sqlite3 "$_lu4_db" "
+INSERT INTO loose_usage(project,project_path,process_key,segment_id,model,cost_usd,total_tokens,segment_open,captured_at,ingested_at) VALUES('p-lu4','/p','proc-old','seg-001','sonnet',0.1,100,0,'2020-01-01T00:00:00Z','$_lu4_now');
+" || { _fail "lu4 seed" "insercao de fixture falhou"; return 1; }
+
+  _lu4_out=$(sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_prune_loose_usage "$1" "$2" --dry-run' _ "$_lu4_db" 90)
+  [ "$_lu4_out" = "1" ] || { _fail "lu4 dry-run contagem" "esperado 1, obtido '$_lu4_out'"; return 1; }
+  _lu4_left=$(sqlite3 "$_lu4_db" "SELECT count(*) FROM loose_usage;")
+  [ "$_lu4_left" = "1" ] || { _fail "lu4 nada removido" "esperado 1 (intacta), obtido $_lu4_left"; return 1; }
+  return 0
+}
+
+# DAYS nao-numerico -> exit 1 (uso incorreto), sem tocar o banco.
+scenario_lu5_prune_dias_invalido() {
+  _have_deps || return 0
+  _lu5_db="$TMPDIR_TEST/lu5/k.db"
+  mkdir -p "$TMPDIR_TEST/lu5"
+  sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_lu5_db" || {
+    _fail "lu5 apply" "recall_apply_schema falhou"; return 1; }
+  assert_exit 1 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_prune_loose_usage "$1" "abc"' _ "$_lu5_db" 2>/dev/null || return 1
+  return 0
+}
+
+# DB inexistente -> no-op de sucesso, contagem 0 (mesma semantica de
+# recall_normalize_db_perms para arquivo ausente).
+scenario_lu6_prune_db_ausente() {
+  _have_deps || return 0
+  _lu6_out=$(sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_prune_loose_usage "$1" "$2"' _ "$TMPDIR_TEST/lu6-nao-existe/k.db" 90)
+  _lu6_rc=$?
+  [ "$_lu6_rc" = "0" ] || { _fail "lu6 exit" "esperado 0, obtido $_lu6_rc"; return 1; }
+  [ "$_lu6_out" = "0" ] || { _fail "lu6 contagem" "esperado 0, obtido '$_lu6_out'"; return 1; }
   return 0
 }
 

--- a/tests/cstk/test_usage.sh
+++ b/tests/cstk/test_usage.sh
@@ -1,0 +1,367 @@
+#!/bin/sh
+# test_usage.sh — cobre cli/lib/usage.sh (feature loose-usage-capture, task 4.5.3)
+#
+# Cenarios:
+#   1  listagem com dados (texto) + participacao
+#   2  listagem sem dados ("nao medido — sem cobertura de captura")
+#   3  --json (objeto {project, category, models[]})
+#   4  compare (loose vs pipeline, blended_cost_per_mtok)
+#   5  compare --json
+#   6  prune --dry-run (nao remove nada)
+#   7  prune real (remove segmento fechado + linha de indice)
+#   8  prune: segmento ABERTO nunca e elegivel, mesmo antigo
+#   9  flag desconhecida -> exit 2
+#   10 subcomando desconhecido -> exit 2
+#   11 --limit invalido -> exit 2
+#   12 --older-than-days nao-numerico -> exit 2
+#   13 degradacao sem sqlite3 (exit 1, listagem e prune)
+#   14 prune sem sidecar -> "nada a podar", exit 0
+#   15 ingest-on-read idempotente (UPSERT, sem duplicar linhas)
+#
+# DB de teste sempre via --db em $TMPDIR_TEST; sidecar sempre sob HOME
+# isolado (nunca ~/.claude real). otel-usage.sh e um STUB determinístico
+# (le fixture-delta.json do proprio segmento) — nao depende de telemetria
+# real nem de rede.
+#
+# Convencao do harness (assert_exit EXPECTED CMD [ARGS...]): assert_exit faz
+# a PROPRIA captura internamente — nao chamar `capture` antes (duplicaria a
+# execucao e a segunda capture, sem args, sobrescreveria _CAPTURED_EXIT com
+# o resultado de rodar nada). Ver tests/lib/harness.sh linhas 138-146.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+CSTK_LIB="$REPO_ROOT/cli/lib"
+export CSTK_LIB
+
+_have_deps() {
+  command -v sqlite3 >/dev/null 2>&1 && command -v jq >/dev/null 2>&1
+}
+
+# _uc_home HOME_DIR CMD... -> roda usage_main com HOME=HOME_DIR isolado. Quando
+# o stub de otel-usage.sh foi instalado (_install_otel_stub), antepoe
+# $TMPDIR_TEST/stubbin ao PATH -- _usage_runtime_script_path resolve por PATH
+# (camada 1) ANTES do layout de repo relativo a CSTK_LIB (camada 2), entao sem
+# isso o mapper acharia o otel-usage.sh REAL da arvore do repo (CSTK_LIB
+# aponta pro repo em dev) em vez do stub deterministico.
+_uc_home() {
+  _uch_home="$1"; shift
+  env PATH="$TMPDIR_TEST/stubbin:$PATH" HOME="$_uch_home" \
+    sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/usage.sh"; usage_main "$@"' _ "$@"
+}
+
+# _install_otel_stub -> instala o stub deterministico de otel-usage.sh em
+# $TMPDIR_TEST/stubbin (resolvido via PATH, camada 1 de
+# _usage_runtime_script_path -- precisa vencer a camada 2/repo). O stub le
+# <state-dir>/fixture-delta.json (JSON literal, inclusive "null") e o ecoa;
+# ausencia de fixture -> "null".
+_install_otel_stub() {
+  mkdir -p "$TMPDIR_TEST/stubbin"
+  cat > "$TMPDIR_TEST/stubbin/otel-usage.sh" <<'STUB'
+#!/bin/sh
+case "$1" in
+  delta)
+    shift
+    _sd=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --state-dir) shift; _sd="$1" ;;
+      esac
+      shift || break
+    done
+    if [ -n "$_sd" ] && [ -f "$_sd/fixture-delta.json" ]; then
+      cat "$_sd/fixture-delta.json"
+    else
+      printf 'null\n'
+    fi
+    ;;
+  *) printf 'null\n' ;;
+esac
+STUB
+  chmod +x "$TMPDIR_TEST/stubbin/otel-usage.sh"
+}
+
+# _write_meta PROC_DIR PROJECT_PATH CUR_SEG -> meta.tsv sintetico (formato
+# real do hook posttooluse-loose-usage.sh: chave<TAB>valor).
+_write_meta() {
+  _wm_dir="$1"; _wm_proj="$2"; _wm_seg="$3"
+  mkdir -p "$_wm_dir"
+  {
+    printf 'schema\t1\n'
+    printf 'project_path\t%s\n' "$_wm_proj"
+    printf 'endpoint\thttp://127.0.0.1:9464\n'
+    printf 'owner_pid\tunknown\n'
+    printf 'created_at\t2026-01-01T00:00:00Z\n'
+    printf 'updated_at\t2026-01-01T00:05:00Z\n'
+    printf 'current_segment\t%s\n' "$_wm_seg"
+  } > "$_wm_dir/meta.tsv"
+}
+
+# _write_segment PROC_DIR SEG_ID CLOSED(0|1) MODEL COST TOKENS -> cria o
+# diretorio do segmento com otel-start.tsv, closed opcional e
+# fixture-delta.json (consumido pelo stub). MODEL vazio -> fixture "null"
+# (segmento sem medicao, nao gera linha em loose_usage).
+_write_segment() {
+  _ws_proc="$1"; _ws_seg="$2"; _ws_closed="$3"; _ws_model="$4"; _ws_cost="$5"; _ws_tok="$6"
+  _ws_dir="$_ws_proc/$_ws_seg"
+  mkdir -p "$_ws_dir"
+  : > "$_ws_dir/otel-start.tsv"
+  if [ "$_ws_closed" = "1" ]; then
+    : > "$_ws_dir/closed"
+  else
+    : > "$_ws_dir/otel-end.tsv"
+  fi
+  if [ -n "$_ws_model" ]; then
+    printf '{"session_id":"s1","total_cost_usd":%s,"total_tokens":%s,"by_model":{"%s":{"cost_usd":%s,"total_tokens":%s}}}\n' \
+      "$_ws_cost" "$_ws_tok" "$_ws_model" "$_ws_cost" "$_ws_tok" > "$_ws_dir/fixture-delta.json"
+  else
+    printf 'null\n' > "$_ws_dir/fixture-delta.json"
+  fi
+}
+
+# _seed_pipeline DB PROJECT MODEL COST TOKENS -> insere uma linha sintetica
+# em wave_model_usage (schema ja existente, alimentada normalmente pela
+# ingestao de state.json/db — aqui semeada direto via sqlite3 por SER
+# FIXTURE DE TESTE, nao codigo de producao; usage.sh continua proibido de
+# chamar sqlite3, essa chamada vive so no arquivo de teste).
+_seed_pipeline() {
+  _sp_db="$1"; _sp_proj="$2"; _sp_model="$3"; _sp_cost="$4"; _sp_tok="$5"
+  sqlite3 -- "$_sp_db" "INSERT INTO wave_model_usage(project,feature,wave,execution_id,source_ts,source_id,model,cost_usd,total_tokens,ingested_at) VALUES('$_sp_proj','featX','onda-001','exec-1','2026-01-01T00:00:00Z','onda-001|$_sp_model','$_sp_model',$_sp_cost,$_sp_tok,'2026-01-01T00:00:00Z');" \
+    >/dev/null 2>&1
+}
+
+# =========================================================================
+# Cenario 1 — Listagem com dados (texto) + participacao
+# =========================================================================
+scenario_01_listagem_com_dados() {
+  _have_deps || return 0
+  _install_otel_stub
+  _proc="$TMPDIR_TEST/.claude/cstk/loose-usage/proj1-abc"
+  _write_meta "$_proc" "/home/dev/proj1" "seg-001"
+  _write_segment "$_proc" "seg-001" 0 "claude-sonnet-5" "0.10" "2000"
+
+  assert_exit 0 _uc_home "$TMPDIR_TEST" --project proj1 --db "$TMPDIR_TEST/k1.db" || return 1
+  assert_stdout_contains "projeto: proj1" || return 1
+  assert_stdout_contains "claude-sonnet-5" || return 1
+  assert_stdout_contains "tokens=2000" || return 1
+  assert_stdout_contains "participacao=100.0%" || return 1
+}
+
+# =========================================================================
+# Cenario 2 — Listagem sem dados (cobertura ausente)
+# =========================================================================
+scenario_02_listagem_sem_dados() {
+  _have_deps || return 0
+  _install_otel_stub
+  assert_exit 0 _uc_home "$TMPDIR_TEST" --project projeto-fantasma --db "$TMPDIR_TEST/k2.db" || return 1
+  assert_stdout_contains "nao medido" || return 1
+}
+
+# =========================================================================
+# Cenario 3 — --json
+# =========================================================================
+scenario_03_json() {
+  _have_deps || return 0
+  _install_otel_stub
+  _proc="$TMPDIR_TEST/.claude/cstk/loose-usage/proj3-abc"
+  _write_meta "$_proc" "/home/dev/proj3" "seg-001"
+  _write_segment "$_proc" "seg-001" 0 "claude-opus-4" "0.25" "5000"
+
+  assert_exit 0 _uc_home "$TMPDIR_TEST" --project proj3 --json --db "$TMPDIR_TEST/k3.db" || return 1
+  assert_stdout_contains '"category": "loose"' || return 1
+  assert_stdout_contains '"model": "claude-opus-4"' || return 1
+  assert_stdout_contains '"total_tokens": 5000' || return 1
+  printf '%s' "$_CAPTURED_STDOUT" | jq -e . >/dev/null 2>&1 || {
+    _fail "json_valido" "saida --json nao e JSON parseavel"
+    return 1
+  }
+}
+
+# =========================================================================
+# Cenario 4 — compare (loose vs pipeline)
+# =========================================================================
+scenario_04_compare() {
+  _have_deps || return 0
+  _install_otel_stub
+  _proc="$TMPDIR_TEST/.claude/cstk/loose-usage/proj4-abc"
+  _write_meta "$_proc" "/home/dev/proj4" "seg-001"
+  _write_segment "$_proc" "seg-001" 0 "claude-sonnet-5" "0.10" "1000000"
+
+  _db="$TMPDIR_TEST/k4.db"
+  # Primeiro roda a listagem para o ingest-on-read aplicar o schema + popular
+  # loose_usage; so entao semeamos a linha de pipeline no mesmo DB.
+  assert_exit 0 _uc_home "$TMPDIR_TEST" --project proj4 --db "$_db" || return 1
+  _seed_pipeline "$_db" "proj4" "claude-sonnet-5" "0.20" "2000000"
+
+  assert_exit 0 _uc_home "$TMPDIR_TEST" compare --project proj4 --db "$_db" || return 1
+  assert_stdout_contains "== loose ==" || return 1
+  assert_stdout_contains "== pipeline ==" || return 1
+  # cost=0.10 / tokens=1_000_000 * 1e6 = 0.10 (mesma proporcao no pipeline:
+  # 0.20 / 2_000_000 * 1e6 = 0.10) -- as duas categorias tem o MESMO blended.
+  assert_stdout_contains "blended_cost_per_mtok=0.100000" || return 1
+}
+
+# =========================================================================
+# Cenario 5 — compare --json
+# =========================================================================
+scenario_05_compare_json() {
+  _have_deps || return 0
+  _install_otel_stub
+  _proc="$TMPDIR_TEST/.claude/cstk/loose-usage/proj5-abc"
+  _write_meta "$_proc" "/home/dev/proj5" "seg-001"
+  _write_segment "$_proc" "seg-001" 0 "claude-haiku" "0.01" "100000"
+
+  _db="$TMPDIR_TEST/k5.db"
+  assert_exit 0 _uc_home "$TMPDIR_TEST" --project proj5 --db "$_db" || return 1
+
+  assert_exit 0 _uc_home "$TMPDIR_TEST" compare --project proj5 --json --db "$_db" || return 1
+  assert_stdout_contains '"category": "loose"' || return 1
+  assert_stdout_contains '"category": "pipeline"' || return 1
+  printf '%s' "$_CAPTURED_STDOUT" | jq -e . >/dev/null 2>&1 || {
+    _fail "compare_json_valido" "saida --json de compare nao e JSON parseavel"
+    return 1
+  }
+}
+
+# =========================================================================
+# Cenario 6 — prune --dry-run (nao remove nada)
+# =========================================================================
+scenario_06_prune_dry_run() {
+  _have_deps || return 0
+  _proc="$TMPDIR_TEST/.claude/cstk/loose-usage/proj6-old"
+  _write_meta "$_proc" "/home/dev/proj6" "seg-001"
+  _write_segment "$_proc" "seg-001" 1 "claude-sonnet-5" "0.05" "500"
+  # Envelhece os arquivos do segmento (closed + otel-start) alem do TTL.
+  touch -t 202401010000 "$_proc/seg-001/closed" "$_proc/seg-001/otel-start.tsv"
+
+  assert_exit 0 _uc_home "$TMPDIR_TEST" prune --dry-run --older-than-days 1 --db "$TMPDIR_TEST/k6.db" || return 1
+  assert_stdout_contains "action=would-remove process_key=proj6-old segment=seg-001" || return 1
+
+  if [ ! -d "$_proc/seg-001" ]; then
+    _fail "dry_run_nao_remove" "dry-run removeu o segmento do sidecar"
+    return 1
+  fi
+}
+
+# =========================================================================
+# Cenario 7 — prune real (remove segmento + linha de indice)
+# =========================================================================
+scenario_07_prune_real() {
+  _have_deps || return 0
+  _install_otel_stub
+  _proc="$TMPDIR_TEST/.claude/cstk/loose-usage/proj7-old"
+  _write_meta "$_proc" "/home/dev/proj7" "seg-001"
+  _write_segment "$_proc" "seg-001" 1 "claude-sonnet-5" "0.05" "500"
+  touch -t 202401010000 "$_proc/seg-001/closed" "$_proc/seg-001/otel-start.tsv"
+
+  _db="$TMPDIR_TEST/k7.db"
+  # Popula loose_usage via ingest-on-read (usa o mtime ANTIGO ja carimbado
+  # acima como captured_at) antes de podar.
+  assert_exit 0 _uc_home "$TMPDIR_TEST" --project proj7 --db "$_db" || return 1
+  _n_before=$(sqlite3 -- "$_db" "SELECT count(*) FROM loose_usage WHERE process_key='proj7-old';" 2>/dev/null)
+  [ "$_n_before" = "1" ] || { _fail "seed_loose_usage" "esperado 1 linha antes da poda, obtido $_n_before"; return 1; }
+
+  assert_exit 0 _uc_home "$TMPDIR_TEST" prune --older-than-days 1 --db "$_db" || return 1
+  assert_stdout_contains "action=removed process_key=proj7-old segment=seg-001" || return 1
+
+  if [ -d "$_proc/seg-001" ]; then
+    _fail "prune_real_remove_fs" "segmento nao foi removido do sidecar"
+    return 1
+  fi
+  _n_after=$(sqlite3 -- "$_db" "SELECT count(*) FROM loose_usage WHERE process_key='proj7-old';" 2>/dev/null)
+  [ "$_n_after" = "0" ] || { _fail "prune_real_remove_db" "esperado 0 linhas apos poda, obtido $_n_after"; return 1; }
+}
+
+# =========================================================================
+# Cenario 8 — segmento ABERTO nunca e elegivel para poda, mesmo antigo
+# =========================================================================
+scenario_08_prune_segmento_aberto_nao_elegivel() {
+  _have_deps || return 0
+  _proc="$TMPDIR_TEST/.claude/cstk/loose-usage/proj8-open"
+  _write_meta "$_proc" "/home/dev/proj8" "seg-001"
+  _write_segment "$_proc" "seg-001" 0 "claude-sonnet-5" "0.05" "500"
+  touch -t 202401010000 "$_proc/seg-001/otel-start.tsv" "$_proc/seg-001/otel-end.tsv"
+
+  assert_exit 0 _uc_home "$TMPDIR_TEST" prune --dry-run --older-than-days 1 --db "$TMPDIR_TEST/k8.db" || return 1
+  assert_stdout_contains "nada a podar" || return 1
+}
+
+# =========================================================================
+# Cenario 9 — flag desconhecida -> exit 2
+# =========================================================================
+scenario_09_flag_desconhecida() {
+  assert_exit 2 _uc_home "$TMPDIR_TEST" --bogus || return 1
+}
+
+# =========================================================================
+# Cenario 10 — subcomando desconhecido -> exit 2
+# =========================================================================
+scenario_10_subcomando_desconhecido() {
+  assert_exit 2 _uc_home "$TMPDIR_TEST" frobnicate || return 1
+}
+
+# =========================================================================
+# Cenario 11 — --limit invalido -> exit 2
+# =========================================================================
+scenario_11_limit_invalido() {
+  assert_exit 2 _uc_home "$TMPDIR_TEST" --limit abc || return 1
+}
+
+# =========================================================================
+# Cenario 12 — --older-than-days nao-numerico -> exit 2
+# =========================================================================
+scenario_12_older_than_days_invalido() {
+  assert_exit 2 _uc_home "$TMPDIR_TEST" prune --older-than-days abc || return 1
+}
+
+# =========================================================================
+# Cenario 13 — Degradacao sem sqlite3 (exit 1)
+# =========================================================================
+scenario_13_sem_sqlite3() {
+  _bin="$TMPDIR_TEST/bin13"
+  mkdir -p "$_bin"
+  for _t in tr wc printf sed grep awk basename dirname date find mkdir rm cat head sleep cp jq stat mktemp sh; do
+    _p=$(command -v "$_t" 2>/dev/null) && ln -sf "$_p" "$_bin/$_t"
+  done
+  # (sqlite3 deliberadamente ausente)
+  assert_exit 1 env PATH="$_bin" HOME="$TMPDIR_TEST" sh -c \
+    '. "'"$CSTK_LIB"'/common.sh"; . "'"$CSTK_LIB"'/usage.sh"; usage_main --project x' || return 1
+  assert_stderr_contains "sqlite3" || return 1
+
+  assert_exit 1 env PATH="$_bin" HOME="$TMPDIR_TEST" sh -c \
+    '. "'"$CSTK_LIB"'/common.sh"; . "'"$CSTK_LIB"'/usage.sh"; usage_main prune' || return 1
+  assert_stderr_contains "sqlite3" || return 1
+}
+
+# =========================================================================
+# Cenario 14 — prune sem sidecar -> "nada a podar", exit 0
+# =========================================================================
+scenario_14_prune_sem_sidecar() {
+  _have_deps || return 0
+  _home_vazio="$TMPDIR_TEST/home-vazio"
+  mkdir -p "$_home_vazio"
+  assert_exit 0 _uc_home "$_home_vazio" prune --db "$TMPDIR_TEST/k14.db" || return 1
+  assert_stdout_contains "nada a podar" || return 1
+}
+
+# =========================================================================
+# Cenario 15 — ingest-on-read idempotente (sem duplicar linhas)
+# =========================================================================
+scenario_15_ingest_idempotente() {
+  _have_deps || return 0
+  _install_otel_stub
+  _proc="$TMPDIR_TEST/.claude/cstk/loose-usage/proj15-abc"
+  _write_meta "$_proc" "/home/dev/proj15" "seg-001"
+  _write_segment "$_proc" "seg-001" 0 "claude-sonnet-5" "0.10" "2000"
+
+  _db="$TMPDIR_TEST/k15.db"
+  assert_exit 0 _uc_home "$TMPDIR_TEST" --project proj15 --db "$_db" || return 1
+  assert_exit 0 _uc_home "$TMPDIR_TEST" --project proj15 --db "$_db" || return 1
+
+  _n=$(sqlite3 -- "$_db" "SELECT count(*) FROM loose_usage WHERE process_key='proj15-abc';" 2>/dev/null)
+  [ "$_n" = "1" ] || { _fail "ingest_idempotente" "esperado 1 linha apos 2 ingest-on-read, obtido $_n"; return 1; }
+}
+
+run_all_scenarios

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -361,6 +361,13 @@ _is_internal_test() {
       # Existence-guarded.
       [ -f "$REPO_ROOT/global/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh" ] && return 0
       return 1 ;;
+    test_posttooluse-loose-usage.sh)
+      # cobre global/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh
+      # (hook PostToolUse OPT-IN de captura de consumo avulso — feature
+      # loose-usage-capture FASE 3) — mesma razao dos 3 casos acima: hooks/
+      # esta fora do escaneio por convencao. Existence-guarded.
+      [ -f "$REPO_ROOT/global/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh" ] && return 0
+      return 1 ;;
     *) return 1 ;;
   esac
 }

--- a/tests/test_pipeline.sh
+++ b/tests/test_pipeline.sh
@@ -163,6 +163,43 @@ scenario_detect_completion_briefing_aceita_path_initialize_docs() {
   }
 }
 
+# ==== Briefing canonico em docs/briefing.md (legado 01-briefing-discovery preservado) ====
+scenario_detect_completion_briefing_aceita_path_canonico_docs() {
+  _fd="$TMPDIR_TEST/feat-canon"
+  _pap="$TMPDIR_TEST/pap-canon"
+  mkdir -p "$_fd" "$_pap/docs"
+
+  # Briefing SO em docs/briefing.md (canonico) -> exit 0 (com PAP)
+  _write_briefing_valido "$_pap/docs/briefing.md"
+  capture "$SCRIPT" detect-completion --feature-dir "$_fd" --stage briefing \
+    --projeto-alvo-path "$_pap"
+  [ "$_CAPTURED_EXIT" = 0 ] || {
+    _fail "briefing canonico em PAP" "esperado 0, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"
+    return 1
+  }
+
+  # Precedencia: canonico INVALIDO vence o legado valido -> exit 1
+  # (prova que docs/briefing.md e checado antes do path legado)
+  mkdir -p "$_pap/docs/01-briefing-discovery"
+  _write_briefing_valido "$_pap/docs/01-briefing-discovery/briefing.md"
+  printf '# so header, sem secoes\n' > "$_pap/docs/briefing.md"
+  capture "$SCRIPT" detect-completion --feature-dir "$_fd" --stage briefing \
+    --projeto-alvo-path "$_pap"
+  [ "$_CAPTURED_EXIT" = 1 ] || {
+    _fail "precedencia canonico sobre legado" "esperado 1, obtido $_CAPTURED_EXIT"
+    return 1
+  }
+
+  # Canonico valido + legado valido -> exit 0 (canonico usado)
+  _write_briefing_valido "$_pap/docs/briefing.md"
+  capture "$SCRIPT" detect-completion --feature-dir "$_fd" --stage briefing \
+    --projeto-alvo-path "$_pap"
+  [ "$_CAPTURED_EXIT" = 0 ] || {
+    _fail "canonico+legado validos" "esperado 0, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"
+    return 1
+  }
+}
+
 # ==== Issue #3: constitution aceita docs/constitution.md via --projeto-alvo-path ====
 scenario_detect_completion_constitution_aceita_path_initialize_docs() {
   _fd="$TMPDIR_TEST/feat"

--- a/tests/test_posttooluse-loose-usage.sh
+++ b/tests/test_posttooluse-loose-usage.sh
@@ -1,0 +1,286 @@
+#!/bin/sh
+# test_posttooluse-loose-usage.sh — cobre
+# global/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh
+# (hook PostToolUse OPT-IN de captura de consumo avulso).
+#
+# Contrato sob teste: docs/specs/loose-usage-capture/contracts/hook-loose-usage.md
+#
+# Fail-OPEN absoluto (mesma politica do molde posttooluse-tool-call-tick.sh):
+# o hook NUNCA sai com exit != 0, NUNCA emite stdout/stderr, e o UNICO efeito
+# permitido e escrita sob $HOME/.claude/cstk/loose-usage/. POLARIDADE
+# INVERTIDA (dec-006) frente ao molde: aqui a captura acontece quando NAO ha
+# execucao 00c ativa; quando ha, o hook so FECHA o segmento aberto.
+#
+# CRITICO: toda invocacao do hook nesta suite isola HOME em $TMPDIR_TEST —
+# o script escreve sob $HOME/.claude/cstk/loose-usage/ e sem isolamento
+# poluiria o home real da maquina.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/global/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh"
+
+# Endpoint que falha rapido (nada escuta) — nunca precisa de exporter real;
+# curl --max-time 3 contra porta fechada retorna connection-refused quase
+# instantaneo (nao espera o teto).
+_FAKE_ENDPOINT="http://127.0.0.1:19999/metrics"
+
+# _run_hook JSON -> invoca o script com JSON via stdin, HOME isolado em
+# $TMPDIR_TEST; herda o restante do ambiente (inclusive vars exportadas
+# pelo scenario, ex: CSTK_OTEL_ENDPOINT/CSTK_LOOSE_USAGE_INTERVAL_S).
+_run_hook() {
+  capture env HOME="$TMPDIR_TEST" sh -c 'printf "%s" "$1" | "$2"' _ "$1" "$SCRIPT"
+}
+
+# _json_for CWD TOOL -> payload PostToolUse minimo do harness.
+_json_for() {
+  printf '{"cwd":"%s","hook_event_name":"PostToolUse","tool_name":"%s","tool_input":{}}' "$1" "$2"
+}
+
+# _require_jq -> ERROR (skip) se jq indisponivel neste ambiente de teste.
+_require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  _error "no_jq" "jq indisponivel neste ambiente de teste"
+  return 1
+}
+
+# _require_sqlite3 -> ERROR (skip) se sqlite3 indisponivel.
+_require_sqlite3() {
+  command -v sqlite3 >/dev/null 2>&1 && return 0
+  _error "no_sqlite3" "sqlite3 indisponivel neste ambiente de teste"
+  return 1
+}
+
+# _make_shim_path_no_jq: PATH controlado com POSIX essenciais + lsof/curl,
+# SEM jq. Espelha o padrao de test_posttooluse-tool-call-tick.sh
+# (_make_shim_path) com o binario extra que este hook usa (cksum).
+_make_shim_path_no_jq() {
+  _shim="$TMPDIR_TEST/shimbin"
+  mkdir -p "$_shim"
+  for _cmd in sh mktemp awk sed grep find head printf cp mv rm mkdir \
+              chmod ls dirname basename tr cut wc env command sort \
+              uniq date cat cksum lsof curl; do
+    _src=$(command -v "$_cmd" 2>/dev/null) || continue
+    [ -n "$_src" ] || continue
+    ln -sf "$_src" "$_shim/$_cmd" 2>/dev/null || :
+  done
+  printf '%s' "$_shim"
+}
+
+# _loose_usage_root -> path do diretorio raiz do sidecar dentro do HOME
+# isolado desta scenario.
+_loose_usage_root() { printf '%s/.claude/cstk/loose-usage' "$TMPDIR_TEST"; }
+
+# _find_meta_files -> lista meta.tsv sob a raiz isolada (0 ou mais linhas).
+_find_meta_files() {
+  find "$(_loose_usage_root)" -name 'meta.tsv' 2>/dev/null
+}
+
+# _file_mode PATH -> modo octal, portavel BSD/GNU (paridade tests/cstk/test_recall.sh).
+_file_mode() {
+  stat -c '%a' -- "$1" 2>/dev/null || stat -f '%Lp' -- "$1" 2>/dev/null
+}
+
+# _meta_get FILE FIELD -> valor da chave em meta.tsv.
+_meta_get() {
+  awk -F '\t' -v k="$2" '$1==k {print $2}' "$1" 2>/dev/null
+}
+
+# _active_agente_json CWD STATUS -> fixture agente-00c-state (backend JSON).
+_active_agente_json() {
+  mkdir -p "$1/.claude/agente-00c-state"
+  printf '{"execution":{"status":"%s"}}' "$2" > "$1/.claude/agente-00c-state/state.json"
+}
+
+# ==== Cenario 1 (3.1.7): CSTK_OTEL_ENDPOINT ausente -> no-op total ====
+
+scenario_endpoint_ausente_no_op() {
+  unset CSTK_OTEL_ENDPOINT 2>/dev/null || :
+  _run_hook "$(_json_for "$TMPDIR_TEST" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio: $_CAPTURED_STDOUT"; return 1; }
+  [ -z "$_CAPTURED_STDERR" ] || { _fail "stderr" "esperado vazio: $_CAPTURED_STDERR"; return 1; }
+  [ -d "$(_loose_usage_root)" ] && { _fail "sidecar" "sem endpoint NAO deveria criar diretorio algum"; return 1; }
+  return 0
+}
+
+# ==== Cenario 2 (3.1.7): jq ausente -> no-op (fail-open, dep opcional) ====
+
+scenario_jq_ausente_no_op() {
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  _shim=$(_make_shim_path_no_jq)
+  _json=$(_json_for "$TMPDIR_TEST" "Bash")
+  capture env -i PATH="$_shim" HOME="$TMPDIR_TEST" CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT" \
+    sh -c 'printf "%s" "$1" | "$2"' _ "$_json" "$SCRIPT"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "fail-open exige exit 0 sem jq, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio: $_CAPTURED_STDOUT"; return 1; }
+  [ -d "$(_loose_usage_root)" ] && { _fail "sidecar" "sem jq nao ha parse seguro -> sem captura"; return 1; }
+  return 0
+}
+
+# ==== Cenario 3 (3.1.7): payload sem .cwd -> no-op ====
+
+scenario_payload_sem_cwd_no_op() {
+  _require_jq || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  _run_hook '{"hook_event_name":"PostToolUse","tool_name":"Bash"}'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -d "$(_loose_usage_root)" ] && { _fail "sidecar" "payload sem cwd nao pode gerar captura"; return 1; }
+  return 0
+}
+
+# ==== Cenario 3b (3.1.7): payload sem .tool_name -> no-op ====
+
+scenario_payload_sem_tool_name_no_op() {
+  _require_jq || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  _run_hook "{\"cwd\":\"$TMPDIR_TEST\",\"hook_event_name\":\"PostToolUse\"}"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -d "$(_loose_usage_root)" ] && { _fail "sidecar" "payload sem tool_name nao pode gerar captura"; return 1; }
+  return 0
+}
+
+# ==== Cenario 4 (3.1.7): execucao INATIVA -> captura (processo novo) ====
+
+scenario_execucao_inativa_captura_processo_novo() {
+  _require_jq || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  _proj="$TMPDIR_TEST/proj"
+  mkdir -p "$_proj"
+  _run_hook "$(_json_for "$_proj" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio: $_CAPTURED_STDOUT"; return 1; }
+  [ -z "$_CAPTURED_STDERR" ] || { _fail "stderr" "esperado vazio: $_CAPTURED_STDERR"; return 1; }
+  _meta=$(_find_meta_files)
+  [ -n "$_meta" ] || { _fail "sidecar" "esperado meta.tsv criado sob $(_loose_usage_root)"; return 1; }
+  [ "$(printf '%s\n' "$_meta" | wc -l | tr -d ' ')" = 1 ] || { _fail "sidecar" "esperado exatamente 1 meta.tsv, obtido: $_meta"; return 1; }
+  _seg=$(_meta_get "$_meta" current_segment)
+  [ "$_seg" = "seg-001" ] || { _fail "segmento" "esperado current_segment=seg-001, obtido: $_seg"; return 1; }
+  _procdir=$(dirname "$_meta")
+  [ -d "$_procdir/seg-001" ] || { _fail "segmento" "diretorio seg-001 nao foi criado"; return 1; }
+  _owner=$(_meta_get "$_meta" owner_pid)
+  [ -n "$_owner" ] || { _fail "owner_pid" "campo owner_pid ausente (deveria ser PID ou 'unknown', nunca vazio)"; return 1; }
+  return 0
+}
+
+# ==== Cenario 5 (3.1.7): throttle nao vencido -> no-op (updated_at intacto) ====
+
+scenario_throttle_nao_vencido_no_op() {
+  _require_jq || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  _proj="$TMPDIR_TEST/proj"
+  mkdir -p "$_proj"
+  # Primeira captura, sem throttle (interval=0 forca passagem imediata).
+  export CSTK_LOOSE_USAGE_INTERVAL_S=0
+  _run_hook "$(_json_for "$_proj" "Bash")"
+  _meta=$(_find_meta_files)
+  [ -n "$_meta" ] || { _error "fixture" "primeira captura nao produziu meta.tsv"; return 2; }
+  _updated_before=$(_meta_get "$_meta" updated_at)
+
+  # Segunda invocacao: interval default (300s) reimposto -> throttle ativo.
+  unset CSTK_LOOSE_USAGE_INTERVAL_S 2>/dev/null || :
+  _run_hook "$(_json_for "$_proj" "Read")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _updated_after=$(_meta_get "$_meta" updated_at)
+  [ "$_updated_before" = "$_updated_after" ] || { _fail "throttle" "updated_at mudou apesar do throttle (antes=$_updated_before depois=$_updated_after)"; return 1; }
+  [ ! -d "$(dirname "$_meta")/seg-002" ] || { _fail "throttle" "novo segmento nao deveria ter sido criado sob throttle"; return 1; }
+  return 0
+}
+
+# ==== Cenario 6 (3.1.7): execucao ATIVA -> fecha segmento, nao captura ====
+
+scenario_execucao_ativa_fecha_segmento() {
+  _require_jq || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  _proj="$TMPDIR_TEST/proj"
+  mkdir -p "$_proj"
+
+  # Abre um segmento primeiro (execucao inativa, throttle desarmado).
+  export CSTK_LOOSE_USAGE_INTERVAL_S=0
+  _run_hook "$(_json_for "$_proj" "Bash")"
+  _meta=$(_find_meta_files)
+  [ -n "$_meta" ] || { _error "fixture" "captura inicial nao produziu meta.tsv"; return 2; }
+  _procdir=$(dirname "$_meta")
+  [ ! -f "$_procdir/seg-001/closed" ] || { _error "fixture" "segmento ja nasceu fechado (inesperado)"; return 2; }
+  _updated_before=$(_meta_get "$_meta" updated_at)
+
+  # Agora marca execucao 00c ATIVA no mesmo cwd e dispara novo tick.
+  _active_agente_json "$_proj" "em_andamento"
+  _run_hook "$(_json_for "$_proj" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio: $_CAPTURED_STDOUT"; return 1; }
+  [ -f "$_procdir/seg-001/closed" ] || { _fail "fechamento" "esperado marcador 'closed' em seg-001 apos tick ativo"; return 1; }
+  [ ! -d "$_procdir/seg-002" ] || { _fail "fechamento" "execucao ativa NAO deveria abrir seg-002 (so fecha, nao captura)"; return 1; }
+  _updated_after=$(_meta_get "$_meta" updated_at)
+  [ "$_updated_before" = "$_updated_after" ] || { _fail "fechamento" "updated_at NAO deveria mudar ao fechar (fechar nao e captura)"; return 1; }
+  return 0
+}
+
+# ==== Cenario 7 (3.1.7): fechado + INATIVA -> abre novo segmento ====
+
+scenario_segmento_fechado_reabre_novo() {
+  _require_jq || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  _proj="$TMPDIR_TEST/proj"
+  mkdir -p "$_proj"
+
+  export CSTK_LOOSE_USAGE_INTERVAL_S=0
+  _run_hook "$(_json_for "$_proj" "Bash")"
+  _meta=$(_find_meta_files)
+  [ -n "$_meta" ] || { _error "fixture" "captura inicial nao produziu meta.tsv"; return 2; }
+  _procdir=$(dirname "$_meta")
+
+  _active_agente_json "$_proj" "em_andamento"
+  _run_hook "$(_json_for "$_proj" "Bash")"
+  [ -f "$_procdir/seg-001/closed" ] || { _error "fixture" "fechamento do seg-001 nao ocorreu"; return 2; }
+
+  # Remove a fixture de execucao ativa -> volta a inativa.
+  rm -rf "$_proj/.claude/agente-00c-state"
+  _run_hook "$(_json_for "$_proj" "Write")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -d "$_procdir/seg-002" ] || { _fail "reabertura" "esperado novo segmento seg-002 apos fechamento"; return 1; }
+  _seg=$(_meta_get "$_meta" current_segment)
+  [ "$_seg" = "seg-002" ] || { _fail "reabertura" "esperado current_segment=seg-002, obtido: $_seg"; return 1; }
+  return 0
+}
+
+# ==== Cenario 8 (3.1.7): estado indeterminada (state.db corrompido) -> no-op ====
+
+scenario_indeterminada_state_db_corrompido_no_op() {
+  _require_jq || return 2
+  _require_sqlite3 || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  _proj="$TMPDIR_TEST/proj"
+  mkdir -p "$_proj/.claude/agente-00c-state"
+  printf 'not a database' > "$_proj/.claude/agente-00c-state/state.db"
+  _run_hook "$(_json_for "$_proj" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "esperado vazio: $_CAPTURED_STDOUT"; return 1; }
+  [ -z "$_CAPTURED_STDERR" ] || { _fail "stderr" "esperado vazio: $_CAPTURED_STDERR"; return 1; }
+  [ -d "$(_loose_usage_root)" ] && { _fail "sidecar" "state indeterminado NUNCA vira captura (Constitution VI)"; return 1; }
+  return 0
+}
+
+# ==== 3.2.3: permissoes restritivas apos captura bem-sucedida (CHK021) ====
+
+scenario_permissoes_apos_captura() {
+  _require_jq || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  _proj="$TMPDIR_TEST/proj"
+  mkdir -p "$_proj"
+  _run_hook "$(_json_for "$_proj" "Bash")"
+  _meta=$(_find_meta_files)
+  [ -n "$_meta" ] || { _error "fixture" "captura nao produziu meta.tsv"; return 2; }
+  _procdir=$(dirname "$_meta")
+  _root=$(_loose_usage_root)
+
+  [ "$(_file_mode "$_root")" = "700" ] || { _fail "modo raiz" "esperado 700, obtido $(_file_mode "$_root")"; return 1; }
+  [ "$(_file_mode "$_procdir")" = "700" ] || { _fail "modo processo" "esperado 700, obtido $(_file_mode "$_procdir")"; return 1; }
+  [ "$(_file_mode "$_procdir/seg-001")" = "700" ] || { _fail "modo segmento" "esperado 700, obtido $(_file_mode "$_procdir/seg-001")"; return 1; }
+  [ "$(_file_mode "$_meta")" = "600" ] || { _fail "modo meta.tsv" "esperado 600, obtido $(_file_mode "$_meta")"; return 1; }
+  return 0
+}
+
+run_all_scenarios
+exit $?

--- a/tests/test_state-parity-sweep.sh
+++ b/tests/test_state-parity-sweep.sh
@@ -231,6 +231,14 @@ scenario_dinamica_15_leitores_sqlite_sem_degradacao() {
 #     tasks.md 7.1.3 pedia os 3 hooks FORA da allowlist; a divergencia e do
 #     desenho ja ratificado (SEC-H1 e MUST), nao um erro de implementacao —
 #     mesmo precedente de tasks.md 4.2.1.
+#
+# Feature loose-usage-capture adiciona:
+#   posttooluse-loose-usage.sh:codigo-real — mesma classe dos 3 hooks acima:
+#     pre-check inline de existencia (`[ -f state.json ] || [ -f state.db ]`,
+#     builtins puros, sem jq/sourcing) ANTES de resolver
+#     _hook-active-exec.sh (SEC-H1/dec-006, polaridade invertida). Checagem
+#     SIMETRICA (nunca le/parseia conteudo, nunca so state.json) — nao
+#     quebra sob backend so-sqlite.
 _static_allowlist() {
   cat <<'EOF'
 state-rw.sh:codigo-real
@@ -249,6 +257,7 @@ _hook-active-exec.sh:codigo-real
 pretooluse-bash-guard.sh:codigo-real
 posttooluse-tool-call-tick.sh:codigo-real
 posttooluse-agent-usage.sh:codigo-real
+posttooluse-loose-usage.sh:codigo-real
 EOF
 }
 

--- a/tips/catalog.md
+++ b/tips/catalog.md
@@ -413,31 +413,19 @@ no que e realmente novo na tarefa 4.2.
 
 ---
 skill: initialize-docs
-category: uso
-text: Use /initialize-docs para criar a hierarquia padrao de documentacao (01-09 dirs, READMEs, briefing, UCs, DER, ADRs, APIs, tests, ops) em projetos novos.
----
-No inicio de um projeto:
-
-```
-/initialize-docs
-```
-
-Cria a estrutura padrao de `docs/` com todos os diretorios padronizados
-e arquivos README.md descritivos. Evita criar estrutura manual inconsistente.
-
----
-skill: initialize-docs
 category: gotcha
-text: O /initialize-docs pula automaticamente se a estrutura ja existe — use --force apenas se quiser recriar diretorios que ja existem (cuidado com sobrescrita).
+text: DEPRECATED (remocao na v7) — nao use /initialize-docs em projetos novos. O layout SDD e docs/briefing.md + docs/constitution.md + docs/specs/, criado pelas proprias skills briefing/constitution/specify.
 ---
-```
-# Verificar antes:
-ls docs/
+A hierarquia numerada 01-09 e legado. Em projetos novos, va direto:
 
-# Se estrutura ja existe, a skill nao sobrescreve por padrao.
-# Para forccar recreacao (CUIDADO — pode sobrescrever):
-/initialize-docs --force
 ```
+/briefing        # -> docs/briefing.md
+/constitution    # -> docs/constitution.md
+/specify ...     # -> docs/specs/<feature>/spec.md
+```
+
+Projetos que ja tem `docs/01-briefing-discovery/` continuam suportados —
+o pipeline aceita os dois layouts ate a remocao da skill na v7.
 
 ---
 skill: model-selector


### PR DESCRIPTION
## Resumo

Release 6.6.0, duas frentes:

**loose-usage-capture** (pipeline feature-00c completa, specify→review-task):
- `cstk usage` / `usage compare` / `usage prune` (`cli/lib/usage.sh` novo) — consumo de tokens/custo de sessões interativas fora dos orquestradores 00c; ausência de medição imprime `nao medido`/`null`, nunca `0` fabricado (Princípio VI)
- Hook opt-in `posttooluse-loose-usage.sh` via `cstk hooks install --with-loose-usage` (snippet separado, default desligado); throttle O(1), detecção de execução 00c ativa com polaridade invertida para não dobrar contagem
- `knowledge.db` schema v13 (12→13, aditiva): tabela `loose_usage`
- Docs `docs/cstk-usage.md` (+ pt-BR) e spec em `docs/specs/loose-usage-capture/`

**briefing canônico + deprecation**:
- `docs/briefing.md` vira caminho canônico; legado `docs/01-briefing-discovery/briefing.md` só em fallback (pipeline.sh + 5 skills + orquestrador/command)
- `initialize-docs` marcada DEPRECATED (remoção na v7)

Inclui fix da allowlist do `test_state-parity-sweep.sh` (hook novo é a mesma classe de pre-check SEC-H1 dos 3 hooks da hooks-db-parity).

## Testado

- Suite completa local (`LC_ALL=C ./tests/run.sh`): 2492 PASS / 1 FAIL (allowlist, corrigido e verde no rerun)
- `./tests/run.sh --check-coverage`: zero órfãos
- `cstk doctor`: drift zero pré-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa