### PR TITLE
feat(install): opt-in de telemetria no bootstrap + cstk help telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,10 +330,16 @@ so `otel_usage` comes out `null` for **every wave** of that execution, with the
 panel showing no cost at all. Real case: a two-day-old `claude -c` from an
 unrelated project held the port and an entire 16-wave run measured nothing.
 
-The fix is a launcher function in your `~/.zshrc` that asks the OS for a free
-port at every launch (binding port `0` lets the kernel pick) and points the
-cstk scraper at it via `CSTK_OTEL_ENDPOINT` — hooks and runtime scripts run
-inside the Claude process, so they inherit both variables:
+The fix is a launcher function in your `~/.zshrc` (or `~/.bashrc`) that asks
+the OS for a free port at every launch (binding port `0` lets the kernel pick)
+and points the cstk scraper at it via `CSTK_OTEL_ENDPOINT` — hooks and runtime
+scripts run inside the Claude process, so they inherit both variables.
+
+> Since v6.9.0 you rarely need to do this by hand: `cstk install` offers this
+> wrapper as an **opt-in** on first install (writes it to your shell rc between
+> `# >>> cstk telemetry >>>` markers, only with explicit consent — never in
+> non-interactive environments), and `cstk help telemetry` prints the canonical
+> ready-to-paste block if you declined or want to set it up later.
 
 ```zsh
 # One OTel exporter per claude process: OS picks a free port at each launch.

--- a/cli/cstk
+++ b/cli/cstk
@@ -216,12 +216,58 @@ HELP
       printf 'Para help inline, rode: cstk 00c --help\n'
       exit "$CSTK_EXIT_OK"
       ;;
+    telemetry)
+      cat <<'TELHELP'
+cstk help telemetry — medicao local de custo/tokens do Claude Code
+
+O exporter OTel vive DENTRO de cada processo `claude` (nasce e morre com a
+sessao) e cada processo precisa da PROPRIA porta. Por isso a ativacao e um
+wrapper `claude()` no seu shell rc (~/.zshrc ou ~/.bashrc, conforme $SHELL),
+que sorteia uma porta livre por lancamento e liga as variaveis SO no
+ambiente do processo `claude` — nada fica exportado no shell (evita o falso
+alarme "exporter-down" em terminais sem sessao ativa) e nada sai da maquina
+(exporter escuta apenas em 127.0.0.1).
+
+O `cstk install` oferece esse opt-in na primeira instalacao. Se voce
+recusou (ou instalou em ambiente nao-interativo), cole o bloco abaixo no
+final do seu shell rc e rode `source <rc>` (ou abra um novo terminal):
+
+# >>> cstk telemetry >>>
+# Gerenciado por `cstk install` — medicao LOCAL de custo/tokens do Claude
+# Code (nada sai da maquina; exporter escuta so em 127.0.0.1, porta sorteada
+# por processo). Remova o bloco inteiro entre os marcadores para desativar.
+claude() {
+  local _otel_port
+  _otel_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null)
+  if [ -n "$_otel_port" ]; then
+    CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+    OTEL_METRICS_EXPORTER=prometheus \
+    OTEL_EXPORTER_PROMETHEUS_PORT=$_otel_port \
+    CSTK_OTEL_ENDPOINT="http://127.0.0.1:${_otel_port}/metrics" \
+    command claude "$@"
+  else
+    CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+    OTEL_METRICS_EXPORTER=prometheus \
+    command claude "$@"
+  fi
+}
+# <<< cstk telemetry <<<
+
+Verificacao (de dentro de uma sessao claude lancada pelo wrapper):
+  ~/.claude/skills/agente-00c-runtime/scripts/otel-usage.sh preflight
+  # esperado: status=ok  (fora de sessao: disabled e normal)
+
+Snippet canonico: identico ao de cli/install.sh (telemetry_snippet) —
+teste de paridade em tests/cstk/test_cstk-main.sh gateia drift entre os dois.
+TELHELP
+      exit "$CSTK_EXIT_OK"
+      ;;
     help|--help|-h)
       _cmd_help ""
       ;;
     *)
       printf 'cstk: comando desconhecido para help: %s\n' "$_sub" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, setup, 00c\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, setup, 00c, telemetry\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -13,14 +13,24 @@
 #      `~/.local/share/cstk/lib/`).
 #   4. Escreve `$INSTALL_LIB/VERSION` com a tag baixada.
 #   5. Avisa se `$INSTALL_BIN` nao esta no PATH (sem modificar shell rc).
+#   6. Oferece OPT-IN de telemetria local (medicao de custo/tokens por onda):
+#      com consentimento explicito, escreve um wrapper `claude()` no shell rc
+#      do usuario (~/.zshrc ou ~/.bashrc, conforme $SHELL), entre marcadores
+#      idempotentes. Sem consentimento (default, e sempre em ambiente
+#      nao-interativo), NADA e escrito — o caminho manual fica documentado em
+#      `cstk help telemetry`.
 #
-# NAO exige sudo, NAO baixa toolchain de build, NAO modifica shell rc do usuario.
+# NAO exige sudo, NAO baixa toolchain de build. So modifica o shell rc do
+# usuario mediante o opt-in explicito de telemetria do passo 6 (default: nao).
 #
 # Variaveis de ambiente honradas (todas opcionais):
 #   CSTK_RELEASE_URL  — URL exata do tarball (skipa GitHub API). Sha vem de URL+".sha256".
 #   CSTK_REPO         — owner/repo no GitHub. Default: JotJunior/cstk.
 #   INSTALL_BIN       — onde colocar o binario `cstk`. Default: ~/.local/bin.
 #   INSTALL_LIB       — onde colocar lib/+VERSION. Default: ~/.local/share/cstk.
+#   CSTK_INSTALL_TELEMETRY — "yes" aplica o opt-in de telemetria sem prompt;
+#                      "no" recusa sem prompt. Ausente: pergunta via /dev/tty
+#                      quando ha TTY; sem TTY, recusa (fail-safe).
 #
 # POSIX sh puro. Deps: curl, tar, mktemp, sha256sum OU shasum, sed, grep, head,
 # mkdir, mv, cp, rm, find, dirname, basename, command, printf, cat.
@@ -203,6 +213,140 @@ EOF
   esac
 }
 
+
+# ==== Telemetria (opt-in, passo 6) ====
+#
+# O exporter OTel do Claude Code vive DENTRO de cada processo `claude` e cada
+# processo precisa da propria porta. O wrapper abaixo sorteia uma porta livre
+# por lancamento e liga as variaveis SO no ambiente do processo `claude` —
+# nada fica exportado no shell (evita falso alarme "exporter-down" em
+# terminais sem sessao ativa). Snippet canonico: manter IDENTICO ao bloco de
+# `cstk help telemetry` em cli/cstk (teste de paridade em
+# tests/cstk/test_cstk-main.sh gateia o drift).
+
+TELEMETRY_MARK_BEGIN='# >>> cstk telemetry >>>'
+TELEMETRY_MARK_END='# <<< cstk telemetry <<<'
+
+telemetry_snippet() {
+  cat <<'SNIP'
+# >>> cstk telemetry >>>
+# Gerenciado por `cstk install` — medicao LOCAL de custo/tokens do Claude
+# Code (nada sai da maquina; exporter escuta so em 127.0.0.1, porta sorteada
+# por processo). Remova o bloco inteiro entre os marcadores para desativar.
+claude() {
+  local _otel_port
+  _otel_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null)
+  if [ -n "$_otel_port" ]; then
+    CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+    OTEL_METRICS_EXPORTER=prometheus \
+    OTEL_EXPORTER_PROMETHEUS_PORT=$_otel_port \
+    CSTK_OTEL_ENDPOINT="http://127.0.0.1:${_otel_port}/metrics" \
+    command claude "$@"
+  else
+    CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+    OTEL_METRICS_EXPORTER=prometheus \
+    command claude "$@"
+  fi
+}
+# <<< cstk telemetry <<<
+SNIP
+}
+
+# telemetry_rc_file -> ecoa o rc alvo conforme $SHELL (zsh -> ~/.zshrc,
+# bash -> ~/.bashrc). Exit 1 para shell desconhecido/vazio — nesse caso
+# NUNCA escrevemos; o usuario recebe o caminho manual (cstk help telemetry).
+telemetry_rc_file() {
+  case "$(basename "${SHELL:-}" 2>/dev/null)" in
+    zsh)  printf '%s\n' "$HOME/.zshrc" ;;
+    bash) printf '%s\n' "$HOME/.bashrc" ;;
+    *) return 1 ;;
+  esac
+}
+
+telemetry_explain() {
+  cat >&2 <<EOF
+
+Telemetria local de consumo (opcional):
+  O cstk consegue medir o custo/tokens REAIS de cada onda dos orquestradores
+  lendo o exporter OTel local do Claude Code. Para isso, um wrapper
+  \`claude()\` precisa existir no seu shell rc, sorteando uma porta livre por
+  processo (mais de um Claude Code aberto = cada um com sua porta).
+
+  Se voce aceitar, este instalador vai:
+    - adicionar um bloco entre marcadores '$TELEMETRY_MARK_BEGIN' ... '$TELEMETRY_MARK_END'
+      ao SEU shell rc (~/.zshrc ou ~/.bashrc, conforme \$SHELL);
+    - o bloco define a funcao \`claude()\` que liga CLAUDE_CODE_ENABLE_TELEMETRY,
+      OTEL_METRICS_EXPORTER=prometheus e a porta sorteada SO no ambiente do
+      processo \`claude\`.
+  Nada sai da maquina: o exporter escuta apenas em 127.0.0.1. Para desfazer,
+  basta remover o bloco entre os marcadores. Se recusar agora, configure
+  depois com: cstk help telemetry
+EOF
+}
+
+# telemetry_apply RC_FILE -> escreve o snippet (idempotente por marcador).
+telemetry_apply() {
+  ta_rc=$1
+  if [ -f "$ta_rc" ] && grep -Fq "$TELEMETRY_MARK_BEGIN" "$ta_rc"; then
+    log_info "telemetria: bloco ja presente em $ta_rc — nada a fazer"
+    return 0
+  fi
+  if [ -f "$ta_rc" ] && grep -Eq '^[[:space:]]*claude[[:space:]]*\(\)' "$ta_rc"; then
+    log_warn "telemetria: $ta_rc ja define uma funcao claude() propria — NAO vou sobrescrever."
+    log_warn "telemetria: integre manualmente (instrucoes: cstk help telemetry)."
+    return 0
+  fi
+  { printf '\n'; telemetry_snippet; } >> "$ta_rc" \
+    || { log_warn "telemetria: falha ao escrever em $ta_rc — configure manualmente (cstk help telemetry)"; return 0; }
+  log_info "telemetria: wrapper claude() adicionado a $ta_rc"
+  log_info "telemetria: rode 'source $ta_rc' (ou abra um novo terminal) e use 'claude' normalmente."
+  return 0
+}
+
+telemetry_optin() {
+  to_answer="${CSTK_INSTALL_TELEMETRY:-}"
+  case "$to_answer" in
+    yes|y|YES|Y) to_answer=yes ;;
+    no|n|NO|N)   to_answer=no ;;
+    '')
+      # `curl | sh` consome o stdin com o proprio script — prompt interativo
+      # so via /dev/tty. Sem TTY (CI, pipe): fail-safe = nao (opt-in nunca
+      # e assumido em silencio).
+      # `-r /dev/tty` passa mesmo sem TTY de controle (o open e que falha);
+      # o teste honesto e tentar ABRIR o device.
+      if ( : < /dev/tty ) 2>/dev/null; then
+        telemetry_explain
+        printf 'Habilitar telemetria local agora? [y/N] ' >&2
+        if IFS= read -r to_reply < /dev/tty 2>/dev/null; then :; else to_reply=""; fi
+        case "$to_reply" in
+          y|Y|yes|YES|sim|s|S) to_answer=yes ;;
+          *) to_answer=no ;;
+        esac
+      else
+        to_answer=no
+        log_info "telemetria: ambiente nao-interativo — opt-in pulado (configure depois com: cstk help telemetry)"
+        return 0
+      fi
+      ;;
+    *)
+      log_warn "telemetria: CSTK_INSTALL_TELEMETRY='$to_answer' invalido (use yes|no) — tratando como no"
+      to_answer=no
+      ;;
+  esac
+
+  if [ "$to_answer" = no ]; then
+    log_info "telemetria: nao habilitada — quando quiser, veja: cstk help telemetry"
+    return 0
+  fi
+
+  if to_rc=$(telemetry_rc_file); then
+    telemetry_apply "$to_rc"
+  else
+    log_warn "telemetria: shell '$(basename "${SHELL:-desconhecido}")' sem rc suportado (zsh/bash) — configure manualmente: cstk help telemetry"
+  fi
+  return 0
+}
+
 # ==== Main ====
 
 main() {
@@ -214,6 +358,7 @@ main() {
   download_and_verify
   extract_and_install
   path_check
+  telemetry_optin
 
   log_info "bootstrap concluido. Teste com: $INSTALL_BIN/cstk --version"
 }

--- a/tests/cstk/test_bootstrap.sh
+++ b/tests/cstk/test_bootstrap.sh
@@ -213,4 +213,90 @@ scenario_bootstrap_tag_inferida_do_url() {
   fi
 }
 
+# ==== Telemetria opt-in no install (feature install-telemetry-optin) ====
+
+# Sem TTY e sem CSTK_INSTALL_TELEMETRY: fail-safe = nao escreve rc nenhum e
+# aponta o caminho manual (cstk help telemetry).
+scenario_bootstrap_telemetry_non_tty_skips() {
+  _h="$TMPDIR_TEST/home-tel-nontty"
+  _r="$TMPDIR_TEST/release-tel-nontty"
+  _make_bootstrap_fixture "$_r" v0.1.0-test || { _error "fixture" "tarball build falhou"; return 2; }
+  capture env HOME="$_h" INSTALL_BIN="$_h/.local/bin" INSTALL_LIB="$_h/.local/share/cstk" \
+    CSTK_RELEASE_URL="file://$_r/cstk-v0.1.0-test.tar.gz" PATH="$PATH" SHELL=/bin/zsh \
+    sh "$BOOTSTRAP"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ ! -f "$_h/.zshrc" ] || { _fail "rc" "sem opt-in nao pode escrever .zshrc"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"cstk help telemetry"*) : ;;
+    *) _fail "pointer" "stderr nao aponta cstk help telemetry: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+}
+
+# CSTK_INSTALL_TELEMETRY=yes + SHELL=zsh: snippet vai para ~/.zshrc entre
+# marcadores; wrapper contem as 4 variaveis no prefixo do processo.
+scenario_bootstrap_telemetry_yes_zsh_writes_zshrc() {
+  _h="$TMPDIR_TEST/home-tel-zsh"
+  _r="$TMPDIR_TEST/release-tel-zsh"
+  _make_bootstrap_fixture "$_r" v0.1.0-test || { _error "fixture" "tarball build falhou"; return 2; }
+  capture env HOME="$_h" INSTALL_BIN="$_h/.local/bin" INSTALL_LIB="$_h/.local/share/cstk" \
+    CSTK_RELEASE_URL="file://$_r/cstk-v0.1.0-test.tar.gz" PATH="$PATH" SHELL=/bin/zsh \
+    CSTK_INSTALL_TELEMETRY=yes sh "$BOOTSTRAP"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
+  grep -Fq '# >>> cstk telemetry >>>' "$_h/.zshrc" || { _fail "marker" "marcador begin ausente de .zshrc"; return 1; }
+  grep -Fq '# <<< cstk telemetry <<<' "$_h/.zshrc" || { _fail "marker" "marcador end ausente"; return 1; }
+  for _var in CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_METRICS_EXPORTER=prometheus \
+              OTEL_EXPORTER_PROMETHEUS_PORT CSTK_OTEL_ENDPOINT; do
+    grep -Fq "$_var" "$_h/.zshrc" || { _fail "var" "wrapper sem $_var"; return 1; }
+  done
+}
+
+# CSTK_INSTALL_TELEMETRY=yes + SHELL=bash: rc alvo e ~/.bashrc (o host pode
+# ser bash — deteccao por $SHELL, nao hardcoded zshrc).
+scenario_bootstrap_telemetry_yes_bash_writes_bashrc() {
+  _h="$TMPDIR_TEST/home-tel-bash"
+  _r="$TMPDIR_TEST/release-tel-bash"
+  _make_bootstrap_fixture "$_r" v0.1.0-test || { _error "fixture" "tarball build falhou"; return 2; }
+  capture env HOME="$_h" INSTALL_BIN="$_h/.local/bin" INSTALL_LIB="$_h/.local/share/cstk" \
+    CSTK_RELEASE_URL="file://$_r/cstk-v0.1.0-test.tar.gz" PATH="$PATH" SHELL=/bin/bash \
+    CSTK_INSTALL_TELEMETRY=yes sh "$BOOTSTRAP"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  grep -Fq '# >>> cstk telemetry >>>' "$_h/.bashrc" || { _fail "rc" "snippet nao foi para .bashrc com SHELL=bash"; return 1; }
+  [ ! -f "$_h/.zshrc" ] || { _fail "rc" "com SHELL=bash nao pode tocar .zshrc"; return 1; }
+}
+
+# Re-run com marcador ja presente: idempotente (1 unico bloco).
+scenario_bootstrap_telemetry_idempotent_rerun() {
+  _h="$TMPDIR_TEST/home-tel-idem"
+  _r="$TMPDIR_TEST/release-tel-idem"
+  _make_bootstrap_fixture "$_r" v0.1.0-test || { _error "fixture" "tarball build falhou"; return 2; }
+  for _i in 1 2; do
+    capture env HOME="$_h" INSTALL_BIN="$_h/.local/bin" INSTALL_LIB="$_h/.local/share/cstk" \
+      CSTK_RELEASE_URL="file://$_r/cstk-v0.1.0-test.tar.gz" PATH="$PATH" SHELL=/bin/zsh \
+      CSTK_INSTALL_TELEMETRY=yes sh "$BOOTSTRAP"
+    [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "run $_i esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  done
+  _n=$(grep -Fc '# >>> cstk telemetry >>>' "$_h/.zshrc")
+  [ "$_n" = 1 ] || { _fail "idem" "esperado 1 bloco apos re-run, obtido $_n"; return 1; }
+}
+
+# rc ja tem claude() proprio (sem marcadores): NUNCA sobrescrever — avisa e
+# aponta o caminho manual.
+scenario_bootstrap_telemetry_existing_claude_fn_preserved() {
+  _h="$TMPDIR_TEST/home-tel-existing"
+  _r="$TMPDIR_TEST/release-tel-existing"
+  _make_bootstrap_fixture "$_r" v0.1.0-test || { _error "fixture" "tarball build falhou"; return 2; }
+  mkdir -p "$_h"
+  printf 'claude() {\n  command claude --meu-wrapper "$@"\n}\n' > "$_h/.zshrc"
+  _before=$(cat "$_h/.zshrc")
+  capture env HOME="$_h" INSTALL_BIN="$_h/.local/bin" INSTALL_LIB="$_h/.local/share/cstk" \
+    CSTK_RELEASE_URL="file://$_r/cstk-v0.1.0-test.tar.gz" PATH="$PATH" SHELL=/bin/zsh \
+    CSTK_INSTALL_TELEMETRY=yes sh "$BOOTSTRAP"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ "$(cat "$_h/.zshrc")" = "$_before" ] || { _fail "preserve" "claude() pre-existente foi alterado"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"cstk help telemetry"*) : ;;
+    *) _fail "pointer" "sem instrucao manual no aviso: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+}
+
 run_all_scenarios

--- a/tests/cstk/test_cstk-main.sh
+++ b/tests/cstk/test_cstk-main.sh
@@ -194,4 +194,27 @@ scenario_hooks_help_inline() {
   assert_stderr_contains "cstk hooks install" || return 1
 }
 
+# ==== cstk help telemetry (feature install-telemetry-optin) ====
+
+scenario_help_telemetry_prints_snippet() {
+  capture env CSTK_LIB="$CSTK_LIB" sh "$CSTK" help telemetry
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  for _tok in '# >>> cstk telemetry >>>' 'CLAUDE_CODE_ENABLE_TELEMETRY=1' \
+              'OTEL_METRICS_EXPORTER=prometheus' 'CSTK_OTEL_ENDPOINT' 'command claude "$@"'; do
+    case "$_CAPTURED_STDOUT" in
+      *"$_tok"*) : ;;
+      *) _fail "conteudo" "help telemetry sem '$_tok'"; return 1 ;;
+    esac
+  done
+}
+
+# Paridade: o snippet entre marcadores em cli/install.sh e cli/cstk MUST ser
+# byte-identico — o help ensina exatamente o que o install escreveria.
+scenario_help_telemetry_snippet_parity_with_install() {
+  _a=$(awk '/^# >>> cstk telemetry >>>$/,/^# <<< cstk telemetry <<<$/' "$REPO_ROOT/cli/install.sh")
+  _b=$(awk '/^# >>> cstk telemetry >>>$/,/^# <<< cstk telemetry <<<$/' "$REPO_ROOT/cli/cstk")
+  [ -n "$_a" ] || { _fail "extract" "snippet ausente de cli/install.sh"; return 1; }
+  [ "$_a" = "$_b" ] || { _fail "parity" "snippet de telemetria divergiu entre cli/install.sh e cli/cstk"; return 1; }
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Summary

Decisao do operador: o momento certo de oferecer a telemetria e o **install** (primeira instalacao), nao o `cstk setup`.

- **`install.sh` passo 6 — opt-in explicito**: apos instalar, explica o que sera feito (wrapper `claude()` com porta dinamica por processo; variaveis ligadas SO no ambiente do processo claude — elimina o falso `exporter-down` em shells sem sessao; nada sai da maquina) e pergunta `[y/N]` via `/dev/tty` (`curl | sh` consome o stdin). Consentimento grava o bloco entre marcadores `# >>> cstk telemetry >>>` no rc detectado por `$SHELL` — **`~/.zshrc` OU `~/.bashrc`** conforme o host.
- **Fail-safe**: sem TTY (CI/pipe) = nao escreve nada e aponta o caminho manual. `CSTK_INSTALL_TELEMETRY=yes|no` para automacao. Idempotente (re-run nao duplica); `claude()` pre-existente NUNCA e sobrescrito.
- **`cstk help telemetry`**: novo topico que explica o mecanismo e imprime o bloco canonico pronto para colar — o caminho de recuperacao para quem recusou no install. Paridade byte-identica entre o snippet do help e o do install.sh **gateada por teste**.

## Test plan

- `tests/cstk/test_bootstrap.sh` 8→13 (non-tty skip, yes+zsh, yes+bash, idempotencia, claude() preexistente preservado)
- `tests/cstk/test_cstk-main.sh` 18→20 (conteudo do help + paridade de snippet)
- `quickstart-e2e` 5/5; `doc-counts` 3/3; `--check-coverage` zero orfaos; shellcheck sem findings novos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa