### PR TITLE
chore(plugins): bump manifests para 7.0.0 (lockstep MP-5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
       "name": "cstk",
       "description": "Pipeline SDD completa (briefing -> review-features), orquestradores autonomos 00c e guardas enforced",
       "source": "./plugins/cstk",
-      "version": "6.8.0",
+      "version": "7.0.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Perfil Go do cstk: skills e hooks especificos de linguagem",
       "source": "./plugins/cstk-language-go",
-      "version": "6.8.0",
+      "version": "7.0.0",
       "category": "development"
     }
   ]

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cstk-language-go",
   "description": "Perfil Go do cstk",
-  "version": "6.8.0",
+  "version": "7.0.0",
   "author": { "name": "JotJunior" }
 }

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cstk",
   "description": "Toolkit de documentacao e SDD para Claude Code",
-  "version": "6.8.0",
+  "version": "7.0.0",
   "author": { "name": "JotJunior" }
 }


### PR DESCRIPTION
Gate MP-5 do release.yml recusou a v7.0.0 (manifestos no placeholder 6.8.0) — funcionando como projetado. Bump nas 4 ocorrencias (marketplace 2 entradas + 2 plugin.json); gate local exit 0; test_validate-plugin-manifests 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa