### PR TITLE
chore(plugins): enriquecer manifests para submissao ao marketplace comunitario

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,18 +1,20 @@
 {
   "name": "cstk",
-  "owner": { "name": "JotJunior" },
-  "description": "Toolkit de documentacao e Spec-Driven Development para Claude Code",
+  "owner": {
+    "name": "JotJunior"
+  },
+  "description": "Spec-Driven Development toolkit for Claude Code",
   "plugins": [
     {
       "name": "cstk",
-      "description": "Pipeline SDD completa (briefing -> review-features), orquestradores autonomos 00c e guardas enforced",
+      "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
       "version": "7.0.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
-      "description": "Perfil Go do cstk: skills e hooks especificos de linguagem",
+      "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
       "version": "7.0.0",
       "category": "development"

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,6 +1,18 @@
 {
   "name": "cstk-language-go",
-  "description": "Perfil Go do cstk",
+  "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
   "version": "7.0.0",
-  "author": { "name": "JotJunior" }
+  "author": {
+    "name": "JotJunior",
+    "url": "https://github.com/JotJunior"
+  },
+  "homepage": "https://github.com/JotJunior/cstk",
+  "repository": "https://github.com/JotJunior/cstk",
+  "license": "MIT",
+  "keywords": [
+    "go",
+    "golang",
+    "sdd",
+    "scaffolding"
+  ]
 }

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,6 +1,20 @@
 {
   "name": "cstk",
-  "description": "Toolkit de documentacao e SDD para Claude Code",
+  "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
   "version": "7.0.0",
-  "author": { "name": "JotJunior" }
+  "author": {
+    "name": "JotJunior",
+    "url": "https://github.com/JotJunior"
+  },
+  "homepage": "https://github.com/JotJunior/cstk",
+  "repository": "https://github.com/JotJunior/cstk",
+  "license": "MIT",
+  "keywords": [
+    "sdd",
+    "spec-driven-development",
+    "documentation",
+    "orchestrator",
+    "workflow",
+    "governance"
+  ]
 }


### PR DESCRIPTION
Prepara a submissao ao anthropics/claude-plugins-community: repository/homepage/license/keywords/author.url + descricoes EN. Validado: gate MP exit 0, claude plugin validate ✔ nos 3 manifests, test 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa