### PR TITLE
feat: cstk setup — wizard interativo de configuracao de projeto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [6.7.0] - 2026-08-07
+
+Onboarding de projeto num comando só: o novo `cstk setup` substitui a
+sequência manual `cstk hooks install` → `cstk state enable-sqlite` →
+`cstk mcp install` → configuração de telemetria por um wizard interativo
+idempotente, com detecção endurecida ("já configurado" só quando o registro
+aponta para o script real do catálogo — nunca por mera presença de chave).
+Feature conduzida pela pipeline feature-00c (spec/plan/checklists em
+`docs/specs/cstk-setup/`; PR #83).
+
+### Added
+
+- **`cstk setup`** (`cli/lib/setup.sh`, novo; dispatch em `cli/cstk`).
+  Wizard interativo com 4 áreas — hooks, state backend, MCP e telemetria —
+  cada uma com detecção read-only ANTES de qualquer aplicação, delegando aos
+  comandos existentes (`hooks_main install`, `enable-sqlite`, `_mcp_cmd_install`)
+  sem reimplementar parsing. Precedência de modo `--dry-run` > `--yes` >
+  interativo; gate de projeto = raiz de repositório git (worktrees contam);
+  `SetupRunSummary` em stdout com ordem fixa das áreas, exit codes
+  contratuais e declaração explícita do escopo verificado (só os 3 hooks
+  obrigatórios são auditados; demais entradas do `settings.json` não).
+  Defaults conservadores: loose-usage e state backend global (`[escopo]=global`,
+  rótulo obrigatório) são opt-in — em `--yes`, loose-usage fica OFF e
+  `enable-sqlite` só aplica quando `reason=` prova ausência de config prévia;
+  área de telemetria é 100% read-only (diagnóstico via `otel-usage.sh
+  preflight` + instruções do README, nunca escreve fora do projeto). MCP
+  instala mesmo sem Docker (registro em `.mcp.json` é inerte; aviso emitido).
+- **`guard-hooks-status.sh --verify-registration` e `--include-loose-usage`**
+  (flags aditivas). `--verify-registration` adiciona 5ª coluna
+  `canonical|divergent|indeterminate`: linha canônica exige path do catálogo
+  E o token `"command"` na mesma linha (fecha linha-isca decorativa);
+  `divergent` muda exit para 1 e o setup reporta remediação em 2 etapas
+  (remover entrada, reinstalar) em vez de "already configured".
+  `--include-loose-usage` emite 4ª linha TSV para o hook opcional sem afetar
+  o exit. O setup consome as flags em chamadas SEPARADAS — o veredito dos 3
+  hooks obrigatórios sai de chamada baseline sem flags, então runtime antigo
+  degrada só a dimensão estendida (sem regressão).
+- **`_mcp_registration_status`** (`cli/lib/mcp.sh`): classifica o registro
+  `mcpServers.cstk-state` de `.mcp.json` em `configured|divergent|not-configured`;
+  candidatos aceitos restritos a sufixo canônico
+  `/skills/agente-00c-runtime/scripts/mcp-launch.sh` existente em disco
+  (ambiente hostil não amplia o conjunto); stdout vazio nunca é resposta
+  válida (fallback `divergent`).
+- **Testes.** `tests/cstk/test_setup.sh` (novo, 24 cenários — inclui modo
+  interativo real via stdin, dry-run sem side-effects, idempotência,
+  telemetria sem escrita em `$HOME`); extensões em
+  `tests/test_guard-hooks-status.sh` (28→38) e `tests/cstk/test_mcp.sh`
+  (94→101); exemção de menção documentada no sweep de confinamento de
+  `tests/cstk/test_serve-docker.sh` (`setup.sh` usa apenas `command -v docker`
+  para texto de aviso — invocação funcional segue confinada a `mcp-docker.sh`).
+
 ## [6.6.0] - 2026-08-07
 
 Duas frentes: (1) rastreio de consumo avulso — tokens/custo das sessões
@@ -5097,6 +5148,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[6.7.0]: https://github.com/JotJunior/cstk/releases/tag/v6.7.0
 [6.6.0]: https://github.com/JotJunior/cstk/releases/tag/v6.6.0
 [6.5.1]: https://github.com/JotJunior/cstk/releases/tag/v6.5.1
 [6.5.0]: https://github.com/JotJunior/cstk/releases/tag/v6.5.0

--- a/cli/cstk
+++ b/cli/cstk
@@ -149,6 +149,8 @@ COMANDOS:
                 (so hooks + settings.json; nao duplica skill/commands/agents)
   usage         Consulta o consumo avulso (fora de execucoes 00c); tambem
                 `usage compare` (avulso vs pipeline) e `usage prune` (TTL)
+  setup         Wizard guiado das 4 areas de configuracao recomendadas
+                (hooks, backend de estado, MCP, telemetria) num projeto-alvo
   00c <path>    Bootstrap interativo de projeto-alvo do agente-00C
                 (cria diretorio, coleta parametros e invoca claude)
 
@@ -204,6 +206,11 @@ HELP
       printf 'Para help inline, rode: cstk usage --help\n'
       exit "$CSTK_EXIT_OK"
       ;;
+    setup)
+      printf 'cstk help setup: consulte docs/specs/cstk-setup/contracts/cli-setup.md\n'
+      printf 'Para help inline, rode: cstk setup --help\n'
+      exit "$CSTK_EXIT_OK"
+      ;;
     00c)
       printf 'cstk help 00c: consulte docs/specs/cstk-cli/contracts/cstk-00c.md\n'
       printf 'Para help inline, rode: cstk 00c --help\n'
@@ -214,7 +221,7 @@ HELP
       ;;
     *)
       printf 'cstk: comando desconhecido para help: %s\n' "$_sub" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, 00c\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, setup, 00c\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac
@@ -247,7 +254,7 @@ _dispatch() {
       . "$_lib_file"
       serve_main "$@"
       ;;
-    install|update|self-update|list|doctor|session|recall|show-tip|hooks|state|mcp|usage)
+    install|update|self-update|list|doctor|session|recall|show-tip|hooks|state|mcp|usage|setup)
       # Boot-check para todos exceto self-update (que e o caminho de recovery
       # da janela transiente — bloquea-lo aqui causaria deadlock).
       case "$_cmd" in
@@ -296,7 +303,7 @@ _dispatch() {
       ;;
     *)
       printf 'cstk: comando desconhecido: %s\n' "$_cmd" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, 00c, help, --version\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, setup, 00c, help, --version\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac

--- a/cli/lib/mcp.sh
+++ b/cli/lib/mcp.sh
@@ -52,6 +52,13 @@
 # de `hooks.sh` — jq permanece CONFINADO aquele arquivo (Constitution
 # carve-out condicao b); `mcp.sh` NUNCA chama `jq` diretamente.
 #
+# `_mcp_registration_status PROJECT_PATH` (feature cstk-setup, FASE 2.3,
+# FR-016): funcao interna (nao subcomando) consumida pelo wizard
+# `cstk setup` para decidir a area MCP sem duplicar a deteccao. stdout
+# `configured`|`divergent`|`not-configured`, exit sempre 0 (contrato de
+# nao-falha, paridade com `state-backend.sh resolve`). Leitura textual sem
+# jq. Ver contracts/cli-setup.md §4.1 (docs/specs/cstk-setup/).
+#
 # Subcomandos:
 #   cstk mcp status [--state-dir DIR] [--project-path PATH] [--live]
 #   cstk mcp start --state-dir DIR
@@ -143,6 +150,101 @@ _mcp_runtime_script_path() {
     return 0
   fi
   return 1
+}
+
+# _mcp_registration_candidate_matches VALUE -> 0 se VALUE e igual (string
+# exata) a um dos tres paths candidatos que `_mcp_runtime_script_path
+# mcp-launch.sh` produziria — a MESMA resolucao PATH -> repo -> catalogo
+# instalado usada por `_mcp_cmd_install` (linhas ~127-146), com a mesma
+# forma literal (nao canonicalizada: o candidato "repo" preserva o `..`).
+#
+# SEC-05 (CHK012): o candidato via PATH (`command -v mcp-launch.sh`) e
+# restrito ao SUFIXO esperado /skills/agente-00c-runtime/scripts/mcp-launch.sh
+# E precisa existir de fato em disco no momento da verificacao — nunca
+# aceitar qualquer resultado de `command -v` sem essa dupla checagem (um
+# `mcp-launch.sh` homonimo em outro diretorio do PATH nao pode contar como
+# instalacao legitima do catalogo).
+_mcp_registration_candidate_matches() {
+  _mrcm_value=$1
+
+  if _mrcm_path=$(command -v mcp-launch.sh 2>/dev/null); then
+    case "$_mrcm_path" in
+      */skills/agente-00c-runtime/scripts/mcp-launch.sh)
+        if [ -f "$_mrcm_path" ] && [ "$_mrcm_value" = "$_mrcm_path" ]; then
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  if [ -n "${CSTK_LIB:-}" ]; then
+    _mrcm_repo="$CSTK_LIB/../../global/skills/agente-00c-runtime/scripts/mcp-launch.sh"
+    if [ -f "$_mrcm_repo" ] && [ "$_mrcm_value" = "$_mrcm_repo" ]; then
+      return 0
+    fi
+  fi
+
+  _mrcm_home="${HOME:-/tmp}/.claude/skills/agente-00c-runtime/scripts/mcp-launch.sh"
+  if [ -f "$_mrcm_home" ] && [ "$_mrcm_value" = "$_mrcm_home" ]; then
+    return 0
+  fi
+
+  return 1
+}
+
+# _mcp_registration_status PROJECT_PATH -> "configured" | "divergent" |
+# "not-configured" (feature cstk-setup, FASE 2.3, FR-016).
+#
+# Leitura textual sem jq (mesma escolha de _gh_registered em
+# guard-hooks-status.sh — nao depender de jq no projeto possivelmente mal
+# provisionado que estamos diagnosticando). Contrato de nao-falha: SEMPRE
+# imprime exatamente uma das 3 palavras e retorna 0 (consulta respondida,
+# nao veredito — mesmo contrato de state-backend.sh resolve).
+#
+# SEC-06 (CHK013): todo caminho de codigo termina em printf explicito; o
+# fallback final ("divergent") garante que a funcao NUNCA emite stdout
+# vazio — um chamador recebendo stdout vazio (bug) deve tratar como
+# indeterminado, nunca como "configured" por omissao.
+_mcp_registration_status() {
+  _mrs_project_path=$1
+  _mrs_file="$_mrs_project_path/.mcp.json"
+
+  if [ ! -f "$_mrs_file" ]; then
+    printf 'not-configured\n'
+    return 0
+  fi
+  if ! grep -Fq -- '"cstk-state"' "$_mrs_file" 2>/dev/null; then
+    printf 'not-configured\n'
+    return 0
+  fi
+
+  # Atribuicao textual por proximidade: a primeira linha "command" que
+  # aparece APOS a linha "cstk-state" (mesmo padrao de atribuicao por
+  # linha/proximidade de _gh_registered — declarado, nao parse estrutural).
+  _mrs_cmd_line=$(awk '
+    /"cstk-state"/ { infield=1; next }
+    infield && /"command"/ { print; exit }
+  ' "$_mrs_file" 2>/dev/null)
+
+  _mrs_cmd_value=""
+  if [ -n "$_mrs_cmd_line" ]; then
+    _mrs_cmd_value=$(printf '%s\n' "$_mrs_cmd_line" \
+      | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  fi
+
+  if [ -z "$_mrs_cmd_value" ]; then
+    # cstk-state presente mas "command" nao atribuivel textualmente ->
+    # "nao e atribuivel" da regra de decisao => divergent.
+    printf 'divergent\n'
+    return 0
+  fi
+
+  if _mcp_registration_candidate_matches "$_mrs_cmd_value"; then
+    printf 'configured\n'
+  else
+    printf 'divergent\n'
+  fi
+  return 0
 }
 
 _mcp_is_active_status() {

--- a/cli/lib/setup.sh
+++ b/cli/lib/setup.sh
@@ -1,0 +1,208 @@
+#!/bin/sh
+# setup.sh — subcomando `cstk setup` (feature cstk-setup): wizard guiado
+# que percorre, em ordem fixa, as quatro areas de configuracao
+# recomendadas de um projeto (hooks obrigatorios + loose-usage opt-in
+# aninhado, backend de estado global, registro MCP de estado,
+# telemetria), delegando toda deteccao/aplicacao aos comandos dedicados
+# ja existentes (guard-hooks-status.sh, cli/lib/state.sh, cli/lib/mcp.sh,
+# otel-usage.sh). Esta lib NUNCA reimplementa deteccao/aplicacao — so
+# orquestra e apresenta.
+#
+# Ref: docs/specs/cstk-setup/spec.md FR-004 a FR-018
+#      docs/specs/cstk-setup/contracts/cli-setup.md §1
+#      docs/specs/cstk-setup/plan.md "Pontos de edicao em cli/cstk", Riscos
+#      docs/specs/cstk-setup/quickstart.md Scenarios 1-18
+#
+# **NEUTRALIZACAO DE EXIT SOB `set -eu` (Risco 2 do plan.md, FR-009)**:
+# esta lib e SOURCEADA (`. "$_lib_file"`) no MESMO shell de `cli/cstk`, que
+# roda `set -eu` desde a primeira linha. Uma falha ou dependencia
+# indisponivel em UMA area NUNCA MUST derrubar o wizard inteiro (FR-009:
+# "each area's outcome is independent") — logo toda chamada de funcao de
+# aplicacao/deteccao de area MUST ser neutralizada explicitamente, nunca
+# invocada "nua":
+#
+#   # CORRETO — neutraliza antes de decidir o outcome da area
+#   if ! _su_area_result=$(_setup_apply_hooks "$PROJECT_PATH"); then
+#     _su_rc=$?
+#     ...
+#   fi
+#
+#   # ou, quando so o exit code importa:
+#   _setup_apply_mcp "$PROJECT_PATH" || _su_rc=$?
+#
+#   # ERRADO — sob set -eu, exit != 0 de _setup_apply_state_backend aqui
+#   # mata o processo inteiro e as areas seguintes (MCP, telemetria) nunca
+#   # rodam, violando FR-009 silenciosamente:
+#   _setup_apply_state_backend "$PROJECT_PATH"
+#
+# Cada `if ! fn; then ...` / `fn || rc=$?` isola exatamente UMA area; o
+# restante do wizard prossegue com o outcome dela marcado `failed` no
+# SetupRunSummary (FR-010), nunca abortando as demais.
+#
+# Exit codes (contracts/cli-setup.md §1 "Exit codes", alinhado as
+# constantes de cli/cstk:30-33):
+#   0 run completo (inclui areas puladas/ja-configuradas e --dry-run)
+#   1 pelo menos uma area terminou em `failed`
+#   2 uso incorreto (flag desconhecida)
+#   3 recusa por pre-condicao: fora de raiz de repo git (FR-011), ou
+#     terminal nao-interativo sem --dry-run/--yes (FR-007)
+#
+# Pre-condicoes (contracts/cli-setup.md §1 "Pre-condicoes"), nesta ordem:
+#   1. FR-011 — `[ -e "$PROJECT_PATH/.git" ]` (arquivo OU diretorio;
+#      git worktree conta, pois `.git` de worktree e um arquivo-ponteiro).
+#      Falha -> exit 3, ZERO escrita.
+#   2. FR-007 — em mode=interactive, TTY obrigatorio via `require_tty`
+#      (cli/lib/ui.sh). Falha -> exit 3 apontando --dry-run/--yes.
+#
+# Precedencia de modo (FR-006, contracts/cli-setup.md §1):
+#   --dry-run presente            -> mode=preview        (nada aplicado)
+#   --yes presente, sem --dry-run -> mode=non-interactive
+#   nenhum dos dois               -> mode=interactive     (exige TTY)
+#
+# Flags deliberadamente ausentes (FR-018): nao ha --catalog nem
+# equivalente; nenhuma flag de override de catalogo e repassada aos
+# comandos delegados. Qualquer flag desconhecida -> exit 2 (uso incorreto).
+#
+# POSIX sh puro. Sem bash-isms. Deps: as das libs sourceadas (common.sh,
+# ui.sh) + test/printf/case built-in.
+
+if [ -n "${_CSTK_SETUP_LOADED:-}" ]; then
+  return 0 2>/dev/null
+fi
+_CSTK_SETUP_LOADED=1
+
+set -eu
+
+# shellcheck source=./common.sh
+. "${CSTK_LIB:?CSTK_LIB must be set}/common.sh"
+# shellcheck source=./ui.sh
+. "${CSTK_LIB}/ui.sh"
+
+_setup_usage() {
+  cat <<'HELP'
+cstk setup — wizard guiado de configuracao (hooks, backend de estado,
+             MCP de estado, telemetria) para um projeto-alvo
+
+USO:
+  cstk setup [--dry-run] [--yes] [--project-path PATH]
+
+FLAGS:
+  --dry-run              Preview: mostra o status e o que seria aplicado
+                          em cada area, sem escrever nada. Precede --yes
+                          se ambas forem passadas.
+  --yes                  Nao-interativo: aplica o default recomendado de
+                          cada area ainda nao configurada, sem prompt.
+  --project-path PATH    Raiz do projeto-alvo (default: diretorio atual).
+                          MUST ser raiz de repositorio git.
+
+Sem nenhuma flag de modo, roda interativo (exige TTY) e pergunta area a
+area. Sem TTY e sem --dry-run/--yes, falha rapido em vez de bloquear
+esperando input (FR-007).
+
+AREAS (ordem fixa): hooks, state-backend, mcp, telemetry.
+
+EXIT CODES:
+  0 run completo   1 alguma area falhou   2 uso incorreto
+  3 recusado por pre-condicao (fora de repo git, ou sem TTY/--dry-run/--yes)
+HELP
+}
+
+# _setup_parse_args ARGS...
+# Preenche as variaveis globais (prefixo _SU_): _SU_PROJECT_PATH,
+# _SU_DRY_RUN (0|1), _SU_YES (0|1), _SU_HELP (0|1).
+# Retorno: 0 OK; 2 flag desconhecida ou argumento faltando (uso incorreto).
+_setup_parse_args() {
+  _SU_PROJECT_PATH="$PWD"
+  _SU_DRY_RUN=0
+  _SU_YES=0
+  _SU_HELP=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --dry-run)
+        _SU_DRY_RUN=1
+        shift
+        ;;
+      --yes)
+        _SU_YES=1
+        shift
+        ;;
+      --project-path)
+        if [ "$#" -lt 2 ]; then
+          log_error "setup: --project-path requer um valor"
+          return 2
+        fi
+        _SU_PROJECT_PATH="$2"
+        shift 2
+        ;;
+      -h|--help)
+        _SU_HELP=1
+        shift
+        ;;
+      *)
+        log_error "setup: flag desconhecida: $1"
+        log_error "setup: tente 'cstk setup --help'"
+        return 2
+        ;;
+    esac
+  done
+  return 0
+}
+
+# _setup_resolve_mode -> stdout: "preview" | "non-interactive" | "interactive"
+# Precedencia FR-006: --dry-run vence --yes; sem nenhuma das duas, interactive.
+_setup_resolve_mode() {
+  if [ "$_SU_DRY_RUN" = 1 ]; then
+    printf 'preview\n'
+  elif [ "$_SU_YES" = 1 ]; then
+    printf 'non-interactive\n'
+  else
+    printf 'interactive\n'
+  fi
+}
+
+# _setup_check_git_root PROJECT_PATH -> 0 se PROJECT_PATH e raiz de repo git
+# (FR-011: `.git` arquivo OU diretorio; worktrees contam). 1 caso contrario.
+# Pure/read-only — nao escreve nada.
+_setup_check_git_root() {
+  [ -e "$1/.git" ]
+}
+
+setup_main() {
+  if ! _setup_parse_args "$@"; then
+    return 2
+  fi
+
+  if [ "$_SU_HELP" = 1 ]; then
+    _setup_usage
+    return 0
+  fi
+
+  # Pre-condicao 1 (FR-011) — ANTES de qualquer outra coisa, zero escrita
+  # em caso de recusa.
+  if ! _setup_check_git_root "$_SU_PROJECT_PATH"; then
+    log_error "setup: '$_SU_PROJECT_PATH' nao parece raiz de um repositorio git (sem .git)."
+    log_error "setup: rode a partir da raiz do projeto-alvo, ou passe --project-path."
+    return 3
+  fi
+
+  _su_mode=$(_setup_resolve_mode)
+
+  # Pre-condicao 2 (FR-007) — so se aplica em modo interativo.
+  if [ "$_su_mode" = "interactive" ]; then
+    if ! require_tty; then
+      log_error "setup: terminal nao-interativo detectado."
+      log_error "setup: use --dry-run (preview) ou --yes (aplica defaults) em vez do modo interativo."
+      return 3
+    fi
+  fi
+
+  # A partir daqui: pre-condicoes satisfeitas, modo resolvido. A
+  # orquestracao das 4 areas (hooks, state-backend, mcp, telemetry) e o
+  # SetupRunSummary sao adicionados nas FASES 3-7 do backlog
+  # (docs/specs/cstk-setup/tasks.md) — este skeleton (FASE 1) cobre
+  # apenas dispatch + pre-condicoes.
+  log_info "setup: pre-condicoes OK (mode=$_su_mode, project-path=$_SU_PROJECT_PATH)."
+  log_info "setup: areas de configuracao ainda nao implementadas nesta versao (FASE 1 de 8)."
+  return 0
+}

--- a/cli/lib/setup.sh
+++ b/cli/lib/setup.sh
@@ -223,6 +223,31 @@ _setup_hooks_status_script_path() {
   return 1
 }
 
+# _setup_otel_script_path -> mesma cadeia de resolucao de
+# _setup_hooks_status_script_path (command -v -> fallback relativo a
+# CSTK_LIB -> fallback $HOME/.claude), agora para `otel-usage.sh`
+# (FASE 6, contracts/cli-setup.md §5.1). Ecoa o path em stdout; exit 1 se
+# nao encontrado em nenhuma das 3 fontes.
+_setup_otel_script_path() {
+  if command -v otel-usage.sh >/dev/null 2>&1; then
+    command -v otel-usage.sh
+    return 0
+  fi
+  if [ -n "${CSTK_LIB:-}" ]; then
+    _sot_repo="$CSTK_LIB/../../global/skills/agente-00c-runtime/scripts/otel-usage.sh"
+    if [ -f "$_sot_repo" ]; then
+      printf '%s\n' "$_sot_repo"
+      return 0
+    fi
+  fi
+  _sot_default="${HOME:-/tmp}/.claude/skills/agente-00c-runtime/scripts/otel-usage.sh"
+  if [ -f "$_sot_default" ]; then
+    printf '%s\n' "$_sot_default"
+    return 0
+  fi
+  return 1
+}
+
 # _setup_prompt_yn QUESTION -> pergunta em stderr, le resposta em stdin.
 # Exit 0 se y/Y/yes/YES; 1 caso contrario (inclusive vazio/EOF). Mesmo
 # padrao de _session_prompt_yn (cli/lib/session.sh:333-343).
@@ -877,6 +902,162 @@ _setup_run_mcp_area() {
   return 0
 }
 
+# ============================================================================
+# Area de Telemetria (FASE 6 — tasks.md; contract em contracts/cli-setup.md
+# §5; data-model.md Entity ConfigurationArea, linha `telemetry`).
+#
+# 100% READ-ONLY (FR-012): esta area NUNCA escreve em nenhum arquivo — nem
+# no projeto, nem em ~/.zshrc, nem em qualquer outro lugar. So diagnostica
+# (delegando a `otel-usage.sh preflight`, script ja existente do catalogo —
+# nenhuma reimplementacao de deteccao de porta/exporter aqui) e exibe os
+# valores EXATOS citados de README.md ("Real per-wave cost"), nunca
+# inventados (Constitution VI). Outcome `applied` e INALCANCAVEL nesta area
+# (task 6.1.3) — so already-configured|skipped|failed.
+# ============================================================================
+
+# _setup_show_telemetry_instructions STATUS -> imprime em stderr as
+# instrucoes/valores EXATOS de ativacao citados de README.md (task 6.1.2).
+# Nunca escreve em arquivo algum — so texto informativo.
+_setup_show_telemetry_instructions() {
+  case "$1" in
+    port-conflict)
+      log_warn "setup: [telemetry] a porta do exporter esta ocupada por OUTRO processo — o consumo DESTA sessao nao sera medido enquanto isso."
+      ;;
+    exporter-down)
+      log_warn "setup: [telemetry] telemetria habilitada mas nada responde no endpoint — o consumo NAO sera medido nesta sessao."
+      ;;
+    unverified)
+      log_warn "setup: [telemetry] o endpoint responde mas a propriedade do exporter nao pode ser confirmada (lsof ausente ou sem visibilidade) — pode ser esta sessao ou outra."
+      ;;
+    *)
+      log_info "setup: [telemetry] telemetria desligada nesta sessao."
+      ;;
+  esac
+  log_info "setup: [telemetry] para ativar, exporte estas variaveis na sua sessao de shell ANTES de rodar 'claude' (README.md, secao 'Real per-wave cost'):"
+  log_info "setup: [telemetry]   export CLAUDE_CODE_ENABLE_TELEMETRY=1"
+  log_info "setup: [telemetry]   export OTEL_METRICS_EXPORTER=prometheus"
+  log_info "setup: [telemetry] o exporter local escuta em 127.0.0.1:9464 por padrao — nada sai da maquina."
+  log_info "setup: [telemetry] mais de um processo Claude Code ao mesmo tempo? So UM pode usar a porta fixa 9464. De a cada processo sua propria porta com OTEL_EXPORTER_PROMETHEUS_PORT (porta sorteada) + CSTK_OTEL_ENDPOINT (URL correspondente) — README.md documenta um wrapper 'claude()' de exemplo para ~/.zshrc que sorteia porta livre a cada lancamento."
+  log_info "setup: [telemetry] este wizard NAO escreve nada disso por voce (FR-012) — a ativacao e sempre manual, fora do diretorio do projeto."
+}
+
+# _setup_run_telemetry_area PROJECT_PATH MODE DRY_RUN
+#
+# Orquestra a area 'telemetry' de ponta a ponta (FASE 6):
+#   1. Deteccao read-only via `otel-usage.sh preflight` (sempre roda,
+#      inclusive em --dry-run — nao ha nada a aplicar de qualquer forma)
+#   2. Apresentacao do status ANTES de qualquer instrucao adicional (FR-002)
+#   3. script `otel-usage.sh` nao encontrado -> outcome=failed (mesmo
+#      padrao das demais areas quando a dependencia delegada esta ausente)
+#   4. `status=ok` (medicao confirmada ativa PARA ESTA sessao — o dono da
+#      porta e ancestral do processo corrente) -> outcome
+#      already-configured, ZERO chamada de aplicacao (nao existe chamada de
+#      aplicacao possivel aqui — I1 trivialmente satisfeita)
+#   5. `status=disabled|port-conflict|exporter-down|unverified` -> NUNCA
+#      already-configured (nao ha confirmacao solida de medicao ativa desta
+#      sessao especifica — Constitution VI, nunca afirmar o que nao foi
+#      confirmado) -> outcome=skipped (data-model.md "Area telemetry
+#      diagnosticada e nao ativa" -> skipped, reason "diagnostico exibido;
+#      ativacao e manual (FR-012)"), sempre seguido das instrucoes exatas
+#      de ativacao (task 6.1.2)
+#   6. saida inesperada (sem token `status=`, ou exit fora do vocabulario
+#      documentado do preflight) -> outcome=failed, citando a saida crua
+#      como evidencia (nunca inventar interpretacao)
+#
+# MODE/DRY_RUN sao aceitos so por simetria de assinatura com as demais
+# _setup_run_*_area — nenhum dos dois muda o comportamento desta area (nao
+# ha decisao de usuario nem aplicacao possivel: 100% read-only sempre).
+#
+# Preenche _SU_TEL_OUTCOME (already-configured|skipped|failed) e
+# _SU_TEL_OUTCOME_REASON (motivo legivel).
+_setup_run_telemetry_area() {
+  _srt_pap=$1
+  _srt_mode=$2
+  _srt_dry=$3
+
+  log_info "setup: [telemetry] area 100% read-only (FR-012, project-path=$_srt_pap, mode=$_srt_mode, dry-run=$_srt_dry) — nenhuma escrita e feita em nenhum caso."
+
+  if ! _srt_script=$(_setup_otel_script_path); then
+    _SU_TEL_OUTCOME="failed"
+    _SU_TEL_OUTCOME_REASON="nao foi possivel localizar otel-usage.sh (rode 'cstk install' ou 'cstk update' antes)"
+    log_error "setup: [telemetry] $_SU_TEL_OUTCOME_REASON"
+    return 0
+  fi
+
+  if _srt_out=$(sh "$_srt_script" preflight 2>/dev/null); then
+    _srt_rc=0
+  else
+    _srt_rc=$?
+  fi
+
+  # FR-002 — status exibido ANTES de qualquer instrucao/decisao.
+  log_info "setup: [telemetry] status atual = $_srt_out"
+
+  _srt_status=""
+  case "$_srt_out" in
+    status=*)
+      _srt_status=${_srt_out#status=}
+      _srt_status=${_srt_status%% *}
+      ;;
+  esac
+
+  case "$_srt_status" in
+    ok)
+      _SU_TEL_OUTCOME="already-configured"
+      _SU_TEL_OUTCOME_REASON=""
+      log_info "setup: [telemetry] medicao confirmada ativa para esta sessao — nenhuma acao necessaria."
+      ;;
+    disabled | port-conflict | exporter-down | unverified)
+      _SU_TEL_OUTCOME="skipped"
+      _SU_TEL_OUTCOME_REASON="diagnostico exibido; ativacao e manual (FR-012)"
+      _setup_show_telemetry_instructions "$_srt_status"
+      ;;
+    *)
+      _SU_TEL_OUTCOME="failed"
+      _SU_TEL_OUTCOME_REASON="otel-usage.sh preflight saida inesperada (exit $_srt_rc): $_srt_out"
+      log_error "setup: [telemetry] $_SU_TEL_OUTCOME_REASON"
+      ;;
+  esac
+  return 0
+}
+
+# ============================================================================
+# SetupRunSummary (FASE 7 — tasks.md; contract em contracts/cli-setup.md §1
+# "Saida (stdout)"; data-model.md Entity AreaOutcome).
+#
+# Toda a orquestracao acima (`_setup_run_*_area`) loga PROGRESSO/diagnostico
+# via log_info/log_warn/log_error — ou seja, sempre em STDERR
+# (cli/lib/common.sh). O summary final e DADO DE SAIDA (Constitution II:
+# "mensagens de erro em stderr, saida de dados em stdout" — task 7.1.3), por
+# isso usa `printf` direto para stdout, nunca log_*.
+# ============================================================================
+
+# _setup_print_summary_line AREA OUTCOME SCOPE REASON -> uma linha em
+# stdout no formato `<area>  <outcome>  [escopo]  [motivo]`
+# (contracts/cli-setup.md §1). SCOPE/REASON vazios sao omitidos (task
+# 7.1.2 — `[escopo]` so aparece na linha de state-backend).
+_setup_print_summary_line() {
+  _spsl_line="$1  $2"
+  [ -n "$3" ] && _spsl_line="$_spsl_line  $3"
+  [ -n "$4" ] && _spsl_line="$_spsl_line  $4"
+  printf '%s\n' "$_spsl_line"
+}
+
+# _setup_print_run_summary -> imprime em stdout (a) a declaracao de escopo
+# da verificacao (achado SEC-07/CHK009, task 7.2.1: os 3 hooks obrigatorios
+# de `_GH_HOOKS` foram verificados; NENHUMA outra entrada do
+# `settings.json`/`.mcp.json` foi auditada — CHK016 permanece {humano},
+# fora de escopo desta feature) e (b) o `SetupRunSummary` (FR-010): uma
+# linha por area, na ordem fixa de FR-001.
+_setup_print_run_summary() {
+  printf 'setup: escopo da verificacao — apenas os 3 hooks obrigatorios de _GH_HOOKS (pretooluse-bash-guard.sh, posttooluse-tool-call-tick.sh, posttooluse-agent-usage.sh) foram verificados nesta execucao. Demais entradas de .claude/settings.json, e entradas de .mcp.json alem de mcpServers.cstk-state, NAO foram auditadas — nenhuma garantia e feita sobre elas.\n'
+  printf '\n'
+  _setup_print_summary_line "hooks" "$_SU_HOOKS_OUTCOME" "" "$_SU_HOOKS_OUTCOME_REASON"
+  _setup_print_summary_line "state-backend" "$_SU_SB_OUTCOME" "global" "$_SU_SB_OUTCOME_REASON"
+  _setup_print_summary_line "mcp" "$_SU_MCP_OUTCOME" "" "$_SU_MCP_OUTCOME_REASON"
+  _setup_print_summary_line "telemetry" "$_SU_TEL_OUTCOME" "" "$_SU_TEL_OUTCOME_REASON"
+}
+
 setup_main() {
   if ! _setup_parse_args "$@"; then
     return 2
@@ -922,10 +1103,16 @@ setup_main() {
   _setup_run_mcp_area "$_SU_PROJECT_PATH" "$_su_mode" "$_SU_DRY_RUN"
   log_info "setup: [mcp] outcome=$_SU_MCP_OUTCOME"
 
-  log_info "setup: area restante (telemetry) ainda nao implementada nesta versao (FASE 5 de 8)."
+  _setup_run_telemetry_area "$_SU_PROJECT_PATH" "$_su_mode" "$_SU_DRY_RUN"
+  log_info "setup: [telemetry] outcome=$_SU_TEL_OUTCOME"
+
+  # FR-010/FASE 7 — SetupRunSummary consolidado, SEMPRE impresso ao final,
+  # inclusive quando alguma area falhou (quickstart Scenario 7, SC-005:
+  # "summary lista as 4 areas" mesmo com falha parcial).
+  _setup_print_run_summary
 
   if [ "$_SU_HOOKS_OUTCOME" = "failed" ] || [ "$_SU_SB_OUTCOME" = "failed" ] \
-    || [ "$_SU_MCP_OUTCOME" = "failed" ]; then
+    || [ "$_SU_MCP_OUTCOME" = "failed" ] || [ "$_SU_TEL_OUTCOME" = "failed" ]; then
     return 1
   fi
   return 0

--- a/cli/lib/setup.sh
+++ b/cli/lib/setup.sh
@@ -77,6 +77,11 @@ set -eu
 . "${CSTK_LIB:?CSTK_LIB must be set}/common.sh"
 # shellcheck source=./ui.sh
 . "${CSTK_LIB}/ui.sh"
+# shellcheck source=./hooks.sh
+# hooks.sh e o UNICO arquivo autorizado a referenciar jq (Constitution
+# carve-out); setup.sh reusa hooks_main/apply_guard_hooks de la — nenhum
+# mecanismo de merge JSON novo (FASE 3, contracts/cli-setup.md §2.4).
+. "${CSTK_LIB}/hooks.sh"
 
 _setup_usage() {
   cat <<'HELP'
@@ -168,6 +173,348 @@ _setup_check_git_root() {
   [ -e "$1/.git" ]
 }
 
+# ============================================================================
+# Area de hooks (FASE 3 — docs/specs/cstk-setup/tasks.md; contract em
+# contracts/cli-setup.md §2; data-model.md Entity ConfigurationArea/
+# HooksAreaDetail).
+# ============================================================================
+
+# _setup_hooks_status_script_path -> imprime o caminho de
+# guard-hooks-status.sh. Mesmo padrao de 3 camadas de
+# _mcp_runtime_script_path (cli/lib/mcp.sh) / _state_migrate_script_path
+# (cli/lib/state.sh): (1) PATH; (2) layout de repo relativo a CSTK_LIB
+# (cli/lib -> ../../global/skills/agente-00c-runtime/scripts); (3) layout
+# instalado em ~/.claude. Necessario porque testes/CI rodam o CLI da
+# arvore do repo (CSTK_LIB=cli/lib) sem o runtime em ~/.claude.
+_setup_hooks_status_script_path() {
+  if command -v guard-hooks-status.sh >/dev/null 2>&1; then
+    command -v guard-hooks-status.sh
+    return 0
+  fi
+  if [ -n "${CSTK_LIB:-}" ]; then
+    _shs_repo="$CSTK_LIB/../../global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh"
+    if [ -f "$_shs_repo" ]; then
+      printf '%s\n' "$_shs_repo"
+      return 0
+    fi
+  fi
+  _shs_default="${HOME:-/tmp}/.claude/skills/agente-00c-runtime/scripts/guard-hooks-status.sh"
+  if [ -f "$_shs_default" ]; then
+    printf '%s\n' "$_shs_default"
+    return 0
+  fi
+  return 1
+}
+
+# _setup_prompt_yn QUESTION -> pergunta em stderr, le resposta em stdin.
+# Exit 0 se y/Y/yes/YES; 1 caso contrario (inclusive vazio/EOF). Mesmo
+# padrao de _session_prompt_yn (cli/lib/session.sh:333-343).
+_setup_prompt_yn() {
+  printf '%s ' "$1" >&2
+  read -r _spy_ans 2>/dev/null || _spy_ans=""
+  case "$_spy_ans" in
+    y | Y | yes | YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# _setup_detect_hooks_area PROJECT_PATH
+#
+# 3 chamadas SEPARADAS a guard-hooks-status.sh (achado SEC-03 —
+# contracts/cli-setup.md §2.1-2.3): (1) baseline sem flags; (2)
+# --verify-registration isolada; (3) --include-loose-usage isolada.
+# NUNCA combinadas numa unica invocacao — um runtime antigo que rejeita
+# UMA flag (exit 2) nao pode perder o veredito basico que ele SABE
+# responder. 100% read-only (nunca escreve nada).
+#
+# Preenche globais:
+#   _SU_HOOKS_MANDATORY_STATUS  configured|not-configured|divergent|unavailable
+#   _SU_HOOKS_MANDATORY_REASON  motivo legivel (vazio quando configured)
+#   _SU_HOOKS_DIVERGENT_NAMES   basenames divergentes, espaco-separado
+#   _SU_HOOKS_LOOSE_STATUS      configured|not-configured|indeterminate
+#
+# Regra de escalada (I5 do data-model, achados SEC-01/SEC-02): a chamada
+# --verify-registration so pode ESCALAR o veredito da baseline, nunca
+# substitui-lo silenciosamente:
+#   - qualquer hook com 5a coluna "divergent" -> status=divergent
+#     (precede a baseline)
+#   - senao, qualquer hook cuja 5a coluna seja "indeterminate" E cuja
+#     3a coluna (a MESMA chamada) seja "registered" -> status=unavailable
+#     (ambiguidade REAL: algo esta registrado mas a forma canonica nao
+#     pode ser confirmada — o caso citado no contrato e o settings.json
+#     minificado). Um hook "indeterminate" cuja 3a coluna e "unregistered"
+#     NAO escala: e o caso trivial "nada para autenticar" (settings.json
+#     ausente ou hook nunca mencionado) — _gh_verify_registration usa o
+#     MESMO grep -F que _gh_registered para decidir isso, entao os dois
+#     vereditos sao consistentes por construcao. Escalar aqui produziria
+#     `unavailable` para TODO projeto ainda nao configurado, contradizendo
+#     quickstart.md Scenario 1 (projeto novo, sem settings.json, MUST
+#     oferecer configurar hooks — nao reportar "indisponivel").
+#   - a chamada --verify-registration inteira com exit 2 (flag rejeitada
+#     por runtime desatualizado) -> unavailable incondicional, sem colunas
+#     para inspecionar (contrato §2.3).
+_setup_detect_hooks_area() {
+  _sdh_pap=$1
+  _SU_HOOKS_MANDATORY_STATUS="unavailable"
+  _SU_HOOKS_MANDATORY_REASON="nao foi possivel localizar guard-hooks-status.sh (rode 'cstk install' ou 'cstk update' antes)"
+  _SU_HOOKS_DIVERGENT_NAMES=""
+  _SU_HOOKS_LOOSE_STATUS="indeterminate"
+
+  if ! _sdh_script=$(_setup_hooks_status_script_path); then
+    return 0
+  fi
+
+  # (1) baseline — SEM flags (contracts/cli-setup.md §2.1)
+  if _sdh_baseline_out=$(sh "$_sdh_script" check --projeto-alvo-path "$_sdh_pap" --quiet 2>/dev/null); then
+    _sdh_baseline_rc=0
+  else
+    _sdh_baseline_rc=$?
+  fi
+  case "$_sdh_baseline_rc" in
+    0)
+      _SU_HOOKS_MANDATORY_STATUS="configured"
+      _SU_HOOKS_MANDATORY_REASON=""
+      ;;
+    1)
+      _SU_HOOKS_MANDATORY_STATUS="not-configured"
+      _SU_HOOKS_MANDATORY_REASON="um ou mais hooks obrigatorios ausentes, nao registrados ou desatualizados"
+      ;;
+    *)
+      _SU_HOOKS_MANDATORY_STATUS="unavailable"
+      _SU_HOOKS_MANDATORY_REASON="guard-hooks-status.sh check (baseline) retornou uso incorreto (exit $_sdh_baseline_rc)"
+      ;;
+  esac
+
+  # (2) --verify-registration — SEPARADA (achado SEC-03, §2.3, FR-016)
+  if _sdh_verify_out=$(sh "$_sdh_script" check --projeto-alvo-path "$_sdh_pap" --quiet --verify-registration 2>/dev/null); then
+    _sdh_verify_rc=0
+  else
+    _sdh_verify_rc=$?
+  fi
+  if [ "$_sdh_verify_rc" = 2 ]; then
+    _SU_HOOKS_MANDATORY_STATUS="unavailable"
+    _SU_HOOKS_MANDATORY_REASON="verificacao de autenticidade do registro indisponivel (runtime desatualizado) — nao foi possivel confirmar nem refutar"
+  else
+    _sdh_divergent=""
+    _sdh_ambiguous=0
+    while IFS='	' read -r _h _pf _rg _fr _vr; do
+      [ -n "$_h" ] || continue
+      case "$_vr" in
+        divergent)
+          _sdh_divergent="${_sdh_divergent:+$_sdh_divergent }$_h"
+          ;;
+        indeterminate)
+          [ "$_rg" = "registered" ] && _sdh_ambiguous=1
+          ;;
+      esac
+    done <<SDHVR
+$_sdh_verify_out
+SDHVR
+    if [ -n "$_sdh_divergent" ]; then
+      _SU_HOOKS_MANDATORY_STATUS="divergent"
+      _SU_HOOKS_DIVERGENT_NAMES="$_sdh_divergent"
+      _SU_HOOKS_MANDATORY_REASON="registro nao-canonico detectado para: $_sdh_divergent"
+    elif [ "$_sdh_ambiguous" = 1 ]; then
+      _SU_HOOKS_MANDATORY_STATUS="unavailable"
+      _SU_HOOKS_MANDATORY_REASON="autenticidade do registro nao pode ser confirmada nem refutada (layout do settings.json impede atribuicao por linha)"
+    fi
+  fi
+
+  # (3) --include-loose-usage — SEPARADA (§2.2); alimenta SO
+  # loose_usage_status, NUNCA a linha acima (hook obrigatorio).
+  if _sdh_loose_out=$(sh "$_sdh_script" check --projeto-alvo-path "$_sdh_pap" --quiet --include-loose-usage 2>/dev/null); then
+    _sdh_loose_rc=0
+  else
+    _sdh_loose_rc=$?
+  fi
+  if [ "$_sdh_loose_rc" = 2 ]; then
+    _SU_HOOKS_LOOSE_STATUS="indeterminate"
+  else
+    _sdh_loose_line=$(printf '%s\n' "$_sdh_loose_out" | awk -F'\t' '$1=="posttooluse-loose-usage.sh"{print;exit}')
+    if [ -z "$_sdh_loose_line" ]; then
+      _SU_HOOKS_LOOSE_STATUS="indeterminate"
+    else
+      _sdh_l_present=$(printf '%s' "$_sdh_loose_line" | awk -F'\t' '{print $2}')
+      _sdh_l_reg=$(printf '%s' "$_sdh_loose_line" | awk -F'\t' '{print $3}')
+      _sdh_l_fresh=$(printf '%s' "$_sdh_loose_line" | awk -F'\t' '{print $4}')
+      if [ "$_sdh_l_present" = "present" ] && [ "$_sdh_l_reg" = "registered" ] && [ "$_sdh_l_fresh" != "stale" ]; then
+        _SU_HOOKS_LOOSE_STATUS="configured"
+      else
+        _SU_HOOKS_LOOSE_STATUS="not-configured"
+      fi
+    fi
+  fi
+  return 0
+}
+
+# _setup_classify_hooks_install_stderr STDERR_TEXT ->
+# merged|paste-instructed|hooks-only|not-applicable|error|unknown
+#
+# `hooks_main install` (cli/lib/hooks.sh) so expoe exit code (0 para
+# merged/paste-instructed/hooks-only; 1 para not-applicable/error) — os 5
+# estados internos de apply_guard_hooks nao chegam ao caller por outro
+# canal. Esta funcao INTERPRETA o texto de log ja documentado e estavel
+# que hooks_main emite para cada estado (cli/lib/hooks.sh, case
+# `$_hooks_state` em `hooks_main`) — nao reimplementa a decisao de estado,
+# so classifica o relatorio que o proprio delegado ja produziu (task
+# 3.2.3): garante que `paste-instructed`/`hooks-only` (jq ausente /
+# catalogo incompleto) nunca virem `applied` silencioso no wizard.
+_setup_classify_hooks_install_stderr() {
+  case "$1" in
+    *"provisionados e registrados em"* | *"provisionaria os hooks 00c em"*)
+      printf 'merged\n'
+      ;;
+    *"REGISTRO em settings.json"*)
+      printf 'paste-instructed\n'
+      ;;
+    *"settings.snippet.json ausente no catalogo"*)
+      printf 'hooks-only\n'
+      ;;
+    *"catalogo nao trouxe os hooks 00c"*)
+      printf 'not-applicable\n'
+      ;;
+    *"falha ao provisionar"*)
+      printf 'error\n'
+      ;;
+    *)
+      printf 'unknown\n'
+      ;;
+  esac
+}
+
+# _setup_run_hooks_area PROJECT_PATH MODE DRY_RUN
+#
+# Orquestra a area 'hooks' de ponta a ponta (FASE 3):
+#   1. Deteccao read-only (sempre roda, mesmo em --dry-run)
+#   2. Apresentacao do status ANTES de oferecer a acao (FR-002)
+#   3. `divergent`/`unavailable` -> outcome=failed, ZERO chamada de
+#      aplicacao (I6, FR-016) — falha fechada com remediacao em 2 etapas
+#   4. `configured` -> outcome=already-configured, ZERO chamada (I1, FR-003)
+#   5. `not-configured` -> decide (prompt interativo ou default de --yes)
+#      a instalacao dos hooks obrigatorios E, como escolha DISTINTA
+#      (FR-008), a do hook opt-in de loose usage (default skip)
+#
+# Preenche _SU_HOOKS_OUTCOME (already-configured|applied|skipped|failed) e
+# _SU_HOOKS_OUTCOME_REASON (motivo legivel; nao vazio em failed e nos
+# avisos pendentes de applied — task 3.2.3).
+_setup_run_hooks_area() {
+  _srh_pap=$1
+  _srh_mode=$2
+  _srh_dry=$3
+
+  _setup_detect_hooks_area "$_srh_pap"
+
+  log_info "setup: [hooks] status atual (obrigatorios) = $_SU_HOOKS_MANDATORY_STATUS"
+  if [ -n "$_SU_HOOKS_MANDATORY_REASON" ]; then
+    log_info "setup: [hooks] motivo: $_SU_HOOKS_MANDATORY_REASON"
+  fi
+  log_info "setup: [hooks] loose usage (opt-in, escolha distinta — FR-008): $_SU_HOOKS_LOOSE_STATUS"
+
+  case "$_SU_HOOKS_MANDATORY_STATUS" in
+    configured)
+      _SU_HOOKS_OUTCOME="already-configured"
+      _SU_HOOKS_OUTCOME_REASON=""
+      log_info "setup: [hooks] ja configurado — nenhuma chamada de aplicacao (I1)."
+      return 0
+      ;;
+    divergent | unavailable)
+      _SU_HOOKS_OUTCOME="failed"
+      _SU_HOOKS_OUTCOME_REASON="$_SU_HOOKS_MANDATORY_REASON"
+      log_error "setup: [hooks] $_SU_HOOKS_MANDATORY_REASON"
+      if [ "$_SU_HOOKS_MANDATORY_STATUS" = "divergent" ]; then
+        log_error "setup: [hooks] remediacao (duas etapas — reescrever por cima NAO substitui o divergente, o merge faz o target vencer): (1) remova a entrada divergente de $_srh_pap/.claude/settings.json; (2) so entao rode 'cstk hooks install --project-path $_srh_pap'."
+      fi
+      log_error "setup: [hooks] nenhuma chamada de aplicacao sera feita (I6)."
+      return 0
+      ;;
+  esac
+
+  # not-configured a partir daqui.
+  if [ "$_srh_dry" = 1 ]; then
+    _SU_HOOKS_OUTCOME="skipped"
+    _SU_HOOKS_OUTCOME_REASON="preview: nenhuma alteracao aplicada"
+    log_info "setup: [hooks] preview — instalaria os hooks obrigatorios (nao aplicado)."
+    return 0
+  fi
+
+  _srh_accept_mandatory=1
+  if [ "$_srh_mode" = "interactive" ]; then
+    if ! _setup_prompt_yn "setup: [hooks] instalar os hooks obrigatorios agora? [y/N]"; then
+      _srh_accept_mandatory=0
+    fi
+  fi
+  if [ "$_srh_accept_mandatory" != 1 ]; then
+    _SU_HOOKS_OUTCOME="skipped"
+    _SU_HOOKS_OUTCOME_REASON="recusado pelo usuario"
+    log_info "setup: [hooks] recusado — hooks obrigatorios NAO instalados."
+    return 0
+  fi
+
+  # Escolha DISTINTA (FR-008, US4) do hook opt-in de loose usage. Default
+  # em --yes = skip (data-model.md loose_usage_choice — unica sub-area
+  # cujo default recomendado e "nao").
+  _srh_with_loose=0
+  if [ "$_srh_mode" = "interactive" ]; then
+    if _setup_prompt_yn "setup: [hooks] tambem habilitar captura de consumo avulso (loose usage, opt-in, default nao)? [y/N]"; then
+      _srh_with_loose=1
+    fi
+  fi
+
+  if ! _srh_err_file=$(mktemp 2>/dev/null); then
+    _SU_HOOKS_OUTCOME="failed"
+    _SU_HOOKS_OUTCOME_REASON="mktemp falhou ao preparar captura de diagnostico de 'hooks install'"
+    log_error "setup: [hooks] $_SU_HOOKS_OUTCOME_REASON"
+    return 0
+  fi
+
+  if [ "$_srh_with_loose" = 1 ]; then
+    if hooks_main install --project-path "$_srh_pap" --with-loose-usage 2>"$_srh_err_file"; then
+      _srh_rc=0
+    else
+      _srh_rc=$?
+    fi
+  else
+    if hooks_main install --project-path "$_srh_pap" 2>"$_srh_err_file"; then
+      _srh_rc=0
+    else
+      _srh_rc=$?
+    fi
+  fi
+  _srh_stderr=$(cat "$_srh_err_file" 2>/dev/null) || _srh_stderr=""
+  rm -f "$_srh_err_file" 2>/dev/null || :
+
+  _srh_state=$(_setup_classify_hooks_install_stderr "$_srh_stderr")
+
+  case "$_srh_state" in
+    merged)
+      _SU_HOOKS_OUTCOME="applied"
+      _SU_HOOKS_OUTCOME_REASON=""
+      log_info "setup: [hooks] aplicado (merged)."
+      ;;
+    paste-instructed)
+      _SU_HOOKS_OUTCOME="applied"
+      _SU_HOOKS_OUTCOME_REASON="jq ausente — registro em settings.json exige colagem manual (bloco impresso acima); sem isso os hooks NAO rodam"
+      log_warn "setup: [hooks] $_SU_HOOKS_OUTCOME_REASON"
+      ;;
+    hooks-only)
+      _SU_HOOKS_OUTCOME="applied"
+      _SU_HOOKS_OUTCOME_REASON="settings.snippet.json ausente no catalogo — hooks copiados mas NAO registrados; atualize o catalogo (cstk update)"
+      log_warn "setup: [hooks] $_SU_HOOKS_OUTCOME_REASON"
+      ;;
+    not-applicable)
+      _SU_HOOKS_OUTCOME="failed"
+      _SU_HOOKS_OUTCOME_REASON="catalogo local nao trouxe os hooks 00c (exit $_srh_rc)"
+      log_error "setup: [hooks] $_SU_HOOKS_OUTCOME_REASON"
+      ;;
+    error | unknown)
+      _SU_HOOKS_OUTCOME="failed"
+      _SU_HOOKS_OUTCOME_REASON="hooks install falhou (exit $_srh_rc)"
+      log_error "setup: [hooks] $_SU_HOOKS_OUTCOME_REASON"
+      ;;
+  esac
+  return 0
+}
+
 setup_main() {
   if ! _setup_parse_args "$@"; then
     return 2
@@ -198,11 +545,19 @@ setup_main() {
   fi
 
   # A partir daqui: pre-condicoes satisfeitas, modo resolvido. A
-  # orquestracao das 4 areas (hooks, state-backend, mcp, telemetry) e o
-  # SetupRunSummary sao adicionados nas FASES 3-7 do backlog
-  # (docs/specs/cstk-setup/tasks.md) — este skeleton (FASE 1) cobre
-  # apenas dispatch + pre-condicoes.
+  # orquestracao das demais 3 areas (state-backend, mcp, telemetry) e o
+  # SetupRunSummary consolidado sao adicionados nas FASES 4-7 do backlog
+  # (docs/specs/cstk-setup/tasks.md) — esta versao (FASE 3) cobre
+  # dispatch + pre-condicoes + area de hooks.
   log_info "setup: pre-condicoes OK (mode=$_su_mode, project-path=$_SU_PROJECT_PATH)."
-  log_info "setup: areas de configuracao ainda nao implementadas nesta versao (FASE 1 de 8)."
+
+  _setup_run_hooks_area "$_SU_PROJECT_PATH" "$_su_mode" "$_SU_DRY_RUN"
+  log_info "setup: [hooks] outcome=$_SU_HOOKS_OUTCOME"
+
+  log_info "setup: areas restantes (state-backend, mcp, telemetry) ainda nao implementadas nesta versao (FASE 3 de 8)."
+
+  if [ "$_SU_HOOKS_OUTCOME" = "failed" ]; then
+    return 1
+  fi
   return 0
 }

--- a/cli/lib/setup.sh
+++ b/cli/lib/setup.sh
@@ -93,6 +93,12 @@ set -eu
 # quando a area state-backend fica unavailable (task 4.4.1) — nenhuma
 # reimplementacao de deteccao de sqlite3/jq.
 . "${CSTK_LIB}/doctor.sh"
+# shellcheck source=./mcp.sh
+# mcp.sh e a lib DONA da area MCP (contracts/cli-setup.md §4) — setup.sh
+# reusa _mcp_registration_status (deteccao, FASE 2.3) e _mcp_cmd_install
+# (aplicacao) de la, sem duplicar parsing de .mcp.json nem invocar docker
+# diretamente (FASE 5, task 5.2/5.3).
+. "${CSTK_LIB}/mcp.sh"
 
 _setup_usage() {
   cat <<'HELP'
@@ -738,6 +744,139 @@ _setup_run_state_backend_area() {
   return 0
 }
 
+# ============================================================================
+# Area de MCP (FASE 5 — tasks.md; contract em contracts/cli-setup.md §4;
+# data-model.md Entity ConfigurationArea, linha `mcp`).
+#
+# Reusa `_mcp_registration_status` (cli/lib/mcp.sh, FASE 2.3) para
+# deteccao e `_mcp_cmd_install` (cli/lib/mcp.sh) para aplicacao — NENHUMA
+# reimplementacao de parsing de .mcp.json nem de invocacao de docker
+# aqui (mesmo principio de state-backend reusar config_state_backend_*).
+# ============================================================================
+
+# _setup_run_mcp_area PROJECT_PATH MODE DRY_RUN
+#
+# Orquestra a area 'mcp' de ponta a ponta (FASE 5):
+#   1. Deteccao read-only via _mcp_registration_status (sempre roda, mesmo
+#      em --dry-run) — task 5.1.1
+#   2. Apresentacao do status ANTES de oferecer a acao (FR-002) — task 5.1.2
+#   3. `configured` -> outcome=already-configured, ZERO chamada (I1) —
+#      task 5.2.1
+#   4. `divergent` -> outcome=failed, ZERO chamada de aplicacao (I6,
+#      FR-016), com remediacao em DUAS etapas — task 5.3 (nunca
+#      already-configured, nunca sobrescrita silenciosa: `_mcp_cmd_install`
+#      faz merge com o target vencendo, entao uma entrada divergente
+#      SOBREVIVE a um novo install — contracts/cli-setup.md §4.1)
+#   5. `not-configured` -> decide (prompt interativo ou default de --yes,
+#      que SEMPRE aplica — FR-015, sem opt-in distinto como state-backend);
+#      aplica `cstk mcp install` MESMO sem Docker detectado, emitindo
+#      aviso claro (task 5.2.3) — o registro fica inerte sem Docker, mas
+#      o start das execucoes ja degrada sozinho para bash-fallback
+#
+# Preenche _SU_MCP_OUTCOME (already-configured|applied|skipped|failed) e
+# _SU_MCP_OUTCOME_REASON (motivo legivel; nao vazio em failed e nos
+# avisos pendentes de applied — task 5.2.4/5.2.5, mesmo tratamento de
+# 3.2.3/3.2.5 para a area de hooks).
+_setup_run_mcp_area() {
+  _srm_pap=$1
+  _srm_mode=$2
+  _srm_dry=$3
+
+  if ! _srm_status=$(_mcp_registration_status "$_srm_pap"); then
+    _srm_status="divergent"
+  fi
+
+  # FR-002 — status exibido ANTES de qualquer decisao de acao.
+  log_info "setup: [mcp] status atual = $_srm_status"
+
+  case "$_srm_status" in
+    configured)
+      _SU_MCP_OUTCOME="already-configured"
+      _SU_MCP_OUTCOME_REASON=""
+      log_info "setup: [mcp] ja configurado — nenhuma chamada de aplicacao (I1)."
+      return 0
+      ;;
+    divergent)
+      _SU_MCP_OUTCOME="failed"
+      _SU_MCP_OUTCOME_REASON="entrada mcpServers.cstk-state em $_srm_pap/.mcp.json aponta para fora do catalogo do toolkit"
+      log_error "setup: [mcp] $_SU_MCP_OUTCOME_REASON"
+      log_error "setup: [mcp] remediacao (duas etapas — 'cstk mcp install' NAO sobrescreve entrada divergente, o merge faz o target vencer): (1) remova a entrada mcpServers.cstk-state de $_srm_pap/.mcp.json; (2) so entao rode 'cstk mcp install --project-path $_srm_pap'."
+      log_error "setup: [mcp] nenhuma chamada de aplicacao sera feita (I6)."
+      return 0
+      ;;
+  esac
+
+  # not-configured a partir daqui.
+  if [ "$_srm_dry" = 1 ]; then
+    _SU_MCP_OUTCOME="skipped"
+    _SU_MCP_OUTCOME_REASON="preview: nenhuma alteracao aplicada"
+    log_info "setup: [mcp] preview — registraria mcpServers.cstk-state em $_srm_pap/.mcp.json (nao aplicado)."
+    return 0
+  fi
+
+  _srm_accept=1
+  if [ "$_srm_mode" = "interactive" ]; then
+    if ! _setup_prompt_yn "setup: [mcp] registrar o servidor de estado MCP (mcpServers.cstk-state) agora? [y/N]"; then
+      _srm_accept=0
+    fi
+  fi
+  # --yes (non-interactive): FR-015 — SEMPRE tenta aplicar como default
+  # recomendado, mesmo sem Docker detectado (sem opt-in distinto, ao
+  # contrario da area state-backend).
+
+  if [ "$_srm_accept" != 1 ]; then
+    _SU_MCP_OUTCOME="skipped"
+    _SU_MCP_OUTCOME_REASON="recusado pelo usuario"
+    log_info "setup: [mcp] recusado — mcpServers.cstk-state NAO registrado."
+    return 0
+  fi
+
+  # FR-015/task 5.2.3 — SOMENTE `command -v docker` para o TEXTO do
+  # aviso; NUNCA invocar docker funcionalmente aqui (mcp-docker.sh e o
+  # UNICO ponto autorizado, e nao e chamado por esta area).
+  _srm_docker_warning=""
+  if ! command -v docker >/dev/null 2>&1; then
+    _srm_docker_warning="Docker nao encontrado no PATH — o registro ficara INERTE ate Docker estar disponivel; execucoes 00c degradam sozinhas para bash-fallback nesse meio-tempo."
+  fi
+
+  if _srm_install_out=$(_mcp_cmd_install --project-path "$_srm_pap" 2>&1); then
+    _srm_rc=0
+  else
+    _srm_rc=$?
+  fi
+
+  if [ "$_srm_rc" = 0 ]; then
+    _SU_MCP_OUTCOME="applied"
+    _SU_MCP_OUTCOME_REASON=""
+    log_info "setup: [mcp] aplicado (mcpServers.cstk-state registrado)."
+
+    # task 5.2.4 — jq ausente cai em print_paste_block (exit 0 preservado
+    # por _mcp_cmd_install); mesmo tratamento de 3.2.3 (hooks
+    # paste-instructed): applied com aviso de acao manual pendente, nunca
+    # applied cego.
+    case "$_srm_install_out" in
+      *"jq ausente"*)
+        _SU_MCP_OUTCOME_REASON="jq ausente — registro em .mcp.json exige colagem manual (bloco impresso acima); sem isso o servidor MCP NAO fica registrado"
+        log_warn "setup: [mcp] $_SU_MCP_OUTCOME_REASON"
+        ;;
+    esac
+
+    if [ -n "$_srm_docker_warning" ]; then
+      if [ -n "$_SU_MCP_OUTCOME_REASON" ]; then
+        _SU_MCP_OUTCOME_REASON="$_SU_MCP_OUTCOME_REASON; $_srm_docker_warning"
+      else
+        _SU_MCP_OUTCOME_REASON="$_srm_docker_warning"
+      fi
+      log_warn "setup: [mcp] $_srm_docker_warning"
+    fi
+  else
+    _SU_MCP_OUTCOME="failed"
+    _SU_MCP_OUTCOME_REASON="cstk mcp install falhou (exit $_srm_rc): $_srm_install_out"
+    log_error "setup: [mcp] $_SU_MCP_OUTCOME_REASON"
+  fi
+  return 0
+}
+
 setup_main() {
   if ! _setup_parse_args "$@"; then
     return 2
@@ -780,9 +919,13 @@ setup_main() {
   _setup_run_state_backend_area "$_SU_PROJECT_PATH" "$_su_mode" "$_SU_DRY_RUN"
   log_info "setup: [state-backend] outcome=$_SU_SB_OUTCOME"
 
-  log_info "setup: areas restantes (mcp, telemetry) ainda nao implementadas nesta versao (FASE 4 de 8)."
+  _setup_run_mcp_area "$_SU_PROJECT_PATH" "$_su_mode" "$_SU_DRY_RUN"
+  log_info "setup: [mcp] outcome=$_SU_MCP_OUTCOME"
 
-  if [ "$_SU_HOOKS_OUTCOME" = "failed" ] || [ "$_SU_SB_OUTCOME" = "failed" ]; then
+  log_info "setup: area restante (telemetry) ainda nao implementada nesta versao (FASE 5 de 8)."
+
+  if [ "$_SU_HOOKS_OUTCOME" = "failed" ] || [ "$_SU_SB_OUTCOME" = "failed" ] \
+    || [ "$_SU_MCP_OUTCOME" = "failed" ]; then
     return 1
   fi
   return 0

--- a/cli/lib/setup.sh
+++ b/cli/lib/setup.sh
@@ -82,6 +82,17 @@ set -eu
 # carve-out); setup.sh reusa hooks_main/apply_guard_hooks de la — nenhum
 # mecanismo de merge JSON novo (FASE 3, contracts/cli-setup.md §2.4).
 . "${CSTK_LIB}/hooks.sh"
+# shellcheck source=./config.sh
+# config.sh delega puramente a state-backend.sh (fonte unica de decisao de
+# backend, Decision 2 de state-backend-config) — setup.sh reusa
+# config_state_backend_resolve/enable_sqlite de la (FASE 4, contracts/
+# cli-setup.md §3). Nenhuma logica de parsing/decisao nova aqui.
+. "${CSTK_LIB}/config.sh"
+# shellcheck source=./doctor.sh
+# doctor.sh fornece _doctor_deps_run, reusada COMO TEXTO DE DIAGNOSTICO
+# quando a area state-backend fica unavailable (task 4.4.1) — nenhuma
+# reimplementacao de deteccao de sqlite3/jq.
+. "${CSTK_LIB}/doctor.sh"
 
 _setup_usage() {
   cat <<'HELP'
@@ -515,6 +526,218 @@ _setup_run_hooks_area() {
   return 0
 }
 
+# ============================================================================
+# Area de state backend (FASE 4 — tasks.md; contract em
+# contracts/cli-setup.md §3; data-model.md Entity ConfigurationArea, linha
+# `state-backend`, e Nota "unavailable").
+#
+# **Investigacao empirica (task 4.1)**: os 6 valores de `reason=`
+# produzidos por `_sb_cmd_resolve` (state-backend.sh:234-269) foram
+# enumerados rodando `resolve` nos 4 cenarios exigidos (nunca-configurado,
+# `state_backend=json` explicito, `state_backend=sqlite` explicito, config
+# ausente) sobre um `HOME` sandboxado real:
+#   nunca-configurado                          (config ausente OU sem a chave)
+#   config-invalida                            (linha sem `=`)
+#   json-explicito                             (`state_backend=json`)
+#   configurado-dependencia-adequada           (`state_backend=sqlite` + sqlite3 >= 3.45.1)
+#   configurado-dependencia-abaixo-do-minimo   (`state_backend=sqlite` + sqlite3 < 3.45.1 — via codigo, `_sb_version_ge`)
+#   configurado-dependencia-ausente            (`state_backend=sqlite` + sqlite3 ausente do PATH — via codigo)
+# Nenhum valor alem destes 6 e produzido pelo case fechado de
+# `_sb_cmd_resolve` (verificado por leitura de state-backend.sh:234-269) —
+# nunca inventado (Constitution VI).
+#
+# **`config_state_backend_capability`** (cli/lib/config.sh:90) NAO checa
+# sqlite3 — imprime `_SB_CAPABILITY_TOKEN` fixo ("1", state-backend.sh:72),
+# um identificador de versao do RUNTIME usado so internamente por
+# `enable-sqlite` (P8, checagem de catalogo instalado). Nao e a fonte para
+# detectar dependencia ausente/abaixo do minimo — essa informacao ja vem
+# EMBUTIDA no `reason=` de `resolve` quando o backend foi declarado
+# sqlite (o caminho `declarado -> sqlite` de `_sb_cmd_resolve` chama
+# `_sb_check_sqlite3` internamente). Portanto a area NUNCA chama
+# `capability` para decidir status — o mapeamento abaixo e suficiente e
+# nao duplica logica de decisao (Decision 2).
+#
+# **Mapeamento reason -> status** (reconcilia data-model.md com a US2 AC3
+# — "escolha deliberada de manter o backend legado NAO e migrada nem
+# reportada como not-configured"):
+#   nunca-configurado, config-invalida                    -> not-configured (nenhuma escolha feita ainda)
+#   json-explicito, configurado-dependencia-adequada       -> configured   (escolha explicita e funcional — inclui US2 AC3)
+#   configurado-dependencia-ausente,
+#   configurado-dependencia-abaixo-do-minimo               -> unavailable  (escolha sqlite feita, dependencia quebrada; um `enable-sqlite` recusaria com exit 3 sem nenhuma escrita — data-model.md Nota "unavailable")
+# ============================================================================
+
+# _setup_state_backend_status_from_reason REASON -> stdout:
+# configured|not-configured|unavailable. Fail-closed (I5): reason fora do
+# dominio conhecido (runtime futuro/desconhecido) NUNCA vira 'configured'.
+_setup_state_backend_status_from_reason() {
+  case "$1" in
+    nunca-configurado | config-invalida)
+      printf 'not-configured\n'
+      ;;
+    json-explicito | configurado-dependencia-adequada)
+      printf 'configured\n'
+      ;;
+    configurado-dependencia-ausente | configurado-dependencia-abaixo-do-minimo)
+      printf 'unavailable\n'
+      ;;
+    *)
+      printf 'unavailable\n'
+      ;;
+  esac
+}
+
+# _setup_detect_state_backend_area -> preenche globais:
+#   _SU_SB_EFFECTIVE  sqlite|json (cru de resolve)
+#   _SU_SB_REASON     motivo cru de resolve
+#   _SU_SB_STATUS     configured|not-configured|unavailable
+_setup_detect_state_backend_area() {
+  _SU_SB_EFFECTIVE="json"
+  _SU_SB_REASON="config_state_backend_resolve indisponivel"
+  _SU_SB_STATUS="unavailable"
+
+  if ! _sdsb_out=$(config_state_backend_resolve 2>/dev/null); then
+    return 0
+  fi
+  if [ -z "$_sdsb_out" ]; then
+    return 0
+  fi
+
+  _sdsb_old_ifs=$IFS
+  IFS='
+'
+  for _sdsb_line in $_sdsb_out; do
+    case "$_sdsb_line" in
+      effective_backend=*) _SU_SB_EFFECTIVE=${_sdsb_line#effective_backend=} ;;
+      reason=*) _SU_SB_REASON=${_sdsb_line#reason=} ;;
+    esac
+  done
+  IFS=$_sdsb_old_ifs
+
+  _SU_SB_STATUS=$(_setup_state_backend_status_from_reason "$_SU_SB_REASON")
+  return 0
+}
+
+# _setup_run_state_backend_area PROJECT_PATH MODE DRY_RUN
+#
+# Orquestra a area 'state-backend' de ponta a ponta (FASE 4):
+#   1. Deteccao read-only (sempre roda, mesmo em --dry-run) — task 4.2.1
+#   2. FR-017: rotulo de ESCOPO GLOBAL exibido SEMPRE, antes de qualquer
+#      decisao e mesmo em --dry-run — task 4.2.3
+#   3. `unavailable` -> outcome=failed, ZERO chamada de aplicacao (mesmo
+#      padrao I6 de hooks); diagnostico de `_doctor_deps_run` anexado —
+#      task 4.3.3/4.4.1
+#   4. `configured` -> outcome=already-configured, ZERO chamada (I1) —
+#      cobre tanto sqlite funcional quanto json deliberado (US2 AC3)
+#   5. `not-configured` -> decide: interativo pergunta sempre; `--yes`
+#      SO aplica quando reason indica ausencia de configuracao (task
+#      4.1.3 + achado SEC-04 — opt-in equivalente ao de loose-usage: o
+#      aviso FR-017 explicito + o escopo restrito a "nunca decidiu nada"
+#      sao o sinal equivalente; nunca migra json-explicito nem re-tenta
+#      dependencia quebrada, que ja caiu em unavailable acima)
+#
+# Preenche _SU_SB_OUTCOME (already-configured|applied|skipped|failed) e
+# _SU_SB_OUTCOME_REASON (motivo legivel).
+_setup_run_state_backend_area() {
+  _srsb_pap=$1
+  _srsb_mode=$2
+  _srsb_dry=$3
+
+  _setup_detect_state_backend_area
+
+  # FR-017 — rotulo de escopo GLOBAL, sempre, antes de qualquer decisao
+  # (inclusive --dry-run). As outras 3 areas NAO carregam este rotulo.
+  log_info "setup: [state-backend] ESCOPO GLOBAL — esta area escreve em \$HOME/.claude/cstk/config e vale para TODOS os projetos desta maquina, nao apenas $_srsb_pap."
+  log_info "setup: [state-backend] status atual = $_SU_SB_STATUS (effective_backend=$_SU_SB_EFFECTIVE, reason=$_SU_SB_REASON)"
+
+  case "$_SU_SB_STATUS" in
+    configured)
+      _SU_SB_OUTCOME="already-configured"
+      _SU_SB_OUTCOME_REASON=""
+      log_info "setup: [state-backend] ja configurado — nenhuma chamada de aplicacao (I1)."
+      return 0
+      ;;
+    unavailable)
+      _SU_SB_OUTCOME="failed"
+      _SU_SB_OUTCOME_REASON="$_SU_SB_REASON"
+      log_error "setup: [state-backend] $_SU_SB_REASON"
+      if command -v _doctor_deps_run >/dev/null 2>&1; then
+        # `_doctor_deps_run` retorna exit 1 quando ha anomalia — que e
+        # EXATAMENTE o caso em que estamos exibindo o diagnostico. Nao
+        # usar `|| _srsb_diag=""` aqui: sob `||`, a atribuicao ja
+        # concluida seria sobrescrita por string vazia so por causa do
+        # exit != 0 do lado direito, apagando o proprio texto que
+        # queremos mostrar.
+        if _srsb_diag=$(_doctor_deps_run 2>/dev/null); then :; else :; fi
+        if [ -n "$_srsb_diag" ]; then
+          log_error "setup: [state-backend] diagnostico (cstk doctor --deps):"
+          printf '%s\n' "$_srsb_diag" >&2
+        fi
+      fi
+      log_error "setup: [state-backend] nenhuma chamada de aplicacao sera feita."
+      return 0
+      ;;
+  esac
+
+  # not-configured a partir daqui.
+  if [ "$_srsb_dry" = 1 ]; then
+    _SU_SB_OUTCOME="skipped"
+    _SU_SB_OUTCOME_REASON="preview: nenhuma alteracao aplicada"
+    log_info "setup: [state-backend] preview — ativaria state_backend=sqlite em \$HOME/.claude/cstk/config (escopo global, nao aplicado)."
+    return 0
+  fi
+
+  _srsb_accept=0
+  if [ "$_srsb_mode" = "interactive" ]; then
+    if _setup_prompt_yn "setup: [state-backend] ativar backend sqlite GLOBALMENTE (\$HOME/.claude/cstk/config, afeta todos os projetos)? [y/N]"; then
+      _srsb_accept=1
+    fi
+  else
+    # --yes (non-interactive): SEC-04 — so aplica quando reason indica
+    # AUSENCIA de configuracao (task 4.1.3); preserva US2 AC3 (json
+    # deliberado nunca migra) e nunca re-tenta dependencia quebrada
+    # (unavailable, tratado acima).
+    case "$_SU_SB_REASON" in
+      nunca-configurado | config-invalida)
+        _srsb_accept=1
+        ;;
+    esac
+  fi
+
+  if [ "$_srsb_accept" != 1 ]; then
+    _SU_SB_OUTCOME="skipped"
+    _SU_SB_OUTCOME_REASON="recusado pelo usuario, ou --yes sem sinal equivalente de opt-in (SEC-04) para reason=$_SU_SB_REASON"
+    log_info "setup: [state-backend] nao aplicado — $_SU_SB_OUTCOME_REASON"
+    return 0
+  fi
+
+  if _srsb_apply_out=$(config_state_backend_enable_sqlite 2>&1); then
+    _srsb_rc=0
+  else
+    _srsb_rc=$?
+  fi
+
+  if [ "$_srsb_rc" = 0 ]; then
+    _SU_SB_OUTCOME="applied"
+    _SU_SB_OUTCOME_REASON=""
+    log_info "setup: [state-backend] aplicado (state_backend=sqlite, escopo global)."
+  else
+    _SU_SB_OUTCOME="failed"
+    _SU_SB_OUTCOME_REASON="enable-sqlite falhou (exit $_srsb_rc): $_srsb_apply_out"
+    log_error "setup: [state-backend] $_SU_SB_OUTCOME_REASON"
+    if [ "$_srsb_rc" = 3 ] && command -v _doctor_deps_run >/dev/null 2>&1; then
+      # Ver comentario acima (case unavailable) — nao usar `|| X=""` aqui,
+      # apagaria o diagnostico capturado quando `_doctor_deps_run` sinaliza
+      # anomalia via exit 1.
+      if _srsb_diag=$(_doctor_deps_run 2>/dev/null); then :; else :; fi
+      if [ -n "$_srsb_diag" ]; then
+        log_error "setup: [state-backend] diagnostico (cstk doctor --deps):"
+        printf '%s\n' "$_srsb_diag" >&2
+      fi
+    fi
+  fi
+  return 0
+}
+
 setup_main() {
   if ! _setup_parse_args "$@"; then
     return 2
@@ -554,9 +777,12 @@ setup_main() {
   _setup_run_hooks_area "$_SU_PROJECT_PATH" "$_su_mode" "$_SU_DRY_RUN"
   log_info "setup: [hooks] outcome=$_SU_HOOKS_OUTCOME"
 
-  log_info "setup: areas restantes (state-backend, mcp, telemetry) ainda nao implementadas nesta versao (FASE 3 de 8)."
+  _setup_run_state_backend_area "$_SU_PROJECT_PATH" "$_su_mode" "$_SU_DRY_RUN"
+  log_info "setup: [state-backend] outcome=$_SU_SB_OUTCOME"
 
-  if [ "$_SU_HOOKS_OUTCOME" = "failed" ]; then
+  log_info "setup: areas restantes (mcp, telemetry) ainda nao implementadas nesta versao (FASE 4 de 8)."
+
+  if [ "$_SU_HOOKS_OUTCOME" = "failed" ] || [ "$_SU_SB_OUTCOME" = "failed" ]; then
     return 1
   fi
   return 0

--- a/docs/specs/cstk-setup/checklists/requirements.md
+++ b/docs/specs/cstk-setup/checklists/requirements.md
@@ -1,0 +1,71 @@
+# Requirements Checklist: cstk-setup
+
+**Purpose**: Validar qualidade (completude, clareza, consistencia, mensurabilidade)
+dos requisitos de `spec.md`, apos o endurecimento pos-`owasp-security`
+(achados SEC-01/SEC-02/SEC-03) aplicado a `plan.md`/`data-model.md`/
+`contracts/cli-setup.md`/`quickstart.md` nesta mesma onda.
+**Created**: 2026-08-07
+**Feature**: [spec.md](../spec.md)
+
+## Completude de Requisitos
+
+- [x] CHK001 - Sao os quatro dominios de configuracao e sua ordem fixa de apresentacao definidos sem ambiguidade? [Completude, Spec §FR-001] {auto}
+  - Evidencia: FR-001 enumera explicitamente hooks (com loose-usage aninhado), state backend, MCP, telemetria, "in a fixed order".
+- [x] CHK002 - E definida, para cada area, a fonte de deteccao read-only e a proibicao de reimplementa-la em `setup.sh`? [Completude, Spec §FR-002] {auto}
+  - Evidencia: `plan.md` Summary ("setup.sh e uma camada de orquestracao pura... nenhuma deteccao nem escrita propria") + `data-model.md` tabela "Fonte de status por area" (4 linhas, uma por area).
+- [x] CHK003 - Os 3 achados de seguranca que alteravam contrato/data-model (SEC-01/02/03) ficaram integralmente refletidos em FR-016 apos o hardening desta onda? [Completude, Spec §FR-016] {auto}
+  - Evidencia: `contracts/cli-setup.md` §2.3 (token `"command"` exigido — SEC-01), `data-model.md` invariante I5 (`indeterminate` → `unavailable` — SEC-02), `data-model.md` tabela de fontes linha `hooks` (3 chamadas separadas — SEC-03).
+- [ ] CHK004 - Os 4 achados de seguranca restantes (SEC-04..SEC-07, sem impacto em contrato/data-model) tem destino explicito para nao virarem debito silencioso? [Completude] {auto} [Gap]
+  - Nao totalmente satisfeito: estao registrados em `plan.md` §Re-check de Constitution com o que cada um exige, mas **ainda nao existem como tarefas** em `tasks.md` (arquivo nem existe — `create-tasks` e a proxima etapa). Destino: `/create-tasks` MUST consumir os 4 achados como tarefas explicitas (nao apenas herdar a prosa do plan.md).
+
+## Clareza de Requisitos
+
+- [ ] CHK005 - E "default recomendado" (FR-005) quantificado numa unica fonte rastreavel, cobrindo as 4 areas e a escolha aninhada de loose-usage? [Clareza, Spec §FR-005] {auto} [Gap]
+  - Nao consolidado: o default de cada area esta espalhado em 4 locais distintos — `data-model.md` (`loose_usage_choice` default=`skip`), `plan.md` §Analise Principio IV ("unica area cujo default recomendado e 'nao'"), FR-015 (MCP aplica mesmo sem Docker) e `data-model.md` `applicable=false` para telemetria. Nenhum artefato tem uma tabela unica "area → default em `--yes`". Recomendado como tarefa de consolidacao documental no `create-tasks` (baixo risco, custo de manutencao).
+- [x] CHK006 - FR-018 ("nao expor override de catalogo") e formulado de forma objetivamente testavel? [Clareza, Spec §FR-018] {auto}
+  - Evidencia: `contracts/cli-setup.md` §2.4 nota FR-018 (tabela dos dois knobs de catalogo + por que nenhum e exposto) + `quickstart.md` Scenario 16 (`--catalog` → exit 2, `CSTK_HOOKS_CATALOG_DIR` → area anuncia referencia nao-padrao).
+- [x] CHK007 - A regra de decisao pos-hardening SEC-01 ("linha canonica") esta redigida sem termo vago, com o residual aceito declarado explicitamente (nao verificado textualmente)? [Clareza, Spec §FR-016] {auto}
+  - Evidencia: `contracts/cli-setup.md` §2.3, bloco "Correcao pos-gate (achado SEC-01, MEDIUM)" declara literalmente o limite ("nao verifica posicionamento estrutural").
+
+## Consistencia de Requisitos
+
+- [x] CHK008 - FR-005 ("aplica o default para toda area nao configurada") e FR-012 ("telemetria NUNCA escreve fora do projeto") sao consistentes entre si? [Consistencia, Spec §FR-005, §FR-012] {auto}
+  - Evidencia: `data-model.md` `ConfigurationArea.applicable=false` para `telemetry` resolve a tensao — a area e sempre diagnosticada, nunca "aplicada" no sentido de escrita, mesmo sob `--yes`.
+- [x] CHK009 - FR-009 (falha isolada por area, nunca crash do wizard inteiro) permanece consistente apos a introducao do status `unavailable` para `hooks` via 5a coluna `indeterminate` (SEC-02)? [Consistencia, Spec §FR-009] {auto}
+  - Evidencia: `quickstart.md` Scenario 15 variante 4, texto explicito: "nao uma excecao/crash da area (FR-009 segue intacto: a area reporta um status valido do enum fechado, o wizard nao aborta)".
+- [x] CHK010 - A tabela de fontes de `data-model.md` (hooks: 3 chamadas separadas, SEC-03) permanece consistente com o Scenario 10 pre-existente (loose-usage ja era chamada separada)? [Consistencia, Spec §FR-009] {auto}
+  - Evidencia: Scenario 10 (pre-existente) ja isolava `--include-loose-usage`; o fix SEC-03 estende a mesma disciplina para `--verify-registration`, que ate entao estava descrita como combinada com a baseline — sem conflito entre os dois scenarios apos o fix (`quickstart.md` Scenario 18 novo).
+
+## Qualidade de Criterios de Aceite / Mensurabilidade
+
+- [x] CHK011 - SC-002 ("zero configuration changes" no 2o run) e mensuravel objetivamente, com metodo definido? [Mensurabilidade, Spec §SC-002] {auto}
+  - Evidencia: `quickstart.md` Scenario 2 define o metodo exato (assinatura de `.claude/settings.json`, `.mcp.json`, `$HOME/.claude/cstk/config`, `.claude/hooks/` antes/depois, comparando conteudo e nao so mtime).
+- [x] CHK012 - SC-006 ("100% divergent / 0% already-configured" para registro redirecionado) tem cenarios de teste que cobrem tanto o caso obvio quanto o caso de decoy textual (SEC-01)? [Mensurabilidade, Spec §SC-006] {auto}
+  - Evidencia: Scenario 13 (comando redirecionado obvio) + Scenario 17 novo (linha-isca decorativa, SEC-01) + Scenario 14 (MCP).
+
+## Cobertura de Cenarios
+
+- [x] CHK013 - O gate deterministico `requirement-coverage.sh` encontrou algum FR de `spec.md` sem cenario de Acceptance/Edge Case associado? [Cobertura] {auto}
+  - Evidencia: `global/skills/checklist/scripts/requirement-coverage.sh docs/specs/cstk-setup/spec.md` rodado nesta onda → `RESULT|...|requirements=18|covered=18|errors=0`, exit 0. Zero FR orfao.
+- [x] CHK014 - Existe cenario cobrindo runtime instalado desatualizado que rejeita `--include-loose-usage` **e**, separadamente, `--verify-registration`? [Cobertura, Spec §FR-009] {auto}
+  - Evidencia: Scenario 10 (loose-usage) + Scenario 18 novo (verify-registration, SEC-03) — os dois testados isoladamente, nao combinados.
+- [ ] CHK015 - US2 AC3 ("backend deliberadamente diferente nao e migrado a forca") tem seu comportamento `--yes` totalmente especificado, incluindo os valores possiveis de `reason=` do `state-backend.sh resolve`? [Cobertura, Spec §US2 AC3] {auto} [Gap]
+  - Nao satisfeito: `plan.md` §Riscos item 1 e `research.md` Decision 10 registram explicitamente que os valores de `reason=` nao estao enumerados e que a decisao do default de `--yes` para esta area foi **adiada para `create-tasks`** (investigacao empirica antes de codificar). Gap pre-existente (nao introduzido nesta onda), reafirmado aqui para garantir que `create-tasks` de fato o consuma.
+
+## Dependencias e Premissas
+
+- [x] CHK016 - A premissa de FR-011 (".git como marcador de onboarding, nao fronteira de confianca") declara sua limitacao conhecida, em vez de a esconder? [Premissas, Spec §FR-011] {auto}
+  - Evidencia: `contracts/cli-setup.md` linhas 80-90, bloco explicito: "`.git` e marcador de onboarding, NAO fronteira de confianca... nao atesta procedencia".
+- [x] CHK017 - A dependencia entre FR-016 e a semantica de merge "target vence" de `hooks install`/`mcp install` esta documentada de forma que a remediacao publicada seja de fato efetiva (nao uma instrucao que nao surte efeito)? [Dependencias, Spec §FR-016] {auto}
+  - Evidencia: `research.md` Decision 11 + `data-model.md` "Por que `divergent` → `failed`, e nao `applied` apos 'corrigir'" — remediacao de duas etapas justificada contra o comportamento real do merge.
+
+## Risco (decisao do dono do produto)
+
+- [ ] CHK018 - A prioridade relativa entre fechar SEC-04..SEC-07 versus avancar as tarefas de US1-US4 no `create-tasks` reflete o apetite de risco do time para este projeto? [Risco] {humano}
+- [ ] CHK019 - O residual aceito do fix SEC-01 (posicionamento estrutural sob `PreToolUse`/`matcher` nao verificado textualmente) e aceitavel para o perfil de ameaca deste projeto, ou justifica investir em parse real (`jq`) numa iteracao futura? [Risco, Spec §FR-016] {humano}
+
+## Notes
+
+- Items `{auto}` ja vem resolvidos pelo agente (`[x]` com citacao, ou marcador `[Gap]`).
+- Items `{humano}` ficam `[ ]` aguardando decisao do dono do produto.
+- Gaps abertos (CHK004, CHK005, CHK015) tem destino: `/create-tasks` deve consumi-los como tarefas explicitas de documentacao/investigacao, nao apenas herdar a prosa do `plan.md`.

--- a/docs/specs/cstk-setup/checklists/security.md
+++ b/docs/specs/cstk-setup/checklists/security.md
@@ -1,0 +1,86 @@
+# Security Checklist: cstk-setup
+
+**Purpose**: Validar a qualidade dos requisitos de seguranca de `spec.md`
+(FR-016 autenticidade, FR-017 escopo global, FR-018 ausencia de override de
+catalogo) apos o re-review `owasp-security` que gerou os achados
+SEC-01..SEC-07 — 3 corrigidos nesta onda (contrato/data-model), 4
+registrados para `create-tasks`.
+**Created**: 2026-08-07
+**Feature**: [spec.md](../spec.md)
+
+## Autenticacao / Autorizacao
+
+- [x] CHK001 - Ha superficie de autenticacao/autorizacao de usuario nesta feature, e se nao houver, isso esta implicitamente correto (nao e um requisito esquecido)? [AuthN/Z] {auto}
+  - Evidencia: `cstk setup` e um subcomando CLI local, sem usuarios/sessoes/tokens — `plan.md` Technical Context nao lista nenhuma dependencia de auth. O requisito mais proximo de "autorizacao" e FR-016 (verificar que o que esta REGISTRADO e de fato o script autorizado do catalogo, nao um substituto), coberto abaixo.
+
+## Protecao de Dados
+
+- [x] CHK002 - Ha algum dado sensivel (segredo/token/credencial) manipulado por esta feature? [Protecao de Dados] {auto}
+  - Evidencia: nenhum. As 4 areas leem/escrevem apenas paths locais (`settings.json`, `.mcp.json`, `$HOME/.claude/cstk/config`) sem credenciais. Unico vetor de "supply chain" considerado e a origem do catalogo (FR-018), coberto abaixo.
+- [x] CHK003 - Existe requisito explicito proibindo escrita fora do escopo declarado (projeto-alvo), com a unica excecao marcada como tal? [Protecao de Dados, Spec §FR-012, §FR-017] {auto}
+  - Evidencia: FR-012 proibe escrita fora do projeto para a area `telemetry`; FR-017 declara EXPLICITAMENTE a unica excecao (`state-backend`, escopo global) com rotulo obrigatorio antes de aplicar, inclusive em `--dry-run` (`quickstart.md` Scenario 16).
+
+## Input Validation
+
+- [x] CHK004 - O requisito de validacao de `--project-path` esta especificado com o gate exato (o que conta como "diretorio valido") e o efeito de falha (exit code, zero escrita)? [Input Validation, Spec §FR-011] {auto}
+  - Evidencia: FR-011 + `contracts/cli-setup.md` §Pre-condicoes item 1 (`[ -e "$PATH/.git" ]`, exit 3, "zero escrita").
+
+## Fail-Safe Defaults / Ambiguidade de Verificacao
+
+- [x] CHK005 - Em caso de ambiguidade na verificacao de autenticidade do registro (5a coluna `indeterminate`), o requisito garante fail-closed — nunca reportar `configured`? [Seguranca, Spec §FR-016] {auto}
+  - Evidencia: pos-hardening SEC-02 — `data-model.md` invariante I5 mapeia `indeterminate` → `unavailable` explicitamente (nunca `configured`, nunca herda o exit 0/1 da chamada baseline).
+- [x] CHK006 - `unavailable` (impossibilidade de verificar) e distinto de `divergent` (confirmacao positiva de subversao), evitando que uma verificacao inconclusiva seja relatada com o mesmo peso de uma deteccao real? [Seguranca, Spec §FR-016] {auto}
+  - Evidencia: `data-model.md` invariante I5 reescrita nesta onda distingue as duas classes de ambiguidade e seus destinos no enum fechado, com a justificativa de custo (falso `unavailable`/`divergent` = aviso; falso `configured` = a garantia que a feature existe para eliminar).
+
+## Resistencia a Decoy / Bypass Trivial
+
+- [x] CHK007 - O requisito de autenticidade (FR-016) resiste a uma tentativa barata de satisfazer a verificacao textual sem ser o registro real — ex. uma linha decorativa citando o basename e o fragmento canonico sem ser a atribuicao `"command"`? [Seguranca, Spec §FR-016] {auto}
+  - Evidencia: pos-hardening SEC-01 — `contracts/cli-setup.md` §2.3 agora exige o token literal `"command"` na mesma linha; `quickstart.md` Scenario 17 (novo) exercita exatamente esse caso.
+  - Residual declarado (nao um gap silencioso): a regra continua sendo co-ocorrencia textual por linha, nao parse estrutural — nao confirma que a linha esta de fato dentro do objeto de hook correto sob `PreToolUse`/`matcher`. Ver CHK019 do checklist `requirements.md` (decisao `{humano}` sobre aceitar esse residual).
+
+## Disponibilidade da Verificacao de Seguranca (nao mascarar o veredito basico)
+
+- [x] CHK008 - Uma extensao de verificacao (`--verify-registration`) que falha em runtime desatualizado (exit 2) preserva o veredito basico dos hooks obrigatorios em vez de o perder/mascarar? [Seguranca, Spec §FR-009, §FR-016] {auto}
+  - Evidencia: pos-hardening SEC-03 — `data-model.md` exige 3 chamadas SEPARADAS (baseline nunca combinada com extensoes); `quickstart.md` Scenario 18 (novo) assertaria explicitamente que a chamada baseline roda e retorna exit 0 independente do exit 2 da extensao.
+
+## Escopo Declarado da Verificacao (transparencia)
+
+- [ ] CHK009 - O `summary` final declara explicitamente o escopo real do que foi verificado (so os 3 hooks obrigatorios de `_GH_HOOKS`), evitando que o usuario infira uma garantia mais ampla (ex. sobre outras entradas do `settings.json`)? [Seguranca/Transparencia, Spec §FR-010, §FR-016] {auto} [Gap]
+  - Nao satisfeito ainda: este e exatamente o achado **SEC-07** do re-review, registrado em `plan.md` §Re-check de Constitution para virar tarefa explicita no `create-tasks` — nao alterava contrato/data-model, por isso nao foi fechado nesta onda. Destino: `/create-tasks`.
+
+## Least Privilege / Superficie de Escrita
+
+- [x] CHK010 - A feature delega toda escrita a comandos ja existentes e dedicados, sem implementar uma segunda via de escrita em `setup.sh`? [Seguranca] {auto}
+  - Evidencia: `plan.md` Summary — "`cli/lib/setup.sh` e uma camada de orquestracao pura... Nao implementa nenhuma deteccao nem nenhuma escrita propria".
+
+## Confused Deputy (resolucao de path do MCP)
+
+- [x] CHK011 - A verificacao de autenticidade do MCP evita falso-positivo entre as camadas legitimas de resolucao de path, sem abrir brecha para aceitar um path arbitrario como legitimo? [Seguranca, Spec §FR-016] {auto}
+  - Evidencia: `contracts/cli-setup.md` §4.1 enumera as 3 camadas aceitas de `_mcp_runtime_script_path` (PATH / repo / catalogo instalado) com justificativa de por que aceitar o conjunto (evita `divergent` espurio em maquina de dev) sem aceitar qualquer path fora dele.
+- [ ] CHK012 - Os "paths candidatos" aceitos (item acima) sao restritos a caminhos com o sufixo esperado (`/skills/agente-00c-runtime/scripts/mcp-launch.sh`) **e** que de fato existem em disco no momento da verificacao, ou a regra e mais permissiva do que isso? [Seguranca, Spec §FR-016] {auto} [Gap]
+  - Nao satisfeito ainda: este e o achado **SEC-05** do re-review — a redacao atual de §4.1 (candidato 1: `command -v mcp-launch.sh` via PATH) e mais ampla do que "sufixo esperado + existente em disco", registrado em `plan.md` para virar tarefa explicita no `create-tasks`, sem impacto no contrato aditivo desta onda (`_mcp_registration_status` continua **[PROPOSTA]**, ainda nao implementada).
+
+## Tratamento de Resposta Vazia/Indeterminada
+
+- [ ] CHK013 - Uma resposta vazia de `_mcp_registration_status` (stdout sem nenhuma das 3 palavras esperadas) e tratada como indeterminado, nunca como uma das respostas validas por omissao? [Seguranca, Spec §FR-016] {auto} [Gap]
+  - Nao satisfeito ainda: achado **SEC-06** do re-review, mesma classe do SEC-02 (fail-open por ausencia de mapeamento explicito) mas para o helper de MCP em vez do de hooks; `contracts/cli-setup.md` §4.1 hoje so enumera 3 saidas possiveis sem declarar o que fazer se a saida NAO for nenhuma delas. Registrado para `create-tasks`.
+
+## Auditabilidade / Rastreabilidade
+
+- [x] CHK014 - A ausencia de persistencia (FR-013 proibe flag de "setup ja rodou") compromete a capacidade de auditar depois o que uma execucao concluiu? [Auditabilidade, Spec §FR-013, §FR-010] {auto}
+  - Evidencia: e uma escolha deliberada (idempotencia por re-checagem viva, nao por estado persistido) — FR-010 garante que o `SetupRunSummary` e sempre impresso na propria execucao; nao ha promessa de log persistido em `spec.md`, entao a ausencia nao e um requisito quebrado, apenas um limite conhecido do design (CLI stateless).
+
+## Secure Defaults
+
+- [x] CHK015 - O default nao-interativo (`--yes`) evita aplicar a escolha de maior superficie/privacidade por padrao, quando existe uma alternativa mais conservadora? [Seguranca, Spec §FR-008] {auto}
+  - Evidencia: `data-model.md` `loose_usage_choice` default em `--yes` = `skip` — unica area cujo default e "nao aplicar" (`plan.md` §Analise Principio IV), preservando o opt-in explicito ja existente de `--with-loose-usage`.
+
+## Decisao do Dono do Produto
+
+- [ ] CHK016 - O escopo de auditoria declarado no summary (uma vez que SEC-07 seja corrigido) deve incluir tambem uma varredura best-effort de OUTRAS entradas do `settings.json`/`.mcp.json` fora das 3 obrigatorias, ou permanece deliberadamente limitado aos 3 hooks de `_GH_HOOKS`? [Risco/Escopo] {humano}
+
+## Notes
+
+- Items `{auto}` ja vem resolvidos pelo agente (`[x]` com citacao, ou marcador `[Gap]`).
+- Items `{humano}` ficam `[ ]` aguardando decisao do dono do produto.
+- 3 Gaps (CHK009/SEC-07, CHK012/SEC-05, CHK013/SEC-06) tem destino ja registrado: `/create-tasks` deve consumi-los como tarefas explicitas — nao sao debito silencioso, so nao alteravam contrato/data-model o suficiente para justificar fechar nesta mesma onda.

--- a/docs/specs/cstk-setup/contracts/cli-setup.md
+++ b/docs/specs/cstk-setup/contracts/cli-setup.md
@@ -1,0 +1,300 @@
+# Contracts: cstk-setup — interface de linha de comando
+
+Contrato do subcomando `cstk setup` (novo) e das fronteiras que ele
+consome.
+
+> **Marcacao de veracidade (Constitution VI)**:
+> - Blocos marcados **[PROPOSTA]** descrevem interface **nova**, ainda
+>   inexistente — a validar na implementacao.
+> - Blocos marcados **[EXISTENTE]** descrevem comportamento ja no repo e
+>   citam `arquivo:linha` verificado em 2026-08-07. Nenhum campo, flag ou
+>   exit code de bloco [EXISTENTE] foi suposto.
+
+---
+
+## 1. `cstk setup` **[PROPOSTA]**
+
+**Invocacao**: `cstk setup [--dry-run] [--yes] [--project-path PATH]`
+**Funcao de entrada**: `setup_main` em `cli/lib/setup.sh`
+**Resolucao**: ramo generico do dispatcher — `cli/cstk:250-273`; nome da
+funcao derivado por `sed 's/-/_/g'` + `_main` (`cli/cstk:267`)
+
+### Flags
+
+| Flag | Tipo | Default | Descricao |
+|------|------|---------|-----------|
+| `--dry-run` | bool | off | Preview: exibe status e o que seria aplicado, sem escrever nada (FR-004). **Precede `--yes`** (FR-006) |
+| `--yes` | bool | off | Nao-interativo: aplica o default recomendado de cada area nao configurada, sem prompt (FR-005) |
+| `--project-path PATH` | path | `$PWD` | Raiz do projeto-alvo. MUST ser raiz de repo git (FR-011) |
+
+### Precedencia de modo (FR-006)
+
+```
+--dry-run presente            -> mode=preview          (nada e aplicado)
+--yes presente, sem --dry-run -> mode=non-interactive
+nenhum dos dois               -> mode=interactive      (exige TTY, FR-007)
+```
+
+### Saida (stdout)
+
+Por area, na ordem fixa de FR-001 (`hooks`, `state-backend`, `mcp`,
+`telemetry`): bloco com o status atual e a acao. Ao final, o
+`SetupRunSummary` (FR-010) com uma linha por area:
+
+```
+<area>  <applied|already-configured|skipped|failed>  [motivo]
+```
+
+Diagnosticos e avisos vao para **stderr** (Constitution II: "Mensagens de
+erro em stderr, saida de dados em stdout").
+
+### Exit codes **[PROPOSTA]**
+
+| Code | Significado |
+|------|-------------|
+| `0` | Run completo — inclui areas puladas, ja configuradas e `--dry-run` |
+| `1` | Pelo menos uma area terminou em `failed` |
+| `2` | Uso incorreto (flag desconhecida) |
+| `3` | Recusa por pre-condicao: fora de raiz de repo git (FR-011), ou terminal nao-interativo sem `--dry-run`/`--yes` (FR-007) |
+
+Alinhado as constantes do binario (`cli/cstk:30-33`:
+`CSTK_EXIT_OK=0`, `CSTK_EXIT_ERROR=1`, `CSTK_EXIT_USAGE=2`,
+`CSTK_EXIT_LOCK=3`) e ao uso de `3` como "recusado por pre-condicao" ja
+publicado por `cstk mcp install` (`cli/lib/mcp.sh:949-953`) e
+`cstk state enable-sqlite` (`cli/lib/state.sh:26-28`).
+
+### Pre-condicoes
+
+1. **FR-011** — `[ -e "$PATH/.git" ]` (arquivo OU diretorio; worktree
+   conta). Falha → exit 3, **zero escrita**.
+2. **FR-007** — em `mode=interactive`, TTY obrigatorio via `require_tty`
+   (`cli/lib/ui.sh:42-50`, teste `[ -t 0 ]` na linha 46, bypass
+   `CSTK_FORCE_INTERACTIVE=1` na linha 43). Falha → exit 3 com mensagem
+   apontando `--dry-run` ou `--yes`.
+
+---
+
+## 2. Fronteira: area de hooks
+
+### 2.1 Deteccao — `guard-hooks-status.sh check` **[EXISTENTE]**
+
+**Invocacao**: `guard-hooks-status.sh check --projeto-alvo-path PATH [--quiet]`
+**Arquivo**: `global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh`
+**Contrato**: cabecalho linhas 49-60; implementacao `_gh_cmd_check` linhas 197-262
+
+**Saida (stdout)** — uma linha TSV por hook, 4 campos:
+
+| Campo | Valores |
+|-------|---------|
+| 1 — arquivo | `pretooluse-bash-guard.sh` \| `posttooluse-tool-call-tick.sh` \| `posttooluse-agent-usage.sh` (lista `_GH_HOOKS`, linhas 104-107) |
+| 2 — presenca | `present` \| `missing` |
+| 3 — registro | `registered` \| `unregistered` (basename aparece em `<PAP>/.claude/settings.json`) |
+| 4 — frescor | `current` \| `stale` \| `unknown` (comparacao byte-a-byte com o catalogo) |
+
+**Exit codes**: `0` os 3 present+registered+(current\|unknown); `1` caso
+contrario (**inclui `stale`**); `2` uso incorreto.
+
+**stderr**: diagnostico + comando de remediacao, suprimido por `--quiet`.
+
+### 2.2 Deteccao do hook opt-in — `--include-loose-usage` **[PROPOSTA]**
+
+**Invocacao**: `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet --include-loose-usage`
+
+Extensao **aditiva** ao contrato 2.1: acrescenta uma 4a linha TSV para
+`posttooluse-loose-usage.sh` no mesmo formato de 4 campos.
+
+**Invariantes obrigatorias da extensao**:
+
+- **NAO altera o exit code**. O hook e opt-in; sua ausencia jamais e
+  anomalia. O exit continua derivado apenas dos 3 hooks de `_GH_HOOKS`.
+- Sem a flag, a saida e byte-a-byte identica a atual (retro-compatibilidade).
+- Runtime instalado anterior a esta feature rejeita a flag desconhecida em
+  `_gh_die_usage` (`guard-hooks-status.sh:205`) com **exit 2** — o
+  consumidor MUST tratar isso como `loose_usage_status=indeterminate`,
+  nunca como falha da area de hooks (FR-009).
+
+**Justificativa**: `posttooluse-loose-usage.sh` existe no catalogo
+(`global/skills/agente-00c-runtime/hooks/`, com
+`settings.loose-usage.snippet.json` proprio) mas nao e coberto por
+nenhuma fonte de deteccao read-only hoje. Ver research.md Decision 3.
+
+### 2.3 Aplicacao — `hooks install` **[EXISTENTE]**
+
+**Invocacao**: `hooks_main install --project-path PATH [--catalog DIR] [--dry-run] [--with-loose-usage]`
+**Arquivo**: `cli/lib/hooks.sh` — `hooks_main` linha 557; flags linhas 583-593
+
+`install` e o **unico** subcomando aceito (linha 566; erro "use: install"
+na linha 568). **Nao existe `cstk hooks status`** — a deteccao vem de 2.1.
+
+`--with-loose-usage` e **opt-in, default desligado** (linhas 513, 543).
+
+**Estados internos** retornados por `apply_guard_hooks` (linha 318,
+chamada na linha 625; documentados nas linhas 38-42; tratados nas linhas
+627-649): `merged` \| `paste-instructed` \| `hooks-only` \|
+`not-applicable` \| `error`.
+
+**Exit codes**: `0` sucesso — **inclui `paste-instructed` e `hooks-only`,
+que sao apenas warnings** (linhas 631-643); `1` erro (linhas 598, 608,
+617, 644); `2` uso incorreto (linhas 568, 594).
+
+**Guarda**: recusa `--project-path` igual a `$HOME` (linhas 617-620) —
+"hooks 00c sao de escopo PROJETO".
+
+> **Consequencia de projeto**: como exit 0 abrange `paste-instructed`
+> (jq ausente → bloco para colar manualmente), o wizard NAO pode
+> reportar `applied` cegamente com base no exit. Deve propagar o aviso ao
+> summary; ver quickstart.md Cenario 7.
+
+---
+
+## 3. Fronteira: area de state backend **[EXISTENTE]**
+
+### 3.1 Deteccao — `config_state_backend_resolve`
+
+**Funcao**: `cli/lib/config.sh:94` (delega via `_config_delegate`, linha 76,
+resolvido por `_config_state_backend_script_path`, linha 52)
+**Script real**: `global/skills/agente-00c-runtime/scripts/state-backend.sh`,
+subcomando `resolve` (`_sb_cmd_resolve`, linhas 234-269)
+
+**Saida (stdout)**:
+
+| Campo | Valores |
+|-------|---------|
+| `effective_backend=` | `sqlite` \| `json` |
+| `reason=` | texto livre (ex. `nunca-configurado`) |
+
+**Contrato de nao-falha**: `resolve` **nunca falha** — `return 0`
+incondicional na linha 269 ("contrato de nao-falha FR-008").
+
+### 3.2 Capacidade — `config_state_backend_capability`
+
+**Funcao**: `cli/lib/config.sh:90` → `state-backend.sh capability` (linha 228).
+Versao minima de `sqlite3`: `_SB_MIN_SQLITE_VERSION="3.45.1"`
+(`state-backend.sh:67`).
+
+### 3.3 Aplicacao — `config_state_backend_enable_sqlite`
+
+**Funcao**: `cli/lib/config.sh:98` — o mesmo alvo que
+`cstk state enable-sqlite` delega (`cli/lib/state.sh:122-131`, repassando
+o exit **verbatim**; `command -v` na linha 124).
+**Script real**: `_sb_cmd_enable_sqlite` (`state-backend.sh:358-397`).
+
+**Efeito**: grava `state_backend=sqlite` em `$HOME/.claude/cstk/config`
+(`_SB_CONFIG_DIR` linha 75, `_SB_CONFIG_FILE` linha 76), com diretorio
+`700` e arquivo `600` (linhas 322-329).
+
+**Exit codes** (documentados em `cli/lib/state.sh:26-28` e linha 97):
+`0` sucesso; `1` falha; `2` uso incorreto; `3` **recusado por
+pre-condicao** — `sqlite3` ausente ou abaixo do minimo (linhas 358-370).
+
+**Idempotencia nativa**: se ja `state_backend=sqlite`, no-op e `return 0`
+(linhas 385-390).
+
+> **Escopo GLOBAL, nao de projeto**: esta e a unica das quatro areas que
+> escreve fora do diretorio do projeto — em `$HOME/.claude/cstk/config`.
+> Isso e comportamento preexistente do comando dedicado, nao introduzido
+> pelo wizard, e nao conflita com FR-012 (que restringe apenas a area de
+> telemetria). Tem consequencia direta em teste: exige `HOME` sandboxado
+> (ver quickstart.md e research.md Decision 10).
+
+### 3.4 Diagnostico complementar — `cstk doctor --deps` **[EXISTENTE]**
+
+**Flag**: `cli/lib/doctor.sh:214`; implementacao `_doctor_deps_run` linhas 408-474.
+
+**Campos impressos** (linhas 464-470):
+
+```
+sqlite3: presente=%s versao=%s minima=3.45.1
+jq: presente=%s versao=%s
+effective_backend: %s
+reason: %s
+```
+
+Seguido de `[ANOMALY] ...` (linha 472) ou `sem anomalias.` (linha 474).
+**Exit codes** (linhas 85-86): `0` sem anomalia; `1` com anomalia.
+
+Reusado pelo wizard como texto de diagnostico quando a area fica
+`unavailable`.
+
+---
+
+## 4. Fronteira: area de MCP **[EXISTENTE]**
+
+### 4.1 Deteccao
+
+Presenca da chave `cstk-state` sob `mcpServers` em
+`<project-path>/.mcp.json` — exatamente o alvo que `_mcp_cmd_install`
+escreve (`cli/lib/mcp.sh:847`; bloco JSON linhas 864-865).
+
+Leitura textual (sem `jq`), coerente com a mesma escolha ja feita por
+`_gh_registered` (`guard-hooks-status.sh:119` e seguintes), que usa busca
+textual em vez de parse justamente para nao depender de `jq` num projeto
+possivelmente mal provisionado.
+
+### 4.2 Aplicacao — `cstk mcp install`
+
+**Funcao**: `_mcp_cmd_install` (`cli/lib/mcp.sh:806-877`)
+**Efeito**: registra a entrada estatica `mcpServers.cstk-state` em
+`<project-path>/.mcp.json`, com `command` apontando para `mcp-launch.sh`
+resolvido do catalogo (linhas 837-840).
+
+**Idempotencia nativa**: via `merge_settings` (target vence em conflito) —
+"entrada ja presente e equivalente => idempotente, exit 0"
+(comentario linhas 800-802).
+
+**Sem `jq`**: cai em `print_paste_block` e **ainda retorna 0**
+(linhas 866-871) — nao falha por ausencia de `jq`.
+
+**Exit codes** (documentados linhas 949-953): `0` criada / ja presente /
+`--dry-run`; `1` erro IO/merge ou catalogo sem `mcp-launch.sh`; `2` uso
+incorreto; `3` recusa `--project-path` = `$HOME` (linhas 831-835).
+
+### 4.3 Docker — diagnostico apenas
+
+`status=active` (`cli/lib/mcp.sh:259`) \| `status=stopped` (linha 239) \|
+`status=unavailable` (linhas 203, 250), via `_mcp_cmd_status` (linha 371).
+
+**Confinamento**: toda invocacao funcional de `docker` vive em
+`cli/lib/mcp-docker.sh` (`_mcp_docker_preflight`; cabecalho linhas 1-11
+declara ser o "UNICO ponto de invocacao FUNCIONAL de docker").
+`cli/lib/mcp.sh` usa `command -v docker` apenas para escolher o motivo
+`docker-absent` (linhas 475-479).
+
+**FR-015**: em `--yes`, a area MCP aplica `mcp install` **mesmo sem
+Docker**, emitindo aviso claro. `setup.sh` **NAO** invoca `docker`
+diretamente — no maximo `command -v docker` para o texto do aviso, mesmo
+padrao de `cli/lib/mcp.sh:475-479`.
+
+---
+
+## 5. Fronteira: area de telemetria **[EXISTENTE]** — read-only
+
+### 5.1 Deteccao — `otel-usage.sh preflight`
+
+**Arquivo**: `global/skills/agente-00c-runtime/scripts/otel-usage.sh`
+**Subcomando**: `preflight` — `_ou_cmd_preflight` linha 469; flag
+`--endpoint URL` linha 473; documentado na linha 545; dispatch linhas
+534-536. Responde "a telemetria DESTA sessao vai ser medida?" (linha 561).
+
+Demais subcomandos existentes: `available`, `snapshot`, `delta`.
+
+**Nao existe `cli/lib/otel*.sh`** — verificado. A unica superficie e o
+script do catalogo.
+
+### 5.2 Instrucoes exibidas (nunca escritas — FR-012)
+
+Valores extraidos do `README.md`, secao de custo por onda:
+
+| Variavel / valor | Fonte |
+|------------------|-------|
+| `CLAUDE_CODE_ENABLE_TELEMETRY=1` | README.md:306 |
+| `OTEL_METRICS_EXPORTER=prometheus` | README.md:307 |
+| `CSTK_OTEL_ENDPOINT` | README.md:317, 349 |
+| `OTEL_EXPORTER_PROMETHEUS_PORT` | README.md:348 |
+| endpoint padrao `127.0.0.1:9464` | README.md:315 |
+| wrapper `claude()` em `~/.zshrc` (sorteia porta livre) | README.md:342-354 |
+
+**FR-012**: o wizard **NAO escreve** em `~/.zshrc` nem em qualquer arquivo
+fora do diretorio do projeto para esta area. Outcome possivel:
+`already-configured` \| `skipped` \| `failed`. **`applied` e
+inalcancavel** para telemetria.

--- a/docs/specs/cstk-setup/contracts/cli-setup.md
+++ b/docs/specs/cstk-setup/contracts/cli-setup.md
@@ -27,6 +27,10 @@ funcao derivado por `sed 's/-/_/g'` + `_main` (`cli/cstk:267`)
 | `--yes` | bool | off | Nao-interativo: aplica o default recomendado de cada area nao configurada, sem prompt (FR-005) |
 | `--project-path PATH` | path | `$PWD` | Raiz do projeto-alvo. MUST ser raiz de repo git (FR-011) |
 
+**Flags deliberadamente ausentes (FR-018)**: nao ha `--catalog` nem
+qualquer equivalente, e nenhuma variavel de override de catalogo e
+repassada aos comandos delegados. Ver §2.4.
+
 ### Precedencia de modo (FR-006)
 
 ```
@@ -42,8 +46,13 @@ Por area, na ordem fixa de FR-001 (`hooks`, `state-backend`, `mcp`,
 `SetupRunSummary` (FR-010) com uma linha por area:
 
 ```
-<area>  <applied|already-configured|skipped|failed>  [motivo]
+<area>  <applied|already-configured|skipped|failed>  [escopo]  [motivo]
 ```
+
+- `[escopo]` marca `global` apenas na area `state-backend` (FR-017); as
+  demais sao de escopo projeto e nao recebem marca.
+- Area com `status=divergent` aparece como `failed`, com `[motivo]`
+  carregando a remediacao de duas etapas (§4.1, data-model).
 
 Diagnosticos e avisos vao para **stderr** (Constitution II: "Mensagens de
 erro em stderr, saida de dados em stdout").
@@ -67,6 +76,18 @@ publicado por `cstk mcp install` (`cli/lib/mcp.sh:949-953`) e
 
 1. **FR-011** — `[ -e "$PATH/.git" ]` (arquivo OU diretorio; worktree
    conta). Falha → exit 3, **zero escrita**.
+
+   > **`.git` e marcador de onboarding, NAO fronteira de confianca.** O
+   > teste responde "isto parece a raiz de um projeto?", evitando que um
+   > `cstk setup` disparado no diretorio errado espalhe `.claude/` e
+   > `.mcp.json` por ali. Ele **nao** atesta procedencia: `.git` e
+   > trivialmente criavel, e um repo clonado de terceiro passa no teste
+   > por construcao — e e exatamente o cenario que a feature mira. Toda
+   > garantia de seguranca desta feature vem de FR-016 (verificar o que
+   > esta registrado) e FR-018 (nao redirecionar a origem do catalogo);
+   > nenhuma vem de FR-011. Endurecer FR-011 exigindo artefato do toolkit
+   > foi rejeitado no clarify por circularidade, e nao daria a garantia
+   > que FR-016 da.
 2. **FR-007** — em `mode=interactive`, TTY obrigatorio via `require_tty`
    (`cli/lib/ui.sh:42-50`, teste `[ -t 0 ]` na linha 46, bypass
    `CSTK_FORCE_INTERACTIVE=1` na linha 43). Falha → exit 3 com mensagem
@@ -90,6 +111,15 @@ publicado por `cstk mcp install` (`cli/lib/mcp.sh:949-953`) e
 | 2 — presenca | `present` \| `missing` |
 | 3 — registro | `registered` \| `unregistered` (basename aparece em `<PAP>/.claude/settings.json`) |
 | 4 — frescor | `current` \| `stale` \| `unknown` (comparacao byte-a-byte com o catalogo) |
+
+> **Limite conhecido da coluna 3** (motiva 2.3, FR-016): `_gh_registered`
+> (`guard-hooks-status.sh:119-127`) e busca textual do **basename** —
+> `grep -Fq -- "$2" "$_gh_settings"`. O comentario no proprio script
+> assume que "a presenca do basename e condicao necessaria e suficiente
+> na pratica". Ela e **necessaria**, mas nao suficiente: um `settings.json`
+> que cite o basename e execute outro programa marca `registered`. A
+> coluna 4 protege o **conteudo** do arquivo em `.claude/hooks/`, nunca o
+> **comando registrado**.
 
 **Exit codes**: `0` os 3 present+registered+(current\|unknown); `1` caso
 contrario (**inclui `stale`**); `2` uso incorreto.
@@ -118,7 +148,62 @@ Extensao **aditiva** ao contrato 2.1: acrescenta uma 4a linha TSV para
 `settings.loose-usage.snippet.json` proprio) mas nao e coberto por
 nenhuma fonte de deteccao read-only hoje. Ver research.md Decision 3.
 
-### 2.3 Aplicacao — `hooks install` **[EXISTENTE]**
+### 2.3 Verificacao de autenticidade do registro — `--verify-registration` **[PROPOSTA]**
+
+**Invocacao**: `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet --verify-registration`
+
+Segunda extensao **aditiva** ao contrato 2.1, exigida por FR-016.
+Acrescenta uma **5a coluna** TSV a cada linha:
+
+| Valor | Significado |
+|-------|-------------|
+| `canonical` | Toda mencao ao basename no `settings.json` esta na forma canonica do snippet |
+| `divergent` | Ha mencao ao basename que **nao** esta na forma canonica |
+| `indeterminate` | Nao foi possivel atribuir o registro (hook nao registrado, `settings.json` ausente, ou layout que impeca a atribuicao por linha) |
+
+**Forma canonica** — literal do catalogo, nao suposto
+(`global/skills/agente-00c-runtime/hooks/settings.snippet.json`, e
+`settings.loose-usage.snippet.json` para o hook opt-in):
+
+```
+"$CLAUDE_PROJECT_DIR"/.claude/hooks/<basename>
+```
+
+**Regra de decisao** (POSIX puro, sem `jq` — mesma restricao de 2.1):
+toda linha do `settings.json` que contenha o basename MUST tambem conter
+o fragmento canonico. Existindo ao menos uma linha com o basename sem o
+fragmento canonico → `divergent`.
+
+**Invariantes obrigatorias da extensao**:
+
+- Sem a flag, a saida e byte-a-byte identica a atual e o exit code e o de
+  2.1 — retro-compatibilidade total com os consumidores existentes
+  (README.md:279 e a prosa dos orquestradores).
+- **Com** a flag, `divergent` em qualquer hook de `_GH_HOOKS` faz o exit
+  ser `1` (mesma classe de "nao esta provisionado corretamente"). Isso e
+  seguro porque a flag e opt-in: nenhum consumidor atual a passa.
+- Runtime instalado anterior rejeita a flag em `_gh_die_usage`
+  (`guard-hooks-status.sh:205`) com **exit 2**. O consumidor MUST tratar
+  como `indeterminate` — e, por I5 do data-model, `indeterminate` na
+  verificacao **nao** autoriza reportar `configured`.
+- A verificacao e **read-only**, como todo o script (cabecalho: "READ-ONLY
+  por construcao").
+
+**Limite textual declarado**: a regra e por linha, e vale para o layout
+que o proprio `merge_settings` produz (`jq` pretty-print). Um
+`settings.json` minificado numa unica linha impede a atribuicao por linha
+→ `indeterminate` (nunca `canonical`). Elevar a verificacao a parse real
+exigiria `jq`, que o script deliberadamente nao usa por ser a dependencia
+que costuma faltar justamente no projeto mal provisionado sob diagnostico
+(comentario em `guard-hooks-status.sh:119-125`).
+
+> **Nota de escopo**: promover esta verificacao a comportamento **default**
+> (sem flag) beneficiaria tambem os orquestradores, mas mudaria formato de
+> saida e exit code de um contrato publicado — BREAKING, exigindo bump
+> MAJOR por Constitution I. Fica registrado como candidato para a proxima
+> major, fora desta feature.
+
+### 2.4 Aplicacao — `hooks install` **[EXISTENTE]**
 
 **Invocacao**: `hooks_main install --project-path PATH [--catalog DIR] [--dry-run] [--with-loose-usage]`
 **Arquivo**: `cli/lib/hooks.sh` — `hooks_main` linha 557; flags linhas 583-593
@@ -139,6 +224,33 @@ que sao apenas warnings** (linhas 631-643); `1` erro (linhas 598, 608,
 
 **Guarda**: recusa `--project-path` igual a `$HOME` (linhas 617-620) —
 "hooks 00c sao de escopo PROJETO".
+
+> **FR-018 — os dois knobs de catalogo, e o que cada um faz**:
+>
+> | Knob | Quem le | Efeito |
+> |------|---------|--------|
+> | `--catalog DIR` (flag) | `hooks install` — default `${HOME}/.claude` (`cli/lib/hooks.sh:575`; origem dos hooks em `:612`) | redireciona **de onde o hook e copiado** |
+> | `CSTK_HOOKS_CATALOG_DIR` (env) | apenas `guard-hooks-status.sh` (`:136-137`; cabecalho: "so para teste/diagnostico") | redireciona **a copia de referencia** da comparacao `current`/`stale` |
+>
+> `setup.sh` **nao expoe flag equivalente, nao repassa `--catalog` e nao
+> define `CSTK_HOOKS_CATALOG_DIR`**. Expor o primeiro daria a um comando
+> copiado de um README de terceiro o poder de provisionar um
+> `pretooluse-bash-guard.sh` arbitrario com aparencia de instalacao
+> oficial.
+>
+> O segundo e **herdado do ambiente** — nao ha como "nao repassar" uma
+> variavel exportada sem apaga-la, e apaga-la quebraria diagnostico
+> legitimo. Como um `CSTK_HOOKS_CATALOG_DIR` apontando para um diretorio
+> arbitrario faz a dimensao `current`/`stale` medir contra a referencia
+> errada, o comportamento exigido e **declarar, nao confiar**: detectada a
+> variavel no ambiente, a area de hooks anuncia que a verificacao usou
+> referencia nao-padrao e **nao** reporta `configured` com base nela.
+> Note que ela nao afeta a verificacao de registro de §2.3 — a forma
+> canonica ali e uma constante, nao lida do catalogo.
+>
+> Testes que precisem de catalogo alternativo devem invocar
+> `hooks install` / `guard-hooks-status.sh` diretamente, nao via
+> `cstk setup`.
 
 > **Consequencia de projeto**: como exit 0 abrange `paste-instructed`
 > (jq ausente → bloco para colar manualmente), o wizard NAO pode
@@ -196,6 +308,16 @@ pre-condicao** — `sqlite3` ausente ou abaixo do minimo (linhas 358-370).
 > pelo wizard, e nao conflita com FR-012 (que restringe apenas a area de
 > telemetria). Tem consequencia direta em teste: exige `HOME` sandboxado
 > (ver quickstart.md e research.md Decision 10).
+>
+> **FR-017 — rotulo obrigatorio na UI**: o usuario invoca `cstk setup`
+> com um `--project-path` na mao e a expectativa razoavel de que esta
+> configurando **aquele projeto**. Esta area quebra essa expectativa: o
+> efeito e da maquina inteira. O wizard MUST, antes de aplicar **e** em
+> `--dry-run`, nomear o alvo real (`$HOME/.claude/cstk/config`) e dizer
+> que a mudanca vale para **todos os projetos**. As outras tres areas sao
+> de escopo projeto e MUST NOT carregar esse rotulo — rotular tudo
+> igualmente destreinaria o usuario a le-lo. O `SetupRunSummary` repete a
+> marca de escopo na linha desta area.
 
 ### 3.4 Diagnostico complementar — `cstk doctor --deps` **[EXISTENTE]**
 
@@ -220,16 +342,54 @@ Reusado pelo wizard como texto de diagnostico quando a area fica
 
 ## 4. Fronteira: area de MCP **[EXISTENTE]**
 
-### 4.1 Deteccao
+### 4.1 Deteccao — `_mcp_registration_status` **[PROPOSTA]**
 
-Presenca da chave `cstk-state` sob `mcpServers` em
-`<project-path>/.mcp.json` — exatamente o alvo que `_mcp_cmd_install`
-escreve (`cli/lib/mcp.sh:847`; bloco JSON linhas 864-865).
+**Funcao**: `_mcp_registration_status PROJECT_PATH` em `cli/lib/mcp.sh`
+(lib **dona** da area — mantem a deteccao junto do comando dedicado,
+como FR-002 exige, em vez de uma segunda implementacao em `setup.sh`)
+**Saida (stdout)**: `configured` \| `divergent` \| `not-configured`
+**Exit**: `0` sempre (consulta respondida, nao veredito) — mesmo contrato
+de nao-falha de `state-backend.sh resolve` (linha 269)
 
 Leitura textual (sem `jq`), coerente com a mesma escolha ja feita por
 `_gh_registered` (`guard-hooks-status.sh:119` e seguintes), que usa busca
 textual em vez de parse justamente para nao depender de `jq` num projeto
 possivelmente mal provisionado.
+
+**Regra de decisao** (FR-016 — a presenca da chave nao basta):
+
+| Condicao | Resultado |
+|----------|-----------|
+| `<project-path>/.mcp.json` ausente, ou sem mencao a `cstk-state` | `not-configured` |
+| `cstk-state` presente **e** o `command` registrado e um dos paths candidatos de `mcp-launch.sh` do catalogo | `configured` |
+| `cstk-state` presente e o `command` aponta para outro lugar, ou nao e atribuivel | `divergent` |
+
+**Paths candidatos** — o conjunto que `_mcp_runtime_script_path`
+(`cli/lib/mcp.sh:127-146`) produziria, nas tres camadas que ele consulta,
+**todas** aceitas:
+
+1. `command -v mcp-launch.sh` (PATH)
+2. `$CSTK_LIB/../../global/skills/agente-00c-runtime/scripts/mcp-launch.sh` (repo)
+3. `$HOME/.claude/skills/agente-00c-runtime/scripts/mcp-launch.sh` (catalogo instalado)
+
+> **Por que o conjunto, e nao so o primeiro hit**: `_mcp_cmd_install`
+> grava o path **resolvido no momento da instalacao** (`cli/lib/mcp.sh:840`,
+> interpolado no bloco JSON). Um `.mcp.json` escrito por uma invocacao a
+> partir do repo e depois verificado por uma invocacao a partir de
+> `~/.claude` produziria paths diferentes para a **mesma** instalacao
+> legitima. Comparar apenas contra o primeiro hit geraria `divergent`
+> falso-positivo rotineiro em maquina de desenvolvimento. Aceitar as tres
+> camadas preserva a propriedade que importa: o comando aponta para um
+> `mcp-launch.sh` **do catalogo do toolkit**, nao para um programa
+> arbitrario.
+
+**Nao remedia sozinho**: `_mcp_cmd_install` faz merge com o target
+vencendo ("entrada ja presente e equivalente => idempotente, exit 0",
+linhas 800-802). Uma entrada divergente **sobrevive** a um novo
+`cstk mcp install` — por isso `divergent` mapeia para `failed` com
+remediacao em duas etapas (remover a entrada, depois reinstalar), nunca
+para uma tentativa cega de aplicacao. Ver `data-model.md`, regras de
+derivacao de `AreaOutcome`.
 
 ### 4.2 Aplicacao — `cstk mcp install`
 

--- a/docs/specs/cstk-setup/contracts/cli-setup.md
+++ b/docs/specs/cstk-setup/contracts/cli-setup.md
@@ -171,8 +171,33 @@ Acrescenta uma **5a coluna** TSV a cada linha:
 
 **Regra de decisao** (POSIX puro, sem `jq` — mesma restricao de 2.1):
 toda linha do `settings.json` que contenha o basename MUST tambem conter
-o fragmento canonico. Existindo ao menos uma linha com o basename sem o
-fragmento canonico → `divergent`.
+o fragmento canonico **e** o token literal `"command"` (a chave JSON,
+com aspas). Existindo ao menos uma linha com o basename sem o fragmento
+canonico, ou sem o token `"command"`, → `divergent`.
+
+> **Correcao pos-gate (achado SEC-01, MEDIUM)**: a regra original exigia
+> so basename+fragmento na mesma linha, satisfazivel por uma **linha-isca
+> decorativa** — ex. um `"description"` ou comentario JSON informal que
+> cite o basename e cole o fragmento canonico ao lado de um `"command"`
+> real apontando para outro programa, em linhas diferentes do pretty-print
+> do `merge_settings`. Exigir o token `"command"` na MESMA linha reduz o
+> caso a exigir que a linha-isca seja, ela propria, uma atribuicao
+> `"command": ...` — que e o unico lugar onde `merge_settings`
+> (`jq` pretty-print, uma chave por linha) de fato emite o path executado.
+>
+> **Limite aceito, declarado (nao verificado textualmente)**: esta regra
+> continua sendo co-ocorrencia textual por linha, nao parse de JSON. Ela
+> **nao verifica posicionamento estrutural** — isto e, nao confirma que a
+> linha `"command"` encontrada esta de fato dentro do objeto de hook
+> correto sob `PreToolUse`/`matcher` esperado (poderia, em tese, estar sob
+> uma chave nao-relacionada com o mesmo par `"command"` + fragmento
+> coincidindo por acaso, ou um objeto de hook malformado que o
+> `merge_settings` ainda assim aceitou). Elevar a essa garantia exigiria
+> `jq` ou um parser real, fora do orcamento desta extensao pelo mesmo
+> motivo do "Limite textual declarado" abaixo (minificacao). Residual
+> aceito porque o objetivo desta extensao e fechar o caso de decoy mais
+> barato de forjar (linha solta com o basename), nao alcancar paridade com
+> parse estrutural.
 
 **Invariantes obrigatorias da extensao**:
 
@@ -184,8 +209,19 @@ fragmento canonico → `divergent`.
   seguro porque a flag e opt-in: nenhum consumidor atual a passa.
 - Runtime instalado anterior rejeita a flag em `_gh_die_usage`
   (`guard-hooks-status.sh:205`) com **exit 2**. O consumidor MUST tratar
-  como `indeterminate` — e, por I5 do data-model, `indeterminate` na
-  verificacao **nao** autoriza reportar `configured`.
+  como `indeterminate` — e, por I5 do data-model, `indeterminate`
+  **nesta chamada** (5a coluna) resolve `ConfigurationArea{hooks}.status`
+  (e `mandatory_status`) para `unavailable` — nunca `configured`, e
+  distinto de `divergent` (que exige confirmacao positiva de nao-canonico,
+  nao mera impossibilidade de verificar). Ver data-model.md §invariante I5
+  e §Nota `unavailable`.
+- **Esta chamada e SEPARADA da chamada baseline** (§2.1, sem flags) e da
+  chamada de `--include-loose-usage` (§2.2) — nunca as tres combinadas
+  numa unica invocacao. Combina-las faria um runtime antigo que rejeita
+  **qualquer uma** das flags (exit 2 em `_gh_die_usage`) perder tambem o
+  veredito basico dos 3 hooks obrigatorios, que aquele runtime SABE
+  responder. Ver data-model.md §Fonte de `status` por area, linha
+  `hooks` (achado SEC-03).
 - A verificacao e **read-only**, como todo o script (cabecalho: "READ-ONLY
   por construcao").
 

--- a/docs/specs/cstk-setup/data-model.md
+++ b/docs/specs/cstk-setup/data-model.md
@@ -1,0 +1,149 @@
+# Data Model: cstk-setup
+
+Esta feature **nao tem persistencia**. FR-013 (INFRA-IDEMP) proibe
+explicitamente qualquer flag persistido de "setup ja rodou": a idempotencia
+vem de re-checar o status vivo de cada area a cada invocacao. Portanto o
+modelo abaixo descreve **estruturas em memoria** durante um unico run —
+variaveis de shell POSIX e linhas de saida, nao tabelas.
+
+> **Nota de representacao**: `cli/lib` roda POSIX sh puro (Constitution
+> II) — sem arrays. As colecoes abaixo sao representadas como linhas de
+> texto acumuladas em variavel (registro por linha, campos separados por
+> TAB), o mesmo formato TSV que `guard-hooks-status.sh check` ja emite
+> (contrato no cabecalho, linhas 49-60).
+
+---
+
+## Entity: ConfigurationArea
+
+Uma das quatro areas que o wizard percorre. A ordem e **fixa** (FR-001) e
+e a propria ordem de apresentacao.
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| `id` | enum | `hooks` \| `state-backend` \| `mcp` \| `telemetry` | Ordem fixa de apresentacao (FR-001); `hooks` primeiro |
+| `label` | string | NOT NULL | Texto exibido ao usuario (pt-br permitido — CLAUDE.md: mensagens podem ser pt-br) |
+| `status` | enum | `configured` \| `not-configured` \| `unavailable` | Vocabulario da spec (FR-002); apurado fresco a cada run (FR-013) |
+| `status_reason` | string | pode ser vazio | Motivo legivel — obrigatorio quando `status=unavailable` |
+| `applicable` | bool | — | `false` para `telemetry` (FR-012 proibe aplicar) |
+| `outcome` | enum | ver `AreaOutcome` | Preenchido ao fim do passo da area |
+
+### Fonte de `status` por area (delegada — nunca reimplementada)
+
+| `id` | Fonte read-only | Mapeamento para `status` |
+|------|-----------------|--------------------------|
+| `hooks` | `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet` (contrato linhas 49-60) | exit 0 → `configured`; exit 1 → `not-configured` (inclui `stale`, ver nota); exit 2 → `unavailable` |
+| `state-backend` | `config_state_backend_resolve` (`cli/lib/config.sh:94`) | `effective_backend=sqlite` → `configured`; `effective_backend=json` → `not-configured` (com `reason=` do proprio resolve em `status_reason`) |
+| `mcp` | chave `cstk-state` presente em `<project>/.mcp.json` (alvo escrito por `cli/lib/mcp.sh:847`, bloco 864-865) | presente → `configured`; ausente → `not-configured` |
+| `telemetry` | `otel-usage.sh preflight` (`otel-usage.sh:469`) | medicao ativa → `configured`; senao → `not-configured` |
+
+> **Nota `stale`**: a 3a coluna do TSV do `guard-hooks-status.sh`
+> (`current|stale|unknown`) faz "presente + registrado" NAO significar
+> configurado. `stale` = copia do projeto diverge do catalogo, e o proprio
+> `check` retorna exit 1 nesse caso (`_gh_cmd_check`, linhas 238-244).
+> O wizard herda esse veredito: `stale` → `not-configured`.
+
+> **Nota `unavailable`**: reservado para dependencia faltando ou fonte de
+> deteccao inutilizavel — ex. `sqlite3` ausente/abaixo de
+> `_SB_MIN_SQLITE_VERSION="3.45.1"` (`state-backend.sh:67`), caso em que
+> `enable-sqlite` recusaria com exit 3 (linhas 358-370). Area
+> `unavailable` ainda e exibida e ainda entra no summary (FR-009/FR-010).
+
+---
+
+## Entity: HooksAreaDetail
+
+Sub-estrutura da area `hooks`. Existe porque FR-008 exige que o hook
+opt-in de loose usage seja uma escolha **distinta** da dos hooks
+obrigatorios.
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| `mandatory_status` | enum | `configured` \| `not-configured` \| `unavailable` | Derivado do exit do `check` sobre os 3 hooks de `_GH_HOOKS` (`guard-hooks-status.sh:104-107`) |
+| `mandatory_detail` | TSV lines | 3 linhas | `<arquivo>\t<present\|missing>\t<registered\|unregistered>\t<current\|stale\|unknown>` |
+| `loose_usage_status` | enum | `configured` \| `not-configured` \| `indeterminate` | `indeterminate` quando a fonte de deteccao nao suporta a consulta — ver research.md Decision 3 |
+| `loose_usage_choice` | enum | `apply` \| `skip` | Default em `--yes` e **`skip`** (opt-in preservado: `--with-loose-usage` e default off, `cli/lib/hooks.sh:513,543`) |
+
+### Relationships
+
+- `ConfigurationArea{id=hooks}` 1:1 `HooksAreaDetail`
+- As demais tres areas nao tem sub-estrutura.
+
+---
+
+## Entity: AreaOutcome
+
+Resultado de uma area apos seu passo. FR-010 fixa o conjunto: applied /
+already configured / skipped by user / failed (com motivo).
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| `area_id` | enum | FK logica → `ConfigurationArea.id` | |
+| `outcome` | enum | `applied` \| `already-configured` \| `skipped` \| `failed` | Conjunto fechado de FR-010 |
+| `reason` | string | NOT NULL quando `outcome=failed` | Motivo legivel; inclui o exit code da fonte quando houver |
+| `source_exit` | int | opcional | Exit code cru do comando delegado — rastreabilidade |
+
+### Regras de derivacao
+
+| Situacao | `outcome` |
+|----------|-----------|
+| `status=configured` na deteccao previa | `already-configured` (e **nenhuma** chamada de aplicacao — FR-003) |
+| Usuario respondeu nao (ou default `skip` em `--yes`) | `skipped` |
+| `--dry-run` ativo | `skipped`, com `reason` = "preview: nenhuma alteracao aplicada" |
+| Aplicacao retornou exit 0 | `applied` |
+| Aplicacao retornou exit != 0 | `failed`, `reason` cita o exit e o comando |
+| `status=unavailable` | `failed`, `reason` = `status_reason` (dependencia ausente) |
+| Area `telemetry` diagnosticada e nao ativa | `skipped`, `reason` = "diagnostico exibido; ativacao e manual (FR-012)" |
+
+> **`telemetry` nunca produz `applied`** — decorre de FR-012 (ver
+> research.md Decision 8). Forcar `applied` ali seria afirmar uma
+> configuracao que o wizard nao realizou.
+
+---
+
+## Entity: SetupRunSummary
+
+O relatorio de fim de run (FR-010). Impresso em **todos** os caminhos de
+saida que chegaram a percorrer areas — interativo, `--yes`, `--dry-run`,
+e runs parcialmente falhos (SC-005).
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| `project_path` | path | NOT NULL | Raiz de repo git validada (FR-011) |
+| `mode` | enum | `interactive` \| `non-interactive` \| `preview` | `preview` vence `non-interactive` (FR-006) |
+| `outcomes` | AreaOutcome[4] | exatamente 4 | Uma entrada por area de FR-001, na ordem fixa |
+| `exit_code` | int | `0` \| `1` | `1` se algum `outcome=failed` — ver research.md Decision 9 |
+
+### Relationships
+
+- `SetupRunSummary` 1:N `AreaOutcome` (N = 4, fixo)
+- `AreaOutcome` 1:1 `ConfigurationArea` por `area_id`
+
+---
+
+## State Transitions
+
+Ciclo de vida de uma `ConfigurationArea` dentro de um run:
+
+```
+detect ──> configured ─────────────────────────> already-configured
+   │
+   ├─────> unavailable ────────────────────────> failed
+   │
+   └─────> not-configured ──┬─ preview ────────> skipped
+                            ├─ declined ───────> skipped
+                            └─ accepted ──┬────> applied      (exit 0)
+                                          └────> failed       (exit != 0)
+```
+
+Invariantes:
+
+- **I1 (FR-003)**: nenhuma transicao a partir de `configured` chama
+  comando de aplicacao. Um projeto totalmente configurado atravessa as 4
+  areas sem uma unica escrita.
+- **I2 (FR-013)**: `detect` roda a cada invocacao, sempre. Nao ha estado
+  carregado de run anterior.
+- **I3 (FR-009)**: a transicao de uma area para `failed` nao altera a
+  transicao de nenhuma outra — as 4 sao independentes.
+- **I4 (FR-004)**: em `mode=preview`, `applied` e inalcancavel para todas
+  as areas.

--- a/docs/specs/cstk-setup/data-model.md
+++ b/docs/specs/cstk-setup/data-model.md
@@ -23,8 +23,8 @@ e a propria ordem de apresentacao.
 |-------|------|-------------|-------|
 | `id` | enum | `hooks` \| `state-backend` \| `mcp` \| `telemetry` | Ordem fixa de apresentacao (FR-001); `hooks` primeiro |
 | `label` | string | NOT NULL | Texto exibido ao usuario (pt-br permitido — CLAUDE.md: mensagens podem ser pt-br) |
-| `status` | enum | `configured` \| `not-configured` \| `unavailable` | Vocabulario da spec (FR-002); apurado fresco a cada run (FR-013) |
-| `status_reason` | string | pode ser vazio | Motivo legivel — obrigatorio quando `status=unavailable` |
+| `status` | enum | `configured` \| `not-configured` \| `divergent` \| `unavailable` | Vocabulario da spec (FR-002); apurado fresco a cada run (FR-013) |
+| `status_reason` | string | pode ser vazio | Motivo legivel — obrigatorio quando `status` e `unavailable` ou `divergent` (neste, carrega a remediacao) |
 | `applicable` | bool | — | `false` para `telemetry` (FR-012 proibe aplicar) |
 | `outcome` | enum | ver `AreaOutcome` | Preenchido ao fim do passo da area |
 
@@ -32,9 +32,9 @@ e a propria ordem de apresentacao.
 
 | `id` | Fonte read-only | Mapeamento para `status` |
 |------|-----------------|--------------------------|
-| `hooks` | `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet` (contrato linhas 49-60) | exit 0 → `configured`; exit 1 → `not-configured` (inclui `stale`, ver nota); exit 2 → `unavailable` |
+| `hooks` | `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet --verify-registration` (contrato linhas 49-60 + extensao [PROPOSTA] em `contracts/cli-setup.md` §2.2) | exit 0 → `configured`; exit 1 → `not-configured` (inclui `stale`, ver nota); **5a coluna `divergent` em qualquer hook obrigatorio → `divergent` (precede o mapeamento por exit)**; exit 2 → `unavailable` |
 | `state-backend` | `config_state_backend_resolve` (`cli/lib/config.sh:94`) | `effective_backend=sqlite` → `configured`; `effective_backend=json` → `not-configured` (com `reason=` do proprio resolve em `status_reason`) |
-| `mcp` | chave `cstk-state` presente em `<project>/.mcp.json` (alvo escrito por `cli/lib/mcp.sh:847`, bloco 864-865) | presente → `configured`; ausente → `not-configured` |
+| `mcp` | `_mcp_registration_status <project-path>` ([PROPOSTA], `cli/lib/mcp.sh` — ver `contracts/cli-setup.md` §4.1) | `configured` (chave `cstk-state` presente **e** `command` apontando para um `mcp-launch.sh` do catalogo) / `divergent` (chave presente, `command` fora do catalogo ou indeterminavel) / `not-configured` (chave ausente) |
 | `telemetry` | `otel-usage.sh preflight` (`otel-usage.sh:469`) | medicao ativa → `configured`; senao → `not-configured` |
 
 > **Nota `stale`**: a 3a coluna do TSV do `guard-hooks-status.sh`
@@ -42,6 +42,25 @@ e a propria ordem de apresentacao.
 > configurado. `stale` = copia do projeto diverge do catalogo, e o proprio
 > `check` retorna exit 1 nesse caso (`_gh_cmd_check`, linhas 238-244).
 > O wizard herda esse veredito: `stale` → `not-configured`.
+
+> **Nota `divergent` (FR-016)**: distingue "a configuracao **nomeia** o
+> controle" de "a configuracao **executa** o controle do catalogo". Para
+> `hooks`, a 4a coluna do TSV ja compara o **conteudo** do arquivo com o
+> catalogo (`cmp` byte-a-byte) — mas o **registro** e apenas presenca
+> textual do basename no `settings.json` (`_gh_registered`,
+> `guard-hooks-status.sh:119-127`), entao um registro que cita o basename
+> e invoca outro programa e hoje indistinguivel de um legitimo. Para
+> `mcp`, a deteccao originalmente desenhada era so a presenca da chave
+> `cstk-state`. Em ambos, `divergent` NUNCA pode colapsar para
+> `configured`: e o unico status que sinaliza um controle de seguranca
+> possivelmente subvertido.
+>
+> **Fail-closed (invariante I5)**: qualquer ambiguidade na apuracao —
+> layout do JSON que impeca atribuir o registro, fonte de deteccao sem
+> suporte a verificacao, path irresolvivel — resolve para `divergent`,
+> jamais para `configured`. O custo de um falso `divergent` e um aviso
+> com remediacao; o de um falso `configured` e a falsa garantia que este
+> requisito existe para eliminar.
 
 > **Nota `unavailable`**: reservado para dependencia faltando ou fonte de
 > deteccao inutilizavel — ex. `sqlite3` ausente/abaixo de
@@ -59,9 +78,10 @@ obrigatorios.
 
 | Field | Type | Constraints | Notes |
 |-------|------|-------------|-------|
-| `mandatory_status` | enum | `configured` \| `not-configured` \| `unavailable` | Derivado do exit do `check` sobre os 3 hooks de `_GH_HOOKS` (`guard-hooks-status.sh:104-107`) |
-| `mandatory_detail` | TSV lines | 3 linhas | `<arquivo>\t<present\|missing>\t<registered\|unregistered>\t<current\|stale\|unknown>` |
-| `loose_usage_status` | enum | `configured` \| `not-configured` \| `indeterminate` | `indeterminate` quando a fonte de deteccao nao suporta a consulta — ver research.md Decision 3 |
+| `mandatory_status` | enum | `configured` \| `not-configured` \| `divergent` \| `unavailable` | Derivado do exit do `check` sobre os 3 hooks de `_GH_HOOKS` (`guard-hooks-status.sh:104-107`), com `divergent` precedendo (FR-016) |
+| `mandatory_detail` | TSV lines | 3 linhas | `<arquivo>\t<present\|missing>\t<registered\|unregistered>\t<current\|stale\|unknown>\t<canonical\|divergent\|indeterminate>` — a 5a coluna so aparece com `--verify-registration` |
+| `divergent_hooks` | lines | pode ser vazio | Basenames cuja 5a coluna != `canonical`; alimenta a remediacao exibida |
+| `loose_usage_status` | enum | `configured` \| `not-configured` \| `divergent` \| `indeterminate` | `indeterminate` quando a fonte de deteccao nao suporta a consulta — ver research.md Decision 3 |
 | `loose_usage_choice` | enum | `apply` \| `skip` | Default em `--yes` e **`skip`** (opt-in preservado: `--with-loose-usage` e default off, `cli/lib/hooks.sh:513,543`) |
 
 ### Relationships
@@ -93,7 +113,26 @@ already configured / skipped by user / failed (com motivo).
 | Aplicacao retornou exit 0 | `applied` |
 | Aplicacao retornou exit != 0 | `failed`, `reason` cita o exit e o comando |
 | `status=unavailable` | `failed`, `reason` = `status_reason` (dependencia ausente) |
+| `status=divergent` | `failed`, `reason` = remediacao (FR-016); **nenhuma** chamada de aplicacao — ver nota abaixo |
 | Area `telemetry` diagnosticada e nao ativa | `skipped`, `reason` = "diagnostico exibido; ativacao e manual (FR-012)" |
+
+> **Por que `divergent` → `failed`, e nao `applied` apos "corrigir"**: o
+> wizard nao tem como corrigir, e nao deve tentar. Os comandos de
+> aplicacao fazem merge com **o target vencendo** — `merge_settings` roda
+> `jq -s '.[0] * .[1]'` com "Source primeiro, target segundo => target
+> vence em conflitos" (`cli/lib/hooks.sh`), e `cstk mcp install` declara
+> "entrada ja presente e equivalente => idempotente, exit 0"
+> (`cli/lib/mcp.sh:800-802`). Logo **re-rodar `cstk hooks install` /
+> `cstk mcp install` sobre uma entrada divergente NAO a substitui**: a
+> entrada existente sobrevive ao merge. A remediacao correta, e a unica
+> que o wizard deve imprimir, e em duas etapas: **(1)** remover a entrada
+> divergente do `.claude/settings.json` / `.mcp.json`, **(2)** rodar
+> `cstk hooks install --project-path <PATH>` / `cstk mcp install
+> --project-path <PATH>` para reescrever a canonica.
+>
+> Mapear para `failed` tambem propaga exit `1` (`SetupRunSummary`), o que
+> impede um run com controle de seguranca subvertido de terminar com o
+> mesmo exit de um run limpo — requisito de SC-006.
 
 > **`telemetry` nunca produz `applied`** — decorre de FR-012 (ver
 > research.md Decision 8). Forcar `applied` ali seria afirmar uma
@@ -130,6 +169,8 @@ detect ──> configured ──────────────────
    │
    ├─────> unavailable ────────────────────────> failed
    │
+   ├─────> divergent ──────────────────────────> failed   (remediacao; sem aplicacao)
+   │
    └─────> not-configured ──┬─ preview ────────> skipped
                             ├─ declined ───────> skipped
                             └─ accepted ──┬────> applied      (exit 0)
@@ -147,3 +188,9 @@ Invariantes:
   transicao de nenhuma outra — as 4 sao independentes.
 - **I4 (FR-004)**: em `mode=preview`, `applied` e inalcancavel para todas
   as areas.
+- **I5 (FR-016, fail-closed)**: nenhuma transicao leva `divergent` a
+  `already-configured` ou `applied`, em nenhum modo — inclusive `--yes`.
+  Toda ambiguidade de apuracao resolve para `divergent`.
+- **I6 (FR-016)**: a partir de `divergent` nao ha chamada de comando de
+  aplicacao. O wizard nao sobrescreve o que nao reconhece; so relata e
+  instrui.

--- a/docs/specs/cstk-setup/data-model.md
+++ b/docs/specs/cstk-setup/data-model.md
@@ -32,7 +32,7 @@ e a propria ordem de apresentacao.
 
 | `id` | Fonte read-only | Mapeamento para `status` |
 |------|-----------------|--------------------------|
-| `hooks` | `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet --verify-registration` (contrato linhas 49-60 + extensao [PROPOSTA] em `contracts/cli-setup.md` §2.2) | exit 0 → `configured`; exit 1 → `not-configured` (inclui `stale`, ver nota); **5a coluna `divergent` em qualquer hook obrigatorio → `divergent` (precede o mapeamento por exit)**; exit 2 → `unavailable` |
+| `hooks` | **3 chamadas SEPARADAS** (achado SEC-03 — NUNCA combinadas): (1) baseline `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet` (contrato §2.1 [EXISTENTE]); (2) `... --quiet --verify-registration` (contrato §2.3 [PROPOSTA]); (3) `... --quiet --include-loose-usage` (contrato §2.2 [PROPOSTA], alimenta so `loose_usage_status` em `HooksAreaDetail`, nunca esta linha) | Veredito base vem **sempre** de (1), que todo runtime instalado suporta: exit 0 → `configured`; exit 1 → `not-configured` (inclui `stale`, ver nota). Chamada (2) so pode **escalar**, nunca substituir silenciosamente o veredito de (1): 5a coluna `divergent` em qualquer hook obrigatorio → `divergent` (precede (1)); 5a coluna `indeterminate` em qualquer hook obrigatorio (inclusive por (2) sair exit 2 em runtime antigo, contrato §2.3) → `unavailable` (precede (1) — I5; nunca herda o `configured`/`not-configured` de (1)) |
 | `state-backend` | `config_state_backend_resolve` (`cli/lib/config.sh:94`) | `effective_backend=sqlite` → `configured`; `effective_backend=json` → `not-configured` (com `reason=` do proprio resolve em `status_reason`) |
 | `mcp` | `_mcp_registration_status <project-path>` ([PROPOSTA], `cli/lib/mcp.sh` — ver `contracts/cli-setup.md` §4.1) | `configured` (chave `cstk-state` presente **e** `command` apontando para um `mcp-launch.sh` do catalogo) / `divergent` (chave presente, `command` fora do catalogo ou indeterminavel) / `not-configured` (chave ausente) |
 | `telemetry` | `otel-usage.sh preflight` (`otel-usage.sh:469`) | medicao ativa → `configured`; senao → `not-configured` |
@@ -55,17 +55,40 @@ e a propria ordem de apresentacao.
 > `configured`: e o unico status que sinaliza um controle de seguranca
 > possivelmente subvertido.
 >
-> **Fail-closed (invariante I5)**: qualquer ambiguidade na apuracao —
-> layout do JSON que impeca atribuir o registro, fonte de deteccao sem
-> suporte a verificacao, path irresolvivel — resolve para `divergent`,
-> jamais para `configured`. O custo de um falso `divergent` e um aviso
-> com remediacao; o de um falso `configured` e a falsa garantia que este
-> requisito existe para eliminar.
+> **Fail-closed (invariante I5)**: jamais `configured` sob ambiguidade —
+> mas ha DUAS ambiguidades distintas, com destinos diferentes no enum
+> fechado de `status`/`mandatory_status` (`configured | not-configured |
+> divergent | unavailable` — **nao ha valor `indeterminate` neste enum**,
+> so na 5a coluna do TSV):
+>
+> - **Confirmacao positiva de nao-canonico** — a 5a coluna leu uma linha
+>   real e concluiu que o registro nao bate com o fragmento canonico →
+>   `divergent`. O custo de um falso `divergent` e um aviso com
+>   remediacao; a garantia e "detectamos algo que nao reconhecemos".
+> - **Impossibilidade de verificar** — layout do JSON que impeca atribuir
+>   o registro (minificado), fonte de deteccao sem suporte a extensao
+>   (runtime antigo, exit 2 em `_gh_die_usage` — mesmo caminho do
+>   quickstart Scenario 15 variante 4), path irresolvivel: a 5a coluna
+>   e/ou a chamada inteira retorna `indeterminate`, e **isso mapeia para
+>   `unavailable`** no `status`/`mandatory_status` (achado SEC-02) —
+>   nunca para `divergent` (nao houve confirmacao de nada) e nunca para
+>   `configured`/`not-configured` herdado da chamada baseline (essa
+>   heranca silenciosa era exatamente o fail-open do achado SEC-02: sem
+>   mapeamento explicito, um implementador podia ignorar a 5a coluna
+>   indeterminada e reportar o exit 0/1 cru da chamada baseline).
+>
+> Em ambos os casos o custo aceito e um falso aviso (`divergent` ou
+> `unavailable`) com remediacao/motivo; o custo rejeitado e a falsa
+> garantia de `configured` que este requisito existe para eliminar.
 
-> **Nota `unavailable`**: reservado para dependencia faltando ou fonte de
-> deteccao inutilizavel — ex. `sqlite3` ausente/abaixo de
+> **Nota `unavailable`**: dependencia faltando ou fonte de deteccao
+> inutilizavel — ex. `sqlite3` ausente/abaixo de
 > `_SB_MIN_SQLITE_VERSION="3.45.1"` (`state-backend.sh:67`), caso em que
-> `enable-sqlite` recusaria com exit 3 (linhas 358-370). Area
+> `enable-sqlite` recusaria com exit 3 (linhas 358-370) — **e tambem** o
+> caso de `hooks` cuja 5a coluna (`--verify-registration`) resolveu
+> `indeterminate` para algum hook obrigatorio (achado SEC-02, ver
+> invariante I5 acima): a autenticidade do registro nao pode ser
+> confirmada nem refutada, entao a area nunca anuncia `configured`. Area
 > `unavailable` ainda e exibida e ainda entra no summary (FR-009/FR-010).
 
 ---
@@ -78,7 +101,7 @@ obrigatorios.
 
 | Field | Type | Constraints | Notes |
 |-------|------|-------------|-------|
-| `mandatory_status` | enum | `configured` \| `not-configured` \| `divergent` \| `unavailable` | Derivado do exit do `check` sobre os 3 hooks de `_GH_HOOKS` (`guard-hooks-status.sh:104-107`), com `divergent` precedendo (FR-016) |
+| `mandatory_status` | enum | `configured` \| `not-configured` \| `divergent` \| `unavailable` | Base = exit da chamada **baseline** (sem flags) sobre os 3 hooks de `_GH_HOOKS` (`guard-hooks-status.sh:104-107`); a chamada `--verify-registration` (separada — SEC-03) so escala: `divergent` precede a base (FR-016), `indeterminate` precede a base e vira `unavailable` (SEC-02) — nunca ambas na mesma chamada da base |
 | `mandatory_detail` | TSV lines | 3 linhas | `<arquivo>\t<present\|missing>\t<registered\|unregistered>\t<current\|stale\|unknown>\t<canonical\|divergent\|indeterminate>` — a 5a coluna so aparece com `--verify-registration` |
 | `divergent_hooks` | lines | pode ser vazio | Basenames cuja 5a coluna != `canonical`; alimenta a remediacao exibida |
 | `loose_usage_status` | enum | `configured` \| `not-configured` \| `divergent` \| `indeterminate` | `indeterminate` quando a fonte de deteccao nao suporta a consulta — ver research.md Decision 3 |
@@ -112,7 +135,7 @@ already configured / skipped by user / failed (com motivo).
 | `--dry-run` ativo | `skipped`, com `reason` = "preview: nenhuma alteracao aplicada" |
 | Aplicacao retornou exit 0 | `applied` |
 | Aplicacao retornou exit != 0 | `failed`, `reason` cita o exit e o comando |
-| `status=unavailable` | `failed`, `reason` = `status_reason` (dependencia ausente) |
+| `status=unavailable` | `failed`, `reason` = `status_reason` (dependencia ausente **ou**, para `hooks`, registro nao-verificavel — SEC-02) |
 | `status=divergent` | `failed`, `reason` = remediacao (FR-016); **nenhuma** chamada de aplicacao — ver nota abaixo |
 | Area `telemetry` diagnosticada e nao ativa | `skipped`, `reason` = "diagnostico exibido; ativacao e manual (FR-012)" |
 

--- a/docs/specs/cstk-setup/data-model.md
+++ b/docs/specs/cstk-setup/data-model.md
@@ -217,3 +217,26 @@ Invariantes:
 - **I6 (FR-016)**: a partir de `divergent` nao ha chamada de comando de
   aplicacao. O wizard nao sobrescreve o que nao reconhece; so relata e
   instrui.
+
+---
+
+## Defaults sob `--yes` (consolidado — CHK005)
+
+Tabela unica "area → o que `--yes` (mode=non-interactive) de fato faz
+quando a area esta `not-configured`", substituindo a dispersao anterior
+em quatro locais (comentarios de `cli/lib/setup.sh` por area + esta
+entidade + `tasks.md`). So se aplica a partir de `not-configured`:
+`configured` nunca aplica (I1), e `divergent`/`unavailable` nunca aplicam
+(I5/I6) — em nenhum modo, `--yes` incluido.
+
+| `id` | Default sob `--yes` | Fonte (arquivo:linha) |
+|------|----------------------|------------------------|
+| `hooks` (obrigatorios) | **Sempre aplica** — `_srh_accept_mandatory` permanece `1` fora do `mode=interactive` (nenhum gate adicional) | `cli/lib/setup.sh:482-487` |
+| `hooks` → `loose_usage` (opt-in) | **Sempre recusa** (`_srh_with_loose` permanece `0` fora do `mode=interactive`) — unica sub-area cujo default recomendado e "nao" | `cli/lib/setup.sh:498-503`; `data-model.md` linha `loose_usage_choice` acima |
+| `state-backend` | **Condicional ao `reason`** (task 4.1.3/4.3.2, achado SEC-04): aplica so quando `reason` prova AUSENCIA de escolha previa (`nunca-configurado` ou `config-invalida`); qualquer outro `reason` (ex.: `json-explicito`) => nao aplica, preserva US2 AC3 | `cli/lib/setup.sh:725-734` |
+| `mcp` | **Sempre aplica** — `_srm_accept` permanece `1` fora do `mode=interactive`; tenta `_mcp_cmd_install` mesmo sem Docker detectado (`command -v docker` so gera o TEXTO do aviso, nunca bloqueia — FR-015), sem opt-in distinto (ao contrario de `state-backend`) | `cli/lib/setup.sh:842-865` |
+| `telemetry` | **N/A** — area 100% read-only (FR-012); `--yes` nao tem efeito nenhum, so o diagnostico de `otel-usage.sh preflight` e exibido; `applied` e INALCANCAVEL nesta area em qualquer modo | `cli/lib/setup.sh:973-978` |
+
+> Nenhum destes defaults e overridable por flag dedicada (FR-018 — ver
+> `contracts/cli-setup.md` §1, "Flags"): a unica alavanca de modo e a
+> precedencia `--dry-run` > `--yes` > interativo (FR-006).

--- a/docs/specs/cstk-setup/plan.md
+++ b/docs/specs/cstk-setup/plan.md
@@ -20,10 +20,46 @@ dedicado") sem criar uma segunda implementacao que derive com o tempo.
 Idempotencia (FR-003/FR-013) cai fora de graca: o status e re-apurado
 vivo a cada invocacao e area ja configurada nao recebe chamada alguma.
 
-Uma unica extensao de contrato e necessaria — o hook opt-in
-`posttooluse-loose-usage.sh` nao tem hoje nenhuma fonte de deteccao
-read-only, embora FR-002 + FR-008 exijam mostrar seu status antes de
-perguntar. Ver research.md Decision 3.
+Tres extensoes de contrato sao necessarias, todas **aditivas** e todas
+alojadas na lib que ja e dona da area — nunca em `setup.sh`, para nao
+criar a segunda implementacao que a abordagem existe para evitar:
+
+1. `guard-hooks-status.sh check --include-loose-usage` — o hook opt-in
+   `posttooluse-loose-usage.sh` nao tem hoje nenhuma fonte de deteccao
+   read-only, embora FR-002 + FR-008 exijam mostrar seu status antes de
+   perguntar. Ver research.md Decision 3.
+2. `guard-hooks-status.sh check --verify-registration` — 5a coluna TSV
+   que verifica se o comando de fato registrado no `settings.json` e o
+   canonico do catalogo (FR-016).
+3. `_mcp_registration_status` em `cli/lib/mcp.sh` — deteccao read-only
+   equivalente para a chave `mcpServers.cstk-state` (FR-016).
+
+### Nota de seguranca: por que (2) e (3) existem
+
+Ambas nasceram de um gate `owasp-security` na fase plan, respondido pelo
+operador (spec.md §Clarifications, sessao de gate). O desenho original
+apurava as duas areas por **presenca de nome**: basename do hook no
+`settings.json` (`_gh_registered`, `guard-hooks-status.sh:119-127`) e
+chave `cstk-state` no `.mcp.json`. Presenca de nome nao distingue um
+registro legitimo de um que cita o nome e executa outro programa — e o
+hook em questao, `pretooluse-bash-guard.sh`, e um controle de seguranca
+(bloqueio fail-closed de comandos durante execucao 00c).
+
+O agravante e a semantica de merge: `merge_settings` roda
+`jq -s '.[0] * .[1]'` com "Source primeiro, target segundo => target
+vence em conflitos" (`cli/lib/hooks.sh`), e `cstk mcp install` declara
+"entrada ja presente e equivalente => idempotente, exit 0"
+(`cli/lib/mcp.sh:800-802`). Uma entrada preexistente **sobrevive** a
+instalacao. Sem (2) e (3), o wizard reportaria `already configured`
+sobre um controle redirecionado — falsa garantia no cenario exato que a
+feature mira, o repo recem-clonado.
+
+A resposta e **deteccao**, nao sobrescrita: o wizard classifica como
+`divergent`, imprime a remediacao de duas etapas (remover a entrada,
+depois reinstalar — porque so reinstalar comprovadamente nao substitui) e
+falha a area. Ele nunca apaga configuracao que nao reconhece.
+Fail-closed: toda ambiguidade de apuracao vira `divergent`, jamais
+`configured` (data-model, invariantes I5/I6).
 
 ## Technical Context
 
@@ -50,8 +86,8 @@ leitura humana
 telemetria nao escreve fora do projeto); FR-007 (falha rapida sem TTY);
 Constitution II (POSIX puro, sem bashismos)
 **Scale/Scope**: 1 lib nova + 1 arquivo de teste novo + edicoes pontuais
-em `cli/cstk` (4 listas) + 1 extensao aditiva de flag em
-`guard-hooks-status.sh`
+em `cli/cstk` (4 listas) + 2 extensoes aditivas de flag em
+`guard-hooks-status.sh` + 1 helper read-only aditivo em `cli/lib/mcp.sh`
 
 Zero `NEEDS CLARIFICATION` remanescentes. As tres ambiguidades originais
 foram fechadas no clarify (spec.md linhas 11-13); as decisoes tecnicas
@@ -138,13 +174,13 @@ cli/
     ├── ui.sh                               require_tty (42-50)
     ├── config.sh                           config_state_backend_{capability,resolve,enable_sqlite} (90/94/98)
     ├── hooks.sh                            hooks_main (557), apply_guard_hooks (318)
-    ├── mcp.sh                              _mcp_cmd_install (806-877), _mcp_cmd_status (371)
+    ├── mcp.sh                              [EDIT] + _mcp_registration_status (FR-016); _mcp_cmd_install (806-877), _mcp_cmd_status (371), _mcp_runtime_script_path (127-146)
     ├── mcp-docker.sh                       _mcp_docker_preflight — nao invocado por setup.sh
     ├── doctor.sh                           _doctor_deps_run (408-474)
     └── state.sh                            state_main (103-149) — referencia de contrato
 global/skills/agente-00c-runtime/
 ├── scripts/
-│   ├── guard-hooks-status.sh               [EDIT] flag --include-loose-usage (aditiva)
+│   ├── guard-hooks-status.sh               [EDIT] flags --include-loose-usage e --verify-registration (ambas aditivas)
 │   ├── state-backend.sh                    resolve (234-269), enable-sqlite (358-397)
 │   └── otel-usage.sh                       preflight (469)
 └── hooks/
@@ -192,13 +228,14 @@ textuais explicitos, documentados em `contracts/cli-setup.md`:
 | `setup.sh` ↔ `state-backend.sh` (via `config.sh`) | `chave=valor` (`effective_backend=`, `reason=`) | `_sb_cmd_resolve`, `state-backend.sh:234-269` |
 | `setup.sh` ↔ `hooks.sh` / `mcp.sh` | funcao sourceada + exit code | contratos em `cli/lib/hooks.sh:526-535`, `cli/lib/mcp.sh:949-953` |
 | `setup.sh` ↔ `otel-usage.sh` | texto de diagnostico + exit | `_ou_cmd_preflight`, `otel-usage.sh:469-561` |
+| `setup.sh` ↔ `mcp.sh` (registro) | palavra unica em stdout (`configured`/`divergent`/`not-configured`) | `_mcp_registration_status` [PROPOSTA], `contracts/cli-setup.md` §4.1 |
 
 **Disciplina equivalente ao "case style"** para esta feature: o
-vocabulario de status (`configured` / `not-configured` / `unavailable`) e
-de outcome (`applied` / `already-configured` / `skipped` / `failed`) e
-**fechado e declarado uma unica vez** em `data-model.md`, e vem
-literalmente de FR-002 e FR-010. Nenhuma area pode inventar um quinto
-valor — e a mesma classe de bug que o template alerta (dois lados
+vocabulario de status (`configured` / `not-configured` / `divergent` /
+`unavailable`) e de outcome (`applied` / `already-configured` /
+`skipped` / `failed`) e **fechado e declarado uma unica vez** em
+`data-model.md`, e vem literalmente de FR-002, FR-016 e FR-010. Nenhuma
+area pode inventar um valor fora desse conjunto — e a mesma classe de bug que o template alerta (dois lados
 falando dialetos diferentes do mesmo dado), transposta para CLI.
 
 ## Re-check de Constitution (pos-Phase 1)
@@ -221,6 +258,15 @@ Revalidacao apos o design estar completo:
   duas metades da instalacao (runtime do binario **e** catalogo),
   exigindo `cstk self-update` **e** `cstk install`. Mitigado pelo
   quickstart Scenario 11 como verificacao manual obrigatoria.
+- **Revisao de seguranca aplicada (gate `owasp-security`, achado HIGH)**:
+  o design pos-gate incorpora FR-016 (autenticidade do registro,
+  fail-closed), FR-017 (rotulo de escrita global) e FR-018 (nao expor
+  override de catalogo). Nenhum dos tres introduz dependencia, camada ou
+  formato novo — sao uma coluna TSV aditiva, um helper read-only e uma
+  flag deliberadamente ausente. Principio II intacto (a verificacao e
+  `grep -F` por linha, sem `jq`); Principio VI intacto (a remediacao
+  publicada foi corrigida contra a semantica real do merge em vez de
+  repetir a instrucao intuitiva que nao surte efeito).
 
 **Veredito**: todos os MUST (I, II, IV, VI) seguem PASS. Nenhum novo
 carve-out necessario.
@@ -256,3 +302,27 @@ Levantados no Phase 1, a converter em tarefas:
 6. **Nome de flag `--yes`** — sem precedente verificado no repo para
    "nao-interativo". Confirmar com o operador antes de congelar o
    contrato publico (research.md Decision 5).
+7. **Falso-positivo de `divergent` no MCP (FR-016)** — o `command`
+   gravado e o path resolvido no momento da instalacao
+   (`cli/lib/mcp.sh:840`), e `_mcp_runtime_script_path` (linhas 127-146)
+   tem tres camadas de resolucao. Comparar contra uma so gera
+   `divergent` espurio em maquina de dev. A regra e aceitar o **conjunto**
+   das tres camadas (contrato §4.1). Testar explicitamente os dois lados:
+   entrada escrita a partir do repo e verificada via `~/.claude`
+   (**nao** divergente) e entrada apontando para fora do catalogo
+   (**divergente**).
+8. **`settings.json` minificado** — a verificacao de registro e por
+   linha. JSON numa unica linha impede atribuir a mencao ao basename e
+   MUST resolver para `indeterminate` → nunca `configured` (I5). Cenario
+   de teste obrigatorio: o caso minificado nao pode passar por
+   `already-configured`.
+9. **Remediacao precisa ser testada, nao so impressa** — o teste de
+   `divergent` deve assertar que o wizard **nao chamou** `hooks install`
+   / `mcp install` (I6) e que o texto exibido inclui a etapa de remocao.
+   Instruir apenas "re-rode o install" seria instrucao comprovadamente
+   inefetiva (merge com target vencendo).
+10. **5a coluna e o exit sob `--verify-registration`** — a extensao muda
+    o exit para `1` em divergencia **apenas** quando a flag e passada.
+    Teste de retro-compatibilidade obrigatorio: sem a flag, saida
+    byte-a-byte e exit identicos aos atuais, para nao quebrar
+    `tests/test_guard-hooks-status.sh` nem os consumidores existentes.

--- a/docs/specs/cstk-setup/plan.md
+++ b/docs/specs/cstk-setup/plan.md
@@ -34,6 +34,17 @@ criar a segunda implementacao que a abordagem existe para evitar:
 3. `_mcp_registration_status` em `cli/lib/mcp.sh` — deteccao read-only
    equivalente para a chave `mcpServers.cstk-state` (FR-016).
 
+> **Invocacao das extensoes (1) e (2) e sempre SEPARADA da baseline
+> (achado SEC-03)**: `setup.sh` MUST chamar
+> `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet` (sem
+> flags) como fonte do veredito dos 3 hooks obrigatorios, e (1)/(2) como
+> chamadas adicionais **isoladas** cuja falha (runtime antigo, exit 2)
+> degrada apenas a propria dimensao — `loose_usage_status` para (1),
+> `mandatory_status`/`status` (via I5, para `unavailable`) para (2).
+> Combinar as tres flags numa unica chamada faria um runtime antigo sem
+> suporte a alguma delas perder tambem o veredito basico que ele sabe
+> responder. Ver data-model.md §Fonte de `status` por area.
+
 ### Nota de seguranca: por que (2) e (3) existem
 
 Ambas nasceram de um gate `owasp-security` na fase plan, respondido pelo
@@ -267,6 +278,42 @@ Revalidacao apos o design estar completo:
   `grep -F` por linha, sem `jq`); Principio VI intacto (a remediacao
   publicada foi corrigida contra a semantica real do merge em vez de
   repetir a instrucao intuitiva que nao surte efeito).
+
+- **Re-review de seguranca pos-hardening (gate `owasp-security`, sem
+  HIGH/CRITICAL, 7 achados MEDIUM/LOW SEC-01..SEC-07)**: os 3 achados que
+  alteravam contrato/data-model foram corrigidos nesta mesma revisao,
+  ANTES de `create-tasks`, para nao gerar retrabalho de tarefas ja
+  quebradas por FASE:
+  - **SEC-01** (MEDIUM, linha-isca decorativa satisfazia a regra de linha
+    canonica de `--verify-registration`): `contracts/cli-setup.md` §2.3
+    agora exige tambem o token `"command"` na mesma linha, e declara
+    explicitamente que posicionamento estrutural sob `PreToolUse`/
+    `matcher` NAO e verificado (residual aceito, mesma classe do limite
+    de JSON minificado).
+  - **SEC-02** (MEDIUM, mapeamento de `indeterminate` sem destino no enum
+    fechado gerava fail-open para `configured`): `data-model.md`
+    invariante I5 agora enumera `indeterminate` → `unavailable`
+    explicitamente (nunca herda o exit 0/1 da chamada baseline), mesmo
+    caminho ja descrito para o exit 2 do quickstart Scenario 15 variante
+    4.
+  - **SEC-03** (MEDIUM, combinar `--include-loose-usage` e
+    `--verify-registration` na mesma chamada regride runtime antigo):
+    `data-model.md` linha `hooks` da tabela de fontes agora exige 3
+    chamadas SEPARADAS — baseline sem flags (fonte real de
+    `configured`/`not-configured`), `--verify-registration` isolada
+    (so escala para `divergent`/`unavailable`) e `--include-loose-usage`
+    isolada (so alimenta `loose_usage_status`).
+  - **SEC-04..SEC-07** (MEDIUM/LOW restantes, sem impacto em
+    contrato/data-model): registrados para virar tarefas explicitas no
+    `create-tasks` em vez de fechados aqui — `--yes` nao deve gravar
+    config global sem opt-in equivalente ao do loose-usage (SEC-04);
+    candidatos de `mcp-launch.sh` em `_mcp_registration_status` devem se
+    restringir ao sufixo `/skills/agente-00c-runtime/scripts/
+    mcp-launch.sh` **existente em disco** (SEC-05); stdout vazio de
+    `_mcp_registration_status` nunca e resposta valida, deve virar
+    indeterminado (SEC-06); o summary deve declarar o escopo real da
+    verificacao — hooks obrigatorios verificados, demais entradas do
+    `settings.json` nao auditadas (SEC-07).
 
 **Veredito**: todos os MUST (I, II, IV, VI) seguem PASS. Nenhum novo
 carve-out necessario.

--- a/docs/specs/cstk-setup/plan.md
+++ b/docs/specs/cstk-setup/plan.md
@@ -1,0 +1,258 @@
+# Implementation Plan: Guided Project Setup Wizard
+
+**Feature**: `cstk-setup` | **Date**: 2026-08-07 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Adicionar `cstk setup`: um subcomando novo do binario CLI que percorre,
+numa ordem fixa, as quatro areas de configuracao recomendadas de um
+projeto — hooks obrigatorios (com o hook opt-in de captura avulsa como
+escolha aninhada), backend de estado global, registro do servidor MCP de
+estado, e telemetria — mostrando o status atual de cada uma antes de
+oferecer aplica-la, e terminando com um sumario por area.
+
+**Abordagem tecnica**: `cli/lib/setup.sh` e uma camada de **orquestracao
+pura**. Nao implementa nenhuma deteccao nem nenhuma escrita propria: cada
+area delega deteccao a uma fonte read-only existente e aplicacao ao
+comando dedicado existente (research.md Decisions 2 e 4). Essa e a unica
+forma de satisfazer FR-002 ("usando a mesma logica de deteccao do comando
+dedicado") sem criar uma segunda implementacao que derive com o tempo.
+Idempotencia (FR-003/FR-013) cai fora de graca: o status e re-apurado
+vivo a cada invocacao e area ja configurada nao recebe chamada alguma.
+
+Uma unica extensao de contrato e necessaria — o hook opt-in
+`posttooluse-loose-usage.sh` nao tem hoje nenhuma fonte de deteccao
+read-only, embora FR-002 + FR-008 exijam mostrar seu status antes de
+perguntar. Ver research.md Decision 3.
+
+## Technical Context
+
+**Language/Version**: POSIX sh (`#!/bin/sh`, `set -eu`) — Constitution II
+**Primary Dependencies**: nenhuma nova. `setup.sh` sourceia libs irmas pelo
+padrao ja estabelecido `. "${CSTK_LIB:?CSTK_LIB must be set}/<lib>.sh"`
+(`cli/lib/hooks.sh:60`, `cli/lib/doctor.sh:51-59`, `cli/lib/list.sh:31-41`)
+e invoca scripts do catalogo como processo. **Nao** chama `sqlite3`
+(confinado a `cli/lib/recall.sh`), **nao** chama `docker` funcionalmente
+(confinado a `cli/lib/mcp-docker.sh`), **nao** exige `jq`
+**Storage**: N/A — feature sem persistencia propria (FR-013 proibe flag
+persistido de "setup ja rodou"). Escritas ocorrem apenas dentro dos
+comandos delegados
+**Testing**: harness POSIX do repo — `tests/cstk/test_setup.sh` (novo),
+cenarios `scenario_<nome>()` descobertos por `run_all_scenarios`
+(`tests/lib/harness.sh:245-251`); mapeamento obrigatorio de
+`tests/run.sh:10-13`, enforced por `./tests/run.sh --check-coverage`
+**Target Platform**: macOS/Linux, shell POSIX. Sem GNU-only (CLAUDE.md)
+**Project Type**: CLI (subcomando de binario existente)
+**Performance Goals**: SC-001 — decidir as 4 areas em menos de 2 min de
+tempo interativo. Nao ha meta de latencia de maquina; o custo dominante e
+leitura humana
+**Constraints**: FR-011 (so roda em raiz de repo git); FR-012 (area de
+telemetria nao escreve fora do projeto); FR-007 (falha rapida sem TTY);
+Constitution II (POSIX puro, sem bashismos)
+**Scale/Scope**: 1 lib nova + 1 arquivo de teste novo + edicoes pontuais
+em `cli/cstk` (4 listas) + 1 extensao aditiva de flag em
+`guard-hooks-status.sh`
+
+Zero `NEEDS CLARIFICATION` remanescentes. As tres ambiguidades originais
+foram fechadas no clarify (spec.md linhas 11-13); as decisoes tecnicas
+restantes estao resolvidas em research.md.
+
+## Constitution Check
+
+*GATE: Deve passar antes do Phase 0. Re-checado apos Phase 1 — ver
+§Re-check.*
+
+| Principio | Status | Notas |
+|-----------|--------|-------|
+| I. SDD recursivo (NON-NEGOTIABLE) | PASS | Feature nao-trivial entrou pela pipeline completa: `spec.md` + `clarify` (3 Q&A registradas) + este `plan.md`; `tasks.md` vem a seguir. Nao ha alteracao de contrato de skill existente, logo sem BREAKING |
+| II. POSIX sh puro (NON-NEGOTIABLE) | PASS | `cli/lib/setup.sh` e `#!/bin/sh` + `set -eu`, sem arrays, `[[ ]]`, `local`, `<<<` ou `function`. **Nenhuma dep nova**: nao invoca `jq`, `sqlite3`, `docker`, `git`. A deteccao de MCP e leitura textual (`grep -F`), mesma escolha que `_gh_registered` (`guard-hooks-status.sh:119`) ja faz explicitamente para nao depender de `jq`. Ver §Registro de dependencias |
+| III. Formato canonico de skill | N/A | Nao e skill — FR-014 fixa subcomando de CLI. Nao ha `SKILL.md` envolvido |
+| IV. Zero coleta remota (NON-NEGOTIABLE) | PASS | Ver §Analise dedicada abaixo — as duas superficies suspeitas (area de telemetria, hook de captura avulsa) sao 100% locais |
+| V. Profundidade sobre adocao | PASS | A feature reduz retrabalho real (substitui conhecimento tribal de 4 comandos por um ponto de entrada), nao gera visibilidade. Nenhuma superficie nova de configuracao foi inventada — so orquestracao do que existe |
+| VI. Veracidade de dados (NON-NEGOTIABLE) | PASS | Todo comportamento existente afirmado nos artefatos cita `arquivo:linha` verificado. Interfaces novas estao marcadas **[PROPOSTA]** em `contracts/cli-setup.md`, distintas de **[EXISTENTE]**. Onde faltou fonte (Scenario 3 do quickstart: valores de `reason=` do `state-backend.sh resolve`), a lacuna foi **registrada como investigacao**, nao preenchida por suposicao |
+
+### Analise dedicada — Principio IV (zero coleta remota)
+
+A feature toca duas superficies que, pelo nome, parecem colidir com
+"nenhuma skill faz requisicao de rede para endpoint de telemetria":
+
+1. **Area de telemetria (OTel)**. O que existe no repo e um exporter
+   **Prometheus local** em `127.0.0.1:9464` (README.md:315), consumido
+   por `otel-usage.sh` na propria maquina. Nao ha endpoint do autor, nao
+   ha upload. Alem disso o wizard **nao ativa nada** — FR-012 restringe a
+   area a diagnosticar (`otel-usage.sh preflight`, `otel-usage.sh:469`) e
+   exibir instrucoes. A decisao de ativar continua inteiramente do
+   usuario, no shell dele.
+2. **Hook opt-in de captura avulsa**. Grava em sidecar local
+   (`~/.claude/cstk/loose-usage/`) e no `knowledge.db` local. E opt-in
+   explicito (`--with-loose-usage` default off, `cli/lib/hooks.sh:513,543`),
+   e o wizard **preserva** esse opt-in: FR-008 exige pergunta separada, e
+   o default em `--yes` e **nao aplicar** (research.md Decision 5) —
+   unica area cujo default recomendado e "nao". Logs e artefatos
+   permanecem no filesystem local, como o Principio IV exige.
+
+**Veredito**: PASS. O wizard nao introduz nenhuma requisicao de rede; ao
+contrario, torna explicita ao usuario uma escolha que hoje esta enterrada
+em documentacao.
+
+### Registro de dependencias (Principio II, carve-outs 1.1.0 e 1.3.0)
+
+`cli/lib/setup.sh` **nao aciona nenhum carve-out**: nao introduz
+dependencia opcional nem obrigatoria. As deps que aparecem
+transitivamente ja estao cobertas por carve-outs anteriores e
+permanecem confinadas onde ja estavam:
+
+| Dep | Onde e usada | Cobertura |
+|-----|--------------|-----------|
+| `jq` | dentro de `hooks install` / `mcp install`, com fallback `print_paste_block` que retorna 0 (`cli/lib/hooks.sh:631-643`, `cli/lib/mcp.sh:866-871`) | carve-out 1.1.0 (opcional com fallback), preexistente |
+| `sqlite3` | dentro de `enable-sqlite` (`state-backend.sh`), com recusa limpa exit 3 quando ausente (linhas 358-370) | carve-out 1.3.0 (camada de estado transacional), preexistente |
+| `docker` | dentro de `cli/lib/mcp-docker.sh` (unico ponto funcional, cabecalho linhas 1-11) | preexistente; `setup.sh` no maximo usa `command -v docker` para texto de aviso, mesmo padrao de `cli/lib/mcp.sh:475-479` |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+docs/specs/cstk-setup/
+├── spec.md
+├── plan.md                  # This file
+├── research.md              # Phase 0 output — 10 decisions
+├── data-model.md            # Phase 1 output — estruturas em memoria
+├── quickstart.md            # Phase 1 output — 12 cenarios
+└── contracts/
+    └── cli-setup.md         # Phase 1 output — contrato CLI + 4 fronteiras
+```
+
+### Source Code (repository root)
+
+Paths verificados no repo em 2026-08-07. `[NOVO]` = arquivo a criar;
+`[EDIT]` = arquivo existente a alterar; demais sao consumidos sem
+alteracao.
+
+```
+cli/
+├── cstk                                    [EDIT] 4 pontos — ver tabela
+└── lib/
+    ├── setup.sh                            [NOVO] setup_main + orquestracao
+    ├── common.sh                           log_info/log_warn/log_error (19/23/27), is_tty (31)
+    ├── ui.sh                               require_tty (42-50)
+    ├── config.sh                           config_state_backend_{capability,resolve,enable_sqlite} (90/94/98)
+    ├── hooks.sh                            hooks_main (557), apply_guard_hooks (318)
+    ├── mcp.sh                              _mcp_cmd_install (806-877), _mcp_cmd_status (371)
+    ├── mcp-docker.sh                       _mcp_docker_preflight — nao invocado por setup.sh
+    ├── doctor.sh                           _doctor_deps_run (408-474)
+    └── state.sh                            state_main (103-149) — referencia de contrato
+global/skills/agente-00c-runtime/
+├── scripts/
+│   ├── guard-hooks-status.sh               [EDIT] flag --include-loose-usage (aditiva)
+│   ├── state-backend.sh                    resolve (234-269), enable-sqlite (358-397)
+│   └── otel-usage.sh                       preflight (469)
+└── hooks/
+    ├── posttooluse-loose-usage.sh          alvo da nova deteccao
+    └── settings.loose-usage.snippet.json   snippet separado (opt-in)
+tests/
+├── run.sh                                  mapeamento (10-13) + --check-coverage
+├── lib/harness.sh                          run_all_scenarios (245-251)
+└── cstk/
+    └── test_setup.sh                       [NOVO] cenarios do quickstart.md
+```
+
+**Pontos de edicao em `cli/cstk`** (todos os quatro sao obrigatorios —
+esquecer um produz UX inconsistente, ver research.md Decision 1):
+
+| Local | Mudanca |
+|-------|---------|
+| `cli/cstk:250` | adicionar `setup` ao `case` do ramo generico de dispatch |
+| `cli/cstk:136-152` | adicionar `setup` a lista de comandos do help geral |
+| `cli/cstk:169-211` | adicionar ramo `setup)` ao `case` de help por subcomando |
+| `cli/cstk:217` e `cli/cstk:299` | incluir `setup` nas listas de comandos validos das mensagens de erro |
+
+**Structure Decision**: `setup` entra pelo ramo **generico** do
+dispatcher, sem ramo dedicado. O ramo generico ja resolve
+`$CSTK_LIB/setup.sh` (`cli/cstk:257`), sourceia (linha 265) e deriva
+`setup_main` pela convencao `sed 's/-/_/g'` + `_main` (linha 267). O
+special-casing de `00c` (linhas 274-291) existe apenas porque nome de
+funcao nao pode comecar com digito — nao se aplica. Um ramo dedicado
+seria codigo morto.
+
+## Convencoes de Borda
+
+**N/A — single-layer.** A feature e um subcomando CLI em POSIX sh puro:
+nao ha borda backend↔frontend, nao ha DB, nao ha broker, nao ha payload
+serializado atravessando camadas. Nenhum mapper, nenhum schema
+compartilhado, nenhuma validacao de case style aplicavel.
+
+A unica fronteira real e **processo ↔ processo** (`setup.sh` consumindo
+stdout/exit de scripts do catalogo), e ela ja e governada por contratos
+textuais explicitos, documentados em `contracts/cli-setup.md`:
+
+| Fronteira | Formato | Fonte da verdade |
+|-----------|---------|------------------|
+| `setup.sh` ↔ `guard-hooks-status.sh` | TSV, 4 campos por linha | cabecalho de `guard-hooks-status.sh:49-60` |
+| `setup.sh` ↔ `state-backend.sh` (via `config.sh`) | `chave=valor` (`effective_backend=`, `reason=`) | `_sb_cmd_resolve`, `state-backend.sh:234-269` |
+| `setup.sh` ↔ `hooks.sh` / `mcp.sh` | funcao sourceada + exit code | contratos em `cli/lib/hooks.sh:526-535`, `cli/lib/mcp.sh:949-953` |
+| `setup.sh` ↔ `otel-usage.sh` | texto de diagnostico + exit | `_ou_cmd_preflight`, `otel-usage.sh:469-561` |
+
+**Disciplina equivalente ao "case style"** para esta feature: o
+vocabulario de status (`configured` / `not-configured` / `unavailable`) e
+de outcome (`applied` / `already-configured` / `skipped` / `failed`) e
+**fechado e declarado uma unica vez** em `data-model.md`, e vem
+literalmente de FR-002 e FR-010. Nenhuma area pode inventar um quinto
+valor — e a mesma classe de bug que o template alerta (dois lados
+falando dialetos diferentes do mesmo dado), transposta para CLI.
+
+## Re-check de Constitution (pos-Phase 1)
+
+Revalidacao apos o design estar completo:
+
+- **Complexidade introduzida**: uma lib nova de orquestracao e uma flag
+  aditiva. Nenhuma camada, nenhum servico, nenhum formato de dado novo.
+  O design REDUZ superficie conceitual (4 comandos → 1 ponto de entrada)
+  em vez de aumenta-la.
+- **Principio II segue integro**: o design explicitamente rejeitou
+  `git rev-parse` (research.md Decision 7), reescrita direta de
+  `settings.json`/`.mcp.json` (Decision 4) e parse com `jq` (Decision 2) —
+  em todos os casos escolhendo a alternativa POSIX ou a delegacao.
+- **Principio VI segue integro apos o design**: o Phase 1 *encontrou* uma
+  lacuna factual (valores de `reason=` do `resolve`) e a registrou como
+  investigacao no quickstart Scenario 3, em vez de inventar o conjunto de
+  valores. Esse e o comportamento que o principio exige.
+- **Risco novo identificado, mitigado por processo**: a feature toca as
+  duas metades da instalacao (runtime do binario **e** catalogo),
+  exigindo `cstk self-update` **e** `cstk install`. Mitigado pelo
+  quickstart Scenario 11 como verificacao manual obrigatoria.
+
+**Veredito**: todos os MUST (I, II, IV, VI) seguem PASS. Nenhum novo
+carve-out necessario.
+
+## Complexity Tracking
+
+Nao aplicavel — Constitution Check sem violacoes, nenhuma excecao
+solicitada, nenhum carve-out novo acionado.
+
+## Riscos e pontos de atencao para `create-tasks`
+
+Levantados no Phase 1, a converter em tarefas:
+
+1. **`reason=` do `state-backend.sh resolve` nao enumerado** — bloqueia a
+   regra de US2 AC3 (nao migrar backend deliberadamente diferente).
+   Tarefa de investigacao empirica ANTES de codificar o default de `--yes`
+   para a area de state backend. Ver quickstart Scenario 3.
+2. **`set -e` e isolamento de falha (FR-009)** — libs sourceadas rodam no
+   mesmo shell sob `set -eu`. Toda chamada de aplicacao MUST ser
+   neutralizada (`if ! fn; then` ou `fn || rc=$?`). Uma unica chamada
+   solta derruba o wizard inteiro e viola FR-009 silenciosamente.
+3. **Exit 0 nao significa `applied`** — `hooks install` e `mcp install`
+   retornam 0 em `paste-instructed` (jq ausente). Mapear para um outcome
+   que carregue o aviso ao summary, senao o usuario le "tudo certo" com
+   acao manual pendente. Caminho mais provavel de falso positivo em
+   producao.
+4. **Sincronizacao das duas metades** — checklist de release deve exigir
+   `cstk self-update` **e** `cstk install` + `cstk doctor` drift zero.
+5. **Teste de "dependencia ausente"** — esbarra no gotcha conhecido do
+   projeto: stub de `PATH` nao esconde binario de `/usr/bin`. Desenhar
+   desacoplando a deteccao do `PATH` interno, ou aceitar como
+   nao-coberto com nota explicita.
+6. **Nome de flag `--yes`** — sem precedente verificado no repo para
+   "nao-interativo". Confirmar com o operador antes de congelar o
+   contrato publico (research.md Decision 5).

--- a/docs/specs/cstk-setup/quickstart.md
+++ b/docs/specs/cstk-setup/quickstart.md
@@ -304,13 +304,19 @@ fechar a feature.
 2. Rodar `cstk setup --project-path "$PROJ" --yes`.
 3. **Expected**:
    - A verificacao de registro devolve `indeterminate`.
-   - A area **nao** e reportada como `already-configured` (I5).
+   - Area `hooks`.`status` = **`unavailable`** (achado SEC-02) — **nao**
+     `already-configured`/`configured` (I5), e tambem **nao** `divergent`
+     (nao houve confirmacao positiva de nao-canonico, so impossibilidade
+     de verificar). `outcome` = `failed` com `reason` = `status_reason`.
    - O motivo distingue "nao consegui verificar" de "esta errado" —
      texto honesto, sem afirmar subversao que nao foi observada.
+   - Exit `1` (houve `failed`).
 4. Variante com runtime instalado antigo (sem `--verify-registration`):
    a chamada retorna exit `2` (`_gh_die_usage`,
-   `guard-hooks-status.sh:205`) e o resultado tambem e `indeterminate`,
-   pelo mesmo caminho — nao uma falha da area (FR-009).
+   `guard-hooks-status.sh:205`) e o resultado tambem e `indeterminate` →
+   `unavailable`, pelo mesmo caminho — **nao** uma excecao/crash da area
+   (FR-009 segue intacto: a area reporta um status valido do enum
+   fechado, o wizard nao aborta).
 
 ---
 
@@ -338,6 +344,64 @@ fechar a feature.
      `already-configured` com base nela. A variavel altera apenas a
      referencia de `guard-hooks-status.sh` (`:136-137`), nunca a origem
      do provisionamento nem a forma canonica de §2.3 do contrato.
+
+---
+
+## Scenario 17: Linha-isca decorativa nao satisfaz o registro canonico (achado SEC-01)
+
+1. Projeto valido, hooks obrigatorios provisionados corretamente em
+   `.claude/hooks/` (4a coluna do TSV = `current`).
+2. Editar `.claude/settings.json` para que a entrada real `"command"` do
+   `PreToolUse` aponte para outro programa (`/tmp/nao-e-o-guard.sh`), e
+   acrescentar em **outra linha** (ex. um campo `"_comment"` decorativo,
+   valido como JSON) o basename **e** o fragmento canonico completo:
+   `"_comment": "espera-se \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pretooluse-bash-guard.sh"`.
+3. Rodar `cstk setup --project-path "$PROJ" --yes`.
+4. **Expected**:
+   - A linha decorativa contem basename + fragmento canonico, mas **nao**
+     contem o token `"command"` — a regra de decisao de §2.3 (pos-fix
+     SEC-01) exige os tres na mesma linha, entao essa linha **nao** conta
+     como `canonical`.
+   - A linha `"command"` real (que executa `/tmp/nao-e-o-guard.sh`) nao
+     contem o fragmento canonico → hook classificado `divergent`.
+   - Area `hooks` = `divergent` (nunca `already-configured`/`configured`).
+   - **Nenhuma chamada** a `hooks install` (invariante I6).
+   - Exit `1`.
+
+---
+
+## Scenario 18: Extensao `--verify-registration` isolada nao regride a deteccao base (achado SEC-03)
+
+1. Projeto valido, hooks obrigatorios **provisionados e registrados
+   corretamente** (baseline `guard-hooks-status.sh check --quiet` sairia
+   exit `0`).
+2. Apontar a resolucao de `guard-hooks-status.sh` para uma copia
+   **anterior** a esta feature — suporta a chamada baseline (§2.1,
+   existente ha mais tempo) mas rejeita `--verify-registration` com exit
+   `2` (`_gh_die_usage`, `guard-hooks-status.sh:205`), mesma tecnica do
+   Scenario 10.
+3. Rodar `cstk setup --project-path "$PROJ" --yes`.
+4. **Expected**:
+   - A chamada baseline (sem flags) roda **separadamente** e retorna
+     exit `0` normalmente — o wizard SABE que os 3 hooks obrigatorios
+     estao presentes+registrados+atuais.
+   - A chamada `--verify-registration` (separada) falha com exit `2` →
+     resultado `indeterminate` para a dimensao de autenticidade.
+   - Por I5/SEC-02, `indeterminate` escala `status` para `unavailable` —
+     mas o wizard chega a esse veredito **por ter rodado as duas
+     chamadas**, nao por a segunda chamada ter destruido o resultado da
+     primeira. Assertar via stub/contador que a chamada baseline (sem
+     `--verify-registration`) de fato ocorreu e retornou exit `0` antes
+     da escalada.
+   - **Regressao que este cenario previne**: se as flags fossem
+     combinadas numa unica chamada (`--quiet --verify-registration` sem
+     baseline separada, redacao pre-SEC-03 de `data-model.md`), o exit
+     `2` da flag desconhecida faria o wizard perder tambem o veredito
+     basico que aquele runtime sabe responder — `status` cairia
+     igualmente em `unavailable`, mas **sem nunca ter consultado** a
+     configuracao real dos 3 hooks, o que quebraria o Scenario 1 (happy
+     path) em qualquer maquina com runtime instalado ligeiramente
+     desatualizado.
 
 ---
 

--- a/docs/specs/cstk-setup/quickstart.md
+++ b/docs/specs/cstk-setup/quickstart.md
@@ -1,0 +1,244 @@
+# Quickstart: cstk-setup
+
+Cenarios que validam a implementacao end-to-end. Todos rodam com `HOME`
+sandboxado (`env HOME="$TMPDIR_TEST/home"`, padrao de
+`tests/cstk/test_mcp.sh:50,58`) — obrigatorio, nao higiene opcional: a
+area de state backend escreve na config **global**
+`$HOME/.claude/cstk/config` (`state-backend.sh:75-76`), e sem sandbox um
+teste alteraria a configuracao real da maquina.
+
+`CSTK_LIB="$REPO_ROOT/cli/lib"` conforme `tests/cstk/test_hooks.sh:13-14`.
+Prompts interativos usam o bypass `CSTK_FORCE_INTERACTIVE=1`
+(`cli/lib/ui.sh:43`) para serem exercitaveis sem TTY real.
+
+---
+
+## Scenario 1: Happy path — projeto sem nada configurado, interativo (US1)
+
+1. Criar diretorio temporario e `git init` (satisfaz FR-011 — `.git`
+   presente).
+2. `HOME` sandboxado, sem `~/.claude/cstk/config`, sem
+   `.claude/settings.json`, sem `.mcp.json` no projeto.
+3. Rodar `cstk setup --project-path "$PROJ"` com `CSTK_FORCE_INTERACTIVE=1`,
+   alimentando stdin com respostas afirmativas para hooks e negativa para
+   loose usage.
+4. **Expected**:
+   - As **quatro** areas sao apresentadas na ordem fixa de FR-001:
+     `hooks`, `state-backend`, `mcp`, `telemetry`.
+   - Cada area exibe o status atual **antes** de oferecer a acao (FR-002).
+   - Apos aceitar hooks: `guard-hooks-status.sh check --projeto-alvo-path
+     "$PROJ" --quiet` passa a sair **0** (antes saia 1).
+   - Summary final lista as 4 areas com outcome cada (FR-010).
+   - Exit `0`.
+
+---
+
+## Scenario 2: Idempotencia — segundo run nao muda nada (US2, SC-002)
+
+1. Partir do estado final do Scenario 1.
+2. Capturar assinatura do estado antes: `.claude/settings.json`,
+   `.mcp.json`, `$HOME/.claude/cstk/config` e `.claude/hooks/` (ex.
+   `find ... | sort` + hash de conteudo).
+3. Rodar `cstk setup --project-path "$PROJ" --yes` de novo.
+4. Comparar a assinatura depois.
+5. **Expected**:
+   - Assinatura **identica** — zero alteracao (FR-003, SC-002).
+   - Areas ja configuradas reportadas como `already-configured`, sem
+     nenhuma chamada de aplicacao.
+   - Exit `0`.
+
+> **Por que comparar conteudo e nao so mtime**: `mcp install` e idempotente
+> por `merge_settings` com target vencendo (`cli/lib/mcp.sh:800-802`) e
+> `enable-sqlite` e no-op quando ja sqlite (`state-backend.sh:385-390`) —
+> ambos poderiam reescrever o arquivo com o mesmo conteudo sem violar
+> FR-003 semanticamente. A garantia forte que queremos e que o wizard
+> **nem chame** essas funcoes quando `status=configured` (invariante I1 do
+> data-model). O teste deve assertar tambem a ausencia da chamada, via
+> stub/contador.
+
+---
+
+## Scenario 3: Backend deliberadamente diferente nao e migrado a forca (US2 AC3)
+
+1. Projeto configurado, mas com `state_backend=json` mantido de proposito
+   em `$HOME/.claude/cstk/config`.
+2. Rodar `cstk setup --project-path "$PROJ" --yes`.
+3. **Expected**: NAO ha migracao forcada.
+
+> **Ponto de atencao — divergencia aparente entre FR-003 e o default de
+> `--yes`**: `effective_backend=json` mapeia para `not-configured`
+> (data-model, secao ConfigurationArea), e o default recomendado de
+> `--yes` para essa area e *aplicar* (research.md Decision 5). Isso
+> aplicaria `enable-sqlite` sobre uma escolha deliberada do usuario,
+> contrariando US2 AC3 (spec linhas 82-86).
+>
+> **Nao ha, no repo, forma de distinguir "json por escolha deliberada" de
+> "json por nunca-configurado"** alem do campo `reason=` que
+> `state-backend.sh resolve` emite (`state-backend.sh:234-269`; o valor
+> `nunca-configurado` aparece citado em CLAUDE.md §"Backend de estado
+> global"). Afirmar aqui qual conjunto exato de valores de `reason=`
+> existe seria fabricacao.
+>
+> **Acao requerida na implementacao**: enumerar empiricamente os valores
+> de `reason=` produzidos por `_sb_cmd_resolve` e definir a regra —
+> proposta: so aplicar em `--yes` quando `reason` indicar ausencia de
+> configuracao; qualquer `reason` que indique escolha explicita →
+> `already-configured` (respeitando US2 AC3). Registrar como task de
+> investigacao em `create-tasks`, nao adivinhar aqui.
+
+---
+
+## Scenario 4: Preview nao escreve nada (US3, FR-004, SC-003)
+
+1. Projeto limpo (`git init`, nada configurado), `HOME` sandboxado.
+2. Capturar assinatura completa do projeto **e** do `HOME` sandboxado.
+3. Rodar `cstk setup --project-path "$PROJ" --dry-run`.
+4. Comparar assinaturas.
+5. **Expected**:
+   - Zero diferenca em ambos (projeto e `HOME`) — nenhuma escrita.
+   - Saida exibe, para as 4 areas, o que seria aplicado.
+   - Todos os outcomes = `skipped` com motivo de preview.
+   - Exit `0`.
+
+---
+
+## Scenario 5: Preview vence nao-interativo (FR-006)
+
+1. Projeto limpo, assinatura capturada.
+2. Rodar `cstk setup --project-path "$PROJ" --dry-run --yes` (ambas as
+   flags).
+3. **Expected**: comportamento identico ao Scenario 4 — `mode=preview`,
+   zero escrita, exit `0`. Nenhuma area em `applied`.
+
+---
+
+## Scenario 6: Terminal nao-interativo sem flag falha rapido (FR-007)
+
+1. Projeto valido (`git init`), **sem** `CSTK_FORCE_INTERACTIVE`.
+2. Rodar `cstk setup --project-path "$PROJ"` com stdin redirecionado de
+   `/dev/null` (sem TTY) e sem `--dry-run` nem `--yes`.
+3. **Expected**:
+   - Falha **imediata**, sem bloquear aguardando input.
+   - Mensagem em stderr apontando explicitamente `--dry-run` ou `--yes`.
+   - Exit `3` (recusa por pre-condicao).
+   - Zero escrita.
+
+---
+
+## Scenario 7: Falha isolada de uma area nao interrompe as demais (FR-009)
+
+1. Projeto valido, `HOME` sandboxado.
+2. Induzir falha **apenas** na area de state backend — ex. tornar
+   `state-backend.sh` irresolvivel para `_config_state_backend_script_path`
+   (`cli/lib/config.sh:52`), ou forcar a condicao de recusa por
+   `sqlite3` ausente/abaixo de `3.45.1` (`state-backend.sh:358-370`,
+   exit 3).
+3. Rodar `cstk setup --project-path "$PROJ" --yes`.
+4. **Expected**:
+   - A area `state-backend` reporta `failed` com motivo legivel citando o
+     exit da fonte.
+   - As areas `mcp` e `telemetry` (posteriores na ordem fixa) **ainda sao
+     percorridas** e reportam seus proprios outcomes.
+   - Summary lista as 4 areas (SC-005).
+   - Exit `1` (houve `failed`).
+
+> **Sub-caso obrigatorio — `jq` ausente**: `hooks install` retorna
+> **exit 0** mesmo em `paste-instructed` (`cli/lib/hooks.sh:631-643`), e
+> `mcp install` tambem retorna 0 caindo em `print_paste_block`
+> (`cli/lib/mcp.sh:866-871`). Assertar que o wizard **nao** reporta
+> `applied` silencioso nesses casos: o aviso de acao manual pendente
+> deve chegar ao summary. Este e o caminho mais provavel de falso
+> "tudo certo" em producao.
+
+---
+
+## Scenario 8: Gate de diretorio (FR-011)
+
+1. Criar diretorio temporario **sem** `git init` (sem `.git`).
+2. Rodar `cstk setup --project-path "$DIR" --yes`.
+3. **Expected**:
+   - Recusa com diagnostico claro.
+   - Exit `3`.
+   - Diretorio permanece **inalterado** — nenhum `.claude/`, nenhum
+     `.mcp.json`, nenhuma config parcial (spec linhas 159-162).
+4. Repetir com um **git worktree** (onde `.git` e arquivo-ponteiro, nao
+   diretorio).
+5. **Expected**: worktree e **aceito** (FR-011: "worktrees contam") —
+   confirma que o teste e `[ -e ]` e nao `[ -d ]`.
+
+---
+
+## Scenario 9: Loose usage e escolha distinta (US4, FR-008)
+
+1. Projeto limpo, modo interativo com `CSTK_FORCE_INTERACTIVE=1`.
+2. Alimentar stdin: **sim** para hooks obrigatorios, **nao** para loose
+   usage.
+3. **Expected**:
+   - Duas perguntas distintas, com explicacao propria do que a captura
+     avulsa registra.
+   - Os 3 hooks obrigatorios ficam instalados
+     (`guard-hooks-status.sh check` → exit 0).
+   - `posttooluse-loose-usage.sh` **nao** e provisionado nem registrado.
+4. Rodar `cstk setup --project-path "$PROJ" --yes` num projeto limpo.
+5. **Expected**: hooks obrigatorios aplicados, loose usage **nao**
+   aplicado — o default de `--yes` para essa sub-area e `skip`
+   (`--with-loose-usage` e opt-in default off,
+   `cli/lib/hooks.sh:513,543`; CLAUDE.md: "NUNCA bundlado silenciosamente
+   ... sem a flag").
+
+---
+
+## Scenario 10: Runtime instalado antigo — flag de deteccao desconhecida
+
+1. Apontar `CSTK_HOOKS_CATALOG_DIR` / o `guard-hooks-status.sh` resolvido
+   para uma copia **anterior** a esta feature (sem
+   `--include-loose-usage`).
+2. Rodar `cstk setup --project-path "$PROJ" --yes`.
+3. **Expected**:
+   - A chamada de deteccao do loose usage retorna exit `2`
+     (`_gh_die_usage`, `guard-hooks-status.sh:205`).
+   - O wizard reporta `loose_usage_status=indeterminate` com motivo, e
+     **nao** trata isso como falha da area de hooks (FR-009).
+   - Os hooks obrigatorios seguem detectados e aplicados normalmente.
+   - Exit `0`.
+
+---
+
+## Scenario 11: Sincronizacao das duas metades (GOTCHA de release)
+
+Nao e teste automatizado — e verificacao manual obrigatoria antes de
+fechar a feature.
+
+1. Editar `cli/lib/setup.sh` + `cli/cstk` (**runtime do binario**) e
+   `global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh`
+   (**catalogo**).
+2. Buildar: `./scripts/build-release.sh X.Y.Z-dev`.
+3. Rodar **ambos**:
+   - `cstk self-update --from "file://$PWD/dist/cstk-X.Y.Z-dev.tar.gz"`
+     (binario + `cli/lib` em `~/.local`)
+   - `cstk install --from "file://$PWD/dist/cstk-X.Y.Z-dev.tar.gz"`
+     (catalogo em `~/.claude`)
+4. `cstk doctor`
+5. **Expected**: drift zero. Rodar apenas um dos dois reproduz o sintoma
+   documentado em CLAUDE.md §"Installed vs Source Drift": "fix funciona no
+   repo mas nao na sessao" — aqui, `cstk setup` novo chamando um
+   `guard-hooks-status.sh` velho que rejeita `--include-loose-usage`.
+
+---
+
+## Scenario 12: Cobertura de teste registrada
+
+1. `./tests/run.sh --check-coverage`
+2. **Expected**: exit `0` — `cli/lib/setup.sh` tem
+   `tests/cstk/test_setup.sh` correspondente, conforme o mapeamento de
+   `tests/run.sh:10-13`. Sem o arquivo de teste, o check falha com exit 1
+   (script orfao).
+3. `./tests/run.sh test_setup` → todos os cenarios verdes.
+
+---
+
+> **Sobre o "Roundtrip End-to-End" do template**: N/A. A feature e
+> single-layer (CLI POSIX sh, sem borda backend↔frontend, sem payload
+> serializado entre camadas). O equivalente funcional de roundtrip aqui e
+> o Scenario 2 (estado real re-lido apos escrita real, sem mock) somado ao
+> Scenario 11 (a copia instalada, nao a do repo, e quem roda de fato).

--- a/docs/specs/cstk-setup/quickstart.md
+++ b/docs/specs/cstk-setup/quickstart.md
@@ -237,6 +237,110 @@ fechar a feature.
 
 ---
 
+## Scenario 13: Hook registrado apontando para outro programa (FR-016, SC-006)
+
+1. Projeto valido, hooks obrigatorios **provisionados corretamente** em
+   `.claude/hooks/` (copias byte-identicas ao catalogo — a 4a coluna do
+   TSV sai `current`).
+2. Editar `.claude/settings.json` para que a entrada `PreToolUse` execute
+   outro programa, mantendo o basename citado na linha (ex.
+   `"command": "/tmp/nao-e-o-guard.sh # pretooluse-bash-guard.sh"`).
+3. Rodar `cstk setup --project-path "$PROJ" --yes`.
+4. **Expected**:
+   - Area `hooks` reportada como **`divergent`**, nunca
+     `already-configured` (SC-006).
+   - Motivo exibido cita o hook afetado e a remediacao de **duas etapas**:
+     remover a entrada divergente e so entao rodar
+     `cstk hooks install --project-path "$PROJ"`.
+   - **Nenhuma chamada** a `hooks install` foi feita (invariante I6 —
+     assertar por stub/contador, nao por efeito colateral).
+   - `.claude/settings.json` permanece **inalterado** — o wizard nao
+     sobrescreve o que nao reconhece.
+   - Exit `1` (houve `failed`).
+5. Repetir com `--dry-run`: mesmo diagnostico, mesma remediacao, exit `0`,
+   zero escrita.
+
+> **Por que a remediacao tem duas etapas**: `merge_settings` roda
+> `jq -s '.[0] * .[1]'` com "Source primeiro, target segundo => target
+> vence em conflitos" (`cli/lib/hooks.sh`). Um `cstk hooks install`
+> sozinho **nao** substitui a entrada divergente. Um teste que so
+> verificasse o texto "rode cstk hooks install" validaria uma instrucao
+> inefetiva.
+
+---
+
+## Scenario 14: MCP — divergente vs. falso-positivo de path (FR-016)
+
+**14a — divergente de verdade**:
+
+1. `.mcp.json` com a chave `mcpServers.cstk-state` presente, mas
+   `command` apontando para um script fora do catalogo (ex.
+   `/tmp/fake-launch.sh`).
+2. Rodar `cstk setup --project-path "$PROJ" --yes`.
+3. **Expected**: area `mcp` = `divergent`; nenhuma chamada a
+   `mcp install`; `.mcp.json` inalterado; remediacao de duas etapas;
+   exit `1`.
+
+**14b — legitimo resolvido por outra camada (nao pode ser divergente)**:
+
+1. Gerar o `.mcp.json` via `cstk mcp install` com `CSTK_LIB` apontando
+   para o **repo** (o `command` grava o path do repo, `cli/lib/mcp.sh:840`).
+2. Rodar a deteccao num contexto em que `_mcp_runtime_script_path`
+   resolveria primeiro para `$HOME/.claude/skills/agente-00c-runtime/scripts/`.
+3. **Expected**: area `mcp` = `configured`, **nao** `divergent` — as tres
+   camadas de resolucao (`cli/lib/mcp.sh:127-146`) sao todas aceitas.
+   Sem esta asserção, o falso-positivo apareceria em toda maquina de
+   desenvolvimento.
+
+**14c — chave ausente**: `.mcp.json` sem `cstk-state` → `not-configured`
+(caminho normal de aplicacao, inalterado).
+
+---
+
+## Scenario 15: Ambiguidade textual falha fechada (FR-016, invariante I5)
+
+1. Projeto com hooks corretamente provisionados e registrados, mas com
+   `.claude/settings.json` **minificado numa unica linha**.
+2. Rodar `cstk setup --project-path "$PROJ" --yes`.
+3. **Expected**:
+   - A verificacao de registro devolve `indeterminate`.
+   - A area **nao** e reportada como `already-configured` (I5).
+   - O motivo distingue "nao consegui verificar" de "esta errado" —
+     texto honesto, sem afirmar subversao que nao foi observada.
+4. Variante com runtime instalado antigo (sem `--verify-registration`):
+   a chamada retorna exit `2` (`_gh_die_usage`,
+   `guard-hooks-status.sh:205`) e o resultado tambem e `indeterminate`,
+   pelo mesmo caminho — nao uma falha da area (FR-009).
+
+---
+
+## Scenario 16: Rotulo de escopo global e ausencia de override (FR-017, FR-018)
+
+1. Projeto limpo, `HOME` sandboxado.
+2. Rodar `cstk setup --project-path "$PROJ" --dry-run`.
+3. **Expected (FR-017)**:
+   - A area `state-backend` declara explicitamente, **antes** de qualquer
+     aplicacao, que escreve em `$HOME/.claude/cstk/config`
+     (`state-backend.sh:75-76`) e que o efeito vale para **todos os
+     projetos** da maquina.
+   - As areas `hooks`, `mcp` e `telemetry` **nao** carregam esse rotulo.
+   - A linha do summary da area `state-backend` repete a marca de escopo.
+4. **Expected (FR-018)**:
+   - `cstk setup --catalog /qualquer/dir` → exit `2` (flag desconhecida).
+     O wizard nao aceita a flag nem a repassa a `hooks install`, cujo
+     default permanece `${HOME}/.claude` (`cli/lib/hooks.sh:575`).
+   - Os hooks provisionados sao byte-identicos aos do catalogo do
+     toolkit — `--catalog` nao e influenciavel por ambiente
+     (`hooks install` nao le nenhuma variavel para essa escolha).
+   - Com `CSTK_HOOKS_CATALOG_DIR` setado no ambiente apontando para um
+     diretorio arbitrario: a area de hooks **anuncia** que a verificacao
+     de frescor usou referencia nao-padrao e **nao** reporta
+     `already-configured` com base nela. A variavel altera apenas a
+     referencia de `guard-hooks-status.sh` (`:136-137`), nunca a origem
+     do provisionamento nem a forma canonica de §2.3 do contrato.
+
+---
+
 > **Sobre o "Roundtrip End-to-End" do template**: N/A. A feature e
 > single-layer (CLI POSIX sh, sem borda backend↔frontend, sem payload
 > serializado entre camadas). O equivalente funcional de roundtrip aqui e

--- a/docs/specs/cstk-setup/research.md
+++ b/docs/specs/cstk-setup/research.md
@@ -396,3 +396,74 @@ ausente esbarra no gotcha ja registrado do projeto — stub de `PATH` nao
 esconde binario de `/usr/bin`. Cenarios de "dependencia ausente" devem
 ser desenhados desacoplando a deteccao do `PATH` interno, ou aceitos como
 nao-cobertos com nota explicita. Decisao adiada para `create-tasks`.
+
+---
+
+## Decision 11: Autenticidade do registro em hooks/MCP (FR-016)
+
+> Adicionada na revisao pos-gate `owasp-security` da fase plan (achado
+> HIGH), apos resposta do operador ao bloqueio. Revisa parcialmente as
+> Decisions 2 e 3, que definiram a deteccao por presenca.
+
+**Decision**: verificar que a configuracao do projeto **invoca** o script
+do catalogo, e nao apenas que **cita** seu nome. Divergencia vira o
+status `divergent`, que jamais colapsa para `configured`. Implementado
+como extensao aditiva na lib dona de cada area — 5a coluna TSV em
+`guard-hooks-status.sh check --verify-registration` e helper read-only
+`_mcp_registration_status` em `cli/lib/mcp.sh` — nunca como deteccao
+propria de `setup.sh` (preserva a Decision 2).
+
+**Problema observado** (nao hipotetico — verificado no codigo):
+
+1. `_gh_registered` (`guard-hooks-status.sh:119-127`) e
+   `grep -Fq -- "$2" "$_gh_settings"`: presenca do **basename**. O
+   comentario do proprio script assume ser "condicao necessaria e
+   suficiente na pratica". E necessaria, nao suficiente.
+2. A deteccao de MCP desenhada na Decision 2 era a presenca da chave
+   `cstk-state` no `.mcp.json`.
+3. Os dois comandos de aplicacao fazem merge com **o target vencendo**:
+   `jq -s '.[0] * .[1]'`, "Source primeiro, target segundo => target
+   vence em conflitos" (`cli/lib/hooks.sh`); "entrada ja presente e
+   equivalente => idempotente, exit 0" (`cli/lib/mcp.sh:800-802`).
+
+Combinados: uma entrada preexistente que cite o nome e execute outro
+programa sobrevive a instalacao **e** era reportada como
+`already configured`. O hook em questao, `pretooluse-bash-guard.sh`, e o
+bloqueio fail-closed de comandos durante execucao 00c — a falsa garantia
+recairia sobre um controle de seguranca, no cenario que a feature mira
+(repo recem-clonado, onde a configuracao veio junto).
+
+**Rationale**: um wizard de onboarding cuja mensagem central e "esta area
+ja esta configurada" so agrega valor se essa afirmacao for verificavel. A
+alternativa de apenas reduzir o escopo da garantia no texto transfere ao
+usuario um julgamento que ele nao tem como fazer — ele nao vai auditar o
+`settings.json` que o wizard acabou de declarar em ordem.
+
+**Alternatives considered**:
+
+- *Reduzir o escopo da garantia (opcao (b) do bloqueio)*: rejeitado pelo
+  operador. Manteria a superficie e trocaria a falsa garantia por um
+  aviso que o usuario tende a nao ler.
+- *Aceitar o risco (opcao (c))*: rejeitado pelo operador.
+- *Sobrescrever a entrada divergente automaticamente*: rejeitado — o
+  wizard passaria a destruir configuracao que nao entende, e o caso
+  legitimo (usuario com wrapper proprio deliberado) e indistinguivel do
+  hostil sem intervencao humana. Detectar e instruir preserva as duas
+  situacoes.
+- *Fazer da verificacao o comportamento default de
+  `guard-hooks-status.sh check`*: adiado. Mudaria formato de saida e exit
+  de um contrato publicado (README.md:279, prosa dos orquestradores) —
+  BREAKING, exigindo bump MAJOR por Constitution I. Registrado como
+  candidato para a proxima major.
+- *Parsear o JSON com `jq` em vez de `grep -F` por linha*: rejeitado —
+  `jq` e justamente a dependencia que costuma faltar no projeto mal
+  provisionado sob diagnostico (Decision 2; comentario em
+  `guard-hooks-status.sh:119-125`). O custo e a limitacao textual
+  documentada (JSON minificado → `indeterminate`), aceitavel porque
+  falha fechada.
+
+**Consequencia na remediacao publicada**: como re-rodar `install` nao
+substitui a entrada divergente (item 3 acima), a remediacao exibida e de
+**duas etapas** — remover a entrada, depois reinstalar. Publicar apenas
+"re-rode `cstk hooks install`" seria uma instrucao comprovadamente
+inefetiva (Constitution VI).

--- a/docs/specs/cstk-setup/research.md
+++ b/docs/specs/cstk-setup/research.md
@@ -1,0 +1,398 @@
+# Research: cstk-setup (Guided Project Setup Wizard)
+
+Documento produzido no Phase 0 do `/plan`. Resolve todos os `NEEDS
+CLARIFICATION` do Technical Context antes do design.
+
+> **Aterramento (Constitution VI)**: toda afirmacao sobre comportamento
+> existente abaixo cita `arquivo:linha` verificado no repo em 2026-08-07,
+> branch `feature/cstk-setup`. Lacunas nao verificaveis estao marcadas
+> explicitamente como **[PROPOSTA]** (design novo, a validar na
+> implementacao), nunca afirmadas como comportamento existente.
+
+---
+
+## Decision 1: Ponto de integracao no dispatcher do binario
+
+**Decision**: `setup` entra no ramo generico de dispatch de `cli/cstk`,
+sem tratamento especial. Concretamente: adicionar o token `setup` ao
+`case` de `cli/cstk:250`, criar `cli/lib/setup.sh` definindo a funcao
+`setup_main`, e acrescentar `setup` as listas de comandos validos de
+`cli/cstk:217` e `cli/cstk:299` mais o help geral (`cli/cstk:136-152`) e
+o `case` de help por subcomando (`cli/cstk:169-211`).
+
+**Rationale**: o ramo generico (`cli/cstk:250-273`) ja faz tudo o que
+`setup` precisa — roda `_check_bin_lib_match` (`cli/cstk:253-256`),
+resolve `_lib_file="$CSTK_LIB/${_cmd}.sh"` (`cli/cstk:257`), sourceia
+(`cli/cstk:265`) e deriva o nome da funcao por
+`sed 's/-/_/g'` + sufixo `_main` (`cli/cstk:267`). Como `setup` nao tem
+hifen nem comeca com digito, `setup_main` sai direto da convencao. Nao ha
+motivo para o special-casing de `00c` (`cli/cstk:274-291`), que existe so
+porque nome de funcao nao pode comecar com digito.
+
+**Alternatives considered**:
+- *Ramo dedicado no `case`* (como `serve`, `cli/cstk:248-250`): rejeitado
+  — `serve` tem ramo proprio por razoes proprias; `setup` nao precisa de
+  pre-processamento algum, e um ramo dedicado seria codigo morto.
+- *Skill/slash-command do Claude Code*: rejeitado pela propria spec —
+  FR-014 fixa "subcomando do binario CLI", decisao ja tomada no clarify
+  (spec.md linha 11).
+
+**Lacuna registrada**: sem `setup` no `case` de `cli/cstk:250`, o comando
+cai no ramo `*)` de comando desconhecido (`cli/cstk:215-219` no help,
+`cli/cstk:299` no dispatch) — ou seja, esquecer qualquer uma das 4 listas
+produz UX inconsistente (comando funciona mas nao aparece no help, ou
+vice-versa). Vira item de checklist na implementacao.
+
+---
+
+## Decision 2: Fonte de deteccao de status por area (FR-002 / FR-013)
+
+**Decision**: `setup.sh` NUNCA reimplementa deteccao. Cada area delega a
+uma fonte read-only ja existente, consultada fresca a cada invocacao
+(FR-013 — nunca um flag persistido "setup ja rodou"):
+
+| Area | Fonte de deteccao (read-only) | Saida consumida |
+|------|-------------------------------|-----------------|
+| Hooks (obrigatorios) | `global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh check --projeto-alvo-path PATH --quiet` (contrato: cabecalho linhas 49-60; implementacao `_gh_cmd_check` linhas 197-262) | TSV `<arquivo>\t<present\|missing>\t<registered\|unregistered>\t<current\|stale\|unknown>`, uma linha por hook; exit 0 = os 3 present+registered+(current\|unknown), exit 1 caso contrario (inclui `stale`) |
+| Hooks (loose usage, opt-in) | **[PROPOSTA]** ver Decision 3 | — |
+| State backend | `config_state_backend_resolve` (`cli/lib/config.sh:94`), que delega a `state-backend.sh resolve` (`global/skills/agente-00c-runtime/scripts/state-backend.sh:234-269`) | `effective_backend=sqlite\|json` + `reason=...`; **nunca falha** (`return 0`, linha 269, "contrato de nao-falha FR-008") |
+| State backend (deps) | `config_state_backend_capability` (`cli/lib/config.sh:90`) → `state-backend.sh capability` (linha 228) | disponibilidade de `sqlite3` vs minimo `_SB_MIN_SQLITE_VERSION="3.45.1"` (linha 67) |
+| MCP | leitura textual de `<project>/.mcp.json` procurando a chave `cstk-state` (o alvo que `_mcp_cmd_install` escreve — `cli/lib/mcp.sh:847`, bloco JSON linhas 864-865) | presente/ausente |
+| Telemetria | `global/skills/agente-00c-runtime/scripts/otel-usage.sh preflight [--endpoint URL]` (`_ou_cmd_preflight`, linha 469; flag `--endpoint` linha 473; documentado linha 545) | responde "a telemetria DESTA sessao vai ser medida?" (linha 561) |
+
+**Rationale**: e a mesma disciplina que `guard-hooks-status.sh` documenta
+para si mesmo (cabecalho linhas 88-92): "Provisionar e trabalho do
+`cstk install --scope project` (unica fonte da regra); reimplementar a
+copia aqui duplicaria a regra em dois lugares — mesmo motivo pelo qual o
+hook PreToolUse delega a decisao a `bash-guard.sh` em vez de
+reimplementa-la." FR-002 exige literalmente "usando a mesma logica de
+deteccao do comando dedicado daquela area"; delegacao e a unica forma de
+garantir isso sem drift.
+
+**Alternatives considered**:
+- *Rodar o comando de aplicacao em `--dry-run` para inferir status*:
+  rejeitado para deteccao. `hooks install --dry-run` (`cli/lib/hooks.sh:589`)
+  reporta o PLANO ("copiaria X -> Y", linhas 351-376), nao o estado atual;
+  nao distingue "ja instalado" de "seria instalado". Serve para preview
+  (Decision 5), nao para status.
+- *Persistir um marcador `.cstk-setup-done`*: rejeitado por FR-013, que
+  proibe explicitamente flag persistido — e corretamente, porque o estado
+  real pode mudar por fora do wizard (alguem roda `cstk hooks install`
+  sozinho, ou o catalogo evolui e a copia fica `stale`).
+
+**Consequencia de projeto**: a dimensao `stale` do `guard-hooks-status.sh`
+(3a coluna do TSV) significa que "hooks presentes e registrados" NAO
+implica "configurado". O wizard MUST tratar `stale` como *nao
+configurado* (oferecer aplicar), espelhando o exit 1 do proprio `check`.
+
+---
+
+## Decision 3: Deteccao do hook opt-in de loose usage (FR-008 / US4)
+
+**Decision** **[PROPOSTA — a validar na implementacao]**: estender
+`guard-hooks-status.sh check` com uma flag nova
+`--include-loose-usage`, que acrescenta ao TSV uma 4a linha para
+`posttooluse-loose-usage.sh` no MESMO formato das outras
+(`<arquivo>\t<present|missing>\t<registered|unregistered>\t<current|stale|unknown>`),
+e que NAO altera o exit code (o hook e opt-in; sua ausencia nunca e
+anomalia). Sem a flag, o comportamento atual permanece byte-a-byte
+identico.
+
+**Rationale**: existe uma lacuna real. A lista `_GH_HOOKS`
+(`guard-hooks-status.sh:104-107`) cobre exatamente os 3 hooks
+obrigatorios provisionados por `apply_guard_hooks()`; o
+`posttooluse-loose-usage.sh` existe no catalogo
+(`global/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh`, com
+snippet separado `settings.loose-usage.snippet.json`) mas **nao e
+coberto por nenhuma fonte de deteccao read-only hoje**. Como FR-008 exige
+apresentar a decisao do loose usage como escolha DISTINTA — e FR-002
+exige mostrar o status antes de oferecer — o wizard precisa dessa
+deteccao. Colocar um `grep` ad-hoc dentro de `setup.sh` violaria a
+disciplina da Decision 2 (duplicaria a regra "present + registered" em
+dois arquivos). Estender a fonte canonica mantem uma unica implementacao.
+
+**Alternatives considered**:
+- *Checagem local em `setup.sh`*: rejeitada — duplica `_gh_present`
+  (linha 110) e `_gh_registered` (linha 119), justamente o antipadrao que
+  o cabecalho do proprio script condena.
+- *Subcomando novo `guard-hooks-status.sh loose-usage-status`*:
+  rejeitado — mais superficie de contrato para a mesma pergunta; a flag
+  reusa o parser e o formato de saida ja existentes.
+- *Nao mostrar status do loose usage, so perguntar*: rejeitado — viola
+  FR-002 (status antes de oferecer) e quebra FR-003 na segunda execucao
+  (perguntaria de novo algo ja configurado).
+
+**Custo de sincronizacao (GOTCHA)**: `guard-hooks-status.sh` e
+**catalogo** (skill `agente-00c-runtime`), nao runtime do binario.
+Alterar esse arquivo exige `cstk install`/`cstk update` para sincronizar
+`~/.claude`, enquanto `cli/lib/setup.sh` + `cli/cstk` exigem
+`cstk self-update`. Esta feature toca as DUAS metades — atualizar so uma
+reproduz o sintoma classico "fix funciona no repo mas nao na sessao"
+(CLAUDE.md §Installed vs Source Drift). Vira item obrigatorio de
+quickstart e de checklist de release.
+
+**Degradacao**: se o `guard-hooks-status.sh` instalado for anterior a
+esta feature, a flag desconhecida cai em `_gh_die_usage`
+(`guard-hooks-status.sh:205`) com exit 2. O wizard MUST tratar exit 2
+dessa chamada como *status indeterminado* para a sub-area loose-usage
+(reportando o motivo), nunca como falha da area de hooks inteira —
+coerente com FR-009 (falha de uma area nao impede as demais).
+
+---
+
+## Decision 4: Aplicacao por area — delegacao aos comandos dedicados
+
+**Decision**: cada area aplica invocando o comando dedicado existente,
+com os exit codes mapeados para o vocabulario de outcome do wizard:
+
+| Area | Acao de aplicacao | Exit codes da fonte |
+|------|-------------------|---------------------|
+| Hooks | `hooks_main install --project-path PATH [--with-loose-usage]` (`cli/lib/hooks.sh:557`, subcomando unico `install` linha 566, flags linhas 583-593) | 0 sucesso (inclui `paste-instructed`/`hooks-only`, tratados como warning nas linhas 631-643); 1 erro (598, 608, 617, 644); 2 uso incorreto (568, 594) |
+| State backend | `config_state_backend_enable_sqlite` (`cli/lib/config.sh:98`), o mesmo alvo que `cstk state enable-sqlite` delega (`cli/lib/state.sh:122-131`, repassando exit verbatim) | 0 sucesso; 1 falha; 2 uso incorreto; 3 recusado por pre-condicao — `sqlite3` ausente ou < `3.45.1` (`state-backend.sh:358-370`) |
+| MCP | `cstk mcp install --project-path PATH` (`_mcp_cmd_install`, `cli/lib/mcp.sh:806-877`) | 0 criada/ja presente/dry-run; 1 erro IO/merge/catalogo; 2 uso; 3 recusa `$HOME` (linhas 831-835; contrato documentado 949-953) |
+| Telemetria | **nenhuma** — area e read-only por FR-012 | — |
+
+**Rationale**: FR-002 exige a mesma logica de deteccao do comando
+dedicado; a simetria natural e que a APLICACAO tambem seja o comando
+dedicado. Isso satisfaz de graca o edge case da spec (linhas 168-173):
+"o wizard MUST deixar a configuracao daquela area em estado consistente
+com o que rodar o comando dedicado deixaria na mesma falha" — trivialmente
+verdadeiro se e literalmente o mesmo comando.
+
+Ganho colateral em FR-003: `mcp install` ja e idempotente por construcao
+(`merge_settings`, target vence — comentario `cli/lib/mcp.sh:800-802`) e
+`enable-sqlite` ja e no-op quando o backend ja e sqlite
+(`state-backend.sh:385-390`). A guarda de FR-003 no wizard (nao chamar
+nada quando ja configurado) e portanto defesa em profundidade, nao a
+unica linha de defesa.
+
+**Alternatives considered**:
+- *`setup.sh` escrever `settings.json` / `.mcp.json` / config global
+  diretamente*: rejeitado — reimplementaria merge, permissoes (dir 700 /
+  arquivo 600, `state-backend.sh:322-329`) e fallback sem `jq`
+  (`cli/lib/mcp.sh:866-871`), triplicando regra critica.
+- *Invocar via `cstk <sub>` em subprocesso*: rejeitado como default.
+  `setup.sh` e sourceado pelo mesmo processo que ja resolveu `CSTK_LIB`
+  (`cli/cstk:265`, `cli/cstk:305`), entao pode sourcear as libs irmas pelo
+  padrao ja estabelecido `. "${CSTK_LIB:?CSTK_LIB must be set}/<lib>.sh"`
+  (`cli/lib/hooks.sh:60`, `cli/lib/doctor.sh:51-59`, `cli/lib/list.sh:31-41`)
+  e chamar as funcoes diretamente — sem custo de subprocesso e sem
+  depender do binario estar no `PATH`. Scripts do **catalogo**
+  (`guard-hooks-status.sh`, `otel-usage.sh`) nao sao sourceaveis e seguem
+  como invocacao de processo.
+
+**Restricao de isolamento (FR-009)**: como as libs sao sourceadas no
+mesmo shell, uma area que falhe NAO pode derrubar o wizard. `cli/lib`
+roda sob `set -eu` (Constitution II). Consequencia de projeto: toda
+chamada de aplicacao MUST ser feita em contexto que neutralize o
+`set -e` (`if ! fn ...; then` ou `fn ... || rc=$?`), nunca como comando
+solto. Item de checklist.
+
+---
+
+## Decision 5: Preview (FR-004) e nao-interativo (FR-005/FR-006)
+
+**Decision**: tres modos mutuamente resolvidos por precedencia fixa:
+
+1. `--dry-run` (preview) — **vence sempre** (FR-006). Para cada area:
+   exibe status atual + o que seria aplicado. Onde a fonte oferece dry-run
+   nativo, delega (`hooks install --dry-run`, `cli/lib/hooks.sh:589`,
+   plano impresso nas linhas 351-376; `mcp install --dry-run`,
+   `cli/lib/mcp.sh:848`). Onde nao oferece (`enable-sqlite` nao tem flag
+   de dry-run — `state-backend.sh:358-397`), o wizard imprime a intencao
+   sem executar. Zero escrita, sempre.
+2. `--yes` (nao-interativo) — aplica o default recomendado de cada area
+   ainda nao configurada, sem prompt (FR-005).
+3. interativo (default) — um prompt por area, mais o prompt aninhado do
+   loose usage (FR-008).
+
+**Nomes de flag** **[PROPOSTA]**: `--dry-run` e `--yes`. `--dry-run` e o
+nome ja usado por `hooks install` (`cli/lib/hooks.sh:589`), `mcp install`
+(`cli/lib/mcp.sh` contrato 949-953) e `cstk usage prune` — reusar o termo
+evita um terceiro vocabulario. `--yes` **[PROPOSTA]** nao tem precedente
+verificado no repo para "nao-interativo"; e escolha nova.
+
+**Rationale**: FR-006 fixa a precedencia preview > nao-interativo. A
+delegacao de preview aos dry-runs nativos e o que torna SC-003 ("100% das
+mudancas de um run real sao visiveis no preview") verificavel em vez de
+aspiracional: o texto do preview vem do mesmo codigo que aplica.
+
+**Alternatives considered**:
+- *`--non-interactive` em vez de `--yes`*: descartado por verbosidade;
+  ambos sao invencao nova, e `--yes` casa com a semantica "aceite os
+  defaults".
+- *Preview reimplementado em `setup.sh`*: rejeitado — divergiria do que e
+  de fato aplicado, quebrando SC-003 silenciosamente.
+
+**Default recomendado por area em `--yes`** (FR-005/FR-015):
+
+| Area | Default recomendado | Fundamento |
+|------|---------------------|------------|
+| Hooks obrigatorios | aplicar | sao "obrigatorios" por definicao (`guard-hooks-status.sh` cabecalho linhas 14-22 documenta o dano de ficarem ausentes) |
+| Loose usage (opt-in) | **NAO aplicar** | opt-in explicito e garantia existente — `--with-loose-usage` e default desligado (`cli/lib/hooks.sh:513`, `543`); CLAUDE.md §"Consumo avulso": "NUNCA bundlado silenciosamente ... sem a flag" |
+| State backend | aplicar (`enable-sqlite`) | recomendado da linha v6; recusa limpa com exit 3 quando `sqlite3` falta (`state-backend.sh:358-370`) |
+| MCP | aplicar mesmo sem Docker | FR-015 literal (spec linhas 236-240), com aviso de Docker ausente |
+| Telemetria | diagnosticar | FR-012 proibe aplicar |
+
+O default do loose usage em `--yes` e o unico "nao aplicar" da tabela, e
+e deliberado: FR-008 protege um opt-in de privacidade preexistente, e
+`--yes` significa "aceite os defaults", nao "aceite tudo".
+
+---
+
+## Decision 6: Terminal nao-interativo e prompt y/n (FR-007)
+
+**Decision**: no modo interativo (nem `--dry-run` nem `--yes`), o wizard
+checa TTY antes de qualquer prompt e falha rapido citando as duas flags.
+Reusa `require_tty` (`cli/lib/ui.sh:42-50`), que testa `[ -t 0 ]`
+(linha 46), honra o bypass `CSTK_FORCE_INTERACTIVE=1` (linha 43) e emite
+`log_error` + `return 1` (linhas 49-50). O helper de prompt y/n e novo:
+`_setup_prompt_yn` **[PROPOSTA]**, local a `cli/lib/setup.sh`.
+
+**Rationale**: **nao existe helper y/n generico reutilizavel no repo** —
+verificado: o unico prompt y/n e inline dentro de `ui_select_interactive`
+(`cli/lib/ui.sh:279-288`: `printf 'Confirmar? [y/N] '` linha 279,
+`IFS= read -r` linha 282, aceita `y|Y|yes|YES|s|S|sim|SIM` linha 285).
+Reusar `require_tty` (que existe) e criar so o que falta e a divisao
+correta. O novo helper MUST aceitar o mesmo conjunto de respostas
+afirmativas da linha 285, para o usuario nao encontrar duas gramaticas de
+confirmacao diferentes dentro do mesmo binario.
+
+O bypass `CSTK_FORCE_INTERACTIVE=1` e o que torna os cenarios
+interativos testaveis sem TTY real — e o mecanismo que `install.sh:126` e
+`update.sh:112` ja usam via `require_tty`.
+
+**Alternatives considered**:
+- *Promover `_setup_prompt_yn` a `ui.sh` de saida*: adiado. Extrair o y/n
+  de dentro de `ui_select_interactive` para um helper compartilhado
+  mudaria um caminho interativo ja estavel sem necessidade nesta feature.
+  Se um terceiro consumidor aparecer, a extracao se justifica.
+- *`[ -t 0 ]` direto em `setup.sh`* (como `update.sh:599`): rejeitado —
+  perderia o bypass `CSTK_FORCE_INTERACTIVE` e a mensagem padronizada.
+
+---
+
+## Decision 7: Gate de diretorio de projeto (FR-011)
+
+**Decision**: o wizard recusa rodar quando o diretorio alvo nao e raiz de
+repositorio git, testando a existencia de `.git` como arquivo OU
+diretorio (`[ -e "$dir/.git" ]`), e sai antes de qualquer escrita.
+
+**Rationale**: e literalmente o marcador que o clarify fixou (spec.md
+linha 12 e FR-011, linhas 219-225): "raiz de repositorio git (presenca de
+`.git`, arquivo ou diretorio — worktrees contam); nao exige artefatos do
+toolkit, para evitar circularidade com o proprio onboarding". Testar
+`-e` (e nao `-d`) e o que faz worktree contar: em worktree, `.git` e um
+arquivo-ponteiro, nao diretorio.
+
+**Alternatives considered**:
+- *`git rev-parse --show-toplevel`*: rejeitado — adiciona dependencia de
+  `git` no PATH para uma checagem que `test -e` resolve, e resolveria
+  para a raiz mesmo invocado de um subdiretorio, o que **muda a
+  semantica**: FR-011 diz "raiz", nao "dentro de".
+- *Exigir `.claude/` ou `docs/constitution.md`*: rejeitado
+  explicitamente pela spec (FR-011, linhas 223-225) por circularidade.
+
+**Guarda complementar herdada**: tanto `hooks install` (`cli/lib/hooks.sh:617-620`)
+quanto `mcp install` (`cli/lib/mcp.sh:831-835`, exit 3) ja recusam
+`--project-path` igual a `$HOME`. O gate do wizard e adicional, nao
+substituto.
+
+---
+
+## Decision 8: Area de telemetria — diagnostico apenas (FR-012)
+
+**Decision**: a area de telemetria roda
+`otel-usage.sh preflight` (`_ou_cmd_preflight`,
+`global/skills/agente-00c-runtime/scripts/otel-usage.sh:469`; dispatch
+linhas 534-536) para diagnosticar, e exibe as instrucoes de ativacao
+manual. Nao escreve nada, e o outcome possivel e apenas
+`ja configurado` / `nao configurado (instrucoes exibidas)` / `falha`.
+
+**Valores exibidos** — extraidos do README, nunca inventados:
+`CLAUDE_CODE_ENABLE_TELEMETRY=1` (README.md:306),
+`OTEL_METRICS_EXPORTER=prometheus` (README.md:307), `CSTK_OTEL_ENDPOINT`
+(README.md:317 e 349), `OTEL_EXPORTER_PROMETHEUS_PORT` (README.md:348),
+endpoint padrao `127.0.0.1:9464` (README.md:315), e o wrapper `claude()`
+de `~/.zshrc` que sorteia porta livre (README.md:342-354).
+
+**Rationale**: a ativacao depende de variaveis exportadas no shell do
+usuario (o wrapper vive em `~/.zshrc`), fora do diretorio do projeto.
+FR-012 proibe escrever fora do projeto; a spec ja antecipa isso no edge
+case das linhas 174-178. Nao existe `cli/lib/otel*.sh` — verificado; a
+unica superficie e o script do catalogo.
+
+**Alternatives considered**:
+- *Escrever no `~/.zshrc` do usuario*: **proibido** por FR-012. Alem
+  disso colidiria com o Principio IV (zero coleta remota) na percepcao do
+  usuario, e mexer no rc do shell alheio e irreversivel na pratica.
+- *Escrever um `.envrc`/script no projeto*: descartado — nao ativa nada
+  sozinho (o wrapper precisa envolver a invocacao do `claude`), entao
+  seria configuracao morta com aparencia de configuracao viva.
+
+**Consequencia**: a area de telemetria nunca reporta `applied`. O
+vocabulario de outcome (data-model.md) precisa acomodar isso sem mentir —
+ver entidade `AreaOutcome`.
+
+---
+
+## Decision 9: Contrato de exit code do `cstk setup`
+
+**Decision** **[PROPOSTA]**: `0` = run completo (inclusive com areas
+puladas ou ja configuradas, e inclusive `--dry-run`); `1` = pelo menos
+uma area terminou em `failed`; `2` = uso incorreto (flag desconhecida);
+`3` = recusa por pre-condicao (fora de raiz de repo git — FR-011; ou TTY
+ausente sem `--dry-run`/`--yes` — FR-007).
+
+**Rationale**: alinha com as constantes ja definidas no binario
+(`cli/cstk:30-33`: `CSTK_EXIT_OK=0`, `CSTK_EXIT_ERROR=1`,
+`CSTK_EXIT_USAGE=2`, `CSTK_EXIT_LOCK=3`) e com o contrato que
+`mcp install` (`cli/lib/mcp.sh:949-953`) e `state enable-sqlite`
+(`cli/lib/state.sh:26-28`) ja publicam, onde `3` significa
+"recusado por pre-condicao". Reusar `3` para as duas recusas do wizard
+mantem o vocabulario do binario consistente.
+
+**Alternatives considered**:
+- *Sempre exit 0 desde que o summary seja impresso*: rejeitado — tornaria
+  `cstk setup` inutil em script de bootstrap/CI, que e exatamente o caso
+  de uso da US3.
+- *Exit code distinto por area falha*: rejeitado — FR-009 estabelece
+  areas independentes; codificar qual falhou no exit multiplicaria o
+  contrato sem ganho (o summary de FR-010 ja diz qual).
+
+---
+
+## Decision 10: Estrategia de teste
+
+**Decision**: `tests/cstk/test_setup.sh` novo, seguindo a convencao
+verificada: sourceia `tests/lib/harness.sh` e define
+`CSTK_LIB="$REPO_ROOT/cli/lib"` (padrao de `tests/cstk/test_hooks.sh:11-14`),
+isola `HOME` via `env HOME="$TMPDIR_TEST/home"` (padrao de
+`tests/cstk/test_mcp.sh:50,58`), e expoe cenarios como funcoes
+`scenario_<nome>()` descobertas por `run_all_scenarios`
+(`tests/lib/harness.sh:245-251`).
+
+O mapeamento e obrigatorio, nao opcional: `tests/run.sh:10-13` define
+`cli/lib/<n>.sh -> tests/cstk/test_<n>.sh`, e `./tests/run.sh
+--check-coverage` falha com exit 1 em script orfao. Hoje **nem
+`cli/lib/setup.sh` nem `tests/cstk/test_setup.sh` existem** — verificado.
+
+**Isolamento critico**: a area de state backend escreve na config
+**global** `$HOME/.claude/cstk/config` (`state-backend.sh:75-76`). Sem
+`HOME` sandboxado, um teste de `enable-sqlite` alteraria a configuracao
+real da maquina de quem roda a suite. O `HOME` falso nao e higiene
+opcional aqui — e requisito de corretude do teste.
+
+**Rationale**: Constitution Quality Standards exige teste automatizado
+para todo script novo, e o `--check-coverage` torna a regra enforced.
+
+**Alternatives considered**:
+- *Cobrir `setup` dentro de `tests/cstk/test_cstk-main.sh`*: rejeitado —
+  quebraria o mapeamento de `tests/run.sh:10-13` e deixaria
+  `cli/lib/setup.sh` orfao no `--check-coverage`.
+
+**Lacuna conhecida (nao bloqueante)**: um teste que force `sqlite3`
+ausente esbarra no gotcha ja registrado do projeto — stub de `PATH` nao
+esconde binario de `/usr/bin`. Cenarios de "dependencia ausente" devem
+ser desenhados desacoplando a deteccao do `PATH` interno, ou aceitos como
+nao-cobertos com nota explicita. Decisao adiada para `create-tasks`.

--- a/docs/specs/cstk-setup/research.md
+++ b/docs/specs/cstk-setup/research.md
@@ -467,3 +467,34 @@ substitui a entrada divergente (item 3 acima), a remediacao exibida e de
 **duas etapas** — remover a entrada, depois reinstalar. Publicar apenas
 "re-rode `cstk hooks install`" seria uma instrucao comprovadamente
 inefetiva (Constitution VI).
+
+> **Endurecimento pos-re-review** (gate `owasp-security` na onda de
+> `checklist`, 7 achados MEDIUM/LOW, nenhum HIGH/CRITICAL — 3 corrigidos
+> nesta mesma onda por alterarem contrato/data-model):
+>
+> - **SEC-01**: a regra de linha canonica de §2.3 (`contracts/
+>   cli-setup.md`) exigia so basename+fragmento na mesma linha —
+>   satisfazivel por uma linha decorativa (comentario/descricao) que cite
+>   os dois sem ser a atribuicao `"command"` real. Fix: exigir tambem o
+>   token `"command"` na mesma linha; residual (posicionamento estrutural
+>   sob `PreToolUse`/`matcher` nao verificado) declarado como limite
+>   aceito, mesma classe do limite ja existente de JSON minificado.
+> - **SEC-02**: o enum fechado de `status`/`mandatory_status` nao tem
+>   valor `indeterminate` (so a 5a coluna do TSV tem); sem uma regra
+>   explicita de para onde `indeterminate` mapeia, um implementador podia
+>   ignorar a 5a coluna e herdar o exit 0/1 cru da chamada baseline —
+>   fail-open para `configured`. Fix: `indeterminate` → `unavailable`
+>   explicito na invariante I5, mesmo destino ja usado pelo caminho do
+>   exit 2 do quickstart Scenario 15 variante 4.
+> - **SEC-03**: a tabela de fontes de `data-model.md` descrevia a area
+>   `hooks` como uma unica chamada `--quiet --verify-registration`. Num
+>   runtime instalado anterior a esta feature, essa flag e desconhecida e
+>   a chamada inteira sai exit 2 (`_gh_die_usage`) — perdendo tambem o
+>   veredito basico dos 3 hooks obrigatorios, que aquele runtime sabe
+>   responder via a chamada baseline sem flags. Fix: 3 chamadas sempre
+>   separadas (baseline / `--verify-registration` / `--include-loose-usage`),
+>   cada extensao so podendo escalar ou degradar a **propria** dimensao.
+>
+> As 4 restantes (SEC-04..SEC-07) nao alteram contrato/data-model —
+> registradas para virar tarefas explicitas em `create-tasks` (ver
+> plan.md §Re-check de Constitution).

--- a/docs/specs/cstk-setup/spec.md
+++ b/docs/specs/cstk-setup/spec.md
@@ -226,7 +226,7 @@ still applies the mandatory hooks.
 - **FR-012**: The telemetry area MUST only diagnose current activation
   status and display the exact instructions/values needed to activate it
   manually; it MUST NOT write to any file outside the project directory.
-- **FR-013 (INFRA-IDEMP)**: Idempotency for every area is achieved by
+- **FR-013**: (INFRA-IDEMP) Idempotency for every area is achieved by
   re-checking that area's live current status immediately before acting,
   every run — never by a persisted "setup already ran" flag. Scope: the
   four areas listed in FR-001, checked fresh on every invocation.

--- a/docs/specs/cstk-setup/spec.md
+++ b/docs/specs/cstk-setup/spec.md
@@ -1,0 +1,264 @@
+# Feature Specification: Guided Project Setup Wizard
+
+**Feature**: `cstk-setup`
+**Created**: 2026-08-07
+**Status**: Draft
+
+## User Scenarios & Testing
+
+### User Story 1 - Guided first-time setup (Priority: P1)
+
+A developer who just cloned or installed the toolkit into a project wants
+to bring that project up to the recommended configuration baseline
+without hunting through documentation for the individual commands that
+each configure one piece (hooks, state backend, MCP integration,
+telemetry). They run a single guided command and are walked, one area at
+a time, through what is currently configured, what is missing, and
+whether they want it applied now.
+
+**Why this priority**: This is the core value of the feature — replacing
+tribal knowledge of 3-4 separate commands with one entry point. Without
+this, the rest of the feature has nothing to guide.
+
+**Independent Test**: Run the guided command on a project with none of
+the four areas configured; confirm the user is walked through all four in
+order, each with a clear current-status statement and an explicit
+choice, and that choosing "apply" for an area leaves that area correctly
+configured afterward.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project with no hooks installed, no state backend chosen,
+   no MCP integration registered, and no telemetry active, **When** the
+   user runs the guided setup interactively, **Then** each of the four
+   areas is presented in turn with its current status and a choice to
+   apply or skip it.
+2. **Given** the user accepts the offer for the hooks area, **When** the
+   step completes, **Then** the project's hooks configuration reflects the
+   applied change and the wizard reports it as "applied" before moving to
+   the next area.
+3. **Given** the user declines an area, **When** the step completes,
+   **Then** no change is made for that area and the wizard reports it as
+   "skipped by user" before moving to the next area.
+
+---
+
+### User Story 2 - Idempotent status awareness on re-run (Priority: P2)
+
+A developer who already ran the guided setup (or configured areas
+individually beforehand) runs it again — out of habit, after onboarding a
+teammate, or to check whether anything drifted. They expect the wizard to
+recognize what is already in place and report it, rather than re-applying
+it, erroring out, or offering to overwrite an existing choice.
+
+**Why this priority**: Idempotency is what makes the wizard safe to run
+repeatedly and recommend as a standard onboarding step; without it, a
+second run risks corrupting or force-migrating an already-initialized
+project, which existing individual commands explicitly guard against.
+
+**Independent Test**: Run the guided setup twice in a row on the same
+project without any change in between; confirm the second run reports
+every area as already configured, applies nothing, and exits the same way
+whether the first run happened seconds or weeks earlier.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project where all four areas are already configured,
+   **When** the user runs the guided setup again, **Then** every area is
+   reported as "already configured" and no underlying configuration is
+   modified.
+2. **Given** a project where only some areas are configured, **When** the
+   user runs the guided setup, **Then** already-configured areas are
+   reported and skipped automatically while unconfigured areas are still
+   offered normally.
+3. **Given** a project that was deliberately configured to use a
+   different backend than the wizard's default (e.g. state backend kept
+   at the legacy option on purpose), **When** the user runs the guided
+   setup, **Then** the wizard does not force a migration and reports the
+   existing choice as already configured.
+
+---
+
+### User Story 3 - Non-interactive setup for automation (Priority: P3)
+
+A developer scripting project onboarding (a bootstrap script, a CI job
+that provisions a fresh workspace, or a teammate who just wants the
+recommended defaults without reading each prompt) wants to run the same
+guided setup without answering prompts, and separately wants a way to see
+exactly what would happen before committing to it.
+
+**Why this priority**: Automation and preview are what make the wizard
+usable outside a single interactive terminal session — without them the
+feature only serves the one-off manual case already covered by P1.
+
+**Independent Test**: Run the guided setup with the non-interactive flag
+on an unconfigured project and confirm it completes with no prompts,
+applying the recommended default for every area; separately, run it with
+the preview flag and confirm the project is left completely unchanged
+while the same information that would have been applied is shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unconfigured project, **When** the user runs the guided
+   setup with the non-interactive flag, **Then** the wizard applies the
+   recommended default for each area without waiting for input and
+   reports the outcome of each at the end.
+2. **Given** an unconfigured project, **When** the user runs the guided
+   setup with the preview flag, **Then** the wizard prints what it would
+   do for each area and exits without changing anything.
+3. **Given** both the non-interactive and preview flags are supplied
+   together, **When** the user runs the guided setup, **Then** preview
+   behavior takes precedence and nothing is applied.
+
+---
+
+### User Story 4 - Granular opt-in for optional usage capture (Priority: P4)
+
+A developer going through the hooks area of the guided setup wants the
+mandatory hooks installed, but wants to decide separately and explicitly
+whether to also opt in to the optional loose usage capture hook, since it
+has a different privacy/footprint trade-off than the mandatory ones.
+
+**Why this priority**: This preserves an existing explicit opt-in
+guarantee (loose usage capture must never be silently bundled) inside the
+new guided flow; it is a refinement of the hooks area from P1, not a
+standalone flow, so it ranks after the core stories.
+
+**Independent Test**: Run the guided setup's hooks area and confirm the
+mandatory hooks question and the optional usage-capture question are
+presented as two distinct choices, and that declining the optional one
+still applies the mandatory hooks.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is in the hooks area of the guided setup, **When**
+   they are asked about optional loose usage capture, **Then** the
+   question is presented separately from the mandatory hooks question,
+   with a clear explanation of what it captures.
+2. **Given** the user declines the optional loose usage capture,
+   **When** the hooks area completes, **Then** the mandatory hooks are
+   still installed and the optional capture remains inactive.
+
+---
+
+### Edge Cases
+
+- What happens when a required underlying tool for one area (e.g. the
+  dependency needed for the state backend check) is missing or below the
+  minimum supported version? The wizard MUST report that specific area as
+  failed/unavailable with the reason, and MUST continue offering the
+  remaining areas rather than stopping the whole run.
+- How does the wizard behave when it is run inside a directory that is
+  not a toolkit-managed project (no recognizable project markers)? It
+  MUST say so clearly and MUST NOT create partial configuration in an
+  unrelated directory.
+- How does the wizard behave when the terminal is not interactive (e.g.
+  piped input, no TTY) and neither the non-interactive nor the preview
+  flag was supplied? It MUST detect the non-interactive terminal and
+  fail with a clear message asking the user to pick one of the two
+  flags, rather than hanging on a prompt no one can answer.
+- What happens if one area's underlying action fails partway (e.g. a
+  step that touches project files is interrupted)? The wizard MUST leave
+  that area's configuration in a state consistent with what individually
+  running that area's existing dedicated command would leave it in on
+  the same failure, and MUST still report the failure and proceed to the
+  remaining areas.
+- What happens for the telemetry area, whose activation ultimately
+  depends on values exported in the user's own shell session rather than
+  anything the wizard can persist inside the project? The wizard MUST
+  only diagnose and display the exact values/instructions needed and
+  MUST NOT modify any file outside the project directory to activate it.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The guided setup MUST offer, in a fixed order, exactly four
+  configuration areas: mandatory project hooks (with the optional loose
+  usage capture as a nested choice), the global state backend, the MCP
+  state-server registration, and telemetry activation.
+- **FR-002**: For each area, before offering to apply anything, the
+  guided setup MUST first determine and display that area's current
+  status in the project (already configured / not configured /
+  unavailable) using the same detection logic as that area's existing
+  dedicated command.
+- **FR-003**: The guided setup MUST NOT re-apply, modify, or force a
+  migration for any area already reported as configured — a
+  fully-configured project run through the wizard again MUST result in
+  zero configuration changes.
+- **FR-004**: The guided setup MUST support a preview mode that displays,
+  for every area, what would be applied without changing any file or
+  persisted configuration.
+- **FR-005**: The guided setup MUST support a non-interactive mode that
+  applies the recommended default outcome for every not-yet-configured
+  area without waiting for a prompt.
+- **FR-006**: When both preview mode and non-interactive mode are
+  requested together, preview MUST take precedence and no changes MUST be
+  applied.
+- **FR-007**: When run with neither preview nor non-interactive mode in a
+  non-interactive terminal, the guided setup MUST fail fast with a
+  message directing the user to one of those two flags, instead of
+  waiting indefinitely for input.
+- **FR-008**: The hooks area MUST present the decision to install the
+  optional loose usage capture hook as a distinct choice from the
+  mandatory hooks, never bundling it silently into a single yes/no.
+- **FR-009**: A failure or unavailable dependency in one area MUST NOT
+  prevent the guided setup from offering the remaining areas; each area's
+  outcome is independent.
+- **FR-010**: At the end of a run, the guided setup MUST present a
+  summary listing, for each of the four areas, one of: applied, already
+  configured, skipped by user, or failed (with reason).
+- **FR-011**: The guided setup MUST refuse to run, with a clear
+  diagnostic, when invoked outside a recognizable toolkit-managed project
+  directory, and MUST NOT write any configuration in that case.
+- **FR-012**: The telemetry area MUST only diagnose current activation
+  status and display the exact instructions/values needed to activate it
+  manually; it MUST NOT write to any file outside the project directory.
+- **FR-013 (INFRA-IDEMP)**: Idempotency for every area is achieved by
+  re-checking that area's live current status immediately before acting,
+  every run — never by a persisted "setup already ran" flag. Scope: the
+  four areas listed in FR-001, checked fresh on every invocation.
+
+> Decisoes de infraestrutura adicionais: N/A — feature nao introduz
+> scheduling, rotacao de chaves, refresh de token externo, mutex
+> multi-processo nem backup; FR-013 cobre a unica decisao de
+> infraestrutura relevante (idempotencia).
+
+### Key Entities
+
+- **Configuration Area**: One of the four things the wizard walks
+  through (hooks, state backend, MCP integration, telemetry). Has a
+  current status (configured / not configured / unavailable) and, after
+  a run, an outcome (applied / already configured / skipped / failed).
+- **Setup Run Summary**: The end-of-run report listing every
+  Configuration Area's outcome for that invocation, used to confirm
+  results in both interactive and non-interactive modes.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A developer starting from a completely unconfigured project
+  can review and decide on all four configuration areas through a single
+  guided command in under 2 minutes of interactive time.
+- **SC-002**: Running the guided setup twice in a row on the same project
+  with no changes in between results in zero configuration changes on the
+  second run, for 100% of areas.
+- **SC-003**: 100% of the changes a non-preview run would apply are
+  visible in preview mode beforehand, in the same order and detail.
+- **SC-004**: A fully non-interactive run on an unconfigured project
+  completes with a final summary and zero unresolved prompts, 100% of the
+  time.
+- **SC-005**: 100% of runs — interactive or not, successful or partially
+  failed — end with a per-area outcome summary that a user can read to
+  know exactly what changed and what did not.
+
+## Delta Requirements
+
+**Skip**: Nova capacidade — nao existe entrada correspondente em
+`docs/specs/current/*.md` para um wizard consolidado de setup, nem para
+os passos individuais que ele orquestra (hooks/state-backend/mcp/otel)
+como capacidade documentada; a feature nao altera o comportamento ativo
+de nenhuma capability existente, apenas oferece um novo ponto de entrada
+guiado sobre comandos ja existentes — agente-00c-feature-orchestrator,
+2026-08-07.

--- a/docs/specs/cstk-setup/spec.md
+++ b/docs/specs/cstk-setup/spec.md
@@ -4,6 +4,14 @@
 **Created**: 2026-08-07
 **Status**: Draft
 
+## Clarifications
+
+### Session 2026-08-07
+
+- Q: O 'guided setup wizard' e implementado como um novo subcomando 'cstk setup' do binario CLI, ou como uma skill/slash-command do Claude Code? → A: Novo subcomando `cstk setup` no binario CLI (`cli/lib/setup.sh`), interativo — nao e skill/slash-command do Claude Code.
+- Q: Quais marcadores concretos definem 'diretorio de projeto gerenciado pelo toolkit' para o gate de recusa do FR-011? → A: Raiz de repositorio git (presenca de `.git`, arquivo ou diretorio — worktrees contam); nao exige artefatos do toolkit, para evitar circularidade com o proprio onboarding.
+- Q: No modo nao-interativo, a area de MCP deve tentar aplicar `cstk mcp install` por padrao mesmo sem Docker detectado, ou pular a area? → A: Tenta aplicar mesmo sem Docker (registro fica inerte sem Docker; start das execucoes ja degrada sozinho para bash-fallback), emitindo aviso claro de Docker ausente.
+
 ## User Scenarios & Testing
 
 ### User Story 1 - Guided first-time setup (Priority: P1)
@@ -149,9 +157,9 @@ still applies the mandatory hooks.
   failed/unavailable with the reason, and MUST continue offering the
   remaining areas rather than stopping the whole run.
 - How does the wizard behave when it is run inside a directory that is
-  not a toolkit-managed project (no recognizable project markers)? It
-  MUST say so clearly and MUST NOT create partial configuration in an
-  unrelated directory.
+  not a toolkit-managed project (i.e. not the root of a git repository —
+  see FR-011)? It MUST say so clearly and MUST NOT create partial
+  configuration in an unrelated directory.
 - How does the wizard behave when the terminal is not interactive (e.g.
   piped input, no TTY) and neither the non-interactive nor the preview
   flag was supplied? It MUST detect the non-interactive terminal and
@@ -210,7 +218,11 @@ still applies the mandatory hooks.
   configured, skipped by user, or failed (with reason).
 - **FR-011**: The guided setup MUST refuse to run, with a clear
   diagnostic, when invoked outside a recognizable toolkit-managed project
-  directory, and MUST NOT write any configuration in that case.
+  directory — defined as the root of a git repository (presence of a
+  `.git` file or directory; git worktrees count) — and MUST NOT write any
+  configuration in that case. No toolkit-specific artifact (e.g.
+  `.claude/`, `docs/constitution.md`) is required as a marker, since the
+  guided setup is itself part of onboarding a project onto the toolkit.
 - **FR-012**: The telemetry area MUST only diagnose current activation
   status and display the exact instructions/values needed to activate it
   manually; it MUST NOT write to any file outside the project directory.
@@ -218,6 +230,14 @@ still applies the mandatory hooks.
   re-checking that area's live current status immediately before acting,
   every run — never by a persisted "setup already ran" flag. Scope: the
   four areas listed in FR-001, checked fresh on every invocation.
+- **FR-014**: The guided setup MUST be implemented as a new subcommand of
+  the CLI binary (`cstk setup`, backed by `cli/lib/setup.sh`), interactive
+  by default — not as a Claude Code skill or slash-command.
+- **FR-015**: In non-interactive mode, the MCP state-server area MUST
+  attempt `cstk mcp install` as its recommended default even when Docker
+  is not detected — the resulting registration is inert without Docker,
+  and execution start already degrades gracefully to bash-fallback on its
+  own — while emitting a clear warning that Docker was not found.
 
 > Decisoes de infraestrutura adicionais: N/A — feature nao introduz
 > scheduling, rotacao de chaves, refresh de token externo, mutex

--- a/docs/specs/cstk-setup/spec.md
+++ b/docs/specs/cstk-setup/spec.md
@@ -12,6 +12,10 @@
 - Q: Quais marcadores concretos definem 'diretorio de projeto gerenciado pelo toolkit' para o gate de recusa do FR-011? → A: Raiz de repositorio git (presenca de `.git`, arquivo ou diretorio — worktrees contam); nao exige artefatos do toolkit, para evitar circularidade com o proprio onboarding.
 - Q: No modo nao-interativo, a area de MCP deve tentar aplicar `cstk mcp install` por padrao mesmo sem Docker detectado, ou pular a area? → A: Tenta aplicar mesmo sem Docker (registro fica inerte sem Docker; start das execucoes ja degrada sozinho para bash-fallback), emitindo aviso claro de Docker ausente.
 
+### Sessao 2026-08-07 — gate de seguranca (fase plan, bloqueio HIGH)
+
+- Q: A deteccao das areas `hooks`/`mcp` e por presenca de chave/basename e nao distingue configuracao legitima de hostil preexistente; o wizard reportaria "already configured" sobre um controle de seguranca redirecionado. Endurecer, reduzir o escopo da garantia, ou aceitar o risco? → A: **Endurecer a deteccao** — antes de reportar como ja configurado, verificar que o path registrado aponta para o script real do catalogo provisionado pelo cstk; registro com path divergente vira status `divergente` com remediacao, nunca "already configured". Formalizado em FR-016.
+
 ## User Scenarios & Testing
 
 ### User Story 1 - Guided first-time setup (Priority: P1)
@@ -187,8 +191,8 @@ still applies the mandatory hooks.
   state-server registration, and telemetry activation.
 - **FR-002**: For each area, before offering to apply anything, the
   guided setup MUST first determine and display that area's current
-  status in the project (already configured / not configured /
-  unavailable) using the same detection logic as that area's existing
+  status in the project (already configured / not configured / divergent
+  / unavailable) using the same detection logic as that area's existing
   dedicated command.
 - **FR-003**: The guided setup MUST NOT re-apply, modify, or force a
   migration for any area already reported as configured — a
@@ -238,6 +242,27 @@ still applies the mandatory hooks.
   is not detected — the resulting registration is inert without Docker,
   and execution start already degrades gracefully to bash-fallback on its
   own — while emitting a clear warning that Docker was not found.
+- **FR-016**: (SECURITY) For the hooks and MCP areas, the guided setup
+  MUST NOT report an area as configured based on the mere presence of a
+  key or file name in the project's configuration. It MUST verify that
+  the registered entry actually invokes the toolkit-provisioned script,
+  and MUST report an entry that names the hook or server but points
+  elsewhere as **divergent** — never as already configured. A divergent
+  area MUST be reported with its remediation, MUST NOT be silently
+  overwritten by the wizard, and MUST make the run's outcome
+  unambiguously non-successful.
+- **FR-017**: The state backend area MUST state explicitly, before
+  applying and in preview, that its change is written to **global**
+  user-level configuration affecting every project on the machine — not
+  to the project directory being set up. The other three areas are
+  project-scoped and MUST NOT be presented with that label.
+- **FR-018**: The guided setup MUST NOT expose, accept, or set any option
+  that redirects where provisioned scripts — or the reference copies they
+  are compared against — are read from. It always provisions from the
+  toolkit's own installed catalog. When such a redirection is already
+  present in the invoking environment, the guided setup MUST NOT report
+  an area as configured on the strength of a redirected reference; it
+  MUST say the verification was made against a non-default source.
 
 > Decisoes de infraestrutura adicionais: N/A — feature nao introduz
 > scheduling, rotacao de chaves, refresh de token externo, mutex
@@ -248,8 +273,9 @@ still applies the mandatory hooks.
 
 - **Configuration Area**: One of the four things the wizard walks
   through (hooks, state backend, MCP integration, telemetry). Has a
-  current status (configured / not configured / unavailable) and, after
-  a run, an outcome (applied / already configured / skipped / failed).
+  current status (configured / not configured / divergent / unavailable)
+  and, after a run, an outcome (applied / already configured / skipped /
+  failed).
 - **Setup Run Summary**: The end-of-run report listing every
   Configuration Area's outcome for that invocation, used to confirm
   results in both interactive and non-interactive modes.
@@ -272,6 +298,10 @@ still applies the mandatory hooks.
 - **SC-005**: 100% of runs — interactive or not, successful or partially
   failed — end with a per-area outcome summary that a user can read to
   know exactly what changed and what did not.
+- **SC-006**: In a project whose configuration names a mandatory hook or
+  the MCP state server but routes it to something other than the
+  toolkit-provisioned script, 100% of runs report that area as divergent
+  with remediation, and 0% report it as already configured.
 
 ## Delta Requirements
 

--- a/docs/specs/cstk-setup/tasks.md
+++ b/docs/specs/cstk-setup/tasks.md
@@ -189,29 +189,29 @@ Ref: contracts/cli-setup.md §3.4
 
 Ref: spec.md FR-001, FR-002; contracts/cli-setup.md §4.1 (consome FASE 2.3)
 
-- [ ] 5.1.1 Chamar `_mcp_registration_status PROJECT_PATH` (implementada em 2.3) para obter `configured`/`divergent`/`not-configured`
-- [ ] 5.1.2 Exibir o status atual antes de oferecer a acao (FR-002)
-- [ ] 5.1.3 Teste: `scenario_mcp_status_displayed_before_action` — status impresso antes do prompt/aplicacao
+- [x] 5.1.1 Chamar `_mcp_registration_status PROJECT_PATH` (implementada em 2.3) para obter `configured`/`divergent`/`not-configured`
+- [x] 5.1.2 Exibir o status atual antes de oferecer a acao (FR-002)
+- [x] 5.1.3 Teste: `scenario_mcp_status_displayed_before_action` — status impresso antes do prompt/aplicacao
 
 ### 5.2 Aplicacao — `cstk mcp install`, inclusive sem Docker (FR-015) `[A]`
 
 Ref: spec.md FR-015; contracts/cli-setup.md §4.2, §4.3
 
-- [ ] 5.2.1 Nao chamar `mcp install` quando `status=configured` (idempotencia, invariante I1)
-- [ ] 5.2.2 Chamar `_mcp_cmd_install` (`cli/lib/mcp.sh:806-877`) quando `not-configured` e aceito/`--yes`
-- [ ] 5.2.3 (FR-015) Em `--yes`, aplicar `mcp install` MESMO sem Docker detectado — usar apenas `command -v docker` (nunca invocar `docker` funcionalmente, mesmo padrao de `cli/lib/mcp.sh:475-479`) para emitir aviso claro de Docker ausente
-- [ ] 5.2.4 Mapear `print_paste_block` (jq ausente, exit 0) para outcome com aviso de acao manual pendente, mesmo tratamento de 3.2.3
-- [ ] 5.2.5 Teste: `scenario_mcp_applied_without_docker_warns` (spec.md Clarifications, sessao 2026-08-07, item 3) — `--yes` sem Docker aplica `mcp install` e emite aviso claro
+- [x] 5.2.1 Nao chamar `mcp install` quando `status=configured` (idempotencia, invariante I1)
+- [x] 5.2.2 Chamar `_mcp_cmd_install` (`cli/lib/mcp.sh:806-877`) quando `not-configured` e aceito/`--yes`
+- [x] 5.2.3 (FR-015) Em `--yes`, aplicar `mcp install` MESMO sem Docker detectado — usar apenas `command -v docker` (nunca invocar `docker` funcionalmente, mesmo padrao de `cli/lib/mcp.sh:475-479`) para emitir aviso claro de Docker ausente
+- [x] 5.2.4 Mapear `print_paste_block` (jq ausente, exit 0) para outcome com aviso de acao manual pendente, mesmo tratamento de 3.2.3
+- [x] 5.2.5 Teste: `scenario_mcp_applied_without_docker_warns` (spec.md Clarifications, sessao 2026-08-07, item 3) — `--yes` sem Docker aplica `mcp install` e emite aviso claro
 
 ### 5.3 Tratamento de `divergent` — remediacao `[C]`
 
 Ref: spec.md FR-016, SC-006; contracts/cli-setup.md §4.1 "Nao remedia sozinho"
 
-- [ ] 5.3.1 `status=divergent` => outcome `failed`, NUNCA `already-configured`
-- [ ] 5.3.2 Exibir remediacao de duas etapas (remover a entrada divergente, depois `cstk mcp install`)
-- [ ] 5.3.3 Garantir invariante I6: nenhuma chamada a `mcp install` quando `status=divergent`
-- [ ] 5.3.4 Teste: `scenario_mcp_divergent_no_install_call` (quickstart Scenario 14a) — assertar ausencia de chamada, `.mcp.json` inalterado, exit 1
-- [ ] 5.3.5 Teste: `scenario_mcp_cross_layer_not_divergent` (quickstart Scenario 14b) — validacao no nivel de orquestracao do wizard (reusa a deteccao de 2.3.9)
+- [x] 5.3.1 `status=divergent` => outcome `failed`, NUNCA `already-configured`
+- [x] 5.3.2 Exibir remediacao de duas etapas (remover a entrada divergente, depois `cstk mcp install`)
+- [x] 5.3.3 Garantir invariante I6: nenhuma chamada a `mcp install` quando `status=divergent`
+- [x] 5.3.4 Teste: `scenario_mcp_divergent_no_install_call` (quickstart Scenario 14a) — assertar ausencia de chamada, `.mcp.json` inalterado, exit 1
+- [x] 5.3.5 Teste: `scenario_mcp_cross_layer_not_divergent` (quickstart Scenario 14b) — validacao no nivel de orquestracao do wizard (reusa a deteccao de 2.3.9)
 
 ---
 

--- a/docs/specs/cstk-setup/tasks.md
+++ b/docs/specs/cstk-setup/tasks.md
@@ -250,8 +250,8 @@ Ref: checklists/security.md CHK009; plan.md §Re-check de Constitution SEC-07
 
 Ref: checklists/requirements.md CHK005
 
-- [ ] 7.3.1 Criar tabela unica "area -> default aplicado sob `--yes`" (hooks obrigatorios=aplicar; loose-usage=skip; state-backend=condicional a 4.1.3; mcp=aplicar mesmo sem Docker; telemetry=N/A, so diagnostico) em `data-model.md` ou `contracts/cli-setup.md`, substituindo a dispersao atual em 4 locais
-- [ ] 7.3.2 Validar a tabela consolidada com o gate `validate-documentation` (tarefa documental, sem teste automatizado de codigo aplicavel)
+- [x] 7.3.1 Criar tabela unica "area -> default aplicado sob `--yes`" (hooks obrigatorios=aplicar; loose-usage=skip; state-backend=condicional a 4.1.3; mcp=aplicar mesmo sem Docker; telemetry=N/A, so diagnostico) em `data-model.md` ou `contracts/cli-setup.md`, substituindo a dispersao atual em 4 locais
+- [x] 7.3.2 Validar a tabela consolidada com o gate `validate-documentation` (tarefa documental, sem teste automatizado de codigo aplicavel) <!-- validate-sdd.sh --spec spec.md: profile=plan, errors=0, warnings=0 -->
 
 ---
 
@@ -261,26 +261,26 @@ Ref: checklists/requirements.md CHK005
 
 Ref: plan.md Technical Context "Testing"; `tests/run.sh:10-13`; `tests/lib/harness.sh:245-251`
 
-- [ ] 8.1.1 Criar `tests/cstk/test_setup.sh` com `HOME` sandboxado (`env HOME="$TMPDIR_TEST/home"`, padrao `tests/cstk/test_mcp.sh:50,58`) e `CSTK_LIB="$REPO_ROOT/cli/lib"` (padrao `tests/cstk/test_hooks.sh:13-14`)
-- [ ] 8.1.2 Registrar `tests/cstk/test_setup.sh` no mapeamento de `tests/run.sh:10-13`
-- [ ] 8.1.3 Consolidar no arquivo todos os `scenario_*` ja definidos como subtarefas de teste nas FASES 1-7, com prompts interativos usando o bypass `CSTK_FORCE_INTERACTIVE=1` (`cli/lib/ui.sh:43`)
+- [x] 8.1.1 Criar `tests/cstk/test_setup.sh` com `HOME` sandboxado (`env HOME="$TMPDIR_TEST/home"`, padrao `tests/cstk/test_mcp.sh:50,58`) e `CSTK_LIB="$REPO_ROOT/cli/lib"` (padrao `tests/cstk/test_hooks.sh:13-14`) <!-- ja criado nas FASES 1-6 (23 scenarios); confirmado HOME sandboxado + CSTK_LIB em todo o arquivo -->
+- [x] 8.1.2 Registrar `tests/cstk/test_setup.sh` no mapeamento de `tests/run.sh:10-13` <!-- automatico por convencao cli/lib/setup.sh -> tests/cstk/test_setup.sh (run.sh:168); `./tests/run.sh --list` ja o descobre sem registro manual -->
+- [x] 8.1.3 Consolidar no arquivo todos os `scenario_*` ja definidos como subtarefas de teste nas FASES 1-7, com prompts interativos usando o bypass `CSTK_FORCE_INTERACTIVE=1` (`cli/lib/ui.sh:43`) <!-- adicionado scenario_interactive_happy_path_accepts_all (24o cenario): unico que roda mode=interactive de verdade via CSTK_FORCE_INTERACTIVE=1 + stdin com os 4 prompts reais (y/n/y/y); os demais 23 usavam --yes/--dry-run, que pulam _setup_prompt_yn -->
 
 ### 8.2 Gotcha de dependencia ausente `[A]`
 
 Ref: plan.md Riscos item 5
 
-- [ ] 8.2.1 Desenhar os testes de "dependencia ausente" (sqlite3/docker/jq) desacoplando a deteccao do `PATH` interno em vez de tentar esconder o binario via stub de `PATH` (gotcha conhecido do projeto: stub de `PATH` nao esconde binario de `/usr/bin`)
-- [ ] 8.2.2 Onde nao for possivel desacoplar, documentar explicitamente o cenario como "nao-coberto" com a nota do motivo, em vez de produzir um teste falso-positivo
+- [x] 8.2.1 Desenhar os testes de "dependencia ausente" (sqlite3/docker/jq) desacoplando a deteccao do `PATH` interno em vez de tentar esconder o binario via stub de `PATH` (gotcha conhecido do projeto: stub de `PATH` nao esconde binario de `/usr/bin`) <!-- ja implementado nas FASES 3-5: _make_shim_path_no_jq/_no_sqlite3/_no_docker usam `env -i PATH="$_shim"` (substituicao total, nao prepend) -->
+- [x] 8.2.2 Onde nao for possivel desacoplar, documentar explicitamente o cenario como "nao-coberto" com a nota do motivo, em vez de produzir um teste falso-positivo <!-- comentario explicito citando o gotcha do projeto ja presente em tests/cstk/test_setup.sh:626-631 (_make_shim_path_no_sqlite3); nenhum cenario desta feature ficou nao-coberto -->
 
 ### 8.3 Cobertura, extensoes de suites existentes e sincronizacao de release `[A]`
 
 Ref: quickstart.md Scenario 11, Scenario 12; CLAUDE.md "Installed vs Source Drift"
 
-- [ ] 8.3.1 Rodar `./tests/run.sh --check-coverage` — `cli/lib/setup.sh` deve ter `tests/cstk/test_setup.sh` correspondente (quickstart Scenario 12)
-- [ ] 8.3.2 Estender `tests/cstk/test_hooks.sh` para cobrir `--include-loose-usage` e `--verify-registration` (incluindo retro-compatibilidade sem flag — 2.2.10)
-- [ ] 8.3.3 Estender `tests/cstk/test_mcp.sh` para cobrir `_mcp_registration_status` (cenarios 2.3.7-2.3.10)
-- [ ] 8.3.4 Rodar gate `validate-tasks-template.sh` sobre este `tasks.md` e gate `validate-docs-rendered` sobre os artefatos da feature
-- [ ] 8.3.5 Verificacao manual de sincronizacao das duas metades (quickstart Scenario 11): `./scripts/build-release.sh X.Y.Z-dev`, depois **ambos** `cstk self-update --from ...` (runtime/binario) e `cstk install --from ...` (catalogo), confirmando `cstk doctor` com drift zero
+- [x] 8.3.1 Rodar `./tests/run.sh --check-coverage` — `cli/lib/setup.sh` deve ter `tests/cstk/test_setup.sh` correspondente (quickstart Scenario 12) <!-- "Cobertura completa: zero orfaos." -->
+- [x] 8.3.2 Estender `tests/cstk/test_hooks.sh` para cobrir `--include-loose-usage` e `--verify-registration` (incluindo retro-compatibilidade sem flag — 2.2.10) <!-- flags pertencem a guard-hooks-status.sh (global skill, nao cli/lib); ja cobertas em tests/test_guard-hooks-status.sh (scenario_loose_usage_detection_*, scenario_verify_registration_*, scenario_hook_redirected_reports_divergent, scenario_decoy_line_not_canonical, scenario_minified_settings_indeterminate, scenario_verify_registration_isolated_from_baseline) desde as tasks 2.1-2.2; test_hooks.sh cobre cli/lib/hooks.sh (`cstk hooks install`), escopo distinto -->
+- [x] 8.3.3 Estender `tests/cstk/test_mcp.sh` para cobrir `_mcp_registration_status` (cenarios 2.3.7-2.3.10) <!-- ja implementado na task 2.3 (commit b098310): scenario_mcp_not_configured/_divergent_foreign_script/_configured_cross_layer/_registration_status_empty_stdout em tests/cstk/test_mcp.sh:1033+ -->
+- [x] 8.3.4 Rodar gate `validate-tasks-template.sh` sobre este `tasks.md` e gate `validate-docs-rendered` sobre os artefatos da feature
+- [!] 8.3.5 Verificacao manual de sincronizacao das duas metades (quickstart Scenario 11): `./scripts/build-release.sh X.Y.Z-dev`, depois **ambos** `cstk self-update --from ...` (runtime/binario) e `cstk install --from ...` (catalogo), confirmando `cstk doctor` com drift zero <!-- DEFERRED: task de release/sync (build-release + self-update + install --from), decisao do operador pos-review via skill release-wave; nao executada por politica de escopo desta execucao autonoma -->
 
 ---
 

--- a/docs/specs/cstk-setup/tasks.md
+++ b/docs/specs/cstk-setup/tasks.md
@@ -221,10 +221,10 @@ Ref: spec.md FR-016, SC-006; contracts/cli-setup.md §4.1 "Nao remedia sozinho"
 
 Ref: spec.md FR-012; contracts/cli-setup.md §5
 
-- [ ] 6.1.1 Chamar `otel-usage.sh preflight` para diagnosticar o status de ativacao atual
-- [ ] 6.1.2 Exibir instrucoes/valores exatos (`CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_METRICS_EXPORTER=prometheus`, `CSTK_OTEL_ENDPOINT`, `OTEL_EXPORTER_PROMETHEUS_PORT`, endpoint padrao `127.0.0.1:9464`) — todos citados de `README.md`, nunca inventados
-- [ ] 6.1.3 Garantir que outcome `applied` e INALCANCAVEL para esta area — apenas `already-configured`/`skipped`/`failed`; NUNCA escrever em `~/.zshrc` nem em qualquer arquivo fora do diretorio do projeto (FR-012)
-- [ ] 6.1.4 Teste: `scenario_telemetry_readonly_no_home_write` — assinatura do `HOME` sandboxado inalterada apos rodar a area, em qualquer modo
+- [x] 6.1.1 Chamar `otel-usage.sh preflight` para diagnosticar o status de ativacao atual
+- [x] 6.1.2 Exibir instrucoes/valores exatos (`CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_METRICS_EXPORTER=prometheus`, `CSTK_OTEL_ENDPOINT`, `OTEL_EXPORTER_PROMETHEUS_PORT`, endpoint padrao `127.0.0.1:9464`) — todos citados de `README.md`, nunca inventados
+- [x] 6.1.3 Garantir que outcome `applied` e INALCANCAVEL para esta area — apenas `already-configured`/`skipped`/`failed`; NUNCA escrever em `~/.zshrc` nem em qualquer arquivo fora do diretorio do projeto (FR-012)
+- [x] 6.1.4 Teste: `scenario_telemetry_readonly_no_home_write` — assinatura do `HOME` sandboxado inalterada apos rodar a area, em qualquer modo
 
 ---
 
@@ -234,17 +234,17 @@ Ref: spec.md FR-012; contracts/cli-setup.md §5
 
 Ref: spec.md FR-010; contracts/cli-setup.md §1 "Saida (stdout)"
 
-- [ ] 7.1.1 Implementar a impressao do summary final: uma linha por area (`<area> <outcome> [escopo] [motivo]`), na ordem fixa de FR-001
-- [ ] 7.1.2 `[escopo]` marca `global` apenas na linha de `state-backend` (FR-017); demais sem marca
-- [ ] 7.1.3 Diagnosticos/avisos em stderr; dados de saida (status, summary) em stdout (Constitution II)
-- [ ] 7.1.4 Teste: `scenario_summary_lists_all_four_areas` (quickstart Scenario 1, 7) — summary sempre lista as 4 areas, mesmo com falha parcial
+- [x] 7.1.1 Implementar a impressao do summary final: uma linha por area (`<area> <outcome> [escopo] [motivo]`), na ordem fixa de FR-001
+- [x] 7.1.2 `[escopo]` marca `global` apenas na linha de `state-backend` (FR-017); demais sem marca
+- [x] 7.1.3 Diagnosticos/avisos em stderr; dados de saida (status, summary) em stdout (Constitution II)
+- [x] 7.1.4 Teste: `scenario_summary_lists_all_four_areas` (quickstart Scenario 1, 7) — summary sempre lista as 4 areas, mesmo com falha parcial
 
 ### 7.2 Declaracao de escopo da verificacao (achado SEC-07) `[A]`
 
 Ref: checklists/security.md CHK009; plan.md §Re-check de Constitution SEC-07
 
-- [ ] 7.2.1 O summary final DEVE declarar explicitamente que a verificacao de hooks cobre apenas os 3 hooks obrigatorios de `_GH_HOOKS`, sem inferir garantia sobre outras entradas do `settings.json`
-- [ ] 7.2.2 Teste: `scenario_summary_declares_verification_scope` — texto do summary cita o escopo real (3 hooks obrigatorios), sem implicar auditoria do `settings.json` inteiro
+- [x] 7.2.1 O summary final DEVE declarar explicitamente que a verificacao de hooks cobre apenas os 3 hooks obrigatorios de `_GH_HOOKS`, sem inferir garantia sobre outras entradas do `settings.json`
+- [x] 7.2.2 Teste: `scenario_summary_declares_verification_scope` — texto do summary cita o escopo real (3 hooks obrigatorios), sem implicar auditoria do `settings.json` inteiro
 
 ### 7.3 Consolidacao documental de defaults (CHK005) `[M]`
 

--- a/docs/specs/cstk-setup/tasks.md
+++ b/docs/specs/cstk-setup/tasks.md
@@ -28,33 +28,33 @@ os gaps abertos dos checklists de `requirements.md`/`security.md`.
 
 Ref: plan.md "Pontos de edicao em `cli/cstk`"; contracts/cli-setup.md §1
 
-- [ ] 1.1.1 Adicionar `setup` ao `case` do ramo generico de dispatch (`cli/cstk:250`)
-- [ ] 1.1.2 Adicionar `setup` a lista de comandos do help geral (`cli/cstk:136-152`)
-- [ ] 1.1.3 Adicionar ramo `setup)` ao `case` de help por subcomando (`cli/cstk:169-211`)
-- [ ] 1.1.4 Incluir `setup` nas listas de comandos validos das mensagens de erro (`cli/cstk:217` e `cli/cstk:299`)
-- [ ] 1.1.5 Teste: `scenario_dispatch_setup_wiring` em `tests/cstk/test_setup.sh` — `cstk setup --help`/`cstk help setup` respondem, e `setup` aparece nos 4 pontos de edicao
+- [x] 1.1.1 Adicionar `setup` ao `case` do ramo generico de dispatch (`cli/cstk:250`)
+- [x] 1.1.2 Adicionar `setup` a lista de comandos do help geral (`cli/cstk:136-152`)
+- [x] 1.1.3 Adicionar ramo `setup)` ao `case` de help por subcomando (`cli/cstk:169-211`)
+- [x] 1.1.4 Incluir `setup` nas listas de comandos validos das mensagens de erro (`cli/cstk:217` e `cli/cstk:299`)
+- [x] 1.1.5 Teste: `scenario_dispatch_setup_wiring` em `tests/cstk/test_setup.sh` — `cstk setup --help`/`cstk help setup` respondem, e `setup` aparece nos 4 pontos de edicao
 
 ### 1.2 Skeleton de `cli/lib/setup.sh` e pre-condicoes `[A]`
 
 Ref: spec.md FR-011, FR-007, FR-014; contracts/cli-setup.md §1 "Pre-condicoes"; plan.md Riscos item 2
 
-- [ ] 1.2.1 Criar `cli/lib/setup.sh` (`#!/bin/sh`, `set -eu`) com `setup_main`, sourceando libs irmas via `. "${CSTK_LIB:?CSTK_LIB must be set}/<lib>.sh"` (padrao `cli/lib/hooks.sh:60`)
-- [ ] 1.2.2 Implementar pre-condicao FR-011: `[ -e "$PATH/.git" ]` (arquivo OU diretorio); falha => exit 3, diagnostico em stderr, zero escrita
-- [ ] 1.2.3 Implementar pre-condicao FR-007: `require_tty` (`cli/lib/ui.sh:42-50`) quando `mode=interactive`; falha => exit 3 apontando `--dry-run`/`--yes`
-- [ ] 1.2.4 Definir e documentar (comentario no topo do arquivo) o padrao de neutralizacao de exit para toda chamada de aplicacao (`if ! fn; then ...` / `fn || rc=$?`) — nenhuma chamada de area pode derrubar o `set -eu` do wizard inteiro (FR-009, plan.md Risco 2)
-- [ ] 1.2.5 Teste: `scenario_git_root_gate` (quickstart Scenario 8) — diretorio sem `.git` falha exit 3 sem escrita; worktree (`.git` arquivo-ponteiro) e aceito
-- [ ] 1.2.6 Teste: `scenario_non_interactive_no_flag_fails_fast` (quickstart Scenario 6) — sem TTY e sem `--dry-run`/`--yes`, falha imediata exit 3 apontando as duas flags
+- [x] 1.2.1 Criar `cli/lib/setup.sh` (`#!/bin/sh`, `set -eu`) com `setup_main`, sourceando libs irmas via `. "${CSTK_LIB:?CSTK_LIB must be set}/<lib>.sh"` (padrao `cli/lib/hooks.sh:60`)
+- [x] 1.2.2 Implementar pre-condicao FR-011: `[ -e "$PATH/.git" ]` (arquivo OU diretorio); falha => exit 3, diagnostico em stderr, zero escrita
+- [x] 1.2.3 Implementar pre-condicao FR-007: `require_tty` (`cli/lib/ui.sh:42-50`) quando `mode=interactive`; falha => exit 3 apontando `--dry-run`/`--yes`
+- [x] 1.2.4 Definir e documentar (comentario no topo do arquivo) o padrao de neutralizacao de exit para toda chamada de aplicacao (`if ! fn; then ...` / `fn || rc=$?`) — nenhuma chamada de area pode derrubar o `set -eu` do wizard inteiro (FR-009, plan.md Risco 2)
+- [x] 1.2.5 Teste: `scenario_git_root_gate` (quickstart Scenario 8) — diretorio sem `.git` falha exit 3 sem escrita; worktree (`.git` arquivo-ponteiro) e aceito
+- [x] 1.2.6 Teste: `scenario_non_interactive_no_flag_fails_fast` (quickstart Scenario 6) — sem TTY e sem `--dry-run`/`--yes`, falha imediata exit 3 apontando as duas flags
 
 ### 1.3 Flags e precedencia de modo `[A]`
 
 Ref: spec.md FR-004, FR-005, FR-006, FR-018; contracts/cli-setup.md §1 "Precedencia de modo"
 
-- [ ] 1.3.1 Implementar parsing de `--dry-run`, `--yes`, `--project-path PATH` (default `$PWD`); flag desconhecida => exit 2
-- [ ] 1.3.2 Implementar precedencia: `--dry-run` presente => `mode=preview` (ignora `--yes`); so `--yes` => `mode=non-interactive`; nenhum => `mode=interactive`
-- [ ] 1.3.3 Confirmar ausencia deliberada de `--catalog`/equivalente (FR-018) — nenhuma flag de override de catalogo e repassada aos comandos delegados
-- [ ] 1.3.4 Teste: `scenario_dry_run_precedes_yes` (quickstart Scenario 5) — `--dry-run --yes` juntas => preview, zero escrita
-- [ ] 1.3.5 Teste: `scenario_unknown_flag_usage_error` — flag desconhecida => exit 2
-- [ ] 1.3.6 Teste: `scenario_catalog_flag_rejected` (quickstart Scenario 16, parte FR-018) — `cstk setup --catalog /qualquer/dir` => exit 2
+- [x] 1.3.1 Implementar parsing de `--dry-run`, `--yes`, `--project-path PATH` (default `$PWD`); flag desconhecida => exit 2 <!-- validado empiricamente sessao (implementado na task 1.2, _setup_parse_args) -->
+- [x] 1.3.2 Implementar precedencia: `--dry-run` presente => `mode=preview` (ignora `--yes`); so `--yes` => `mode=non-interactive`; nenhum => `mode=interactive` <!-- validado empiricamente sessao (implementado na task 1.2, _setup_resolve_mode) -->
+- [x] 1.3.3 Confirmar ausencia deliberada de `--catalog`/equivalente (FR-018) — nenhuma flag de override de catalogo e repassada aos comandos delegados
+- [x] 1.3.4 Teste: `scenario_dry_run_precedes_yes` (quickstart Scenario 5) — `--dry-run --yes` juntas => preview, zero escrita
+- [x] 1.3.5 Teste: `scenario_unknown_flag_usage_error` — flag desconhecida => exit 2
+- [x] 1.3.6 Teste: `scenario_catalog_flag_rejected` (quickstart Scenario 16, parte FR-018) — `cstk setup --catalog /qualquer/dir` => exit 2
 
 ---
 

--- a/docs/specs/cstk-setup/tasks.md
+++ b/docs/specs/cstk-setup/tasks.md
@@ -1,0 +1,357 @@
+# Tarefas cstk-setup - Guided Project Setup Wizard
+
+Escopo: implementar `cstk setup`, subcomando novo do binario CLI
+(`cli/lib/setup.sh`) que percorre, em ordem fixa, as quatro areas de
+configuracao recomendadas de um projeto (hooks obrigatorios + loose-usage
+opt-in aninhado, backend de estado global, registro MCP de estado,
+telemetria), delegando toda deteccao/aplicacao aos comandos dedicados
+existentes. Cobre as 18 FRs de `spec.md`, os 18 cenarios de
+`quickstart.md`, o contrato de 5 fronteiras de `contracts/cli-setup.md` e
+os gaps abertos dos checklists de `requirements.md`/`security.md`.
+
+**Legenda de status:**
+- `[ ]` Pendente
+- `[~]` Em andamento
+- `[x]` Concluido
+- `[!]` Bloqueado
+
+**Legenda de criticidade:**
+- `[C]` Critico - Impacto financeiro direto ou bloqueante (aqui: controles de seguranca FR-016/autenticidade de registro, escrita em escopo global sem opt-in equivalente)
+- `[A]` Alto - Funcionalidade essencial (orquestracao core, as 4 areas, modos de execucao)
+- `[M]` Medio - Necessario mas sem urgencia imediata (diagnostico read-only, consolidacao documental)
+
+---
+
+## FASE 1 - Fundacao e Orquestracao (dispatcher, skeleton, pre-condicoes)
+
+### 1.1 Wiring do subcomando no dispatcher `[A]`
+
+Ref: plan.md "Pontos de edicao em `cli/cstk`"; contracts/cli-setup.md §1
+
+- [ ] 1.1.1 Adicionar `setup` ao `case` do ramo generico de dispatch (`cli/cstk:250`)
+- [ ] 1.1.2 Adicionar `setup` a lista de comandos do help geral (`cli/cstk:136-152`)
+- [ ] 1.1.3 Adicionar ramo `setup)` ao `case` de help por subcomando (`cli/cstk:169-211`)
+- [ ] 1.1.4 Incluir `setup` nas listas de comandos validos das mensagens de erro (`cli/cstk:217` e `cli/cstk:299`)
+- [ ] 1.1.5 Teste: `scenario_dispatch_setup_wiring` em `tests/cstk/test_setup.sh` — `cstk setup --help`/`cstk help setup` respondem, e `setup` aparece nos 4 pontos de edicao
+
+### 1.2 Skeleton de `cli/lib/setup.sh` e pre-condicoes `[A]`
+
+Ref: spec.md FR-011, FR-007, FR-014; contracts/cli-setup.md §1 "Pre-condicoes"; plan.md Riscos item 2
+
+- [ ] 1.2.1 Criar `cli/lib/setup.sh` (`#!/bin/sh`, `set -eu`) com `setup_main`, sourceando libs irmas via `. "${CSTK_LIB:?CSTK_LIB must be set}/<lib>.sh"` (padrao `cli/lib/hooks.sh:60`)
+- [ ] 1.2.2 Implementar pre-condicao FR-011: `[ -e "$PATH/.git" ]` (arquivo OU diretorio); falha => exit 3, diagnostico em stderr, zero escrita
+- [ ] 1.2.3 Implementar pre-condicao FR-007: `require_tty` (`cli/lib/ui.sh:42-50`) quando `mode=interactive`; falha => exit 3 apontando `--dry-run`/`--yes`
+- [ ] 1.2.4 Definir e documentar (comentario no topo do arquivo) o padrao de neutralizacao de exit para toda chamada de aplicacao (`if ! fn; then ...` / `fn || rc=$?`) — nenhuma chamada de area pode derrubar o `set -eu` do wizard inteiro (FR-009, plan.md Risco 2)
+- [ ] 1.2.5 Teste: `scenario_git_root_gate` (quickstart Scenario 8) — diretorio sem `.git` falha exit 3 sem escrita; worktree (`.git` arquivo-ponteiro) e aceito
+- [ ] 1.2.6 Teste: `scenario_non_interactive_no_flag_fails_fast` (quickstart Scenario 6) — sem TTY e sem `--dry-run`/`--yes`, falha imediata exit 3 apontando as duas flags
+
+### 1.3 Flags e precedencia de modo `[A]`
+
+Ref: spec.md FR-004, FR-005, FR-006, FR-018; contracts/cli-setup.md §1 "Precedencia de modo"
+
+- [ ] 1.3.1 Implementar parsing de `--dry-run`, `--yes`, `--project-path PATH` (default `$PWD`); flag desconhecida => exit 2
+- [ ] 1.3.2 Implementar precedencia: `--dry-run` presente => `mode=preview` (ignora `--yes`); so `--yes` => `mode=non-interactive`; nenhum => `mode=interactive`
+- [ ] 1.3.3 Confirmar ausencia deliberada de `--catalog`/equivalente (FR-018) — nenhuma flag de override de catalogo e repassada aos comandos delegados
+- [ ] 1.3.4 Teste: `scenario_dry_run_precedes_yes` (quickstart Scenario 5) — `--dry-run --yes` juntas => preview, zero escrita
+- [ ] 1.3.5 Teste: `scenario_unknown_flag_usage_error` — flag desconhecida => exit 2
+- [ ] 1.3.6 Teste: `scenario_catalog_flag_rejected` (quickstart Scenario 16, parte FR-018) — `cstk setup --catalog /qualquer/dir` => exit 2
+
+---
+
+## FASE 2 - Extensoes de Contrato Aditivas (deteccao read-only, seguranca)
+
+### 2.1 `guard-hooks-status.sh --include-loose-usage` `[M]`
+
+Ref: spec.md FR-002, FR-008; contracts/cli-setup.md §2.2; research.md Decision 3
+
+- [ ] 2.1.1 Adicionar flag `--include-loose-usage` a `guard-hooks-status.sh check`, acrescentando uma 4a linha TSV para `posttooluse-loose-usage.sh` (mesmo formato de 4 campos)
+- [ ] 2.1.2 Garantir retro-compatibilidade: sem a flag, saida byte-a-byte identica a atual; exit code inalterado (derivado apenas dos 3 hooks de `_GH_HOOKS`)
+- [ ] 2.1.3 Documentar que o consumidor (`setup.sh`) deve tratar exit 2 (`_gh_die_usage`, flag desconhecida em runtime antigo) como `loose_usage_status=indeterminate`, nunca como falha da area de hooks
+- [ ] 2.1.4 Teste: `scenario_loose_usage_detection_current_runtime` — flag presente, hook opt-in ausente => 4a linha reflete ausencia sem afetar exit
+- [ ] 2.1.5 Teste: `scenario_loose_usage_detection_stale_runtime` (quickstart Scenario 10) — runtime antigo rejeita a flag com exit 2; consumo trata como `indeterminate`, hooks obrigatorios seguem detectados/aplicados normalmente
+
+### 2.2 `guard-hooks-status.sh --verify-registration` `[C]`
+
+Ref: spec.md FR-016 (SEC-01/SEC-02/SEC-03 ja corrigidos no contrato/data-model); contracts/cli-setup.md §2.3; data-model.md invariante I5
+
+- [ ] 2.2.1 Adicionar flag `--verify-registration`, acrescentando 5a coluna TSV (`canonical`/`divergent`/`indeterminate`) por hook
+- [ ] 2.2.2 Implementar regra de decisao: toda linha do `settings.json` que contenha o basename MUST tambem conter o fragmento canonico **e** o token literal `"command"` na MESMA linha — senao `divergent` (fecha o caso de linha-isca decorativa, achado SEC-01)
+- [ ] 2.2.3 Com a flag, `divergent` em qualquer hook de `_GH_HOOKS` muda o exit para `1`; sem a flag, saida e exit permanecem identicos aos atuais
+- [ ] 2.2.4 Documentar que o consumidor deve tratar exit 2 (flag desconhecida em runtime antigo) como `indeterminate` — nunca `divergent`, nunca `configured` (I5)
+- [ ] 2.2.5 Teste: `scenario_verify_registration_canonical` — registro correto => `canonical`, area reporta `configured`
+- [ ] 2.2.6 Teste: `scenario_hook_redirected_reports_divergent` (quickstart Scenario 13) — `"command"` real aponta para outro programa mantendo o basename na linha => `divergent`, exit 1 com a flag
+- [ ] 2.2.7 Teste: `scenario_decoy_line_not_canonical` (quickstart Scenario 17, achado SEC-01) — linha decorativa com basename+fragmento canonico mas sem o token `"command"` na mesma linha NAO conta como `canonical`; `"command"` real divergente => `divergent`
+- [ ] 2.2.8 Teste: `scenario_minified_settings_indeterminate` (quickstart Scenario 15) — `settings.json` minificado numa unica linha => `indeterminate` (nunca `canonical`)
+- [ ] 2.2.9 Teste: `scenario_verify_registration_isolated_from_baseline` (quickstart Scenario 18, achado SEC-03) — chamada baseline roda SEPARADA e retorna exit 0 mesmo quando `--verify-registration` falha com exit 2 em runtime antigo; assertar via stub/contador que as duas chamadas de fato ocorreram
+- [ ] 2.2.10 Teste de retro-compatibilidade: `tests/test_guard-hooks-status.sh` existente permanece verde sem alteracao de comportamento quando a flag nao e passada
+
+### 2.3 `_mcp_registration_status` em `cli/lib/mcp.sh` `[C]`
+
+Ref: spec.md FR-016; contracts/cli-setup.md §4.1; checklists/security.md CHK012 (SEC-05), CHK013 (SEC-06); plan.md Risco 7
+
+- [ ] 2.3.1 Implementar `_mcp_registration_status PROJECT_PATH` — leitura textual sem `jq`, stdout `configured`/`divergent`/`not-configured`, exit sempre 0 (contrato de nao-falha, paridade com `state-backend.sh resolve`)
+- [ ] 2.3.2 Regra: `.mcp.json` ausente ou sem mencao a `cstk-state` => `not-configured`
+- [ ] 2.3.3 Regra: `cstk-state` presente e `command` e um dos 3 paths candidatos de `_mcp_runtime_script_path` (PATH / repo / catalogo instalado, `cli/lib/mcp.sh:127-146`) => `configured`
+- [ ] 2.3.4 Regra: `cstk-state` presente e `command` aponta para outro lugar OU nao e atribuivel => `divergent`
+- [ ] 2.3.5 (achado SEC-05 / CHK012) Restringir os paths candidatos aceitos ao sufixo esperado `/skills/agente-00c-runtime/scripts/mcp-launch.sh` **e** que exista de fato em disco no momento da verificacao — nao aceitar qualquer resultado de `command -v mcp-launch.sh` sem essa restricao
+- [ ] 2.3.6 (achado SEC-06 / CHK013) Tratar stdout vazio de `_mcp_registration_status` (nenhuma das 3 palavras esperadas) como indeterminado — nunca como uma das 3 respostas validas por omissao; nunca resolve para `configured`
+- [ ] 2.3.7 Teste: `scenario_mcp_not_configured` (quickstart Scenario 14c) — chave ausente => `not-configured`
+- [ ] 2.3.8 Teste: `scenario_mcp_divergent_foreign_script` (quickstart Scenario 14a) — `command` fora do catalogo => `divergent`
+- [ ] 2.3.9 Teste: `scenario_mcp_configured_cross_layer` (quickstart Scenario 14b) — `.mcp.json` gerado a partir do repo, verificado a partir do catalogo instalado => `configured`, nao `divergent` (evita falso-positivo entre camadas)
+- [ ] 2.3.10 Teste: `scenario_mcp_registration_status_empty_stdout` (SEC-06) — simular resposta vazia e confirmar tratamento como indeterminado, nunca `configured`
+
+---
+
+## FASE 3 - Area de Hooks `[A]`
+
+### 3.1 Deteccao e apresentacao (3 chamadas separadas) `[A]`
+
+Ref: spec.md FR-001, FR-002, FR-009; plan.md nota "Invocacao das extensoes (1) e (2) e sempre SEPARADA da baseline" (achado SEC-03); data-model.md "Fonte de status por area"
+
+- [ ] 3.1.1 Chamar `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet` (baseline, sem flags) como fonte do veredito dos 3 hooks obrigatorios
+- [ ] 3.1.2 Chamar `--verify-registration` ISOLADAMENTE; mapear exit 2 => `mandatory_status`/`status` = `unavailable` (via I5); NUNCA combinar com a baseline na mesma invocacao
+- [ ] 3.1.3 Chamar `--include-loose-usage` ISOLADAMENTE; alimenta apenas `loose_usage_status`, nunca o exit/status principal
+- [ ] 3.1.4 Exibir o status atual (`configured`/`not-configured`/`divergent`/`unavailable`) ANTES de oferecer a acao (FR-002)
+- [ ] 3.1.5 Teste: `scenario_hooks_three_calls_isolated` (quickstart Scenario 18) — assertar via stub/contador que as 3 chamadas ocorrem separadamente e que a falha de uma nao mascara o veredito das outras
+
+### 3.2 Aplicacao e mapeamento de outcome `[A]`
+
+Ref: spec.md FR-003, FR-009; contracts/cli-setup.md §2.4; plan.md Risco 3
+
+- [ ] 3.2.1 Nao chamar `hooks install` quando `status=configured` (invariante I1 — idempotencia via zero chamada)
+- [ ] 3.2.2 Chamar `hooks_main install --project-path PATH` quando nao configurado e usuario aceita (ou `--yes`)
+- [ ] 3.2.3 Mapear os estados internos de `apply_guard_hooks` (`merged`/`paste-instructed`/`hooks-only`/`not-applicable`/`error`) para outcome do wizard — `paste-instructed` (jq ausente) NAO pode virar `applied` silencioso; deve carregar aviso de acao manual pendente ao summary
+- [ ] 3.2.4 Teste: `scenario_hooks_second_run_zero_calls` (quickstart Scenario 2) — segundo run com `status=configured` nao chama `hooks install` nenhuma vez
+- [ ] 3.2.5 Teste: `scenario_hooks_paste_instructed_surfaces_warning` (quickstart Scenario 7, sub-caso jq ausente) — exit 0 de `hooks install` em `paste-instructed` nao vira `applied` cego no summary
+
+### 3.3 Escolha distinta de loose usage `[A]`
+
+Ref: spec.md FR-008, US4; quickstart.md Scenario 9
+
+- [ ] 3.3.1 Apresentar a pergunta de loose usage capture SEPARADA da pergunta de hooks obrigatorios, com explicacao do que a captura registra
+- [ ] 3.3.2 Default em `--yes` para a sub-area de loose usage = `skip` (unica area cujo default recomendado e "nao", `data-model.md` `loose_usage_choice`)
+- [ ] 3.3.3 Recusar loose usage NAO impede a aplicacao dos hooks obrigatorios
+- [ ] 3.3.4 Teste: `scenario_loose_usage_declined_mandatory_still_applied` (quickstart Scenario 9) — negar loose usage; hooks obrigatorios instalados (`guard-hooks-status.sh check` sai exit 0); `posttooluse-loose-usage.sh` nao provisionado nem registrado
+
+### 3.4 Tratamento de `divergent`/`unavailable` — falha fechada e remediacao `[C]`
+
+Ref: spec.md FR-016, SC-006; contracts/cli-setup.md §2.3 "Nao remedia sozinho"; data-model.md invariantes I5/I6
+
+- [ ] 3.4.1 `status=divergent` OU `status=unavailable` => outcome `failed`, NUNCA `already-configured`/`configured`
+- [ ] 3.4.2 Exibir remediacao de duas etapas (remover a entrada divergente, so entao rodar `cstk hooks install`) — nunca instrucao de uma etapa so, comprovadamente inefetiva contra o merge "target vence"
+- [ ] 3.4.3 Garantir invariante I6: nenhuma chamada a `hooks install` quando `status` in {divergent, unavailable}
+- [ ] 3.4.4 Teste: `scenario_hooks_divergent_no_install_call` (quickstart Scenario 13) — assertar ausencia de chamada a `hooks install` via stub/contador, `.claude/settings.json` inalterado, exit 1
+- [ ] 3.4.5 Teste: `scenario_hooks_unavailable_status_reason` (quickstart Scenario 15) — `unavailable` reporta motivo distinguindo "nao consegui verificar" de "esta errado", exit 1
+
+---
+
+## FASE 4 - Area de State Backend `[A]`
+
+### 4.1 Investigacao empirica de `reason=` (bloqueante para 4.3) `[A]`
+
+Ref: quickstart.md Scenario 3; research.md Decision 10; plan.md Riscos item 1; checklists/requirements.md CHK015
+
+- [ ] 4.1.1 Enumerar empiricamente os valores de `reason=` produzidos por `_sb_cmd_resolve` (`state-backend.sh:234-269`), rodando `resolve` nos cenarios: nunca-configurado, `state_backend=json` explicito, `state_backend=sqlite` explicito, config ausente
+- [ ] 4.1.2 Documentar os valores encontrados (citando `arquivo:linha`) — nunca inventar valor nao observado empiricamente (Constitution VI)
+- [ ] 4.1.3 Definir a regra de aplicacao: `--yes` so aplica `enable-sqlite` quando `reason` indicar ausencia de configuracao; qualquer `reason` que indique escolha explicita => `already-configured` (preserva US2 AC3)
+- [ ] 4.1.4 Teste: `scenario_state_backend_deliberate_json_not_migrated` (quickstart Scenario 3) — `state_backend=json` mantido de proposito; `--yes` NAO migra
+
+### 4.2 Deteccao e rotulo de escopo global `[A]`
+
+Ref: spec.md FR-002, FR-017; contracts/cli-setup.md §3.1, §3.2, §3.4
+
+- [ ] 4.2.1 Chamar `config_state_backend_resolve` (`cli/lib/config.sh:94`) para obter `effective_backend=`/`reason=` (contrato de nao-falha, sempre exit 0)
+- [ ] 4.2.2 Chamar `config_state_backend_capability` para checar `sqlite3` ausente/abaixo de `3.45.1` — mapear para `status=unavailable` com motivo
+- [ ] 4.2.3 (FR-017) Antes de aplicar E em `--dry-run`, declarar explicitamente que a mudanca e escrita em `$HOME/.claude/cstk/config` e vale para TODOS os projetos da maquina — as outras 3 areas NAO carregam esse rotulo
+- [ ] 4.2.4 Teste: `scenario_state_backend_global_label_shown` (quickstart Scenario 16, parte FR-017) — rotulo global aparece so na area `state-backend`, inclusive em `--dry-run`; linha do summary repete a marca
+
+### 4.3 Aplicacao com opt-in equivalente (achado SEC-04) `[C]`
+
+Ref: spec.md FR-005; checklists/requirements.md CHK004; plan.md §Re-check de Constitution SEC-04
+
+- [ ] 4.3.1 Chamar `config_state_backend_enable_sqlite` (`cli/lib/config.sh:98`) somente quando 4.1.3 autorizar E (usuario aceita interativamente OU `--yes` com `reason` de ausencia de configuracao)
+- [ ] 4.3.2 (achado SEC-04) `--yes` NAO deve gravar a config global sem um sinal equivalente ao opt-in ja exigido para loose-usage — aplicar o mesmo padrao de "aviso explicito + default conservador quando ambiguo" antes de escrever fora do escopo do projeto
+- [ ] 4.3.3 Isolar falha de `enable-sqlite` (`sqlite3` ausente/abaixo do minimo, exit 3) como outcome `failed` da area, sem interromper as areas seguintes (FR-009)
+- [ ] 4.3.4 Teste: `scenario_state_backend_unavailable_sqlite_missing` (quickstart Scenario 7) — `sqlite3` ausente/abaixo de `3.45.1` => area `failed`; `mcp` e `telemetry` (areas seguintes na ordem fixa) continuam sendo percorridas e reportam outcome proprio
+
+### 4.4 Diagnostico complementar via `cstk doctor --deps` `[M]`
+
+Ref: contracts/cli-setup.md §3.4
+
+- [ ] 4.4.1 Reusar `_doctor_deps_run` (`cli/lib/doctor.sh:408-474`) como texto de diagnostico quando a area fica `unavailable`
+- [ ] 4.4.2 Teste: `scenario_state_backend_doctor_diagnostic_surfaced` — texto de `doctor --deps` (sqlite3/jq presente+versao) aparece no motivo exibido para `unavailable`
+
+---
+
+## FASE 5 - Area de MCP `[A]`
+
+### 5.1 Deteccao e apresentacao `[A]`
+
+Ref: spec.md FR-001, FR-002; contracts/cli-setup.md §4.1 (consome FASE 2.3)
+
+- [ ] 5.1.1 Chamar `_mcp_registration_status PROJECT_PATH` (implementada em 2.3) para obter `configured`/`divergent`/`not-configured`
+- [ ] 5.1.2 Exibir o status atual antes de oferecer a acao (FR-002)
+- [ ] 5.1.3 Teste: `scenario_mcp_status_displayed_before_action` — status impresso antes do prompt/aplicacao
+
+### 5.2 Aplicacao — `cstk mcp install`, inclusive sem Docker (FR-015) `[A]`
+
+Ref: spec.md FR-015; contracts/cli-setup.md §4.2, §4.3
+
+- [ ] 5.2.1 Nao chamar `mcp install` quando `status=configured` (idempotencia, invariante I1)
+- [ ] 5.2.2 Chamar `_mcp_cmd_install` (`cli/lib/mcp.sh:806-877`) quando `not-configured` e aceito/`--yes`
+- [ ] 5.2.3 (FR-015) Em `--yes`, aplicar `mcp install` MESMO sem Docker detectado — usar apenas `command -v docker` (nunca invocar `docker` funcionalmente, mesmo padrao de `cli/lib/mcp.sh:475-479`) para emitir aviso claro de Docker ausente
+- [ ] 5.2.4 Mapear `print_paste_block` (jq ausente, exit 0) para outcome com aviso de acao manual pendente, mesmo tratamento de 3.2.3
+- [ ] 5.2.5 Teste: `scenario_mcp_applied_without_docker_warns` (spec.md Clarifications, sessao 2026-08-07, item 3) — `--yes` sem Docker aplica `mcp install` e emite aviso claro
+
+### 5.3 Tratamento de `divergent` — remediacao `[C]`
+
+Ref: spec.md FR-016, SC-006; contracts/cli-setup.md §4.1 "Nao remedia sozinho"
+
+- [ ] 5.3.1 `status=divergent` => outcome `failed`, NUNCA `already-configured`
+- [ ] 5.3.2 Exibir remediacao de duas etapas (remover a entrada divergente, depois `cstk mcp install`)
+- [ ] 5.3.3 Garantir invariante I6: nenhuma chamada a `mcp install` quando `status=divergent`
+- [ ] 5.3.4 Teste: `scenario_mcp_divergent_no_install_call` (quickstart Scenario 14a) — assertar ausencia de chamada, `.mcp.json` inalterado, exit 1
+- [ ] 5.3.5 Teste: `scenario_mcp_cross_layer_not_divergent` (quickstart Scenario 14b) — validacao no nivel de orquestracao do wizard (reusa a deteccao de 2.3.9)
+
+---
+
+## FASE 6 - Area de Telemetria `[M]`
+
+### 6.1 Diagnostico read-only `[M]`
+
+Ref: spec.md FR-012; contracts/cli-setup.md §5
+
+- [ ] 6.1.1 Chamar `otel-usage.sh preflight` para diagnosticar o status de ativacao atual
+- [ ] 6.1.2 Exibir instrucoes/valores exatos (`CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_METRICS_EXPORTER=prometheus`, `CSTK_OTEL_ENDPOINT`, `OTEL_EXPORTER_PROMETHEUS_PORT`, endpoint padrao `127.0.0.1:9464`) — todos citados de `README.md`, nunca inventados
+- [ ] 6.1.3 Garantir que outcome `applied` e INALCANCAVEL para esta area — apenas `already-configured`/`skipped`/`failed`; NUNCA escrever em `~/.zshrc` nem em qualquer arquivo fora do diretorio do projeto (FR-012)
+- [ ] 6.1.4 Teste: `scenario_telemetry_readonly_no_home_write` — assinatura do `HOME` sandboxado inalterada apos rodar a area, em qualquer modo
+
+---
+
+## FASE 7 - Sumario Final e Documentacao `[A]`
+
+### 7.1 `SetupRunSummary` (FR-010) `[A]`
+
+Ref: spec.md FR-010; contracts/cli-setup.md §1 "Saida (stdout)"
+
+- [ ] 7.1.1 Implementar a impressao do summary final: uma linha por area (`<area> <outcome> [escopo] [motivo]`), na ordem fixa de FR-001
+- [ ] 7.1.2 `[escopo]` marca `global` apenas na linha de `state-backend` (FR-017); demais sem marca
+- [ ] 7.1.3 Diagnosticos/avisos em stderr; dados de saida (status, summary) em stdout (Constitution II)
+- [ ] 7.1.4 Teste: `scenario_summary_lists_all_four_areas` (quickstart Scenario 1, 7) — summary sempre lista as 4 areas, mesmo com falha parcial
+
+### 7.2 Declaracao de escopo da verificacao (achado SEC-07) `[A]`
+
+Ref: checklists/security.md CHK009; plan.md §Re-check de Constitution SEC-07
+
+- [ ] 7.2.1 O summary final DEVE declarar explicitamente que a verificacao de hooks cobre apenas os 3 hooks obrigatorios de `_GH_HOOKS`, sem inferir garantia sobre outras entradas do `settings.json`
+- [ ] 7.2.2 Teste: `scenario_summary_declares_verification_scope` — texto do summary cita o escopo real (3 hooks obrigatorios), sem implicar auditoria do `settings.json` inteiro
+
+### 7.3 Consolidacao documental de defaults (CHK005) `[M]`
+
+Ref: checklists/requirements.md CHK005
+
+- [ ] 7.3.1 Criar tabela unica "area -> default aplicado sob `--yes`" (hooks obrigatorios=aplicar; loose-usage=skip; state-backend=condicional a 4.1.3; mcp=aplicar mesmo sem Docker; telemetry=N/A, so diagnostico) em `data-model.md` ou `contracts/cli-setup.md`, substituindo a dispersao atual em 4 locais
+- [ ] 7.3.2 Validar a tabela consolidada com o gate `validate-documentation` (tarefa documental, sem teste automatizado de codigo aplicavel)
+
+---
+
+## FASE 8 - Testes de Integracao, Cobertura e Release
+
+### 8.1 Harness `tests/cstk/test_setup.sh` `[A]`
+
+Ref: plan.md Technical Context "Testing"; `tests/run.sh:10-13`; `tests/lib/harness.sh:245-251`
+
+- [ ] 8.1.1 Criar `tests/cstk/test_setup.sh` com `HOME` sandboxado (`env HOME="$TMPDIR_TEST/home"`, padrao `tests/cstk/test_mcp.sh:50,58`) e `CSTK_LIB="$REPO_ROOT/cli/lib"` (padrao `tests/cstk/test_hooks.sh:13-14`)
+- [ ] 8.1.2 Registrar `tests/cstk/test_setup.sh` no mapeamento de `tests/run.sh:10-13`
+- [ ] 8.1.3 Consolidar no arquivo todos os `scenario_*` ja definidos como subtarefas de teste nas FASES 1-7, com prompts interativos usando o bypass `CSTK_FORCE_INTERACTIVE=1` (`cli/lib/ui.sh:43`)
+
+### 8.2 Gotcha de dependencia ausente `[A]`
+
+Ref: plan.md Riscos item 5
+
+- [ ] 8.2.1 Desenhar os testes de "dependencia ausente" (sqlite3/docker/jq) desacoplando a deteccao do `PATH` interno em vez de tentar esconder o binario via stub de `PATH` (gotcha conhecido do projeto: stub de `PATH` nao esconde binario de `/usr/bin`)
+- [ ] 8.2.2 Onde nao for possivel desacoplar, documentar explicitamente o cenario como "nao-coberto" com a nota do motivo, em vez de produzir um teste falso-positivo
+
+### 8.3 Cobertura, extensoes de suites existentes e sincronizacao de release `[A]`
+
+Ref: quickstart.md Scenario 11, Scenario 12; CLAUDE.md "Installed vs Source Drift"
+
+- [ ] 8.3.1 Rodar `./tests/run.sh --check-coverage` — `cli/lib/setup.sh` deve ter `tests/cstk/test_setup.sh` correspondente (quickstart Scenario 12)
+- [ ] 8.3.2 Estender `tests/cstk/test_hooks.sh` para cobrir `--include-loose-usage` e `--verify-registration` (incluindo retro-compatibilidade sem flag — 2.2.10)
+- [ ] 8.3.3 Estender `tests/cstk/test_mcp.sh` para cobrir `_mcp_registration_status` (cenarios 2.3.7-2.3.10)
+- [ ] 8.3.4 Rodar gate `validate-tasks-template.sh` sobre este `tasks.md` e gate `validate-docs-rendered` sobre os artefatos da feature
+- [ ] 8.3.5 Verificacao manual de sincronizacao das duas metades (quickstart Scenario 11): `./scripts/build-release.sh X.Y.Z-dev`, depois **ambos** `cstk self-update --from ...` (runtime/binario) e `cstk install --from ...` (catalogo), confirmando `cstk doctor` com drift zero
+
+---
+
+## Matriz de Dependencias
+
+```mermaid
+flowchart TD
+    F1[Fase 1 - Fundacao]
+    F2[Fase 2 - Extensoes de Contrato Aditivas]
+    F3[Fase 3 - Area de Hooks]
+    F4[Fase 4 - Area de State Backend]
+    F5[Fase 5 - Area de MCP]
+    F6[Fase 6 - Area de Telemetria]
+    F7[Fase 7 - Sumario Final e Documentacao]
+    F8[Fase 8 - Testes, Cobertura e Release]
+
+    F1 --> F2
+    F1 --> F4
+    F1 --> F6
+    F2 --> F3
+    F2 --> F5
+    F3 --> F7
+    F4 --> F7
+    F5 --> F7
+    F6 --> F7
+    F7 --> F8
+```
+
+> Nota: a ordem de CONSTRUCAO acima (foundation -> extensoes de seguranca ->
+> areas -> sumario -> testes) e independente da ordem fixa de APRESENTACAO
+> em runtime exigida por FR-001 (hooks, state-backend, mcp, telemetry),
+> que e responsabilidade de `setup_main` (FASE 1.2/7.1) e nao do backlog
+> de implementacao.
+
+## Resumo Quantitativo
+
+| Fase | Tarefas | Subtarefas | Criticidade |
+|------|---------|------------|-------------|
+| 1 - Fundacao e Orquestracao | 3 | 17 | A |
+| 2 - Extensoes de Contrato Aditivas | 3 | 25 | C/M |
+| 3 - Area de Hooks | 4 | 19 | A/C |
+| 4 - Area de State Backend | 4 | 14 | A/C/M |
+| 5 - Area de MCP | 3 | 13 | A/C |
+| 6 - Area de Telemetria | 1 | 4 | M |
+| 7 - Sumario Final e Documentacao | 3 | 8 | A/M |
+| 8 - Testes, Cobertura e Release | 3 | 10 | A |
+| **Total** | **24** | **110** | - |
+
+## Escopo Coberto
+
+| Item | Descricao | Fase |
+|------|-----------|------|
+| FR-001..FR-018 | As 18 Functional Requirements de `spec.md` (4 areas em ordem fixa, modos preview/non-interactive/interactive, autenticidade de registro FR-016, rotulo de escopo global FR-017, ausencia de override de catalogo FR-018) | FASE 1-7 |
+| SC-001..SC-006 | Os 6 Success Criteria mensuraveis de `spec.md` | Verificados pelos testes de FASE 8 |
+| SEC-04 | `--yes` nao grava config global sem opt-in equivalente | FASE 4.3 |
+| SEC-05 | Restricao de sufixo + existencia em disco dos paths candidatos MCP | FASE 2.3.5 |
+| SEC-06 | Stdout vazio de `_mcp_registration_status` tratado como indeterminado | FASE 2.3.6 |
+| SEC-07 | Declaracao de escopo real da verificacao no summary | FASE 7.2 |
+| CHK004 (requirements.md) | SEC-04..SEC-07 com destino explicito em tarefas | FASE 2.3, 4.3, 7.2 |
+| CHK005 (requirements.md) | Consolidacao documental de defaults de `--yes` | FASE 7.3 |
+| CHK015 (requirements.md) | Investigacao empirica de `reason=` antes de codificar default de state-backend | FASE 4.1 |
+| Scenarios 1-18 (quickstart.md) | Cenarios end-to-end de validacao | Referenciados como subtarefas de teste nas FASES 1-7, consolidados em FASE 8.1 |
+| Contratos §1-§5 (cli-setup.md) | As 5 fronteiras processo-a-processo | FASE 1 (§1), FASE 3 (§2), FASE 4 (§3), FASE 5 (§4), FASE 6 (§5) |
+
+## Escopo Excluido
+
+| Item | Descricao | Motivo |
+|------|-----------|--------|
+| SEC-01/SEC-02/SEC-03 | Achados de seguranca que alteravam contrato/data-model | Ja corrigidos em `contracts/cli-setup.md`/`data-model.md` na mesma onda do `plan.md`, antes do `create-tasks` — nao repetidos como tarefa |
+| CHK018, CHK019 (requirements.md) | Apetite de risco SEC-04..SEC-07 vs US1-US4; residual aceito de SEC-01 | Marcados `{humano}` — aguardam decisao explicita do dono do produto, fora do backlog automatico |
+| CHK016 (security.md) | Escopo de auditoria: varrer OUTRAS entradas de `settings.json`/`.mcp.json` alem dos 3 hooks obrigatorios | Marcado `{humano}` — decisao de escopo pendente; a FASE 7.2 so implementa a declaracao honesta do escopo atual (3 hooks), nao uma varredura mais ampla |
+| Parse estrutural (`jq`) para `--verify-registration` | Confirmar que a linha `"command"` esta de fato sob `PreToolUse`/`matcher` (nao so co-ocorrencia textual) | Residual aceito e declarado em `contracts/cli-setup.md` §2.3; promover a comportamento default seria BREAKING (bump MAJOR), registrado como candidato para proxima major, fora desta feature |
+| Persistencia de "setup ja rodou" | Qualquer flag/arquivo marcando execucao anterior | FR-013 proibe explicitamente — idempotencia e por re-checagem viva, nunca por estado persistido |
+| `--catalog` / override de origem do catalogo | Flag ou variavel que redirecione de onde os scripts provisionados/comparados sao lidos | FR-018 proibe expor esse knob no `cstk setup`; os dois knobs existentes (`--catalog` de `hooks install`, `CSTK_HOOKS_CATALOG_DIR`) permanecem fora da superficie do wizard |

--- a/docs/specs/cstk-setup/tasks.md
+++ b/docs/specs/cstk-setup/tasks.md
@@ -151,35 +151,35 @@ Ref: spec.md FR-016, SC-006; contracts/cli-setup.md §2.3 "Nao remedia sozinho";
 
 Ref: quickstart.md Scenario 3; research.md Decision 10; plan.md Riscos item 1; checklists/requirements.md CHK015
 
-- [ ] 4.1.1 Enumerar empiricamente os valores de `reason=` produzidos por `_sb_cmd_resolve` (`state-backend.sh:234-269`), rodando `resolve` nos cenarios: nunca-configurado, `state_backend=json` explicito, `state_backend=sqlite` explicito, config ausente
-- [ ] 4.1.2 Documentar os valores encontrados (citando `arquivo:linha`) — nunca inventar valor nao observado empiricamente (Constitution VI)
-- [ ] 4.1.3 Definir a regra de aplicacao: `--yes` so aplica `enable-sqlite` quando `reason` indicar ausencia de configuracao; qualquer `reason` que indique escolha explicita => `already-configured` (preserva US2 AC3)
-- [ ] 4.1.4 Teste: `scenario_state_backend_deliberate_json_not_migrated` (quickstart Scenario 3) — `state_backend=json` mantido de proposito; `--yes` NAO migra
+- [x] 4.1.1 Enumerar empiricamente os valores de `reason=` produzidos por `_sb_cmd_resolve` (`state-backend.sh:234-269`), rodando `resolve` nos cenarios: nunca-configurado, `state_backend=json` explicito, `state_backend=sqlite` explicito, config ausente
+- [x] 4.1.2 Documentar os valores encontrados (citando `arquivo:linha`) — nunca inventar valor nao observado empiricamente (Constitution VI)
+- [x] 4.1.3 Definir a regra de aplicacao: `--yes` so aplica `enable-sqlite` quando `reason` indicar ausencia de configuracao; qualquer `reason` que indique escolha explicita => `already-configured` (preserva US2 AC3)
+- [x] 4.1.4 Teste: `scenario_state_backend_deliberate_json_not_migrated` (quickstart Scenario 3) — `state_backend=json` mantido de proposito; `--yes` NAO migra
 
 ### 4.2 Deteccao e rotulo de escopo global `[A]`
 
 Ref: spec.md FR-002, FR-017; contracts/cli-setup.md §3.1, §3.2, §3.4
 
-- [ ] 4.2.1 Chamar `config_state_backend_resolve` (`cli/lib/config.sh:94`) para obter `effective_backend=`/`reason=` (contrato de nao-falha, sempre exit 0)
-- [ ] 4.2.2 Chamar `config_state_backend_capability` para checar `sqlite3` ausente/abaixo de `3.45.1` — mapear para `status=unavailable` com motivo
-- [ ] 4.2.3 (FR-017) Antes de aplicar E em `--dry-run`, declarar explicitamente que a mudanca e escrita em `$HOME/.claude/cstk/config` e vale para TODOS os projetos da maquina — as outras 3 areas NAO carregam esse rotulo
-- [ ] 4.2.4 Teste: `scenario_state_backend_global_label_shown` (quickstart Scenario 16, parte FR-017) — rotulo global aparece so na area `state-backend`, inclusive em `--dry-run`; linha do summary repete a marca
+- [x] 4.2.1 Chamar `config_state_backend_resolve` (`cli/lib/config.sh:94`) para obter `effective_backend=`/`reason=` (contrato de nao-falha, sempre exit 0)
+- [x] 4.2.2 ~~Chamar `config_state_backend_capability`~~ — achado empirico (4.1): `capability` imprime so um token fixo de versao de runtime (`_SB_CAPABILITY_TOKEN="1"`, state-backend.sh:72), usado internamente por `enable-sqlite`/P8; NAO checa sqlite3. O sinal de `sqlite3` ausente/abaixo do minimo ja vem embutido no `reason=` de `resolve` (`configurado-dependencia-ausente`/`configurado-dependencia-abaixo-do-minimo`, produzido quando o backend foi declarado `sqlite`) — mapeado para `status=unavailable` em `_setup_state_backend_status_from_reason` (cli/lib/setup.sh) sem nenhuma chamada adicional. Ver comentario de cabecalho da area em `cli/lib/setup.sh` para o mapeamento completo reason->status.
+- [x] 4.2.3 (FR-017) Antes de aplicar E em `--dry-run`, declarar explicitamente que a mudanca e escrita em `$HOME/.claude/cstk/config` e vale para TODOS os projetos da maquina — as outras 3 areas NAO carregam esse rotulo
+- [x] 4.2.4 Teste: `scenario_state_backend_global_label_shown` (quickstart Scenario 16, parte FR-017) — rotulo global aparece so na area `state-backend`, inclusive em `--dry-run`; linha do summary repete a marca (repeticao no summary consolidado fica para a FASE 7, quando o `SetupRunSummary` for implementado — nao existe ainda)
 
 ### 4.3 Aplicacao com opt-in equivalente (achado SEC-04) `[C]`
 
 Ref: spec.md FR-005; checklists/requirements.md CHK004; plan.md §Re-check de Constitution SEC-04
 
-- [ ] 4.3.1 Chamar `config_state_backend_enable_sqlite` (`cli/lib/config.sh:98`) somente quando 4.1.3 autorizar E (usuario aceita interativamente OU `--yes` com `reason` de ausencia de configuracao)
-- [ ] 4.3.2 (achado SEC-04) `--yes` NAO deve gravar a config global sem um sinal equivalente ao opt-in ja exigido para loose-usage — aplicar o mesmo padrao de "aviso explicito + default conservador quando ambiguo" antes de escrever fora do escopo do projeto
-- [ ] 4.3.3 Isolar falha de `enable-sqlite` (`sqlite3` ausente/abaixo do minimo, exit 3) como outcome `failed` da area, sem interromper as areas seguintes (FR-009)
-- [ ] 4.3.4 Teste: `scenario_state_backend_unavailable_sqlite_missing` (quickstart Scenario 7) — `sqlite3` ausente/abaixo de `3.45.1` => area `failed`; `mcp` e `telemetry` (areas seguintes na ordem fixa) continuam sendo percorridas e reportam outcome proprio
+- [x] 4.3.1 Chamar `config_state_backend_enable_sqlite` (`cli/lib/config.sh:98`) somente quando 4.1.3 autorizar E (usuario aceita interativamente OU `--yes` com `reason` de ausencia de configuracao)
+- [x] 4.3.2 (achado SEC-04) `--yes` NAO deve gravar a config global sem um sinal equivalente ao opt-in ja exigido para loose-usage — aplicar o mesmo padrao de "aviso explicito + default conservador quando ambiguo" antes de escrever fora do escopo do projeto. Implementado como: o aviso FR-017 (4.2.3) e SEMPRE exibido antes de decidir, em qualquer modo; e o "default conservador" e `--yes` so aplicar quando `reason` prova que NENHUMA escolha foi feita (`nunca-configurado`/`config-invalida`) — nunca migra `json-explicito` (US2 AC3) nem re-tenta uma dependencia ja conhecida como quebrada (`unavailable`, tratado sem chamada).
+- [x] 4.3.3 Isolar falha de `enable-sqlite` (`sqlite3` ausente/abaixo do minimo, exit 3) como outcome `failed` da area, sem interromper as areas seguintes (FR-009)
+- [x] 4.3.4 Teste: `scenario_state_backend_unavailable_sqlite_missing` (quickstart Scenario 7) — `sqlite3` ausente/abaixo de `3.45.1` => area `failed`; `mcp` e `telemetry` (areas seguintes na ordem fixa) continuam sendo percorridas e reportam outcome proprio (verificado ate onde essas areas existem nesta versao — `mcp`/`telemetry` ainda sao FASES futuras; o teste confirma que o wizard prossegue apos a falha isolada, exibindo a linha de areas restantes)
 
 ### 4.4 Diagnostico complementar via `cstk doctor --deps` `[M]`
 
 Ref: contracts/cli-setup.md §3.4
 
-- [ ] 4.4.1 Reusar `_doctor_deps_run` (`cli/lib/doctor.sh:408-474`) como texto de diagnostico quando a area fica `unavailable`
-- [ ] 4.4.2 Teste: `scenario_state_backend_doctor_diagnostic_surfaced` — texto de `doctor --deps` (sqlite3/jq presente+versao) aparece no motivo exibido para `unavailable`
+- [x] 4.4.1 Reusar `_doctor_deps_run` (`cli/lib/doctor.sh:408-474`) como texto de diagnostico quando a area fica `unavailable`
+- [x] 4.4.2 Teste: `scenario_state_backend_doctor_diagnostic_surfaced` — texto de `doctor --deps` (sqlite3/jq presente+versao) aparece no motivo exibido para `unavailable`
 
 ---
 

--- a/docs/specs/cstk-setup/tasks.md
+++ b/docs/specs/cstk-setup/tasks.md
@@ -108,40 +108,40 @@ Ref: spec.md FR-016; contracts/cli-setup.md §4.1; checklists/security.md CHK012
 
 Ref: spec.md FR-001, FR-002, FR-009; plan.md nota "Invocacao das extensoes (1) e (2) e sempre SEPARADA da baseline" (achado SEC-03); data-model.md "Fonte de status por area"
 
-- [ ] 3.1.1 Chamar `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet` (baseline, sem flags) como fonte do veredito dos 3 hooks obrigatorios
-- [ ] 3.1.2 Chamar `--verify-registration` ISOLADAMENTE; mapear exit 2 => `mandatory_status`/`status` = `unavailable` (via I5); NUNCA combinar com a baseline na mesma invocacao
-- [ ] 3.1.3 Chamar `--include-loose-usage` ISOLADAMENTE; alimenta apenas `loose_usage_status`, nunca o exit/status principal
-- [ ] 3.1.4 Exibir o status atual (`configured`/`not-configured`/`divergent`/`unavailable`) ANTES de oferecer a acao (FR-002)
-- [ ] 3.1.5 Teste: `scenario_hooks_three_calls_isolated` (quickstart Scenario 18) — assertar via stub/contador que as 3 chamadas ocorrem separadamente e que a falha de uma nao mascara o veredito das outras
+- [x] 3.1.1 Chamar `guard-hooks-status.sh check --projeto-alvo-path PATH --quiet` (baseline, sem flags) como fonte do veredito dos 3 hooks obrigatorios
+- [x] 3.1.2 Chamar `--verify-registration` ISOLADAMENTE; mapear exit 2 => `mandatory_status`/`status` = `unavailable` (via I5); NUNCA combinar com a baseline na mesma invocacao
+- [x] 3.1.3 Chamar `--include-loose-usage` ISOLADAMENTE; alimenta apenas `loose_usage_status`, nunca o exit/status principal
+- [x] 3.1.4 Exibir o status atual (`configured`/`not-configured`/`divergent`/`unavailable`) ANTES de oferecer a acao (FR-002)
+- [x] 3.1.5 Teste: `scenario_hooks_three_calls_isolated` (quickstart Scenario 18) — assertar via stub/contador que as 3 chamadas ocorrem separadamente e que a falha de uma nao mascara o veredito das outras
 
 ### 3.2 Aplicacao e mapeamento de outcome `[A]`
 
 Ref: spec.md FR-003, FR-009; contracts/cli-setup.md §2.4; plan.md Risco 3
 
-- [ ] 3.2.1 Nao chamar `hooks install` quando `status=configured` (invariante I1 — idempotencia via zero chamada)
-- [ ] 3.2.2 Chamar `hooks_main install --project-path PATH` quando nao configurado e usuario aceita (ou `--yes`)
-- [ ] 3.2.3 Mapear os estados internos de `apply_guard_hooks` (`merged`/`paste-instructed`/`hooks-only`/`not-applicable`/`error`) para outcome do wizard — `paste-instructed` (jq ausente) NAO pode virar `applied` silencioso; deve carregar aviso de acao manual pendente ao summary
-- [ ] 3.2.4 Teste: `scenario_hooks_second_run_zero_calls` (quickstart Scenario 2) — segundo run com `status=configured` nao chama `hooks install` nenhuma vez
-- [ ] 3.2.5 Teste: `scenario_hooks_paste_instructed_surfaces_warning` (quickstart Scenario 7, sub-caso jq ausente) — exit 0 de `hooks install` em `paste-instructed` nao vira `applied` cego no summary
+- [x] 3.2.1 Nao chamar `hooks install` quando `status=configured` (invariante I1 — idempotencia via zero chamada)
+- [x] 3.2.2 Chamar `hooks_main install --project-path PATH` quando nao configurado e usuario aceita (ou `--yes`)
+- [x] 3.2.3 Mapear os estados internos de `apply_guard_hooks` (`merged`/`paste-instructed`/`hooks-only`/`not-applicable`/`error`) para outcome do wizard — `paste-instructed` (jq ausente) NAO pode virar `applied` silencioso; deve carregar aviso de acao manual pendente ao summary
+- [x] 3.2.4 Teste: `scenario_hooks_second_run_zero_calls` (quickstart Scenario 2) — segundo run com `status=configured` nao chama `hooks install` nenhuma vez
+- [x] 3.2.5 Teste: `scenario_hooks_paste_instructed_surfaces_warning` (quickstart Scenario 7, sub-caso jq ausente) — exit 0 de `hooks install` em `paste-instructed` nao vira `applied` cego no summary
 
 ### 3.3 Escolha distinta de loose usage `[A]`
 
 Ref: spec.md FR-008, US4; quickstart.md Scenario 9
 
-- [ ] 3.3.1 Apresentar a pergunta de loose usage capture SEPARADA da pergunta de hooks obrigatorios, com explicacao do que a captura registra
-- [ ] 3.3.2 Default em `--yes` para a sub-area de loose usage = `skip` (unica area cujo default recomendado e "nao", `data-model.md` `loose_usage_choice`)
-- [ ] 3.3.3 Recusar loose usage NAO impede a aplicacao dos hooks obrigatorios
-- [ ] 3.3.4 Teste: `scenario_loose_usage_declined_mandatory_still_applied` (quickstart Scenario 9) — negar loose usage; hooks obrigatorios instalados (`guard-hooks-status.sh check` sai exit 0); `posttooluse-loose-usage.sh` nao provisionado nem registrado
+- [x] 3.3.1 Apresentar a pergunta de loose usage capture SEPARADA da pergunta de hooks obrigatorios, com explicacao do que a captura registra
+- [x] 3.3.2 Default em `--yes` para a sub-area de loose usage = `skip` (unica area cujo default recomendado e "nao", `data-model.md` `loose_usage_choice`)
+- [x] 3.3.3 Recusar loose usage NAO impede a aplicacao dos hooks obrigatorios
+- [x] 3.3.4 Teste: `scenario_loose_usage_declined_mandatory_still_applied` (quickstart Scenario 9) — negar loose usage; hooks obrigatorios instalados (`guard-hooks-status.sh check` sai exit 0); `posttooluse-loose-usage.sh` nao provisionado nem registrado
 
 ### 3.4 Tratamento de `divergent`/`unavailable` — falha fechada e remediacao `[C]`
 
 Ref: spec.md FR-016, SC-006; contracts/cli-setup.md §2.3 "Nao remedia sozinho"; data-model.md invariantes I5/I6
 
-- [ ] 3.4.1 `status=divergent` OU `status=unavailable` => outcome `failed`, NUNCA `already-configured`/`configured`
-- [ ] 3.4.2 Exibir remediacao de duas etapas (remover a entrada divergente, so entao rodar `cstk hooks install`) — nunca instrucao de uma etapa so, comprovadamente inefetiva contra o merge "target vence"
-- [ ] 3.4.3 Garantir invariante I6: nenhuma chamada a `hooks install` quando `status` in {divergent, unavailable}
-- [ ] 3.4.4 Teste: `scenario_hooks_divergent_no_install_call` (quickstart Scenario 13) — assertar ausencia de chamada a `hooks install` via stub/contador, `.claude/settings.json` inalterado, exit 1
-- [ ] 3.4.5 Teste: `scenario_hooks_unavailable_status_reason` (quickstart Scenario 15) — `unavailable` reporta motivo distinguindo "nao consegui verificar" de "esta errado", exit 1
+- [x] 3.4.1 `status=divergent` OU `status=unavailable` => outcome `failed`, NUNCA `already-configured`/`configured`
+- [x] 3.4.2 Exibir remediacao de duas etapas (remover a entrada divergente, so entao rodar `cstk hooks install`) — nunca instrucao de uma etapa so, comprovadamente inefetiva contra o merge "target vence"
+- [x] 3.4.3 Garantir invariante I6: nenhuma chamada a `hooks install` quando `status` in {divergent, unavailable}
+- [x] 3.4.4 Teste: `scenario_hooks_divergent_no_install_call` (quickstart Scenario 13) — assertar ausencia de chamada a `hooks install` via stub/contador, `.claude/settings.json` inalterado, exit 1
+- [x] 3.4.5 Teste: `scenario_hooks_unavailable_status_reason` (quickstart Scenario 15) — `unavailable` reporta motivo distinguindo "nao consegui verificar" de "esta errado", exit 1
 
 ---
 

--- a/docs/specs/cstk-setup/tasks.md
+++ b/docs/specs/cstk-setup/tasks.md
@@ -64,41 +64,41 @@ Ref: spec.md FR-004, FR-005, FR-006, FR-018; contracts/cli-setup.md §1 "Precede
 
 Ref: spec.md FR-002, FR-008; contracts/cli-setup.md §2.2; research.md Decision 3
 
-- [ ] 2.1.1 Adicionar flag `--include-loose-usage` a `guard-hooks-status.sh check`, acrescentando uma 4a linha TSV para `posttooluse-loose-usage.sh` (mesmo formato de 4 campos)
-- [ ] 2.1.2 Garantir retro-compatibilidade: sem a flag, saida byte-a-byte identica a atual; exit code inalterado (derivado apenas dos 3 hooks de `_GH_HOOKS`)
-- [ ] 2.1.3 Documentar que o consumidor (`setup.sh`) deve tratar exit 2 (`_gh_die_usage`, flag desconhecida em runtime antigo) como `loose_usage_status=indeterminate`, nunca como falha da area de hooks
-- [ ] 2.1.4 Teste: `scenario_loose_usage_detection_current_runtime` — flag presente, hook opt-in ausente => 4a linha reflete ausencia sem afetar exit
-- [ ] 2.1.5 Teste: `scenario_loose_usage_detection_stale_runtime` (quickstart Scenario 10) — runtime antigo rejeita a flag com exit 2; consumo trata como `indeterminate`, hooks obrigatorios seguem detectados/aplicados normalmente
+- [x] 2.1.1 Adicionar flag `--include-loose-usage` a `guard-hooks-status.sh check`, acrescentando uma 4a linha TSV para `posttooluse-loose-usage.sh` (mesmo formato de 4 campos)
+- [x] 2.1.2 Garantir retro-compatibilidade: sem a flag, saida byte-a-byte identica a atual; exit code inalterado (derivado apenas dos 3 hooks de `_GH_HOOKS`)
+- [x] 2.1.3 Documentar que o consumidor (`setup.sh`) deve tratar exit 2 (`_gh_die_usage`, flag desconhecida em runtime antigo) como `loose_usage_status=indeterminate`, nunca como falha da area de hooks
+- [x] 2.1.4 Teste: `scenario_loose_usage_detection_current_runtime` — flag presente, hook opt-in ausente => 4a linha reflete ausencia sem afetar exit
+- [x] 2.1.5 Teste: `scenario_loose_usage_detection_stale_runtime` (quickstart Scenario 10) — runtime antigo rejeita a flag com exit 2; consumo trata como `indeterminate`, hooks obrigatorios seguem detectados/aplicados normalmente
 
 ### 2.2 `guard-hooks-status.sh --verify-registration` `[C]`
 
 Ref: spec.md FR-016 (SEC-01/SEC-02/SEC-03 ja corrigidos no contrato/data-model); contracts/cli-setup.md §2.3; data-model.md invariante I5
 
-- [ ] 2.2.1 Adicionar flag `--verify-registration`, acrescentando 5a coluna TSV (`canonical`/`divergent`/`indeterminate`) por hook
-- [ ] 2.2.2 Implementar regra de decisao: toda linha do `settings.json` que contenha o basename MUST tambem conter o fragmento canonico **e** o token literal `"command"` na MESMA linha — senao `divergent` (fecha o caso de linha-isca decorativa, achado SEC-01)
-- [ ] 2.2.3 Com a flag, `divergent` em qualquer hook de `_GH_HOOKS` muda o exit para `1`; sem a flag, saida e exit permanecem identicos aos atuais
-- [ ] 2.2.4 Documentar que o consumidor deve tratar exit 2 (flag desconhecida em runtime antigo) como `indeterminate` — nunca `divergent`, nunca `configured` (I5)
-- [ ] 2.2.5 Teste: `scenario_verify_registration_canonical` — registro correto => `canonical`, area reporta `configured`
-- [ ] 2.2.6 Teste: `scenario_hook_redirected_reports_divergent` (quickstart Scenario 13) — `"command"` real aponta para outro programa mantendo o basename na linha => `divergent`, exit 1 com a flag
-- [ ] 2.2.7 Teste: `scenario_decoy_line_not_canonical` (quickstart Scenario 17, achado SEC-01) — linha decorativa com basename+fragmento canonico mas sem o token `"command"` na mesma linha NAO conta como `canonical`; `"command"` real divergente => `divergent`
-- [ ] 2.2.8 Teste: `scenario_minified_settings_indeterminate` (quickstart Scenario 15) — `settings.json` minificado numa unica linha => `indeterminate` (nunca `canonical`)
-- [ ] 2.2.9 Teste: `scenario_verify_registration_isolated_from_baseline` (quickstart Scenario 18, achado SEC-03) — chamada baseline roda SEPARADA e retorna exit 0 mesmo quando `--verify-registration` falha com exit 2 em runtime antigo; assertar via stub/contador que as duas chamadas de fato ocorreram
-- [ ] 2.2.10 Teste de retro-compatibilidade: `tests/test_guard-hooks-status.sh` existente permanece verde sem alteracao de comportamento quando a flag nao e passada
+- [x] 2.2.1 Adicionar flag `--verify-registration`, acrescentando 5a coluna TSV (`canonical`/`divergent`/`indeterminate`) por hook
+- [x] 2.2.2 Implementar regra de decisao: toda linha do `settings.json` que contenha o basename MUST tambem conter o fragmento canonico **e** o token literal `"command"` na MESMA linha — senao `divergent` (fecha o caso de linha-isca decorativa, achado SEC-01)
+- [x] 2.2.3 Com a flag, `divergent` em qualquer hook de `_GH_HOOKS` muda o exit para `1`; sem a flag, saida e exit permanecem identicos aos atuais
+- [x] 2.2.4 Documentar que o consumidor deve tratar exit 2 (flag desconhecida em runtime antigo) como `indeterminate` — nunca `divergent`, nunca `configured` (I5)
+- [x] 2.2.5 Teste: `scenario_verify_registration_canonical` — registro correto => `canonical`, area reporta `configured`
+- [x] 2.2.6 Teste: `scenario_hook_redirected_reports_divergent` (quickstart Scenario 13) — `"command"` real aponta para outro programa mantendo o basename na linha => `divergent`, exit 1 com a flag
+- [x] 2.2.7 Teste: `scenario_decoy_line_not_canonical` (quickstart Scenario 17, achado SEC-01) — linha decorativa com basename+fragmento canonico mas sem o token `"command"` na mesma linha NAO conta como `canonical`; `"command"` real divergente => `divergent`
+- [x] 2.2.8 Teste: `scenario_minified_settings_indeterminate` (quickstart Scenario 15) — `settings.json` minificado numa unica linha => `indeterminate` (nunca `canonical`)
+- [x] 2.2.9 Teste: `scenario_verify_registration_isolated_from_baseline` (quickstart Scenario 18, achado SEC-03) — chamada baseline roda SEPARADA e retorna exit 0 mesmo quando `--verify-registration` falha com exit 2 em runtime antigo; assertar via stub/contador que as duas chamadas de fato ocorreram
+- [x] 2.2.10 Teste de retro-compatibilidade: `tests/test_guard-hooks-status.sh` existente permanece verde sem alteracao de comportamento quando a flag nao e passada
 
 ### 2.3 `_mcp_registration_status` em `cli/lib/mcp.sh` `[C]`
 
 Ref: spec.md FR-016; contracts/cli-setup.md §4.1; checklists/security.md CHK012 (SEC-05), CHK013 (SEC-06); plan.md Risco 7
 
-- [ ] 2.3.1 Implementar `_mcp_registration_status PROJECT_PATH` — leitura textual sem `jq`, stdout `configured`/`divergent`/`not-configured`, exit sempre 0 (contrato de nao-falha, paridade com `state-backend.sh resolve`)
-- [ ] 2.3.2 Regra: `.mcp.json` ausente ou sem mencao a `cstk-state` => `not-configured`
-- [ ] 2.3.3 Regra: `cstk-state` presente e `command` e um dos 3 paths candidatos de `_mcp_runtime_script_path` (PATH / repo / catalogo instalado, `cli/lib/mcp.sh:127-146`) => `configured`
-- [ ] 2.3.4 Regra: `cstk-state` presente e `command` aponta para outro lugar OU nao e atribuivel => `divergent`
-- [ ] 2.3.5 (achado SEC-05 / CHK012) Restringir os paths candidatos aceitos ao sufixo esperado `/skills/agente-00c-runtime/scripts/mcp-launch.sh` **e** que exista de fato em disco no momento da verificacao — nao aceitar qualquer resultado de `command -v mcp-launch.sh` sem essa restricao
-- [ ] 2.3.6 (achado SEC-06 / CHK013) Tratar stdout vazio de `_mcp_registration_status` (nenhuma das 3 palavras esperadas) como indeterminado — nunca como uma das 3 respostas validas por omissao; nunca resolve para `configured`
-- [ ] 2.3.7 Teste: `scenario_mcp_not_configured` (quickstart Scenario 14c) — chave ausente => `not-configured`
-- [ ] 2.3.8 Teste: `scenario_mcp_divergent_foreign_script` (quickstart Scenario 14a) — `command` fora do catalogo => `divergent`
-- [ ] 2.3.9 Teste: `scenario_mcp_configured_cross_layer` (quickstart Scenario 14b) — `.mcp.json` gerado a partir do repo, verificado a partir do catalogo instalado => `configured`, nao `divergent` (evita falso-positivo entre camadas)
-- [ ] 2.3.10 Teste: `scenario_mcp_registration_status_empty_stdout` (SEC-06) — simular resposta vazia e confirmar tratamento como indeterminado, nunca `configured`
+- [x] 2.3.1 Implementar `_mcp_registration_status PROJECT_PATH` — leitura textual sem `jq`, stdout `configured`/`divergent`/`not-configured`, exit sempre 0 (contrato de nao-falha, paridade com `state-backend.sh resolve`)
+- [x] 2.3.2 Regra: `.mcp.json` ausente ou sem mencao a `cstk-state` => `not-configured`
+- [x] 2.3.3 Regra: `cstk-state` presente e `command` e um dos 3 paths candidatos de `_mcp_runtime_script_path` (PATH / repo / catalogo instalado, `cli/lib/mcp.sh:127-146`) => `configured`
+- [x] 2.3.4 Regra: `cstk-state` presente e `command` aponta para outro lugar OU nao e atribuivel => `divergent`
+- [x] 2.3.5 (achado SEC-05 / CHK012) Restringir os paths candidatos aceitos ao sufixo esperado `/skills/agente-00c-runtime/scripts/mcp-launch.sh` **e** que exista de fato em disco no momento da verificacao — nao aceitar qualquer resultado de `command -v mcp-launch.sh` sem essa restricao
+- [x] 2.3.6 (achado SEC-06 / CHK013) Tratar stdout vazio de `_mcp_registration_status` (nenhuma das 3 palavras esperadas) como indeterminado — nunca como uma das 3 respostas validas por omissao; nunca resolve para `configured`
+- [x] 2.3.7 Teste: `scenario_mcp_not_configured` (quickstart Scenario 14c) — chave ausente => `not-configured`
+- [x] 2.3.8 Teste: `scenario_mcp_divergent_foreign_script` (quickstart Scenario 14a) — `command` fora do catalogo => `divergent`
+- [x] 2.3.9 Teste: `scenario_mcp_configured_cross_layer` (quickstart Scenario 14b) — `.mcp.json` gerado a partir do repo, verificado a partir do catalogo instalado => `configured`, nao `divergent` (evita falso-positivo entre camadas)
+- [x] 2.3.10 Teste: `scenario_mcp_registration_status_empty_stdout` (SEC-06) — simular resposta vazia e confirmar tratamento como indeterminado, nunca `configured`
 
 ---
 

--- a/global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
+++ b/global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
@@ -47,16 +47,43 @@
 #
 # Subcomandos:
 #   guard-hooks-status.sh check --projeto-alvo-path PATH [--quiet]
-#       — stdout: uma linha TSV por hook:
-#             <arquivo>\t<present|missing>\t<registered|unregistered>\t<current|stale|unknown>
+#       [--include-loose-usage] [--verify-registration]
+#       — stdout: uma linha TSV por hook (4 colunas; 5 com
+#         --verify-registration):
+#             <arquivo>\t<present|missing>\t<registered|unregistered>\t<current|stale|unknown>[\t<canonical|divergent|indeterminate>]
 #         "registered" = o basename aparece em <PAP>/.claude/settings.json
 #         (o hook so roda de fato se estiver copiado E registrado).
 #         "current"/"stale" = comparacao byte-a-byte (cmp) da copia do
 #         projeto com a do catalogo; "unknown" = hook ausente ou catalogo
 #         irresolvivel (nao e veredito, nao reprova).
 #       — stderr: diagnostico + comando de remediacao (suprimido por --quiet).
-#       — exit 0 se os 3 estao present+registered+(current|unknown);
-#         1 caso contrario (inclui stale).
+#       — exit 0 se os 3 estao present+registered+(current|unknown), e (com
+#         --verify-registration) nenhum "divergent"; 1 caso contrario
+#         (inclui stale e divergent).
+#
+#       --include-loose-usage (feature cstk-setup, FASE 2.1, FR-002/FR-008):
+#         extensao ADITIVA — acrescenta uma 4a linha TSV para
+#         posttooluse-loose-usage.sh (mesmo formato de 4 colunas; NUNCA
+#         ganha a 5a coluna mesmo com --verify-registration — ver abaixo).
+#         NAO altera o exit code (hook opt-in, ausencia nunca e anomalia).
+#         Sem a flag, saida byte-a-byte identica a atual. Runtime instalado
+#         anterior a esta extensao rejeita a flag em _gh_die_usage com
+#         exit 2 — o consumidor MUST tratar como
+#         loose_usage_status=indeterminate, nunca como falha da area.
+#
+#       --verify-registration (feature cstk-setup, FASE 2.2, FR-016):
+#         extensao ADITIVA — acrescenta uma 5a coluna TSV
+#         (canonical|divergent|indeterminate) a cada hook de _GH_HOOKS,
+#         verificando que o "command" registrado em settings.json e a
+#         forma canonica do catalogo (fecha o caso de linha-isca
+#         decorativa, achado SEC-01). "divergent" muda o exit para 1.
+#         Sem a flag, saida e exit identicos aos atuais. Runtime instalado
+#         anterior rejeita a flag com exit 2 — o consumidor MUST tratar
+#         como indeterminate (nunca divergent, nunca configured — I5).
+#         SEMPRE invocada ISOLADA da chamada baseline (achado SEC-03): nunca
+#         combine as duas flags com a baseline numa unica invocacao — um
+#         runtime antigo que rejeita qualquer uma delas perderia tambem o
+#         veredito basico que ele SABE responder.
 #
 #   guard-hooks-status.sh tick-mode --projeto-alvo-path PATH
 #       — stdout: "hook" se posttooluse-tool-call-tick.sh esta ativo
@@ -194,13 +221,72 @@ _gh_backend_blind() {
   return 0
 }
 
+# _gh_verify_registration PAP HOOK -> "canonical" | "divergent" | "indeterminate"
+# (feature cstk-setup, FASE 2.2, FR-016). Extensao aditiva consumida via
+# `check --verify-registration`. Regra textual (achado SEC-01): toda linha
+# do settings.json que contenha o basename do hook MUST tambem conter o
+# fragmento canonico (a forma literal do snippet do catalogo,
+# "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<basename>") E o token literal
+# "command" NA MESMA LINHA — senao "divergent". Isso fecha o caso de uma
+# linha-isca decorativa (ex.: "description") que cite basename+fragmento
+# canonico sem ser a atribuicao "command" de fato.
+# "indeterminate" (nunca reprova, nunca vira "canonical" por omissao):
+#   - settings.json ausente;
+#   - hook nao mencionado em nenhuma linha (nao registrado);
+#   - layout minificado numa unica linha fisica (impede atribuicao por
+#     linha; ver "Limite textual declarado" em contracts/cli-setup.md §2.3).
+# Read-only, POSIX puro (sem jq — mesma restricao de _gh_registered).
+_gh_verify_registration() {
+  _gh_vr_pap="$1"
+  _gh_vr_hook="$2"
+  _gh_vr_settings="$_gh_vr_pap/.claude/settings.json"
+
+  [ -f "$_gh_vr_settings" ] || { printf 'indeterminate'; return 0; }
+
+  # Layout minificado (uma unica linha fisica) impede atribuicao por linha.
+  _gh_vr_nr=$(awk 'END{print NR}' "$_gh_vr_settings" 2>/dev/null || printf '0')
+  case "$_gh_vr_nr" in '' | 0 | 1) printf 'indeterminate'; return 0 ;; esac
+
+  _gh_vr_canonical="\\\"\$CLAUDE_PROJECT_DIR\\\"/.claude/hooks/$_gh_vr_hook"
+  _gh_vr_matched=0
+  _gh_vr_all_ok=1
+  while IFS= read -r _gh_vr_line; do
+    [ -n "$_gh_vr_line" ] || continue
+    _gh_vr_matched=1
+    _gh_vr_has_cmd=0
+    _gh_vr_has_canon=0
+    case "$_gh_vr_line" in *'"command"'*) _gh_vr_has_cmd=1 ;; esac
+    case "$_gh_vr_line" in *"$_gh_vr_canonical"*) _gh_vr_has_canon=1 ;; esac
+    if [ "$_gh_vr_has_cmd" = 0 ] || [ "$_gh_vr_has_canon" = 0 ]; then
+      _gh_vr_all_ok=0
+    fi
+  done <<GHVR
+$(grep -F -- "$_gh_vr_hook" "$_gh_vr_settings" 2>/dev/null)
+GHVR
+
+  if [ "$_gh_vr_matched" -eq 0 ]; then
+    printf 'indeterminate'
+    return 0
+  fi
+  if [ "$_gh_vr_all_ok" -eq 1 ]; then
+    printf 'canonical'
+  else
+    printf 'divergent'
+  fi
+  return 0
+}
+
 _gh_cmd_check() {
   _pap=""
   _quiet=0
+  _include_loose=0
+  _verify_reg=0
   while [ "$#" -gt 0 ]; do
     case "$1" in
-      --projeto-alvo-path) _pap=$2; shift 2 ;;
-      --quiet)             _quiet=1; shift ;;
+      --projeto-alvo-path)     _pap=$2; shift 2 ;;
+      --quiet)                 _quiet=1; shift ;;
+      --include-loose-usage)   _include_loose=1; shift ;;
+      --verify-registration)   _verify_reg=1; shift ;;
       *) _gh_die_usage "check: flag desconhecida: $1" ;;
     esac
   done
@@ -209,8 +295,10 @@ _gh_cmd_check() {
 
   _missing=0
   _stale=0
+  _divergent=0
   _guard_missing=0
   _guard_stale=0
+  _guard_divergent=0
   for _h in $_GH_HOOKS; do
     if _gh_present "$_pap" "$_h"; then
       _st_file="present"
@@ -223,7 +311,12 @@ _gh_cmd_check() {
       _st_reg="unregistered"
     fi
     _st_fresh=$(_gh_freshness "$_pap" "$_h")
-    printf '%s\t%s\t%s\t%s\n' "$_h" "$_st_file" "$_st_reg" "$_st_fresh"
+    if [ "$_verify_reg" = 1 ]; then
+      _st_verify=$(_gh_verify_registration "$_pap" "$_h")
+      printf '%s\t%s\t%s\t%s\t%s\n' "$_h" "$_st_file" "$_st_reg" "$_st_fresh" "$_st_verify"
+    else
+      printf '%s\t%s\t%s\t%s\n' "$_h" "$_st_file" "$_st_reg" "$_st_fresh"
+    fi
     if [ "$_st_file" != "present" ] || [ "$_st_reg" != "registered" ]; then
       _missing=$((_missing + 1))
       [ "$_h" = "pretooluse-bash-guard.sh" ] && _guard_missing=1
@@ -233,9 +326,37 @@ _gh_cmd_check() {
       _stale=$((_stale + 1))
       [ "$_h" = "pretooluse-bash-guard.sh" ] && _guard_stale=1
     fi
+    if [ "$_verify_reg" = 1 ] && [ "$_st_verify" = divergent ]; then
+      _divergent=$((_divergent + 1))
+      [ "$_h" = "pretooluse-bash-guard.sh" ] && _guard_divergent=1
+    fi
   done
 
-  [ "$_missing" -eq 0 ] && [ "$_stale" -eq 0 ] && return 0
+  # --include-loose-usage: 4a linha aditiva para o hook opt-in. NUNCA soma
+  # a _missing/_stale/_divergent — o hook e opt-in, sua ausencia jamais e
+  # anomalia; o exit continua derivado apenas dos 3 hooks de _GH_HOOKS.
+  if [ "$_include_loose" = 1 ]; then
+    _lh="posttooluse-loose-usage.sh"
+    if _gh_present "$_pap" "$_lh"; then
+      _lst_file="present"
+    else
+      _lst_file="missing"
+    fi
+    if _gh_registered "$_pap" "$_lh"; then
+      _lst_reg="registered"
+    else
+      _lst_reg="unregistered"
+    fi
+    _lst_fresh=$(_gh_freshness "$_pap" "$_lh")
+    if [ "$_verify_reg" = 1 ]; then
+      _lst_verify=$(_gh_verify_registration "$_pap" "$_lh")
+      printf '%s\t%s\t%s\t%s\t%s\n' "$_lh" "$_lst_file" "$_lst_reg" "$_lst_fresh" "$_lst_verify"
+    else
+      printf '%s\t%s\t%s\t%s\n' "$_lh" "$_lst_file" "$_lst_reg" "$_lst_fresh"
+    fi
+  fi
+
+  [ "$_missing" -eq 0 ] && [ "$_stale" -eq 0 ] && [ "$_divergent" -eq 0 ] && return 0
 
   if [ "$_quiet" = 0 ]; then
     if [ "$_missing" -gt 0 ]; then
@@ -244,11 +365,17 @@ _gh_cmd_check() {
     if [ "$_stale" -gt 0 ]; then
       _gh_err "$_stale de 3 hooks 00c estao STALE em $_pap/.claude/hooks/ (copia diverge do catalogo)"
     fi
+    if [ "$_divergent" -gt 0 ]; then
+      _gh_err "$_divergent de 3 hooks 00c estao com registro DIVERGENTE (settings.json aponta para outro comando)"
+    fi
     if [ "$_guard_missing" = 1 ]; then
       _gh_err "ATENCAO: pretooluse-bash-guard.sh inativo — a guarda fail-closed de Bash NAO esta enforced nesta execucao."
     fi
     if [ "$_guard_stale" = 1 ]; then
       _gh_err "ATENCAO: pretooluse-bash-guard.sh STALE — a guarda roda com regras de uma versao anterior do catalogo."
+    fi
+    if [ "$_guard_divergent" = 1 ]; then
+      _gh_err "ATENCAO: pretooluse-bash-guard.sh com registro DIVERGENTE — o \"command\" registrado nao aponta para a copia canonica."
     fi
     _gh_err "Remediacao (so os hooks; rode uma vez):"
     _gh_err "  cstk hooks install --project-path $_pap"
@@ -305,10 +432,15 @@ guard-hooks-status.sh — hooks 00c provisionados no projeto-alvo? (READ-ONLY)
 
 USO:
   guard-hooks-status.sh check     --projeto-alvo-path PATH [--quiet]
+                                   [--include-loose-usage] [--verify-registration]
   guard-hooks-status.sh tick-mode --projeto-alvo-path PATH
 
 check     TSV <hook>\t<present|missing>\t<registered|unregistered>\t<current|stale|unknown>;
           exit 0 se os 3 ativos E atuais, 1 caso contrario.
+          --include-loose-usage acrescenta 4a linha (posttooluse-loose-usage.sh),
+          nao afeta o exit. --verify-registration acrescenta 5a coluna
+          (canonical|divergent|indeterminate); "divergent" muda exit p/ 1.
+          Invoque cada flag SEPARADA da chamada baseline (nunca combinadas).
 tick-mode "hook" ou "manual" — o orquestrador so ticka na mao em "manual".
           "manual" tambem quando a copia do hook e cega a backend (pre
           hooks-db-parity) e o projeto ja usa state.db.

--- a/tests/cstk/test_mcp.sh
+++ b/tests/cstk/test_mcp.sh
@@ -1030,4 +1030,130 @@ scenario_mcp_subcomando_desconhecido_lista_install() {
   assert_stderr_contains "install" || return 1
 }
 
+# ---------- _mcp_registration_status (feature cstk-setup, FASE 2.3, FR-016) ----------
+#
+# Funcao interna (nao subcomando `cstk mcp`), consumida pelo wizard
+# `cstk setup`. Testada sourcing cli/lib/mcp.sh diretamente e chamando a
+# funcao — mesmo motivo de nao existir `cstk mcp registration-status`
+# (contracts/cli-setup.md §4.1: "lib DONA da area", nao um comando novo).
+#
+# INVARIANTES:
+#   SEC-05 (CHK012): candidato via PATH restrito ao sufixo
+#     /skills/agente-00c-runtime/scripts/mcp-launch.sh E existente em disco.
+#   SEC-06 (CHK013): stdout NUNCA vazio; sem atribuicao textual => divergent
+#     (nunca "configured" por omissao).
+
+# _registration_status PROJECT_PATH -> stdout de _mcp_registration_status,
+# rodando com CSTK_LIB=repo (mesmo contexto de _cstk_mcp install) e PATH
+# controlavel via $_MCP_INNER_PATH (default: PATH corrente).
+_registration_status() {
+  env CSTK_LIB="$CSTK_LIB_DIR" PATH="${_MCP_INNER_PATH:-$PATH}" \
+    sh -c '. "$CSTK_LIB/mcp.sh"; _mcp_registration_status "$1"' _ "$1"
+}
+
+scenario_mcp_not_configured_arquivo_ausente() {
+  _p="$TMPDIR_TEST/reg-ausente"
+  mkdir -p "$_p"
+  capture _registration_status "$_p"
+  [ "$_CAPTURED_STDOUT" = "not-configured" ] \
+    || { _fail "stdout" "esperado 'not-configured', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+scenario_mcp_not_configured_sem_cstk_state() {
+  _p="$TMPDIR_TEST/reg-outro-servidor"
+  mkdir -p "$_p"
+  printf '{"mcpServers":{"outro-servidor":{"type":"stdio","command":"/bin/true","args":[]}}}\n' \
+    > "$_p/.mcp.json"
+  capture _registration_status "$_p"
+  [ "$_CAPTURED_STDOUT" = "not-configured" ] \
+    || { _fail "stdout" "esperado 'not-configured', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+scenario_mcp_configured_apos_install_real() {
+  _p="$TMPDIR_TEST/reg-configured"
+  mkdir -p "$_p"
+  capture _cstk_mcp install --project-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "install exit" "$_CAPTURED_STDERR"; return 1; }
+  capture _registration_status "$_p"
+  [ "$_CAPTURED_STDOUT" = "configured" ] \
+    || { _fail "stdout" "esperado 'configured', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+scenario_mcp_divergent_foreign_script() {
+  _p="$TMPDIR_TEST/reg-divergent"
+  mkdir -p "$_p"
+  printf '{\n  "mcpServers": {\n    "cstk-state": {\n      "type": "stdio",\n      "command": "/usr/local/bin/outro-launcher.sh",\n      "args": []\n    }\n  }\n}\n' \
+    > "$_p/.mcp.json"
+  capture _registration_status "$_p"
+  [ "$_CAPTURED_STDOUT" = "divergent" ] \
+    || { _fail "stdout" "esperado 'divergent', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+# Cross-layer (quickstart Scenario 14b): .mcp.json com o "command" na forma
+# HOME/catalogo instalado (candidato independente de CSTK_LIB), verificado
+# num contexto com CSTK_LIB=repo — deve dar "configured", nunca "divergent"
+# (evita falso-positivo entre camadas, contracts/cli-setup.md §4.1).
+scenario_mcp_configured_cross_layer() {
+  _p="$TMPDIR_TEST/reg-cross-layer"
+  mkdir -p "$_p"
+  _fake_home="$TMPDIR_TEST/reg-cross-layer-home"
+  _catalog_launcher="$_fake_home/.claude/skills/agente-00c-runtime/scripts/mcp-launch.sh"
+  mkdir -p "$(dirname "$_catalog_launcher")"
+  printf '#!/bin/sh\nexit 0\n' > "$_catalog_launcher"
+  chmod +x "$_catalog_launcher"
+  printf '{\n  "mcpServers": {\n    "cstk-state": {\n      "type": "stdio",\n      "command": "%s",\n      "args": []\n    }\n  }\n}\n' \
+    "$_catalog_launcher" > "$_p/.mcp.json"
+  # Verifica com CSTK_LIB=repo (contexto DIFERENTE do HOME onde o
+  # candidato "instalado" mora) + HOME apontando para o catalogo fake —
+  # candidato 3 (home) e independente de CSTK_LIB, entao casa mesmo assim.
+  capture env CSTK_LIB="$CSTK_LIB_DIR" HOME="$_fake_home" PATH="${_MCP_INNER_PATH:-$PATH}" \
+    sh -c '. "$CSTK_LIB/mcp.sh"; _mcp_registration_status "$1"' _ "$_p"
+  [ "$_CAPTURED_STDOUT" = "configured" ] \
+    || { _fail "stdout" "esperado 'configured' (cross-layer), obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+# SEC-06 (CHK013): cstk-state presente mas "command" nao atribuivel
+# textualmente (bloco malformado, sem linha "command" apos "cstk-state")
+# => "divergent", NUNCA stdout vazio, NUNCA "configured" por omissao.
+scenario_mcp_registration_status_empty_stdout() {
+  _p="$TMPDIR_TEST/reg-malformado"
+  mkdir -p "$_p"
+  printf '{\n  "mcpServers": {\n    "cstk-state": {\n      "type": "stdio"\n    }\n  }\n}\n' \
+    > "$_p/.mcp.json"
+  capture _registration_status "$_p"
+  [ -n "$_CAPTURED_STDOUT" ] \
+    || { _fail "stdout" "_mcp_registration_status NUNCA pode emitir stdout vazio (SEC-06)"; return 1; }
+  [ "$_CAPTURED_STDOUT" = "divergent" ] \
+    || { _fail "stdout" "esperado 'divergent' (nao-atribuivel), obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+# SEC-05 (CHK012): candidato via PATH homonimo FORA do sufixo esperado
+# NAO pode contar como legitimo, mesmo apontando para um arquivo real.
+scenario_mcp_path_candidate_fora_do_sufixo_nao_conta() {
+  _p="$TMPDIR_TEST/reg-path-homonimo"
+  mkdir -p "$_p"
+  _fake_bin="$TMPDIR_TEST/reg-path-homonimo-bin"
+  mkdir -p "$_fake_bin"
+  printf '#!/bin/sh\nexit 0\n' > "$_fake_bin/mcp-launch.sh"
+  chmod +x "$_fake_bin/mcp-launch.sh"
+  printf '{\n  "mcpServers": {\n    "cstk-state": {\n      "type": "stdio",\n      "command": "%s",\n      "args": []\n    }\n  }\n}\n' \
+    "$_fake_bin/mcp-launch.sh" > "$_p/.mcp.json"
+  # Homonimo na FRENTE do PATH real (command -v acha ele primeiro); o
+  # sufixo de path esperado nao bate, entao SEC-05 deve rejeita-lo mesmo
+  # apontando para um arquivo que de fato existe em disco.
+  capture env CSTK_LIB="$CSTK_LIB_DIR" HOME="$TMPDIR_TEST/reg-path-homonimo-home" \
+    PATH="$_fake_bin:$PATH" \
+    sh -c '. "$CSTK_LIB/mcp.sh"; _mcp_registration_status "$1"' _ "$_p"
+  [ "$_CAPTURED_STDOUT" = "divergent" ] \
+    || { _fail "stdout" "candidato PATH fora do sufixo nao pode contar (SEC-05), obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
 run_all_scenarios

--- a/tests/cstk/test_serve-docker.sh
+++ b/tests/cstk/test_serve-docker.sh
@@ -581,13 +581,16 @@ scenario_docker_mentions_confined_to_serve_docker_lib() {
   # docker tem UM arquivo confinado com a invocacao funcional:
   #   (docker, serve) -> cli/lib/serve-docker.sh
   #   (docker, mcp)   -> cli/lib/mcp-docker.sh
-  # cli/lib/mcp.sh e exempto da checagem de MENCAO (comentarios, strings de
-  # modo "docker|bash-fallback", sourcing e chamadas _mcp_docker_*), mas a
-  # checagem de INVOCACAO FUNCIONAL abaixo continua cobrindo-o.
+  # cli/lib/mcp.sh e cli/lib/setup.sh sao exemptados da checagem de MENCAO
+  # (mcp.sh: comentarios, strings de modo "docker|bash-fallback", sourcing e
+  # chamadas _mcp_docker_*; setup.sh: `command -v docker` para TEXTO de aviso
+  # em FR-015, nunca invocacao funcional), mas a checagem de INVOCACAO
+  # FUNCIONAL abaixo continua cobrindo ambos.
   _hits=$(grep -rniE 'docker' "$REPO_ROOT/cli" 2>/dev/null \
             | grep -v '/cli/lib/serve-docker\.sh:' \
             | grep -v '/cli/lib/mcp-docker\.sh:' \
             | grep -v '/cli/lib/mcp\.sh:' \
+            | grep -v '/cli/lib/setup\.sh:' \
             | grep -vE '/cli/lib/serve\.sh:[0-9]+: *-*-docker\)[[:space:]]*$' \
             | grep -vE '/cli/lib/serve\.sh:[0-9]+: *\. "\$\{CSTK_LIB\}/serve-docker\.sh"$' \
             | grep -vE '/cli/lib/serve\.sh:[0-9]+: *_serve_docker_main ' \

--- a/tests/cstk/test_setup.sh
+++ b/tests/cstk/test_setup.sh
@@ -45,8 +45,24 @@
 #      Scenario 15) — status=unavailable distingue "nao consegui
 #      verificar" do texto de divergent ("esta errado").
 #
-# Ref: docs/specs/cstk-setup/tasks.md FASE 1, FASE 3;
-#      contracts/cli-setup.md §1, §2.
+# FASE 4 (area de state-backend, contracts/cli-setup.md §3):
+#  13  scenario_state_backend_deliberate_json_not_migrated (task 4.1.4,
+#      quickstart Scenario 3, US2 AC3) — `state_backend=json` explicito e
+#      reportado como already-configured (nunca not-configured) e `--yes`
+#      NAO migra para sqlite.
+#  14  scenario_state_backend_global_label_shown (task 4.2.4, quickstart
+#      Scenario 16 parte FR-017) — rotulo de escopo GLOBAL aparece so na
+#      area state-backend (inclusive em --dry-run), nunca em hooks.
+#  15  scenario_state_backend_unavailable_sqlite_missing (task 4.3.4,
+#      quickstart Scenario 7) — sqlite3 ausente do PATH que o SUT enxerga
+#      (state_backend=sqlite declarado) => area failed, zero escrita,
+#      exit 1; o wizard prossegue (nao aborta o processo).
+#  16  scenario_state_backend_doctor_diagnostic_surfaced (task 4.4.2) —
+#      texto de `cstk doctor --deps` (sqlite3 presente+versao) aparece no
+#      motivo exibido para status=unavailable.
+#
+# Ref: docs/specs/cstk-setup/tasks.md FASE 1, FASE 3, FASE 4;
+#      contracts/cli-setup.md §1, §2, §3.
 
 TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
@@ -91,11 +107,17 @@ _make_fake_catalog() {
 # (tests/cstk/test_hooks.sh) — PATH curado SEM jq, para exercitar o
 # caminho paste-instructed (jq ausente). Inclui `cmp` (freshness) e `sh`
 # (necessario para o proprio `env -i PATH=... sh "$CSTK" ...` executar).
+# Inclui `sqlite3` deliberadamente (FASE 4): este shim so quer isolar jq
+# — sem sqlite3 no PATH, a area state-backend (agora ativa) tentaria
+# `enable-sqlite` (reason=nunca-configurado) e falharia com exit 3,
+# mudando o exit code GERAL do wizard e quebrando cenarios desta area que
+# testam so o comportamento de `hooks`. Cenarios que precisam de sqlite3
+# genuinamente ausente usam `_make_shim_path_no_sqlite3` (abaixo).
 _make_shim_path_no_jq() {
   _msp_dir=$(mktemp -d "$TMPDIR_TEST/shimbin.XXXXXX")
   for _msp_c in sh mktemp awk sed grep find head printf cp mv rm mkdir \
                 chmod ls dirname basename tr cut wc env command sort \
-                uniq date cat cmp; do
+                uniq date cat cmp sqlite3; do
     _msp_src=$(command -v "$_msp_c" 2>/dev/null) || continue
     [ -n "$_msp_src" ] || continue
     ln -sf "$_msp_src" "$_msp_dir/$_msp_c" 2>/dev/null || :
@@ -554,6 +576,207 @@ scenario_hooks_unavailable_status_reason() {
     *)
       _fail "scenario_hooks_unavailable_status_reason" \
         "reason nao distingue 'nao consegui verificar': $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+}
+
+# ==== Helpers FASE 4 (area de state-backend) ====
+
+# _make_shim_path_no_sqlite3 -> mesmo padrao de _make_shim_path_no_jq:
+# PATH curado SEM sqlite3 nem jq (nenhum dos dois esta na allowlist copiada),
+# desacoplando a deteccao do SUT do PATH real do harness (gotcha registrado
+# no projeto — "PATH-stub nao esconde binario de /usr/bin": nao tentamos
+# "esconder" nada, construimos um PATH isolado que nunca inclui o dir onde
+# sqlite3 mora, em vez de tentar sobrepor um dir anterior).
+_make_shim_path_no_sqlite3() {
+  _mss_dir=$(mktemp -d "$TMPDIR_TEST/shimbin-nosqlite.XXXXXX")
+  for _mss_c in sh mktemp awk sed grep find head printf cp mv rm mkdir \
+                chmod ls dirname basename tr cut wc env command sort \
+                uniq date cat cmp; do
+    _mss_src=$(command -v "$_mss_c" 2>/dev/null) || continue
+    [ -n "$_mss_src" ] || continue
+    ln -sf "$_mss_src" "$_mss_dir/$_mss_c" 2>/dev/null || :
+  done
+  printf '%s' "$_mss_dir"
+}
+
+# ==== FASE 4 — Area de state-backend ====
+
+# ==== 4.1.4 escolha deliberada de json NAO e migrada (US2 AC3, quickstart
+# Scenario 3) ====
+
+scenario_state_backend_deliberate_json_not_migrated() {
+  _repo="$TMPDIR_TEST/repo-sb-json-deliberate"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-sb-json-deliberate"
+  mkdir -p "$_home/.claude/cstk"
+  printf 'state_backend=json\n' > "$_home/.claude/cstk/config"
+  chmod 600 "$_home/.claude/cstk/config"
+
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  case "$_CAPTURED_STDERR" in
+    *"[state-backend] status atual = configured"*"reason=json-explicito"*) : ;;
+    *)
+      _fail "scenario_state_backend_deliberate_json_not_migrated" \
+        "esperava status=configured com reason=json-explicito: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"[state-backend] ja configurado"*) : ;;
+    *)
+      _fail "scenario_state_backend_deliberate_json_not_migrated" \
+        "esperava 'ja configurado' (I1, zero chamada de aplicacao): $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+
+  _content_after=$(cat "$_home/.claude/cstk/config")
+  if [ "$_content_after" != "state_backend=json" ]; then
+    _fail "scenario_state_backend_deliberate_json_not_migrated" \
+      "--yes migrou a escolha deliberada de json para: $_content_after"
+    return 1
+  fi
+}
+
+# ==== 4.2.4 rotulo de escopo GLOBAL — FR-017 (quickstart Scenario 16) ====
+
+scenario_state_backend_global_label_shown() {
+  _repo="$TMPDIR_TEST/repo-sb-global-label"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-sb-global-label"
+  mkdir -p "$_home"
+
+  # (a) em --dry-run: rotulo aparece ANTES de qualquer decisao, mesmo sem
+  # aplicar nada.
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --dry-run
+  case "$_CAPTURED_STDERR" in
+    *"[state-backend] ESCOPO GLOBAL"*"TODOS os projetos"*) : ;;
+    *)
+      _fail "scenario_state_backend_global_label_shown" \
+        "rotulo de escopo global ausente em --dry-run: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+
+  # (b) em --yes tambem (nao so em preview).
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  case "$_CAPTURED_STDERR" in
+    *"[state-backend] ESCOPO GLOBAL"*) : ;;
+    *)
+      _fail "scenario_state_backend_global_label_shown" \
+        "rotulo de escopo global ausente em --yes: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+
+  # (c) as outras areas (hooks) NAO carregam esse rotulo.
+  _hooks_block=$(printf '%s\n' "$_CAPTURED_STDERR" | grep '\[hooks\]')
+  case "$_hooks_block" in
+    *"ESCOPO GLOBAL"*)
+      _fail "scenario_state_backend_global_label_shown" \
+        "area de hooks carregou o rotulo de escopo global (FR-017 restringe a state-backend)"
+      return 1
+      ;;
+  esac
+}
+
+# ==== 4.3.4 sqlite3 ausente/abaixo do minimo => area failed, isolada
+# (task 4.3.3, quickstart Scenario 7) ====
+
+scenario_state_backend_unavailable_sqlite_missing() {
+  _repo="$TMPDIR_TEST/repo-sb-unavailable"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-sb-unavailable"
+  mkdir -p "$_home/.claude/cstk"
+  # backend=sqlite ja declarado -> resolve() checa sqlite3 internamente e
+  # devolve reason=configurado-dependencia-ausente quando nao encontrado
+  # no PATH que o SUT enxerga.
+  printf 'state_backend=sqlite\n' > "$_home/.claude/cstk/config"
+  chmod 600 "$_home/.claude/cstk/config"
+  _shim=$(_make_shim_path_no_sqlite3)
+
+  capture env -i PATH="$_shim" HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "scenario_state_backend_unavailable_sqlite_missing" \
+      "esperado exit 1 (area failed), obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"[state-backend] status atual = unavailable"*"reason=configurado-dependencia-ausente"*) : ;;
+    *)
+      _fail "scenario_state_backend_unavailable_sqlite_missing" \
+        "esperava status=unavailable/reason=configurado-dependencia-ausente: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"[state-backend] nenhuma chamada de aplicacao sera feita."*) : ;;
+    *)
+      _fail "scenario_state_backend_unavailable_sqlite_missing" \
+        "esperava aviso de zero chamada de aplicacao: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  # config global INTOCADA (zero escrita sobre status=unavailable).
+  _content_after=$(cat "$_home/.claude/cstk/config")
+  if [ "$_content_after" != "state_backend=sqlite" ]; then
+    _fail "scenario_state_backend_unavailable_sqlite_missing" \
+      "config global foi escrita apesar de status=unavailable: $_content_after"
+    return 1
+  fi
+  # FR-009: o wizard prossegue apos a falha isolada — nao aborta o
+  # processo no meio da area; a linha de areas restantes ainda e emitida.
+  case "$_CAPTURED_STDERR" in
+    *"areas restantes"*) : ;;
+    *)
+      _fail "scenario_state_backend_unavailable_sqlite_missing" \
+        "wizard nao prosseguiu apos falha isolada em state-backend (FR-009): $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+}
+
+# ==== 4.4.2 diagnostico de `cstk doctor --deps` reusado quando unavailable
+# (task 4.4.1) ====
+
+scenario_state_backend_doctor_diagnostic_surfaced() {
+  _repo="$TMPDIR_TEST/repo-sb-doctor-diag"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-sb-doctor-diag"
+  mkdir -p "$_home/.claude/cstk"
+  printf 'state_backend=sqlite\n' > "$_home/.claude/cstk/config"
+  chmod 600 "$_home/.claude/cstk/config"
+  _shim=$(_make_shim_path_no_sqlite3)
+
+  capture env -i PATH="$_shim" HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  case "$_CAPTURED_STDERR" in
+    *"diagnostico (cstk doctor --deps)"*) : ;;
+    *)
+      _fail "scenario_state_backend_doctor_diagnostic_surfaced" \
+        "diagnostico de cstk doctor --deps ausente: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"sqlite3: presente=nao"*) : ;;
+    *)
+      _fail "scenario_state_backend_doctor_diagnostic_surfaced" \
+        "diagnostico nao cita sqlite3 presente=nao: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"minima=3.45.1"*) : ;;
+    *)
+      _fail "scenario_state_backend_doctor_diagnostic_surfaced" \
+        "diagnostico nao cita a versao minima exigida: $_CAPTURED_STDERR"
       return 1
       ;;
   esac

--- a/tests/cstk/test_setup.sh
+++ b/tests/cstk/test_setup.sh
@@ -61,7 +61,25 @@
 #      texto de `cstk doctor --deps` (sqlite3 presente+versao) aparece no
 #      motivo exibido para status=unavailable.
 #
-# Ref: docs/specs/cstk-setup/tasks.md FASE 1, FASE 3, FASE 4;
+# FASE 5 (area de MCP, contracts/cli-setup.md §4):
+#  17  scenario_mcp_status_displayed_before_action (task 5.1.3, FR-002) —
+#      status da area mcp e impresso ANTES da linha de preview/acao,
+#      mesmo em --dry-run.
+#  18  scenario_mcp_applied_without_docker_warns (task 5.2.5, quickstart
+#      Scenario 14 + Clarifications item 3, FR-015) — `--yes` sem Docker
+#      no PATH aplica `mcp install` mesmo assim e emite aviso claro;
+#      `.mcp.json` e escrito de verdade.
+#  19  scenario_mcp_divergent_no_install_call (task 5.3.4, quickstart
+#      Scenario 14a, I6) — status=divergent nunca chama `mcp install`;
+#      `.mcp.json` permanece byte-a-byte identico; remediacao em duas
+#      etapas exibida.
+#  20  scenario_mcp_cross_layer_not_divergent (task 5.3.5, quickstart
+#      Scenario 14b) — mesmo cenario cross-layer de
+#      scenario_mcp_configured_cross_layer (test_mcp.sh, FASE 2.3.9),
+#      agora validado no nivel de orquestracao do wizard: `configured`,
+#      nunca falso-positivo `divergent`.
+#
+# Ref: docs/specs/cstk-setup/tasks.md FASE 1, FASE 3, FASE 4, FASE 5;
 #      contracts/cli-setup.md §1, §2, §3.
 
 TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
@@ -731,9 +749,9 @@ scenario_state_backend_unavailable_sqlite_missing() {
     return 1
   fi
   # FR-009: o wizard prossegue apos a falha isolada — nao aborta o
-  # processo no meio da area; a linha de areas restantes ainda e emitida.
+  # processo no meio da area; a area seguinte (mcp) ainda roda.
   case "$_CAPTURED_STDERR" in
-    *"areas restantes"*) : ;;
+    *"[mcp] outcome="*) : ;;
     *)
       _fail "scenario_state_backend_unavailable_sqlite_missing" \
         "wizard nao prosseguiu apos falha isolada em state-backend (FR-009): $_CAPTURED_STDERR"
@@ -777,6 +795,212 @@ scenario_state_backend_doctor_diagnostic_surfaced() {
     *)
       _fail "scenario_state_backend_doctor_diagnostic_surfaced" \
         "diagnostico nao cita a versao minima exigida: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+}
+
+# ==== Helpers FASE 5 (area de MCP) ====
+
+# _make_shim_path_no_docker -> mesmo padrao de _make_shim_path_no_jq /
+# _make_shim_path_no_sqlite3: PATH curado incluindo jq E sqlite3 (para
+# isolar a area mcp de efeitos colaterais nas outras 3 areas) mas
+# deliberadamente SEM docker, para exercitar o aviso de Docker ausente
+# (task 5.2.3/5.2.5) sem depender de o Docker estar instalado ou nao na
+# maquina que roda a suite.
+_make_shim_path_no_docker() {
+  _msnd_dir=$(mktemp -d "$TMPDIR_TEST/shimbin-nodocker.XXXXXX")
+  for _msnd_c in sh mktemp awk sed grep find head printf cp mv rm mkdir \
+                chmod ls dirname basename tr cut wc env command sort \
+                uniq date cat cmp jq sqlite3; do
+    _msnd_src=$(command -v "$_msnd_c" 2>/dev/null) || continue
+    [ -n "$_msnd_src" ] || continue
+    ln -sf "$_msnd_src" "$_msnd_dir/$_msnd_c" 2>/dev/null || :
+  done
+  printf '%s' "$_msnd_dir"
+}
+
+# ==== FASE 5 — Area de MCP ====
+
+# ==== 5.1.3 status exibido ANTES de qualquer decisao (FR-002) ====
+
+scenario_mcp_status_displayed_before_action() {
+  _repo="$TMPDIR_TEST/repo-mcp-status-order"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-mcp-status-order"
+  mkdir -p "$_home"
+
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --dry-run
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "scenario_mcp_status_displayed_before_action" \
+      "esperado exit 0 (dry-run), obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"[mcp] status atual = not-configured"*) : ;;
+    *)
+      _fail "scenario_mcp_status_displayed_before_action" \
+        "status da area mcp nao foi exibido: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+
+  _status_line=$(printf '%s\n' "$_CAPTURED_STDERR" | grep -n '\[mcp\] status atual' | head -1 | cut -d: -f1)
+  _preview_line=$(printf '%s\n' "$_CAPTURED_STDERR" | grep -n '\[mcp\] preview' | head -1 | cut -d: -f1)
+  if [ -z "$_status_line" ] || [ -z "$_preview_line" ]; then
+    _fail "scenario_mcp_status_displayed_before_action" \
+      "nao foi possivel localizar as duas linhas para comparar ordem: $_CAPTURED_STDERR"
+    return 1
+  fi
+  if [ "$_status_line" -ge "$_preview_line" ]; then
+    _fail "scenario_mcp_status_displayed_before_action" \
+      "status (linha $_status_line) nao apareceu ANTES do preview de acao (linha $_preview_line) — FR-002"
+    return 1
+  fi
+}
+
+# ==== 5.2.5 --yes sem Docker aplica mesmo assim e avisa (FR-015) ====
+
+scenario_mcp_applied_without_docker_warns() {
+  if ! command -v jq >/dev/null 2>&1; then
+    _error "no_jq" "jq nao disponivel no ambiente — cenario exige jq presente no PATH real para o merge de verdade ocorrer"
+  fi
+  _repo="$TMPDIR_TEST/repo-mcp-no-docker"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-mcp-no-docker"
+  mkdir -p "$_home"
+  _cat=$(_make_fake_catalog "$_home")
+  _shim=$(_make_shim_path_no_docker)
+
+  capture env -i PATH="$_shim" HOME="$_home" CSTK_HOOKS_CATALOG_DIR="$_cat" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  case "$_CAPTURED_STDERR" in
+    *"[mcp] outcome=applied"*) : ;;
+    *)
+      _fail "scenario_mcp_applied_without_docker_warns" \
+        "area mcp nao ficou applied mesmo sem Docker (FR-015): $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"Docker nao encontrado"*) : ;;
+    *)
+      _fail "scenario_mcp_applied_without_docker_warns" \
+        "aviso claro de Docker ausente nao foi emitido: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  if ! grep -Fq -- '"cstk-state"' "$_repo/.mcp.json" 2>/dev/null; then
+    _fail "scenario_mcp_applied_without_docker_warns" \
+      ".mcp.json nao foi escrito com a entrada mcpServers.cstk-state"
+    return 1
+  fi
+}
+
+# ==== 5.3.4 status=divergent nunca chama `mcp install` (I6, FR-016) ====
+
+scenario_mcp_divergent_no_install_call() {
+  _repo="$TMPDIR_TEST/repo-mcp-divergent"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-mcp-divergent"
+  mkdir -p "$_home"
+  _mcp_file="$_repo/.mcp.json"
+  cat > "$_mcp_file" <<'JSON'
+{
+  "mcpServers": {
+    "cstk-state": {
+      "type": "stdio",
+      "command": "/tmp/fake-launch.sh",
+      "args": []
+    }
+  }
+}
+JSON
+  _snapshot=$(cat "$_mcp_file")
+
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "scenario_mcp_divergent_no_install_call" \
+      "esperado exit 1 (mcp divergent), obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"[mcp] status atual = divergent"*) : ;;
+    *)
+      _fail "scenario_mcp_divergent_no_install_call" \
+        "status divergent nao reportado: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"[mcp] outcome=failed"*) : ;;
+    *)
+      _fail "scenario_mcp_divergent_no_install_call" \
+        "outcome divergent nao virou failed: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"[mcp] remediacao (duas etapas"*) : ;;
+    *)
+      _fail "scenario_mcp_divergent_no_install_call" \
+        "remediacao em duas etapas ausente: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  _after=$(cat "$_mcp_file")
+  if [ "$_after" != "$_snapshot" ]; then
+    _fail "scenario_mcp_divergent_no_install_call" \
+      ".mcp.json foi alterado apesar de status=divergent (I6)"
+    return 1
+  fi
+}
+
+# ==== 5.3.5 cross-layer legitimo NAO pode ser divergent (quickstart 14b) ====
+
+scenario_mcp_cross_layer_not_divergent() {
+  _repo="$TMPDIR_TEST/repo-mcp-cross-layer"
+  _make_repo "$_repo"
+  _fake_home="$TMPDIR_TEST/home-mcp-cross-layer"
+  _catalog_launcher="$_fake_home/.claude/skills/agente-00c-runtime/scripts/mcp-launch.sh"
+  mkdir -p "$(dirname "$_catalog_launcher")"
+  printf '#!/bin/sh\nexit 0\n' > "$_catalog_launcher"
+  chmod +x "$_catalog_launcher"
+  printf '{\n  "mcpServers": {\n    "cstk-state": {\n      "type": "stdio",\n      "command": "%s",\n      "args": []\n    }\n  }\n}\n' \
+    "$_catalog_launcher" > "$_repo/.mcp.json"
+
+  # Mesmo cenario de scenario_mcp_configured_cross_layer (test_mcp.sh,
+  # FASE 2.3.9): CSTK_LIB=repo (contexto DIFERENTE do HOME onde o
+  # candidato "instalado" mora) — agora validado no nivel do wizard.
+  capture env HOME="$_fake_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --dry-run
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "scenario_mcp_cross_layer_not_divergent" \
+      "esperado exit 0 (dry-run, configured), obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"[mcp] status atual = configured"*) : ;;
+    *)
+      _fail "scenario_mcp_cross_layer_not_divergent" \
+        "esperado status=configured (cross-layer), obtido: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"[mcp] status atual = divergent"*)
+      _fail "scenario_mcp_cross_layer_not_divergent" \
+        "falso-positivo: cross-layer legitimo reportado como divergent"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"[mcp] ja configurado"*) : ;;
+    *)
+      _fail "scenario_mcp_cross_layer_not_divergent" \
+        "already-configured/I1 nao confirmado: $_CAPTURED_STDERR"
       return 1
       ;;
   esac

--- a/tests/cstk/test_setup.sh
+++ b/tests/cstk/test_setup.sh
@@ -79,8 +79,30 @@
 #      agora validado no nivel de orquestracao do wizard: `configured`,
 #      nunca falso-positivo `divergent`.
 #
-# Ref: docs/specs/cstk-setup/tasks.md FASE 1, FASE 3, FASE 4, FASE 5;
-#      contracts/cli-setup.md §1, §2, §3.
+# FASE 6 (area de telemetria, contracts/cli-setup.md §5):
+#  21  scenario_telemetry_readonly_no_home_write (task 6.1.4, FR-012) —
+#      `otel-usage.sh preflight` diagnostica (status=disabled no HOME
+#      sandboxado, sem as env vars de telemetria); a arvore de $HOME e
+#      byte-a-byte identica antes/depois; outcome nunca `applied`
+#      (INALCANCAVEL nesta area); as instrucoes exibidas citam os valores
+#      EXATOS de README.md (CLAUDE_CODE_ENABLE_TELEMETRY=1,
+#      OTEL_METRICS_EXPORTER=prometheus, CSTK_OTEL_ENDPOINT,
+#      OTEL_EXPORTER_PROMETHEUS_PORT, 127.0.0.1:9464), nunca inventados.
+#
+# FASE 7 (sumario final, contracts/cli-setup.md §1 "Saida (stdout)"):
+#  22  scenario_summary_lists_all_four_areas (task 7.1.4, quickstart
+#      Scenario 1/7) — o `SetupRunSummary` lista as 4 areas em STDOUT, na
+#      ordem fixa `hooks`/`state-backend`/`mcp`/`telemetry`, mesmo com
+#      falha parcial (sqlite3 ausente força a area state-backend a
+#      `failed`); `[escopo]=global` so na linha de state-backend; texto
+#      de diagnostico/progresso continua so em stderr.
+#  23  scenario_summary_declares_verification_scope (task 7.2.2, achado
+#      SEC-07/CHK009) — o summary declara que so os 3 hooks obrigatorios
+#      de `_GH_HOOKS` foram verificados, sem implicar auditoria do
+#      `settings.json`/`.mcp.json` inteiro.
+#
+# Ref: docs/specs/cstk-setup/tasks.md FASE 1, FASE 3, FASE 4, FASE 5,
+#      FASE 6, FASE 7; contracts/cli-setup.md §1, §2, §3, §5.
 
 TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
@@ -1001,6 +1023,200 @@ scenario_mcp_cross_layer_not_divergent() {
     *)
       _fail "scenario_mcp_cross_layer_not_divergent" \
         "already-configured/I1 nao confirmado: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+}
+
+# ==== 6.1.4 telemetria e 100% read-only, zero escrita em $HOME (FR-012) ====
+
+scenario_telemetry_readonly_no_home_write() {
+  _repo="$TMPDIR_TEST/repo-telemetry-ro"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-telemetry-ro"
+  mkdir -p "$_home"
+
+  # Snapshot recursivo de $HOME (nomes + conteudo) ANTES do run. Sem env
+  # de telemetria setadas -> otel-usage.sh preflight reporta
+  # status=disabled (nem CLAUDE_CODE_ENABLE_TELEMETRY nem
+  # OTEL_METRICS_EXPORTER estao presentes neste `env -i`).
+  _before=$(find "$_home" -type f -exec cksum {} + 2>/dev/null | sort)
+
+  capture env -i HOME="$_home" PATH="$PATH" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --dry-run
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "scenario_telemetry_readonly_no_home_write" \
+      "esperado exit 0 (--dry-run), obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+
+  _after=$(find "$_home" -type f -exec cksum {} + 2>/dev/null | sort)
+  if [ "$_before" != "$_after" ]; then
+    _fail "scenario_telemetry_readonly_no_home_write" \
+      "\$HOME mudou apos o wizard — area telemetry (e nenhuma outra, em --dry-run) MUST ser 100% read-only (FR-012)"
+    return 1
+  fi
+
+  # FR-002 — status exibido ANTES de qualquer instrucao/decisao.
+  case "$_CAPTURED_STDERR" in
+    *"[telemetry] status atual = status=disabled"*) : ;;
+    *)
+      _fail "scenario_telemetry_readonly_no_home_write" \
+        "status nao exibido (ou inesperado): $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+
+  # outcome=applied e INALCANCAVEL para esta area (task 6.1.3).
+  case "$_CAPTURED_STDERR" in
+    *"[telemetry] outcome=applied"*)
+      _fail "scenario_telemetry_readonly_no_home_write" \
+        "outcome=applied apareceu para telemetry — INALCANCAVEL por FR-012"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"[telemetry] outcome=skipped"*) : ;;
+    *)
+      _fail "scenario_telemetry_readonly_no_home_write" \
+        "esperado outcome=skipped (status=disabled), obtido: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+
+  # task 6.1.2 — valores EXATOS citados de README.md, nunca inventados.
+  for _val in "CLAUDE_CODE_ENABLE_TELEMETRY=1" "OTEL_METRICS_EXPORTER=prometheus" \
+              "CSTK_OTEL_ENDPOINT" "OTEL_EXPORTER_PROMETHEUS_PORT" "127.0.0.1:9464"; do
+    case "$_CAPTURED_STDERR" in
+      *"$_val"*) : ;;
+      *)
+        _fail "scenario_telemetry_readonly_no_home_write" \
+          "instrucao exibida nao contem o valor exato '$_val' (README.md): $_CAPTURED_STDERR"
+        return 1
+        ;;
+    esac
+  done
+}
+
+# ==== FASE 7 — Sumario Final ====
+
+# ==== 7.1.4 summary lista as 4 areas, mesmo com falha parcial (quickstart
+# Scenario 1/7, SC-005) ====
+
+scenario_summary_lists_all_four_areas() {
+  _repo="$TMPDIR_TEST/repo-summary-4areas"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-summary-4areas"
+  mkdir -p "$_home/.claude/cstk"
+  # Mesmo padrao de scenario_state_backend_unavailable_sqlite_missing:
+  # forca SO a area state-backend a `failed`, isolando o efeito nas
+  # demais 3 (FR-009 — falha isolada nao interrompe o resto).
+  printf 'state_backend=sqlite\n' > "$_home/.claude/cstk/config"
+  chmod 600 "$_home/.claude/cstk/config"
+  _shim=$(_make_shim_path_no_sqlite3)
+
+  capture env -i PATH="$_shim" HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "scenario_summary_lists_all_four_areas" \
+      "esperado exit 1 (state-backend failed), obtido $_CAPTURED_EXIT (stdout: $_CAPTURED_STDOUT; stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+
+  # As 4 areas aparecem no summary, na ordem fixa de FR-001, MESMO com
+  # state-backend em failed.
+  _sm_prev_line=0
+  for _sm_area in hooks state-backend mcp telemetry; do
+    _sm_line=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -n "^$_sm_area  " | head -n 1 | cut -d: -f1)
+    if [ -z "$_sm_line" ]; then
+      _fail "scenario_summary_lists_all_four_areas" \
+        "area '$_sm_area' ausente do summary: $_CAPTURED_STDOUT"
+      return 1
+    fi
+    if [ "$_sm_line" -le "$_sm_prev_line" ]; then
+      _fail "scenario_summary_lists_all_four_areas" \
+        "ordem fixa violada em '$_sm_area' (linha $_sm_line, anterior $_sm_prev_line): $_CAPTURED_STDOUT"
+      return 1
+    fi
+    _sm_prev_line=$_sm_line
+  done
+
+  case "$_CAPTURED_STDOUT" in
+    *"state-backend  failed  global"*) : ;;
+    *)
+      _fail "scenario_summary_lists_all_four_areas" \
+        "linha de state-backend nao reporta failed+escopo global: $_CAPTURED_STDOUT"
+      return 1
+      ;;
+  esac
+
+  # `[escopo]=global` e EXCLUSIVO de state-backend (FR-017/task 7.1.2) —
+  # nenhuma outra linha do summary carrega " global".
+  _sm_global_lines=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c '  global')
+  if [ "$_sm_global_lines" != "1" ]; then
+    _fail "scenario_summary_lists_all_four_areas" \
+      "rotulo 'global' apareceu $_sm_global_lines vezes no summary (esperado 1, so em state-backend): $_CAPTURED_STDOUT"
+    return 1
+  fi
+
+  # Progresso/diagnostico (log_info/log_warn/log_error) continua em
+  # stderr — o summary em si nao duplica no stdout.
+  case "$_CAPTURED_STDOUT" in
+    *"[hooks]"* | *"[mcp]"* | *"[telemetry]"* | *"[state-backend]"*)
+      _fail "scenario_summary_lists_all_four_areas" \
+        "stdout carrega linhas de progresso ([area]) que deveriam estar so em stderr: $_CAPTURED_STDOUT"
+      return 1
+      ;;
+  esac
+}
+
+# ==== 7.2.2 summary declara o escopo real da verificacao (SEC-07/CHK009)
+# ====
+
+scenario_summary_declares_verification_scope() {
+  _repo="$TMPDIR_TEST/repo-summary-scope"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-summary-scope"
+  mkdir -p "$_home"
+
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --dry-run
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "scenario_summary_declares_verification_scope" \
+      "esperado exit 0 (--dry-run), obtido $_CAPTURED_EXIT (stdout: $_CAPTURED_STDOUT; stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+
+  # Cita os 3 hooks obrigatorios REAIS de _GH_HOOKS (nunca inventados).
+  for _sv_hook in "pretooluse-bash-guard.sh" "posttooluse-tool-call-tick.sh" \
+                  "posttooluse-agent-usage.sh"; do
+    case "$_CAPTURED_STDOUT" in
+      *"$_sv_hook"*) : ;;
+      *)
+        _fail "scenario_summary_declares_verification_scope" \
+          "declaracao de escopo nao cita '$_sv_hook': $_CAPTURED_STDOUT"
+        return 1
+        ;;
+    esac
+  done
+
+  # Declara explicitamente que o settings.json/.mcp.json NAO foi todo
+  # auditado — nao pode implicar garantia mais ampla (CHK009).
+  case "$_CAPTURED_STDOUT" in
+    *"nao foi auditada"* | *"NAO foi auditada"* \
+      | *"nao foram auditadas"* | *"NAO foram auditadas"*) : ;;
+    *)
+      _fail "scenario_summary_declares_verification_scope" \
+        "declaracao nao deixa claro que o restante do settings.json/.mcp.json NAO foi auditado: $_CAPTURED_STDOUT"
+      return 1
+      ;;
+  esac
+
+  # A declaracao de escopo vive em stdout (dado de saida), nao stderr.
+  case "$_CAPTURED_STDERR" in
+    *"_GH_HOOKS"*)
+      _fail "scenario_summary_declares_verification_scope" \
+        "declaracao de escopo vazou para stderr em vez de stdout: $_CAPTURED_STDERR"
       return 1
       ;;
   esac

--- a/tests/cstk/test_setup.sh
+++ b/tests/cstk/test_setup.sh
@@ -1,0 +1,225 @@
+#!/bin/sh
+# test_setup.sh — cobre cli/lib/setup.sh (feature cstk-setup, wizard guiado
+# de configuracao: hooks, backend de estado, MCP, telemetria).
+#
+# Cenarios:
+#   1  scenario_dispatch_setup_wiring (task 1.1.5) — wiring do dispatcher:
+#      `setup` existe no case generico, no help geral, no help por
+#      subcomando e nas 2 listas de "Comandos validos" das mensagens de
+#      erro. Segue o precedente de `scenario_help_lista_hooks` /
+#      `scenario_help_hooks_aponta_doc` em test_cstk-main.sh (5.27.0):
+#      o que se testa aqui e o WIRING — o comando existe, aparece no help
+#      e nao cai no ramo "comando desconhecido" — independente de
+#      cli/lib/setup.sh ja ter a implementacao completa da area.
+#   2  scenario_git_root_gate (task 1.2.5, quickstart Scenario 8, FR-011) —
+#      diretorio sem `.git` recusa com exit 3 e zero escrita; worktree
+#      (`.git` arquivo-ponteiro) e aceito.
+#   3  scenario_non_interactive_no_flag_fails_fast (task 1.2.6, quickstart
+#      Scenario 6, FR-007) — sem TTY e sem --dry-run/--yes, falha imediata
+#      exit 3 apontando as duas flags, sem bloquear esperando input.
+#   4  scenario_dry_run_precedes_yes (task 1.3.4, quickstart Scenario 5,
+#      FR-006) — `--dry-run --yes` juntas => mode=preview, zero escrita.
+#   5  scenario_unknown_flag_usage_error (task 1.3.5) — flag desconhecida
+#      => exit 2.
+#   6  scenario_catalog_flag_rejected (task 1.3.6, quickstart Scenario 16,
+#      FR-018) — `cstk setup --catalog /qualquer/dir` => exit 2 (nenhuma
+#      flag de override de catalogo existe neste subcomando).
+#
+# Ref: docs/specs/cstk-setup/tasks.md FASE 1; contracts/cli-setup.md §1.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+CSTK="$REPO_ROOT/cli/cstk"
+CSTK_LIB="$REPO_ROOT/cli/lib"
+export CSTK_LIB
+
+# Helper: cria repo git limpo em $1 (DIR), commit inicial vazio, branch main.
+# Mesmo padrao de tests/cstk/test_session.sh::_make_repo.
+_make_repo() {
+  _mr_dir=$1
+  mkdir -p "$_mr_dir"
+  ( cd "$_mr_dir" \
+    && git init -q -b main \
+    && git config user.email test@example.com \
+    && git config user.name "Test" \
+    && git commit -q --allow-empty -m "init" )
+}
+
+# ==== 1.1.5 wiring do dispatcher ====
+
+scenario_dispatch_setup_wiring() {
+  # (a) aparece no help geral
+  assert_exit 0 sh "$CSTK" --help || return 1
+  assert_stdout_contains "setup" || return 1
+
+  # (b) `cstk help setup` aponta para o contrato
+  assert_exit 0 sh "$CSTK" help setup || return 1
+  assert_stdout_contains "setup" || return 1
+  assert_stdout_contains "cli-setup.md" || return 1
+
+  # (c) `cstk setup --help` chega no ramo generico do dispatcher — nunca
+  # "comando desconhecido" (exit 2), esteja setup.sh ja implementado ou
+  # ainda no estagio de scaffold ("nao implementado ainda", exit 1).
+  capture sh "$CSTK" setup --help
+  if [ "$_CAPTURED_EXIT" = "2" ]; then
+    _fail "scenario_dispatch_setup_wiring" \
+      "cstk setup --help caiu no ramo de comando desconhecido (exit 2)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"comando desconhecido"*)
+      _fail "scenario_dispatch_setup_wiring" \
+        "stderr contem 'comando desconhecido': $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+
+  # (d) checagem estatica dos 4 pontos de edicao em cli/cstk
+  grep -q "setup.*Wizard guiado" "$CSTK" || {
+    _fail "scenario_dispatch_setup_wiring" "COMANDOS: entrada de setup ausente"
+    return 1
+  }
+  grep -qE '^ *setup\)$' "$CSTK" || {
+    _fail "scenario_dispatch_setup_wiring" "case de help por subcomando: setup) ausente"
+    return 1
+  }
+  grep -qE '\|setup\)$' "$CSTK" || {
+    _fail "scenario_dispatch_setup_wiring" "case generico do dispatch: |setup) ausente"
+    return 1
+  }
+  _n_validos=$(grep -c "usage, setup, 00c" "$CSTK") || _n_validos=0
+  if [ "$_n_validos" -lt 2 ]; then
+    _fail "scenario_dispatch_setup_wiring" \
+      "esperava setup nas 2 listas 'Comandos validos', achou $_n_validos"
+    return 1
+  fi
+}
+
+# ==== 1.2.5 gate de raiz de repo git (FR-011, quickstart Scenario 8) ====
+
+scenario_git_root_gate() {
+  # (a) diretorio SEM .git -> exit 3, diagnostico claro, zero escrita
+  _bare="$TMPDIR_TEST/no-git-dir"
+  mkdir -p "$_bare"
+  capture sh "$CSTK" setup --project-path "$_bare" --yes
+  if [ "$_CAPTURED_EXIT" != "3" ]; then
+    _fail "scenario_git_root_gate" \
+      "esperado exit 3 sem .git, obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  _n_entries=$(find "$_bare" -mindepth 1 | wc -l | tr -d ' ')
+  if [ "$_n_entries" != "0" ]; then
+    _fail "scenario_git_root_gate" \
+      "diretorio sem .git nao deveria receber escrita, achou $_n_entries entradas"
+    return 1
+  fi
+
+  # (b) worktree real (.git e arquivo-ponteiro, nao diretorio) -> aceito,
+  # ou seja, NAO recusado pela pre-condicao FR-011 (segue adiante e
+  # retorna 0 — FASE 1 ainda nao implementa as areas).
+  _src="$TMPDIR_TEST/repo-wt-gate"
+  _make_repo "$_src"
+  _wt_path="$( cd "$TMPDIR_TEST" && pwd -P )/repo-wt-gate-feat"
+  ( cd "$_src" && git worktree add -q -b feat-gate "$_wt_path" ) || {
+    _fail "scenario_git_root_gate" "git worktree add falhou"
+    return 1
+  }
+  [ -f "$_wt_path/.git" ] || {
+    _fail "scenario_git_root_gate" "pre-condicao do teste falhou: .git da worktree nao e arquivo"
+    return 1
+  }
+  assert_exit 0 sh "$CSTK" setup --project-path "$_wt_path" --dry-run || return 1
+}
+
+# ==== 1.2.6 falha rapida sem TTY e sem --dry-run/--yes (FR-007, quickstart
+# Scenario 6) ====
+
+scenario_non_interactive_no_flag_fails_fast() {
+  _repo="$TMPDIR_TEST/repo-no-tty"
+  _make_repo "$_repo"
+
+  # stdin de /dev/null simula ausencia de TTY sem bloquear o test runner.
+  capture sh -c 'sh "$1" setup --project-path "$2" < /dev/null' _ "$CSTK" "$_repo"
+  if [ "$_CAPTURED_EXIT" != "3" ]; then
+    _fail "scenario_non_interactive_no_flag_fails_fast" \
+      "esperado exit 3, obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"--dry-run"*"--yes"*|*"--yes"*"--dry-run"*) : ;;
+    *)
+      _fail "scenario_non_interactive_no_flag_fails_fast" \
+        "stderr nao aponta --dry-run/--yes: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+}
+
+# ==== 1.3.4 --dry-run precede --yes (FR-006, quickstart Scenario 5) ====
+
+scenario_dry_run_precedes_yes() {
+  _repo="$TMPDIR_TEST/repo-dryrun-yes"
+  _make_repo "$_repo"
+  _before=$(find "$_repo" -mindepth 1 | sort)
+
+  assert_exit 0 sh "$CSTK" setup --project-path "$_repo" --dry-run --yes || return 1
+  # Diagnosticos de modo vao para stderr (Constitution II: dados em stdout,
+  # erros/avisos em stderr) — cli/lib/common.sh::log_info.
+  assert_stderr_contains "mode=preview" || return 1
+
+  _after=$(find "$_repo" -mindepth 1 | sort)
+  if [ "$_before" != "$_after" ]; then
+    _fail "scenario_dry_run_precedes_yes" \
+      "esperava zero escrita com --dry-run --yes; arvore mudou"
+    return 1
+  fi
+
+  # Ordem invertida (--yes --dry-run) deve dar o mesmo resultado —
+  # precedencia e por PRESENCA da flag, nao por posicao.
+  assert_exit 0 sh "$CSTK" setup --project-path "$_repo" --yes --dry-run || return 1
+  assert_stderr_contains "mode=preview" || return 1
+}
+
+# ==== 1.3.5 flag desconhecida => exit 2 (uso incorreto) ====
+
+scenario_unknown_flag_usage_error() {
+  capture sh "$CSTK" setup --project-path "$PWD" --bogus-flag
+  if [ "$_CAPTURED_EXIT" != "2" ]; then
+    _fail "scenario_unknown_flag_usage_error" \
+      "esperado exit 2, obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"flag desconhecida"*) : ;;
+    *)
+      _fail "scenario_unknown_flag_usage_error" \
+        "stderr nao menciona 'flag desconhecida': $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+}
+
+# ==== 1.3.6 --catalog e rejeitada — FR-018, ausencia deliberada
+# (quickstart Scenario 16) ====
+
+scenario_catalog_flag_rejected() {
+  # Nenhuma flag de override de catalogo existe neste subcomando (FR-018)
+  # — --catalog cai no mesmo ramo generico de "flag desconhecida" que
+  # qualquer outra flag nao reconhecida, exit 2.
+  assert_exit 2 sh "$CSTK" setup --catalog /qualquer/dir || return 1
+
+  # Confirmacao estatica: setup.sh nunca implementa um case-arm para
+  # --catalog (mencoes em comentario explicando a ausencia deliberada,
+  # como esta propria linha do header do arquivo, nao contam).
+  if grep -qE -- '--catalog\)' "$CSTK_LIB/setup.sh"; then
+    _fail "scenario_catalog_flag_rejected" \
+      "cli/lib/setup.sh implementa um case-arm --catalog) — FR-018 exige ausencia deliberada"
+    return 1
+  fi
+  return 0
+}
+
+run_all_scenarios

--- a/tests/cstk/test_setup.sh
+++ b/tests/cstk/test_setup.sh
@@ -25,7 +25,28 @@
 #      FR-018) — `cstk setup --catalog /qualquer/dir` => exit 2 (nenhuma
 #      flag de override de catalogo existe neste subcomando).
 #
-# Ref: docs/specs/cstk-setup/tasks.md FASE 1; contracts/cli-setup.md §1.
+# FASE 3 (area de hooks, contracts/cli-setup.md §2):
+#   7  scenario_hooks_three_calls_isolated (task 3.1.5, achado SEC-03) —
+#      as 3 chamadas a guard-hooks-status.sh (baseline, --verify-registration,
+#      --include-loose-usage) ocorrem SEPARADAS, nunca combinadas.
+#   8  scenario_hooks_second_run_zero_calls (task 3.2.4, quickstart
+#      Scenario 2, I1) — segundo run com status=configured nao chama
+#      `hooks install`; arvore .claude identica antes/depois.
+#   9  scenario_hooks_paste_instructed_surfaces_warning (task 3.2.5,
+#      quickstart Scenario 7 sub-caso jq ausente) — exit 0 de `hooks
+#      install` em paste-instructed carrega aviso, nao vira applied cego.
+#  10  scenario_loose_usage_declined_mandatory_still_applied (task 3.3.4,
+#      quickstart Scenario 9, FR-008) — default skip do hook opt-in nao
+#      impede a aplicacao dos 3 hooks obrigatorios.
+#  11  scenario_hooks_divergent_no_install_call (task 3.4.4, quickstart
+#      Scenario 13, I6) — status=divergent nunca chama `hooks install`;
+#      .claude nem chega a ser criado no projeto.
+#  12  scenario_hooks_unavailable_status_reason (task 3.4.5, quickstart
+#      Scenario 15) — status=unavailable distingue "nao consegui
+#      verificar" do texto de divergent ("esta errado").
+#
+# Ref: docs/specs/cstk-setup/tasks.md FASE 1, FASE 3;
+#      contracts/cli-setup.md §1, §2.
 
 TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
@@ -46,6 +67,40 @@ _make_repo() {
     && git config user.email test@example.com \
     && git config user.name "Test" \
     && git commit -q --allow-empty -m "init" )
+}
+
+# ==== Helpers FASE 3 (area de hooks) ====
+
+# _make_fake_catalog HOME_DIR -> cria um catalogo MINIMO em
+# $HOME_DIR/.claude/skills/agente-00c-runtime/hooks com os 3 hooks
+# obrigatorios (scripts triviais, so precisam existir+ser copiaveis) e o
+# settings.snippet.json REAL do repo (para que jq faca merge de verdade).
+# Ecoa o path do catalogo em stdout.
+_make_fake_catalog() {
+  _mfc_dir="$1/.claude/skills/agente-00c-runtime/hooks"
+  mkdir -p "$_mfc_dir"
+  for _mfc_h in pretooluse-bash-guard.sh posttooluse-tool-call-tick.sh posttooluse-agent-usage.sh; do
+    printf '#!/bin/sh\nexit 0\n' > "$_mfc_dir/$_mfc_h"
+    chmod +x "$_mfc_dir/$_mfc_h"
+  done
+  cp "$REPO_ROOT/global/skills/agente-00c-runtime/hooks/settings.snippet.json" "$_mfc_dir/"
+  printf '%s' "$_mfc_dir"
+}
+
+# _make_shim_path_no_jq -> mesmo padrao de _make_shim_path
+# (tests/cstk/test_hooks.sh) — PATH curado SEM jq, para exercitar o
+# caminho paste-instructed (jq ausente). Inclui `cmp` (freshness) e `sh`
+# (necessario para o proprio `env -i PATH=... sh "$CSTK" ...` executar).
+_make_shim_path_no_jq() {
+  _msp_dir=$(mktemp -d "$TMPDIR_TEST/shimbin.XXXXXX")
+  for _msp_c in sh mktemp awk sed grep find head printf cp mv rm mkdir \
+                chmod ls dirname basename tr cut wc env command sort \
+                uniq date cat cmp; do
+    _msp_src=$(command -v "$_msp_c" 2>/dev/null) || continue
+    [ -n "$_msp_src" ] || continue
+    ln -sf "$_msp_src" "$_msp_dir/$_msp_c" 2>/dev/null || :
+  done
+  printf '%s' "$_msp_dir"
 }
 
 # ==== 1.1.5 wiring do dispatcher ====
@@ -220,6 +275,288 @@ scenario_catalog_flag_rejected() {
     return 1
   fi
   return 0
+}
+
+# ==== FASE 3 — Area de hooks ====
+
+# ==== 3.1.5 tres chamadas isoladas (achado SEC-03) ====
+
+scenario_hooks_three_calls_isolated() {
+  _repo="$TMPDIR_TEST/repo-hooks-isolated"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-hooks-isolated"
+  mkdir -p "$_home"
+
+  _stubbin="$TMPDIR_TEST/stubbin-isolated"
+  mkdir -p "$_stubbin"
+  _calls="$TMPDIR_TEST/gh-calls-isolated.log"
+  : > "$_calls"
+  cat > "$_stubbin/guard-hooks-status.sh" <<STUB
+#!/bin/sh
+printf '%s\n' "\$*" >> "$_calls"
+case "\$*" in
+  *--verify-registration*)
+    printf 'pretooluse-bash-guard.sh\tpresent\tregistered\tcurrent\tcanonical\n'
+    printf 'posttooluse-tool-call-tick.sh\tpresent\tregistered\tcurrent\tcanonical\n'
+    printf 'posttooluse-agent-usage.sh\tpresent\tregistered\tcurrent\tcanonical\n'
+    exit 0 ;;
+  *--include-loose-usage*)
+    printf 'pretooluse-bash-guard.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-tool-call-tick.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-agent-usage.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-loose-usage.sh\tmissing\tunregistered\tunknown\n'
+    exit 0 ;;
+  *)
+    printf 'pretooluse-bash-guard.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-tool-call-tick.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-agent-usage.sh\tpresent\tregistered\tcurrent\n'
+    exit 0 ;;
+esac
+STUB
+  chmod +x "$_stubbin/guard-hooks-status.sh"
+
+  assert_exit 0 env PATH="$_stubbin:$PATH" HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --dry-run || return 1
+
+  _n=$(wc -l < "$_calls" | tr -d ' ')
+  if [ "$_n" != "3" ]; then
+    _fail "scenario_hooks_three_calls_isolated" \
+      "esperava exatamente 3 chamadas, obteve $_n: $(cat "$_calls")"
+    return 1
+  fi
+
+  if grep -qE -- '--verify-registration.*--include-loose-usage|--include-loose-usage.*--verify-registration' "$_calls"; then
+    _fail "scenario_hooks_three_calls_isolated" \
+      "as duas flags de extensao foram combinadas numa unica chamada"
+    return 1
+  fi
+
+  _n_baseline=$(grep -vc -- '--verify-registration\|--include-loose-usage' "$_calls")
+  if [ "$_n_baseline" != "1" ]; then
+    _fail "scenario_hooks_three_calls_isolated" \
+      "esperava exatamente 1 chamada baseline sem flags, obteve $_n_baseline"
+    return 1
+  fi
+  grep -q -- '--verify-registration' "$_calls" || {
+    _fail "scenario_hooks_three_calls_isolated" "chamada --verify-registration ausente"
+    return 1
+  }
+  grep -q -- '--include-loose-usage' "$_calls" || {
+    _fail "scenario_hooks_three_calls_isolated" "chamada --include-loose-usage ausente"
+    return 1
+  }
+}
+
+# ==== 3.2.4 status=configured -> zero chamadas de aplicacao (I1) ====
+
+scenario_hooks_second_run_zero_calls() {
+  _repo="$TMPDIR_TEST/repo-hooks-idem"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-hooks-idem"
+  mkdir -p "$_home"
+  _cat=$(_make_fake_catalog "$_home")
+
+  assert_exit 0 env HOME="$_home" CSTK_HOOKS_CATALOG_DIR="$_cat" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes || return 1
+
+  [ -f "$_repo/.claude/hooks/pretooluse-bash-guard.sh" ] || {
+    _fail "scenario_hooks_second_run_zero_calls" \
+      "pre-condicao do teste falhou: primeiro run nao provisionou os hooks"
+    return 1
+  }
+  cp -R "$_repo/.claude" "$TMPDIR_TEST/hooks-idem-snapshot"
+
+  capture env HOME="$_home" CSTK_HOOKS_CATALOG_DIR="$_cat" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "scenario_hooks_second_run_zero_calls" \
+      "segundo run esperava exit 0, obteve $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"already-configured"*) : ;;
+    *)
+      _fail "scenario_hooks_second_run_zero_calls" \
+        "segundo run nao reportou already-configured: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+
+  if ! diff -r "$TMPDIR_TEST/hooks-idem-snapshot" "$_repo/.claude" >/dev/null 2>&1; then
+    _fail "scenario_hooks_second_run_zero_calls" \
+      ".claude mudou no segundo run — esperava zero chamada de aplicacao (I1)"
+    return 1
+  fi
+}
+
+# ==== 3.2.5 paste-instructed (jq ausente) nao vira applied cego ====
+
+scenario_hooks_paste_instructed_surfaces_warning() {
+  if ! command -v jq >/dev/null 2>&1; then
+    _error "no_jq" "jq nao disponivel no ambiente — cenario exige jq presente no PATH real para o shim ter algo a excluir"
+  fi
+  _repo="$TMPDIR_TEST/repo-hooks-paste"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-hooks-paste"
+  mkdir -p "$_home"
+  _cat=$(_make_fake_catalog "$_home")
+  _shim=$(_make_shim_path_no_jq)
+
+  capture env -i PATH="$_shim" HOME="$_home" CSTK_HOOKS_CATALOG_DIR="$_cat" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "scenario_hooks_paste_instructed_surfaces_warning" \
+      "esperado exit 0 (applied com aviso), obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"jq ausente"*) : ;;
+    *)
+      _fail "scenario_hooks_paste_instructed_surfaces_warning" \
+        "stderr nao carrega o aviso de jq ausente / colagem manual: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"outcome=applied"*) : ;;
+    *)
+      _fail "scenario_hooks_paste_instructed_surfaces_warning" \
+        "outcome nao reportado como applied: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+}
+
+# ==== 3.3.4 loose usage recusado nao impede hooks obrigatorios (FR-008) ====
+
+scenario_loose_usage_declined_mandatory_still_applied() {
+  _repo="$TMPDIR_TEST/repo-hooks-loose-declined"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-hooks-loose-declined"
+  mkdir -p "$_home"
+  _cat=$(_make_fake_catalog "$_home")
+  # Hook opt-in TAMBEM presente no catalogo — prova que a ausencia no
+  # projeto e por ESCOLHA (default skip em --yes), nao por ausencia no
+  # catalogo.
+  printf '#!/bin/sh\nexit 0\n' > "$_cat/posttooluse-loose-usage.sh"
+  chmod +x "$_cat/posttooluse-loose-usage.sh"
+
+  assert_exit 0 env HOME="$_home" CSTK_HOOKS_CATALOG_DIR="$_cat" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes || return 1
+
+  assert_exit 0 env HOME="$_home" CSTK_HOOKS_CATALOG_DIR="$_cat" \
+    sh "$REPO_ROOT/global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh" \
+    check --projeto-alvo-path "$_repo" --quiet || return 1
+
+  if [ -f "$_repo/.claude/hooks/posttooluse-loose-usage.sh" ]; then
+    _fail "scenario_loose_usage_declined_mandatory_still_applied" \
+      "hook opt-in de loose usage foi provisionado apesar do default skip"
+    return 1
+  fi
+  if grep -q "posttooluse-loose-usage" "$_repo/.claude/settings.json" 2>/dev/null; then
+    _fail "scenario_loose_usage_declined_mandatory_still_applied" \
+      "hook opt-in de loose usage foi registrado em settings.json apesar do default skip"
+    return 1
+  fi
+}
+
+# ==== 3.4.4 status=divergent -> zero chamada de aplicacao (I6) ====
+
+scenario_hooks_divergent_no_install_call() {
+  _repo="$TMPDIR_TEST/repo-hooks-divergent"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-hooks-divergent"
+  mkdir -p "$_home"
+  # Catalogo REAL presente — se hooks_main fosse chamado por engano isso
+  # deixaria rastro (.claude criado/populado no projeto).
+  _make_fake_catalog "$_home" >/dev/null
+
+  _stubbin="$TMPDIR_TEST/stubbin-divergent"
+  mkdir -p "$_stubbin"
+  cat > "$_stubbin/guard-hooks-status.sh" <<'STUB'
+#!/bin/sh
+case "$*" in
+  *--verify-registration*)
+    printf 'pretooluse-bash-guard.sh\tpresent\tregistered\tcurrent\tdivergent\n'
+    printf 'posttooluse-tool-call-tick.sh\tpresent\tregistered\tcurrent\tcanonical\n'
+    printf 'posttooluse-agent-usage.sh\tpresent\tregistered\tcurrent\tcanonical\n'
+    exit 1 ;;
+  *--include-loose-usage*)
+    printf 'pretooluse-bash-guard.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-tool-call-tick.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-agent-usage.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-loose-usage.sh\tmissing\tunregistered\tunknown\n'
+    exit 0 ;;
+  *)
+    printf 'pretooluse-bash-guard.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-tool-call-tick.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-agent-usage.sh\tpresent\tregistered\tcurrent\n'
+    exit 0 ;;
+esac
+STUB
+  chmod +x "$_stubbin/guard-hooks-status.sh"
+
+  capture env PATH="$_stubbin:$PATH" HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "scenario_hooks_divergent_no_install_call" \
+      "esperado exit 1 (area divergente), obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  if [ -e "$_repo/.claude" ]; then
+    _fail "scenario_hooks_divergent_no_install_call" \
+      "status=divergent NAO pode chamar aplicacao (I6); .claude foi criado no projeto"
+    return 1
+  fi
+}
+
+# ==== 3.4.5 status=unavailable distingue motivo de divergent ====
+
+scenario_hooks_unavailable_status_reason() {
+  _repo="$TMPDIR_TEST/repo-hooks-unavailable"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-hooks-unavailable"
+  mkdir -p "$_home"
+  mkdir -p "$_repo/.claude/hooks"
+  printf '#!/bin/sh\nexit 0\n' > "$_repo/.claude/hooks/pretooluse-bash-guard.sh"
+  chmod +x "$_repo/.claude/hooks/pretooluse-bash-guard.sh"
+  # settings.json minificado numa unica linha fisica: impede atribuicao
+  # por linha em _gh_verify_registration -> indeterminate (nunca
+  # canonical) — e como o hook ESTA registrado (baseline), isso e
+  # ambiguidade REAL, nao o caso trivial "nada para autenticar".
+  printf '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"\\"$CLAUDE_PROJECT_DIR\\"/.claude/hooks/pretooluse-bash-guard.sh"}]}]}}' \
+    > "$_repo/.claude/settings.json"
+
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" --yes
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "scenario_hooks_unavailable_status_reason" \
+      "esperado exit 1 (unavailable), obtido $_CAPTURED_EXIT (stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+  case "$_CAPTURED_STDERR" in
+    *"unavailable"*) : ;;
+    *)
+      _fail "scenario_hooks_unavailable_status_reason" \
+        "stderr nao reporta status=unavailable: $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"registro nao-canonico detectado"*)
+      _fail "scenario_hooks_unavailable_status_reason" \
+        "reason usou o texto de divergent ('esta errado') em vez do de unavailable ('nao consegui verificar')"
+      return 1
+      ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"nao pode ser confirmada nem refutada"*) : ;;
+    *)
+      _fail "scenario_hooks_unavailable_status_reason" \
+        "reason nao distingue 'nao consegui verificar': $_CAPTURED_STDERR"
+      return 1
+      ;;
+  esac
 }
 
 run_all_scenarios

--- a/tests/cstk/test_setup.sh
+++ b/tests/cstk/test_setup.sh
@@ -101,8 +101,20 @@
 #      de `_GH_HOOKS` foram verificados, sem implicar auditoria do
 #      `settings.json`/`.mcp.json` inteiro.
 #
+# FASE 8 (integracao — tasks.md 8.1.3, quickstart Scenario 1):
+#  24  scenario_interactive_happy_path_accepts_all (task 8.1.3) — UNICO
+#      cenario que roda em mode=interactive de verdade (sem --yes/--dry-run),
+#      via CSTK_FORCE_INTERACTIVE=1 (bypassa require_tty, ui.sh:43) +
+#      stdin alimentado com as respostas dos 4 prompts reais na ordem fixa
+#      (hooks-mandatorio, loose-usage, state-backend, mcp — telemetria
+#      nunca pergunta, FR-012): y/n/y/y (quickstart Scenario 1: afirmativa
+#      p/ hooks, negativa p/ loose usage). Todos os demais 23 cenarios
+#      usam --yes/--dry-run, que pulam _setup_prompt_yn inteiramente — este
+#      e o unico que exercita a leitura de stdin do wizard de ponta a
+#      ponta.
+#
 # Ref: docs/specs/cstk-setup/tasks.md FASE 1, FASE 3, FASE 4, FASE 5,
-#      FASE 6, FASE 7; contracts/cli-setup.md §1, §2, §3, §5.
+#      FASE 6, FASE 7, FASE 8; contracts/cli-setup.md §1, §2, §3, §5.
 
 TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
@@ -1220,6 +1232,88 @@ scenario_summary_declares_verification_scope() {
       return 1
       ;;
   esac
+}
+
+# ==== FASE 8 — Integracao: modo interativo real (task 8.1.3) ====
+
+# ==== 8.1.3 happy path interativo aceitando os 4 prompts (quickstart
+# Scenario 1) ====
+
+scenario_interactive_happy_path_accepts_all() {
+  if ! command -v jq >/dev/null 2>&1; then
+    _error "no_jq" "jq nao disponivel no ambiente — cenario exige jq presente no PATH real para os merges de hooks/mcp ocorrerem de verdade"
+  fi
+  if ! command -v sqlite3 >/dev/null 2>&1; then
+    _error "no_sqlite3" "sqlite3 nao disponivel no ambiente — cenario exige sqlite3 presente no PATH real para enable-sqlite aplicar de verdade"
+  fi
+
+  _repo="$TMPDIR_TEST/repo-interactive-happy"
+  _make_repo "$_repo"
+  _home="$TMPDIR_TEST/home-interactive-happy"
+  mkdir -p "$_home"
+  _cat=$(_make_fake_catalog "$_home")
+
+  # Sem --yes/--dry-run -> mode=interactive (_setup_resolve_mode). Os 4
+  # prompts reais de _setup_prompt_yn, na ordem em que o wizard os emite:
+  #   1. [hooks] instalar os hooks obrigatorios agora?      -> y
+  #   2. [hooks] tambem habilitar loose usage (default nao)? -> n
+  #   3. [state-backend] ativar backend sqlite GLOBALMENTE?  -> y
+  #   4. [mcp] registrar o servidor de estado MCP agora?     -> y
+  # (telemetria e 100% read-only, FR-012 — nunca pergunta.)
+  capture env CSTK_FORCE_INTERACTIVE=1 HOME="$_home" \
+    CSTK_HOOKS_CATALOG_DIR="$_cat" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_repo" <<EOF
+y
+n
+y
+y
+EOF
+
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "scenario_interactive_happy_path_accepts_all" \
+      "esperado exit 0, obtido $_CAPTURED_EXIT (stdout: $_CAPTURED_STDOUT; stderr: $_CAPTURED_STDERR)"
+    return 1
+  fi
+
+  # As 4 areas presentes no summary final (FR-010), ordem fixa de FR-001.
+  for _a in "hooks" "state-backend" "mcp" "telemetry"; do
+    case "$_CAPTURED_STDOUT" in
+      *"$_a "*) : ;;
+      *)
+        _fail "scenario_interactive_happy_path_accepts_all" \
+          "summary nao lista a area '$_a': $_CAPTURED_STDOUT"
+        return 1
+        ;;
+    esac
+  done
+
+  # hooks obrigatorios de fato provisionados apos aceite interativo (y).
+  if [ ! -f "$_repo/.claude/hooks/pretooluse-bash-guard.sh" ]; then
+    _fail "scenario_interactive_happy_path_accepts_all" \
+      "hooks obrigatorios nao foram aplicados apesar do aceite interativo (y)"
+    return 1
+  fi
+
+  # loose usage recusado interativamente (n) -> hook opt-in NAO provisionado.
+  if [ -f "$_repo/.claude/hooks/posttooluse-loose-usage.sh" ]; then
+    _fail "scenario_interactive_happy_path_accepts_all" \
+      "loose usage foi provisionado apesar da resposta negativa (n)"
+    return 1
+  fi
+
+  # state-backend aceito interativamente (y) -> config global GRAVADA.
+  if ! grep -q '^state_backend=sqlite$' "$_home/.claude/cstk/config" 2>/dev/null; then
+    _fail "scenario_interactive_happy_path_accepts_all" \
+      "state-backend nao foi migrado apesar do aceite interativo (y); config: $(cat "$_home/.claude/cstk/config" 2>/dev/null)"
+    return 1
+  fi
+
+  # mcp aceito interativamente (y) -> .mcp.json ESCRITO no projeto.
+  if ! grep -Fq -- '"cstk-state"' "$_repo/.mcp.json" 2>/dev/null; then
+    _fail "scenario_interactive_happy_path_accepts_all" \
+      ".mcp.json nao foi escrito apesar do aceite interativo (y)"
+    return 1
+  fi
 }
 
 run_all_scenarios

--- a/tests/test_guard-hooks-status.sh
+++ b/tests/test_guard-hooks-status.sh
@@ -94,6 +94,30 @@ _register() {
   } > "$_rp/.claude/settings.json"
 }
 
+# _register_canonical PAP HOOK... -> settings.json na FORMA CANONICA real
+# (mesmos bytes que apply_guard_hooks/merge_settings produzem via jq
+# pretty-print: uma "command" por hook, cada um na sua propria linha,
+# contendo o token "command" + o fragmento canonico
+# \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/<basename>). Usado pelos cenarios
+# de --verify-registration (2.2), que precisam do byte exato — diferente
+# de `_register` (forma simplificada acima, usada so p/ registered/unregistered).
+_register_canonical() {
+  _rc_p=$1
+  shift
+  {
+    printf '{\n  "hooks": {\n    "PostToolUse": [\n'
+    _rc_first=1
+    for _rc_h in "$@"; do
+      [ "$_rc_first" = 1 ] || printf ',\n'
+      _rc_first=0
+      printf '      {\n        "hooks": [\n          {\n            "type": "command",\n'
+      printf '            "command": "\\\"$CLAUDE_PROJECT_DIR\\\"/.claude/hooks/%s"\n' "$_rc_h"
+      printf '          }\n        ]\n      }'
+    done
+    printf '\n    ]\n  }\n}\n'
+  } > "$_rc_p/.claude/settings.json"
+}
+
 # _fully_provisioned PAP -> os 3 hooks presentes E registrados.
 _fully_provisioned() {
   for _h in $_HOOKS; do _put_hook "$1" "$_h"; done
@@ -423,6 +447,188 @@ scenario_funciona_sem_jq() {
   capture env PATH="$_shim" sh "$SCRIPT" check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 0 ] \
     || { _fail "exit" "sem jq deveria continuar exit 0, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+# ==== --include-loose-usage (feature cstk-setup, FASE 2.1, FR-002/FR-008) ====
+
+# Flag presente, hook opt-in ausente => 4a linha reflete ausencia SEM
+# afetar o exit (derivado so dos 3 hooks obrigatorios).
+scenario_loose_usage_detection_current_runtime() {
+  _p=$(_mkproj proj-loose-current)
+  _fully_provisioned "$_p"
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --include-loose-usage
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 (hook opt-in ausente nao afeta exit), obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-loose-usage.sh	missing	unregistered	' \
+    || { _fail "TSV" "esperado 4a linha posttooluse-loose-usage.sh missing/unregistered"; return 1; }
+  _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | wc -l | tr -d ' ')
+  [ "$_n" = 4 ] || { _fail "TSV" "esperado 4 linhas com --include-loose-usage, obtido $_n"; return 1; }
+  return 0
+}
+
+# Sem a flag: saida byte-a-byte identica (retro-compat) — 3 linhas so.
+scenario_loose_usage_sem_flag_saida_identica() {
+  _p=$(_mkproj proj-loose-sem-flag)
+  _fully_provisioned "$_p"
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | wc -l | tr -d ' ')
+  [ "$_n" = 3 ] || { _fail "TSV" "sem a flag deve continuar 3 linhas, obtido $_n"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q 'loose-usage' \
+    && { _fail "TSV" "sem a flag nao pode citar loose-usage"; return 1; }
+  return 0
+}
+
+# Runtime antigo (git HEAD, antes desta extensao) rejeita a flag
+# desconhecida com exit 2 — o consumidor MUST tratar como
+# loose_usage_status=indeterminate, nunca como falha da area de hooks.
+scenario_loose_usage_detection_stale_runtime() {
+  _old="$TMPDIR_TEST/old-guard-hooks-status.sh"
+  if ! git -C "$REPO_ROOT" show HEAD:global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh \
+       > "$_old" 2>/dev/null; then
+    printf '# scenario_loose_usage_detection_stale_runtime: HEAD sem versao anterior — pulando\n'
+    return 0
+  fi
+  _p=$(_mkproj proj-loose-stale)
+  _fully_provisioned "$_p"
+  capture sh "$_old" check --projeto-alvo-path "$_p" --include-loose-usage --quiet
+  [ "$_CAPTURED_EXIT" = 2 ] \
+    || { _fail "exit" "runtime antigo deveria rejeitar --include-loose-usage com exit 2, obtido $_CAPTURED_EXIT"; return 1; }
+  # A chamada baseline (sem a flag nova), no MESMO runtime antigo, segue
+  # respondendo normalmente — a falha e isolada a flag desconhecida.
+  capture sh "$_old" check --projeto-alvo-path "$_p" --quiet
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "exit" "baseline no runtime antigo deveria seguir exit 0, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+# ==== --verify-registration (feature cstk-setup, FASE 2.2, FR-016, SEC-01) ====
+
+scenario_verify_registration_canonical() {
+  _p=$(_mkproj proj-verify-canonical)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  # shellcheck disable=SC2086
+  _register_canonical "$_p" $_HOOKS
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --verify-registration
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "registro canonico deveria manter exit 0, obtido $_CAPTURED_EXIT"; return 1; }
+  for _h in $_HOOKS; do
+    printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered	current	canonical$" \
+      || { _fail "TSV" "esperado 5a coluna 'canonical' para $_h"; return 1; }
+  done
+  return 0
+}
+
+# Sem a flag: saida e exit identicos aos atuais (retro-compat) — 4 colunas so.
+scenario_verify_registration_sem_flag_saida_identica() {
+  _p=$(_mkproj proj-verify-sem-flag)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  # shellcheck disable=SC2086
+  _register_canonical "$_p" $_HOOKS
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q 'canonical\|divergent\|indeterminate' \
+    && { _fail "TSV" "sem a flag nao pode ter 5a coluna"; return 1; }
+  return 0
+}
+
+# quickstart Scenario 13: "command" real aponta para outro programa
+# mantendo o basename na linha => divergent, exit 1 com a flag.
+scenario_hook_redirected_reports_divergent() {
+  _p=$(_mkproj proj-verify-redirected)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  {
+    printf '{\n  "hooks": {\n    "PostToolUse": [\n'
+    printf '      {\n        "hooks": [\n          {\n            "type": "command",\n'
+    printf '            "command": "/opt/rogue/wrapper.sh pretooluse-bash-guard.sh"\n'
+    printf '          }\n        ]\n      },\n'
+    printf '      {\n        "hooks": [\n          {\n            "type": "command",\n'
+    printf '            "command": "\\\"$CLAUDE_PROJECT_DIR\\\"/.claude/hooks/posttooluse-tool-call-tick.sh"\n'
+    printf '          }\n        ]\n      },\n'
+    printf '      {\n        "hooks": [\n          {\n            "type": "command",\n'
+    printf '            "command": "\\\"$CLAUDE_PROJECT_DIR\\\"/.claude/hooks/posttooluse-agent-usage.sh"\n'
+    printf '          }\n        ]\n      }\n    ]\n  }\n}\n'
+  } > "$_p/.claude/settings.json"
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --verify-registration --quiet
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "hook redirecionado deve reprovar com a flag, esperado 1 obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^pretooluse-bash-guard.sh	present	registered	current	divergent$' \
+    || { _fail "TSV" "esperado 'divergent' para pretooluse-bash-guard.sh"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-tool-call-tick.sh	present	registered	current	canonical$' \
+    || { _fail "TSV" "os demais hooks deveriam continuar 'canonical'"; return 1; }
+  return 0
+}
+
+# Achado SEC-01: linha-isca decorativa com basename+fragmento canonico MAS
+# sem o token "command" na mesma linha NAO conta como canonical; a linha
+# "command" real (divergente) tambem cita o basename => divergent.
+scenario_decoy_line_not_canonical() {
+  _p=$(_mkproj proj-verify-decoy)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  {
+    printf '{\n  "hooks": {\n'
+    printf '    "_comment_decoy": "hook oficial: \\\"$CLAUDE_PROJECT_DIR\\\"/.claude/hooks/pretooluse-bash-guard.sh",\n'
+    printf '    "PostToolUse": [\n'
+    printf '      {\n        "hooks": [\n          {\n            "type": "command",\n'
+    printf '            "command": "/tmp/rogue-wrapper-pretooluse-bash-guard.sh"\n'
+    printf '          }\n        ]\n      },\n'
+    printf '      {\n        "hooks": [\n          {\n            "type": "command",\n'
+    printf '            "command": "\\\"$CLAUDE_PROJECT_DIR\\\"/.claude/hooks/posttooluse-tool-call-tick.sh"\n'
+    printf '          }\n        ]\n      },\n'
+    printf '      {\n        "hooks": [\n          {\n            "type": "command",\n'
+    printf '            "command": "\\\"$CLAUDE_PROJECT_DIR\\\"/.claude/hooks/posttooluse-agent-usage.sh"\n'
+    printf '          }\n        ]\n      }\n    ]\n  }\n}\n'
+  } > "$_p/.claude/settings.json"
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --verify-registration --quiet
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "decoy + command divergente deve reprovar, esperado 1 obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^pretooluse-bash-guard.sh	present	registered	current	divergent$' \
+    || { _fail "TSV" "linha-isca nao pode contar como canonical (SEC-01)"; return 1; }
+  return 0
+}
+
+# Limite textual declarado: settings.json minificado numa unica linha
+# fisica impede atribuicao por linha => indeterminate (nunca canonical).
+scenario_minified_settings_indeterminate() {
+  _p=$(_mkproj proj-verify-minified)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  # shellcheck disable=SC2086
+  _register_canonical "$_p" $_HOOKS
+  # Colapsa para uma unica linha fisica preservando todo o conteudo textual.
+  _minified=$(tr '\n' ' ' < "$_p/.claude/settings.json")
+  printf '%s' "$_minified" > "$_p/.claude/settings.json"
+  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --verify-registration
+  for _h in $_HOOKS; do
+    printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered	current	indeterminate$" \
+      || { _fail "TSV" "settings.json minificado deveria dar 'indeterminate' para $_h"; return 1; }
+  done
+  return 0
+}
+
+# Achado SEC-03: --verify-registration roda SEMPRE isolada da chamada
+# baseline. Num runtime antigo (git HEAD anterior a esta extensao) a flag
+# falha com exit 2, mas a chamada baseline SEPARADA (sem a flag), no MESMO
+# runtime antigo, continua respondendo o veredito basico normalmente —
+# nenhuma das duas mascara a outra.
+scenario_verify_registration_isolated_from_baseline() {
+  _old="$TMPDIR_TEST/old-guard-hooks-status-verify.sh"
+  if ! git -C "$REPO_ROOT" show HEAD:global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh \
+       > "$_old" 2>/dev/null; then
+    printf '# scenario_verify_registration_isolated_from_baseline: HEAD sem versao anterior — pulando\n'
+    return 0
+  fi
+  _p=$(_mkproj proj-verify-isolated)
+  _fully_provisioned "$_p"
+  capture sh "$_old" check --projeto-alvo-path "$_p" --verify-registration --quiet
+  [ "$_CAPTURED_EXIT" = 2 ] \
+    || { _fail "exit" "verify-registration no runtime antigo deveria dar exit 2, obtido $_CAPTURED_EXIT"; return 1; }
+  capture sh "$_old" check --projeto-alvo-path "$_p" --quiet
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "exit" "baseline SEPARADA no mesmo runtime antigo deveria seguir exit 0, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+# Retro-compatibilidade: flag desconhecida em runtime CORRENTE continua
+# exit 2 (comportamento generico de parsing, nao especifico das novas flags).
+scenario_check_flag_ainda_rejeitada_apos_extensoes() {
+  _p=$(_mkproj proj-flag-pos-extensao)
+  assert_exit 2 sh "$SCRIPT" check --projeto-alvo-path "$_p" --flag-totalmente-inventada || return 1
   return 0
 }
 

--- a/tests/test_guard-hooks-status.sh
+++ b/tests/test_guard-hooks-status.sh
@@ -481,11 +481,23 @@ scenario_loose_usage_sem_flag_saida_identica() {
 # Runtime antigo (git HEAD, antes desta extensao) rejeita a flag
 # desconhecida com exit 2 — o consumidor MUST tratar como
 # loose_usage_status=indeterminate, nunca como falha da area de hooks.
+#
+# NAO usar "HEAD" como proxy de "runtime antigo" — mesmo achado de campo
+# do comentario em scenario_verify_registration_isolated_from_baseline:
+# a partir do commit em que --include-loose-usage e commitada, HEAD **e**
+# o runtime que ja suporta a flag. Resolve-se o commit de introducao via
+# pickaxe e usa-se o PAI dele.
 scenario_loose_usage_detection_stale_runtime() {
   _old="$TMPDIR_TEST/old-guard-hooks-status.sh"
-  if ! git -C "$REPO_ROOT" show HEAD:global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh \
+  _intro=$(git -C "$REPO_ROOT" log -S'--include-loose-usage' --format=%H \
+    -- global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh | tail -1)
+  if [ -z "$_intro" ]; then
+    printf '# scenario_loose_usage_detection_stale_runtime: commit de introducao nao encontrado — pulando\n'
+    return 0
+  fi
+  if ! git -C "$REPO_ROOT" show "${_intro}~1:global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh" \
        > "$_old" 2>/dev/null; then
-    printf '# scenario_loose_usage_detection_stale_runtime: HEAD sem versao anterior — pulando\n'
+    printf '# scenario_loose_usage_detection_stale_runtime: sem versao anterior a introducao — pulando\n'
     return 0
   fi
   _p=$(_mkproj proj-loose-stale)
@@ -602,15 +614,30 @@ scenario_minified_settings_indeterminate() {
 }
 
 # Achado SEC-03: --verify-registration roda SEMPRE isolada da chamada
-# baseline. Num runtime antigo (git HEAD anterior a esta extensao) a flag
-# falha com exit 2, mas a chamada baseline SEPARADA (sem a flag), no MESMO
-# runtime antigo, continua respondendo o veredito basico normalmente —
-# nenhuma das duas mascara a outra.
+# baseline. Num runtime antigo (git anterior a introducao desta extensao)
+# a flag falha com exit 2, mas a chamada baseline SEPARADA (sem a flag),
+# no MESMO runtime antigo, continua respondendo o veredito basico
+# normalmente — nenhuma das duas mascara a outra.
+#
+# NAO usar "HEAD" como proxy de "runtime antigo": a extensao
+# --verify-registration foi commitada JUNTO com este proprio teste (task
+# cstk-setup 2.2), entao a partir do commit em que ambos aterrissam, HEAD
+# **e** o runtime que ja suporta a flag — "HEAD:<path>" deixa de ser uma
+# versao antiga e o cenario falha silenciosamente (achado de campo,
+# onda cstk-setup FASE 3). Resolve-se o commit de INTRODUCAO da flag via
+# pickaxe (`git log -S`) e usa-se o PAI dele — robusto a qualquer commit
+# futuro que volte a tocar o arquivo (nao depende de HEAD/HEAD~1).
 scenario_verify_registration_isolated_from_baseline() {
   _old="$TMPDIR_TEST/old-guard-hooks-status-verify.sh"
-  if ! git -C "$REPO_ROOT" show HEAD:global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh \
+  _intro=$(git -C "$REPO_ROOT" log -S'--verify-registration' --format=%H \
+    -- global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh | tail -1)
+  if [ -z "$_intro" ]; then
+    printf '# scenario_verify_registration_isolated_from_baseline: commit de introducao nao encontrado — pulando\n'
+    return 0
+  fi
+  if ! git -C "$REPO_ROOT" show "${_intro}~1:global/skills/agente-00c-runtime/scripts/guard-hooks-status.sh" \
        > "$_old" 2>/dev/null; then
-    printf '# scenario_verify_registration_isolated_from_baseline: HEAD sem versao anterior — pulando\n'
+    printf '# scenario_verify_registration_isolated_from_baseline: sem versao anterior a introducao — pulando\n'
     return 0
   fi
   _p=$(_mkproj proj-verify-isolated)


### PR DESCRIPTION
## Summary

Novo subcomando interativo `cstk setup` (cli/lib/setup.sh) que consolida num unico fluxo guiado as configuracoes de projeto que antes exigiam varios comandos individuais:

- **Hooks** (3 obrigatorios via `cstk hooks install`, com opt-in explicito de `--with-loose-usage`)
- **State backend** (`cstk state enable-sqlite` + `cstk doctor --deps`, rotulo explicito de escopo global; em `--yes` so aplica quando nao ha config previa)
- **MCP state-server** (`cstk mcp install`, funciona mesmo sem Docker — registro inerte + aviso)
- **Telemetria OTel** (area 100% read-only: diagnostico via `otel-usage.sh preflight` + instrucoes do README; nunca escreve fora do projeto)

## Destaques de design

- Deteccao ENDURECIDA (gate owasp block-004): "ja configurado" exige path registrado apontando para o script real do catalogo — registro divergente vira status `divergent` com remediacao em 2 etapas, nunca falso "already configured"
- SEC-01..07 do re-review fechados (linha-isca, fail-open de indeterminate, retrocompat de flags em chamadas separadas, opt-in de config global em --yes, candidatos MCP restritos, stdout vazio nunca e resposta, summary declara escopo da verificacao)
- Idempotente; precedencia `--dry-run` > `--yes` > interativo; gate FR-011 = raiz de repo git
- Pipeline SDD completa (feature-00c): spec + plan + checklists + 24 tasks / 110 subtasks, 15 ondas, 4 bloqueios humanos respondidos

## Test plan

- `tests/cstk/test_setup.sh` novo: 24 cenarios (todas as areas + interativo real + dry-run + idempotencia)
- Extensoes: `tests/test_guard-hooks-status.sh` (38 cen.), `tests/cstk/test_mcp.sh` (101 cen.), `tests/cstk/test_serve-docker.sh` (53 cen.)
- Suite completa: PASS 2533 / 1 fail corrigido em 7bab7da; `--check-coverage` zero orfaos; shellcheck limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa