### PR TITLE
fix: escopo dos hooks 00c na raiz do projeto + motivo da ausencia OTel (v7.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [7.0.1] - 2026-08-09
+
+Dois defeitos observados em campo no mesmo projeto-alvo, com o mesmo
+sintoma visivel (numero que some do painel) e causas sem nenhuma relacao
+entre si. O primeiro nao era so perda de metrica: deixou a guarda
+fail-closed inerte por ~25h.
+
+### Fixed
+
+- **Hooks 00c cegos por deriva de cwd.** O `.cwd` do payload do harness e
+  o diretorio corrente do shell da sessao, nao a raiz do projeto — e ele
+  gruda em qualquer subdiretorio assim que o agente roda `cd sub && ...`
+  (o cwd do Bash persiste entre tool calls) e nao volta sozinho. Enquanto
+  durava a deriva, o pre-check inline dos 4 hooks saia 1 em toda tool
+  call: `pretooluse-bash-guard.sh` (fail-closed POR DESENHO) ficava
+  inerte sem registrar nada no `enforcement-log.jsonl`, e as ondas
+  fechavam com `tool_calls=0`. O pre-check virou resolvedor de raiz
+  (builtins puros, preserva SEC-H1): cwd exato → ancestrais → para em
+  `$CLAUDE_PROJECT_DIR`, diretorio com `.git`, `/` ou teto de 16 niveis.
+  `$CLAUDE_PROJECT_DIR` e consultado como candidato POR ULTIMO — havendo
+  state alcancavel por cwd/ancestrais a env var nao consegue sombrea-lo
+  (numa guarda fail-closed, sombrear seria vetor de bypass); como
+  fronteira superior, so restringe. Passam a usar a raiz resolvida:
+  state-dir, whitelist do operador, `enforcement-log.jsonl` e resolucao
+  do catalogo `project`. Em `posttooluse-loose-usage.sh` a identidade
+  (`process_key` / `project_path`) usa ancora SEPARADA
+  (`$CLAUDE_PROJECT_DIR`), porque consumo avulso ocorre justamente onde
+  nao ha state 00c. Cobertura em `tests/test_pretooluse-bash-guard.sh`,
+  `test_posttooluse-tool-call-tick.sh`, `test_posttooluse-agent-usage.sh`
+  e `test_posttooluse-loose-usage.sh`.
+- **`otel_usage: null` deixa de ser mudo.** O motivo da ausencia sempre
+  foi conhecido no fechamento da onda e sempre foi descartado pelo
+  `2>/dev/null` com que `_so_otel_delta` invoca o `otel-usage.sh` — o
+  operador ficava com "s/ dado" no painel e nenhuma pista. `otel-usage.sh
+  delta` ganha `--reason-file PATH`, que deposita um slug estavel
+  (`exporter-trocou`, `sem-snapshot`, `sessoes-ambiguas`,
+  `formato-antigo`, `sem-crescimento`, `jq-ausente`, `falha-join`); sem a
+  flag, o comportamento e byte-a-byte o anterior. `state-ondas.sh end`
+  persiste o slug: chave achatada `.waves[-1].otel_absent_reason` no
+  backend JSON e catch-all `extra_fields` sob SQLite, sempre por MERGE
+  (o campo e compartilhado com `touched_key_aspects`). Cobertura em
+  `tests/test_otel-usage.sh` e `tests/test_state-ondas.sh`.
+
+### Changed
+
+- **A guarda de Bash passa a valer em subdiretorios do projeto-alvo.**
+  Consequencia direta do fix de escopo: comando que viola regra rodado de
+  um subdiretorio agora e negado, onde antes passava sem avaliacao. E o
+  comportamento pretendido desde a feature `enforced-guards`, mas aparece
+  como endurecimento para quem convivia com o defeito.
+
+### Nao incluido (deliberado)
+
+- **Motivo da ausencia OTel no painel.** Levar o slug ate o `cstk-panel`
+  exige coluna nova na `knowledge.db` (`RECALL_SCHEMA_VERSION` 13 → 14) e
+  o painel valida schema contra allowlist RIGIDA (`DEFAULT_SCHEMA_VERSIONS`
+  termina em `'13'`): bumpar sem release coordenada derruba o painel
+  inteiro com `schema-mismatch`. Fica para release conjunta, painel
+  primeiro. Nesta versao o motivo e legivel direto do `state.json` /
+  `state.db`.
+
 ## [7.0.0] - 2026-08-08
 
 **BREAKING** — feature `claude-plugin-packaging`. O catalogo do toolkit
@@ -5284,6 +5345,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[7.0.1]: https://github.com/JotJunior/cstk/releases/tag/v7.0.1
 [7.0.0]: https://github.com/JotJunior/cstk/releases/tag/v7.0.0
 [6.8.0]: https://github.com/JotJunior/cstk/releases/tag/v6.8.0
 [6.7.0]: https://github.com/JotJunior/cstk/releases/tag/v6.7.0

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/hooks/posttooluse-agent-usage.sh
@@ -73,6 +73,9 @@ set -u
 _PAU_CAP_LINES=500
 
 _PAU_SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || _PAU_SELF_DIR=""
+# Raiz do projeto-alvo, resolvida por _pau_precheck_active_scope a partir
+# do `.cwd` do payload (que pode estar num subdiretorio).
+_PAU_SCOPE=""
 
 # Bootstrap: localizar+sourcear `_resolve-root.sh` (feature
 # claude-plugin-packaging, task 3.2.3). Ordem A (fail-open, consumidor
@@ -105,26 +108,75 @@ _PAU_TOOL_NAME=$(printf '%s' "$_PAU_INPUT" | jq -r '.tool_name // ""' 2>/dev/nul
 # (contracts/hook-posttooluse-agent-usage.md §1.2).
 [ "$_PAU_TOOL_NAME" = "Agent" ] || exit 0
 
-# _pau_precheck_active_scope -> 0 se ao menos um `state.json` OU `state.db`
-# existe sob `$_PAU_CWD/.claude/agente-00c-state/` ou
-# `$_PAU_CWD/.claude/feature-00c-state/*/` (SEC-H1, spec.md FR-008). Usa
-# EXCLUSIVAMENTE builtins do shell — nenhuma resolucao de dependencia nem
-# sourcing acontece antes desta checagem.
-_pau_precheck_active_scope() {
-  _pau_pa_agente="$_PAU_CWD/.claude/agente-00c-state"
-  if [ -f "$_pau_pa_agente/state.json" ] || [ -f "$_pau_pa_agente/state.db" ]; then
+# _pau_scope_has_state DIR -> 0 se DIR abriga o state de uma execucao 00c
+# (`state.json` OU `state.db` sob `agente-00c-state/` ou
+# `feature-00c-state/*/`). Usa EXCLUSIVAMENTE builtins do shell — nenhuma
+# resolucao de dependencia nem sourcing acontece dentro nem antes desta
+# checagem (SEC-H1, spec.md FR-008).
+_pau_scope_has_state() {
+  _pau_sh_dir=$1
+  [ -n "$_pau_sh_dir" ] || return 1
+
+  _pau_sh_agente="$_pau_sh_dir/.claude/agente-00c-state"
+  if [ -f "$_pau_sh_agente/state.json" ] || [ -f "$_pau_sh_agente/state.db" ]; then
     return 0
   fi
 
-  _pau_pa_froot="$_PAU_CWD/.claude/feature-00c-state"
-  if [ -d "$_pau_pa_froot" ]; then
-    for _pau_pa_d in "$_pau_pa_froot"/*/; do
-      [ -d "$_pau_pa_d" ] || continue
-      if [ -f "${_pau_pa_d}state.json" ] || [ -f "${_pau_pa_d}state.db" ]; then
+  _pau_sh_froot="$_pau_sh_dir/.claude/feature-00c-state"
+  if [ -d "$_pau_sh_froot" ]; then
+    for _pau_sh_d in "$_pau_sh_froot"/*/; do
+      [ -d "$_pau_sh_d" ] || continue
+      if [ -f "${_pau_sh_d}state.json" ] || [ -f "${_pau_sh_d}state.db" ]; then
         return 0
       fi
     done
   fi
+  return 1
+}
+
+# _pau_precheck_active_scope -> 0 assinalando `_PAU_SCOPE` com a RAIZ do
+# projeto-alvo; 1 se nenhum candidato abriga state.
+#
+# MOTIVO (deriva de cwd): o `.cwd` do payload gruda em subdiretorios apos
+# um `cd sub && ...` do agente (o cwd do Bash persiste entre tool calls) e
+# nao volta sozinho. Enquanto durar a deriva, o spawn de subagente nao e
+# contabilizado e a onda perde a metrica de tokens por spawn. Cadeia
+# identica a do pretooluse-bash-guard.sh — ver o cabecalho de
+# `_pbg_precheck_active_scope` para o racional de seguranca de manter
+# `$CLAUDE_PROJECT_DIR` como ULTIMO candidato.
+_pau_precheck_active_scope() {
+  if _pau_scope_has_state "$_PAU_CWD"; then
+    _PAU_SCOPE="$_PAU_CWD"
+    return 0
+  fi
+
+  _pau_pa_cur="$_PAU_CWD"
+  _pau_pa_depth=0
+  while [ "$_pau_pa_depth" -lt 16 ]; do
+    if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ "$_pau_pa_cur" = "$CLAUDE_PROJECT_DIR" ]; then
+      break
+    fi
+
+    _pau_pa_parent="${_pau_pa_cur%/*}"
+    [ -n "$_pau_pa_parent" ] || _pau_pa_parent="/"
+    [ "$_pau_pa_parent" = "$_pau_pa_cur" ] && break
+    _pau_pa_cur="$_pau_pa_parent"
+
+    if _pau_scope_has_state "$_pau_pa_cur"; then
+      _PAU_SCOPE="$_pau_pa_cur"
+      return 0
+    fi
+
+    [ -e "$_pau_pa_cur/.git" ] && break
+    [ "$_pau_pa_cur" = "/" ] && break
+    _pau_pa_depth=$((_pau_pa_depth + 1))
+  done
+
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && _pau_scope_has_state "$CLAUDE_PROJECT_DIR"; then
+    _PAU_SCOPE="$CLAUDE_PROJECT_DIR"
+    return 0
+  fi
+
   return 1
 }
 
@@ -152,8 +204,8 @@ _pau_resolve_dep_hae() {
     printf '%s' "$_pau_root/$_pau_rel"
     return 0
   fi
-  if [ -n "${_PAU_CWD:-}" ] && [ -r "$_PAU_CWD/.claude/skills/agente-00c-runtime/$_pau_rel" ]; then
-    printf '%s' "$_PAU_CWD/.claude/skills/agente-00c-runtime/$_pau_rel"
+  if [ -n "${_PAU_SCOPE:-}" ] && [ -r "$_PAU_SCOPE/.claude/skills/agente-00c-runtime/$_pau_rel" ]; then
+    printf '%s' "$_PAU_SCOPE/.claude/skills/agente-00c-runtime/$_pau_rel"
     return 0
   fi
   return 1
@@ -169,7 +221,7 @@ _PAU_HAE_HELPER=$(_pau_resolve_dep_hae "scripts/_hook-active-exec.sh") || exit 0
 HAE_BUSY_TIMEOUT_MS=50
 export HAE_BUSY_TIMEOUT_MS
 
-if _PAU_HAE_OUT=$(hook_active_exec "$_PAU_CWD"); then
+if _PAU_HAE_OUT=$(hook_active_exec "$_PAU_SCOPE"); then
   _PAU_HAE_RC=0
 else
   _PAU_HAE_RC=$?

--- a/plugins/cstk/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh
@@ -74,6 +74,19 @@ _PLU_TOOL_NAME=$(printf '%s' "$_PLU_INPUT" | jq -r '.tool_name // ""' 2>/dev/nul
 # tool_name vazio = payload anomalo do harness; nao inventa captura.
 [ -n "$_PLU_TOOL_NAME" ] || exit 0
 
+# Raiz do projeto para IDENTIDADE (process_key + project_path). Ancora
+# DIFERENTE da usada no Passo 5: aqui nao se pode exigir state 00c —
+# consumo avulso acontece justamente em projeto sem execucao nenhuma.
+# `$CLAUDE_PROJECT_DIR` e a raiz da sessao e nao se move com o `cd` do
+# agente; sem ela, uma unica sessao que derivou de cwd se fragmenta em
+# dois process_key (e grava `project_path` do subdiretorio, atribuindo o
+# consumo ao lugar errado). Sessao sem deriva: `CLAUDE_PROJECT_DIR` ==
+# `.cwd`, key byte-identica a atual — nenhum sidecar existente e orfanado.
+_PLU_PROJECT="${CLAUDE_PROJECT_DIR:-$_PLU_CWD}"
+# Raiz de escopo de deteccao 00c (Passo 5), resolvida por
+# _plu_precheck_active_scope; vazia ate la.
+_PLU_SCOPE=""
+
 [ -n "${HOME:-}" ] || exit 0
 
 # ---------------------------------------------------------------------------
@@ -117,8 +130,8 @@ if _PLU_EP_PORT=$(_plu_ep_port "$_PLU_ENDPOINT" 2>/dev/null); then
   fi
 fi
 
-_PLU_KEY_BASE=$(_plu_sanitize "$(basename "$_PLU_CWD" 2>/dev/null)")
-_PLU_KEY_HASH=$(_plu_hash "${_PLU_ENDPOINT}|${_PLU_CWD}")
+_PLU_KEY_BASE=$(_plu_sanitize "$(basename "$_PLU_PROJECT" 2>/dev/null)")
+_PLU_KEY_HASH=$(_plu_hash "${_PLU_ENDPOINT}|${_PLU_PROJECT}")
 [ -n "$_PLU_KEY_HASH" ] || exit 0
 if [ "$_PLU_OWNER_PID" != "unknown" ]; then
   _PLU_PROCESS_KEY="${_PLU_KEY_BASE}-${_PLU_KEY_HASH}-${_PLU_OWNER_PID}"
@@ -192,21 +205,66 @@ fi
 # captura. So quando o pre-check acha algum state presente e que vale a
 # pena sondar de fato via _hook-active-exec.sh.
 # ---------------------------------------------------------------------------
-_plu_precheck_active_scope() {
-  _plu_pa_agente="$_PLU_CWD/.claude/agente-00c-state"
-  if [ -f "$_plu_pa_agente/state.json" ] || [ -f "$_plu_pa_agente/state.db" ]; then
+_plu_scope_has_state() {
+  _plu_sh_dir=$1
+  [ -n "$_plu_sh_dir" ] || return 1
+
+  _plu_sh_agente="$_plu_sh_dir/.claude/agente-00c-state"
+  if [ -f "$_plu_sh_agente/state.json" ] || [ -f "$_plu_sh_agente/state.db" ]; then
     return 0
   fi
 
-  _plu_pa_froot="$_PLU_CWD/.claude/feature-00c-state"
-  if [ -d "$_plu_pa_froot" ]; then
-    for _plu_pa_d in "$_plu_pa_froot"/*/; do
-      [ -d "$_plu_pa_d" ] || continue
-      if [ -f "${_plu_pa_d}state.json" ] || [ -f "${_plu_pa_d}state.db" ]; then
+  _plu_sh_froot="$_plu_sh_dir/.claude/feature-00c-state"
+  if [ -d "$_plu_sh_froot" ]; then
+    for _plu_sh_d in "$_plu_sh_froot"/*/; do
+      [ -d "$_plu_sh_d" ] || continue
+      if [ -f "${_plu_sh_d}state.json" ] || [ -f "${_plu_sh_d}state.db" ]; then
         return 0
       fi
     done
   fi
+  return 1
+}
+
+# Assinala `_PLU_SCOPE` com a RAIZ do projeto-alvo (cadeia identica a do
+# pretooluse-bash-guard.sh). Sob POLARIDADE INVERTIDA a deriva de cwd e
+# especialmente traicoeira: o pre-check falha, o hook conclui "sem
+# execucao ativa" e CAPTURA consumo que na verdade pertence a uma onda
+# 00c — dupla contagem exatamente do que `cstk usage compare` promete
+# separar.
+_plu_precheck_active_scope() {
+  if _plu_scope_has_state "$_PLU_CWD"; then
+    _PLU_SCOPE="$_PLU_CWD"
+    return 0
+  fi
+
+  _plu_pa_cur="$_PLU_CWD"
+  _plu_pa_depth=0
+  while [ "$_plu_pa_depth" -lt 16 ]; do
+    if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ "$_plu_pa_cur" = "$CLAUDE_PROJECT_DIR" ]; then
+      break
+    fi
+
+    _plu_pa_parent="${_plu_pa_cur%/*}"
+    [ -n "$_plu_pa_parent" ] || _plu_pa_parent="/"
+    [ "$_plu_pa_parent" = "$_plu_pa_cur" ] && break
+    _plu_pa_cur="$_plu_pa_parent"
+
+    if _plu_scope_has_state "$_plu_pa_cur"; then
+      _PLU_SCOPE="$_plu_pa_cur"
+      return 0
+    fi
+
+    [ -e "$_plu_pa_cur/.git" ] && break
+    [ "$_plu_pa_cur" = "/" ] && break
+    _plu_pa_depth=$((_plu_pa_depth + 1))
+  done
+
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && _plu_scope_has_state "$CLAUDE_PROJECT_DIR"; then
+    _PLU_SCOPE="$CLAUDE_PROJECT_DIR"
+    return 0
+  fi
+
   return 1
 }
 
@@ -229,8 +287,8 @@ if _plu_precheck_active_scope; then
       printf '%s' "$_plu_root/$_plu_rel"
       return 0
     fi
-    if [ -n "${_PLU_CWD:-}" ] && [ -r "$_PLU_CWD/.claude/skills/agente-00c-runtime/$_plu_rel" ]; then
-      printf '%s' "$_PLU_CWD/.claude/skills/agente-00c-runtime/$_plu_rel"
+    if [ -n "${_PLU_SCOPE:-}" ] && [ -r "$_PLU_SCOPE/.claude/skills/agente-00c-runtime/$_plu_rel" ]; then
+      printf '%s' "$_PLU_SCOPE/.claude/skills/agente-00c-runtime/$_plu_rel"
       return 0
     fi
     return 1
@@ -245,7 +303,7 @@ if _plu_precheck_active_scope; then
     HAE_BUSY_TIMEOUT_MS=50
     export HAE_BUSY_TIMEOUT_MS
 
-    if _PLU_HAE_OUT=$(hook_active_exec "$_PLU_CWD" 2>/dev/null); then
+    if _PLU_HAE_OUT=$(hook_active_exec "$_PLU_SCOPE" 2>/dev/null); then
       _PLU_HAE_RC=0
     else
       _PLU_HAE_RC=$?
@@ -272,8 +330,8 @@ _plu_resolve_dep_otel() {
     printf '%s' "$_plu_root/$_plu_rel"
     return 0
   fi
-  if [ -n "${_PLU_CWD:-}" ] && [ -x "$_PLU_CWD/.claude/skills/agente-00c-runtime/$_plu_rel" ]; then
-    printf '%s' "$_PLU_CWD/.claude/skills/agente-00c-runtime/$_plu_rel"
+  if [ -n "${_PLU_PROJECT:-}" ] && [ -x "$_PLU_PROJECT/.claude/skills/agente-00c-runtime/$_plu_rel" ]; then
+    printf '%s' "$_PLU_PROJECT/.claude/skills/agente-00c-runtime/$_plu_rel"
     return 0
   fi
   return 1
@@ -296,7 +354,7 @@ _plu_write_meta() {
   _plu_tmp="$_PLU_META.tmp.$$"
   {
     printf 'schema\t1\n'
-    printf 'project_path\t%s\n' "$_PLU_CWD"
+    printf 'project_path\t%s\n' "$_PLU_PROJECT"
     printf 'endpoint\t%s\n' "$_PLU_ENDPOINT"
     printf 'owner_pid\t%s\n' "$_PLU_OWNER_PID"
     printf 'created_at\t%s\n' "$_plu_created"

--- a/plugins/cstk/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/hooks/posttooluse-tool-call-tick.sh
@@ -64,6 +64,9 @@
 set -u
 
 _PTT_SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || _PTT_SELF_DIR=""
+# Raiz do projeto-alvo, resolvida por _ptt_precheck_active_scope a partir
+# do `.cwd` do payload (que pode estar num subdiretorio).
+_PTT_SCOPE=""
 
 # Bootstrap: localizar+sourcear `_resolve-root.sh` (feature
 # claude-plugin-packaging, task 3.2.4). Ordem A (fail-open, consumidor
@@ -95,26 +98,77 @@ _PTT_TOOL_NAME=$(printf '%s' "$_PTT_INPUT" | jq -r '.tool_name // ""' 2>/dev/nul
 # tool_name vazio = payload anomalo do harness; nao inventa tick.
 [ -n "$_PTT_TOOL_NAME" ] || exit 0
 
-# _ptt_precheck_active_scope -> 0 se ao menos um `state.json` OU `state.db`
-# existe sob `$_PTT_CWD/.claude/agente-00c-state/` ou
-# `$_PTT_CWD/.claude/feature-00c-state/*/` (SEC-H1, spec.md FR-008). Usa
-# EXCLUSIVAMENTE builtins do shell — nenhuma resolucao de dependencia nem
-# sourcing acontece antes desta checagem.
-_ptt_precheck_active_scope() {
-  _ptt_pa_agente="$_PTT_CWD/.claude/agente-00c-state"
-  if [ -f "$_ptt_pa_agente/state.json" ] || [ -f "$_ptt_pa_agente/state.db" ]; then
+# _ptt_scope_has_state DIR -> 0 se DIR abriga o state de uma execucao 00c
+# (`state.json` OU `state.db` sob `agente-00c-state/` ou
+# `feature-00c-state/*/`). Usa EXCLUSIVAMENTE builtins do shell — nenhuma
+# resolucao de dependencia nem sourcing acontece dentro nem antes desta
+# checagem (SEC-H1, spec.md FR-008).
+_ptt_scope_has_state() {
+  _ptt_sh_dir=$1
+  [ -n "$_ptt_sh_dir" ] || return 1
+
+  _ptt_sh_agente="$_ptt_sh_dir/.claude/agente-00c-state"
+  if [ -f "$_ptt_sh_agente/state.json" ] || [ -f "$_ptt_sh_agente/state.db" ]; then
     return 0
   fi
 
-  _ptt_pa_froot="$_PTT_CWD/.claude/feature-00c-state"
-  if [ -d "$_ptt_pa_froot" ]; then
-    for _ptt_pa_d in "$_ptt_pa_froot"/*/; do
-      [ -d "$_ptt_pa_d" ] || continue
-      if [ -f "${_ptt_pa_d}state.json" ] || [ -f "${_ptt_pa_d}state.db" ]; then
+  _ptt_sh_froot="$_ptt_sh_dir/.claude/feature-00c-state"
+  if [ -d "$_ptt_sh_froot" ]; then
+    for _ptt_sh_d in "$_ptt_sh_froot"/*/; do
+      [ -d "$_ptt_sh_d" ] || continue
+      if [ -f "${_ptt_sh_d}state.json" ] || [ -f "${_ptt_sh_d}state.db" ]; then
         return 0
       fi
     done
   fi
+  return 1
+}
+
+# _ptt_precheck_active_scope -> 0 assinalando `_PTT_SCOPE` com a RAIZ do
+# projeto-alvo; 1 se nenhum candidato abriga state.
+#
+# MOTIVO (deriva de cwd): o `.cwd` do payload e o diretorio corrente do
+# shell da sessao, nao a raiz do projeto — e ele gruda em qualquer
+# subdiretorio assim que o agente roda `cd sub && ...` (o cwd do Bash
+# persiste entre tool calls). Enquanto durar a deriva, TODO tick e
+# descartado e a onda fecha com `tool_calls=0` apesar de dezenas de calls
+# reais. Cadeia identica a do pretooluse-bash-guard.sh (mesma primitiva,
+# mesma ordem, mesmas fronteiras) — ver o cabecalho de
+# `_pbg_precheck_active_scope` para o racional de seguranca de manter
+# `$CLAUDE_PROJECT_DIR` como ULTIMO candidato.
+_ptt_precheck_active_scope() {
+  if _ptt_scope_has_state "$_PTT_CWD"; then
+    _PTT_SCOPE="$_PTT_CWD"
+    return 0
+  fi
+
+  _ptt_pa_cur="$_PTT_CWD"
+  _ptt_pa_depth=0
+  while [ "$_ptt_pa_depth" -lt 16 ]; do
+    if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ "$_ptt_pa_cur" = "$CLAUDE_PROJECT_DIR" ]; then
+      break
+    fi
+
+    _ptt_pa_parent="${_ptt_pa_cur%/*}"
+    [ -n "$_ptt_pa_parent" ] || _ptt_pa_parent="/"
+    [ "$_ptt_pa_parent" = "$_ptt_pa_cur" ] && break
+    _ptt_pa_cur="$_ptt_pa_parent"
+
+    if _ptt_scope_has_state "$_ptt_pa_cur"; then
+      _PTT_SCOPE="$_ptt_pa_cur"
+      return 0
+    fi
+
+    [ -e "$_ptt_pa_cur/.git" ] && break
+    [ "$_ptt_pa_cur" = "/" ] && break
+    _ptt_pa_depth=$((_ptt_pa_depth + 1))
+  done
+
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && _ptt_scope_has_state "$CLAUDE_PROJECT_DIR"; then
+    _PTT_SCOPE="$CLAUDE_PROJECT_DIR"
+    return 0
+  fi
+
   return 1
 }
 
@@ -143,8 +197,8 @@ _ptt_resolve_dep_hae() {
     printf '%s' "$_ptt_root/$_ptt_rel"
     return 0
   fi
-  if [ -n "${_PTT_CWD:-}" ] && [ -r "$_PTT_CWD/.claude/skills/agente-00c-runtime/$_ptt_rel" ]; then
-    printf '%s' "$_PTT_CWD/.claude/skills/agente-00c-runtime/$_ptt_rel"
+  if [ -n "${_PTT_SCOPE:-}" ] && [ -r "$_PTT_SCOPE/.claude/skills/agente-00c-runtime/$_ptt_rel" ]; then
+    printf '%s' "$_PTT_SCOPE/.claude/skills/agente-00c-runtime/$_ptt_rel"
     return 0
   fi
   return 1
@@ -160,7 +214,7 @@ _PTT_HAE_HELPER=$(_ptt_resolve_dep_hae "scripts/_hook-active-exec.sh") || exit 0
 HAE_BUSY_TIMEOUT_MS=50
 export HAE_BUSY_TIMEOUT_MS
 
-if _PTT_HAE_OUT=$(hook_active_exec "$_PTT_CWD"); then
+if _PTT_HAE_OUT=$(hook_active_exec "$_PTT_SCOPE"); then
   _PTT_HAE_RC=0
 else
   _PTT_HAE_RC=$?

--- a/plugins/cstk/skills/agente-00c-runtime/hooks/pretooluse-bash-guard.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/hooks/pretooluse-bash-guard.sh
@@ -69,6 +69,11 @@ set -eu
 
 _PBG_NAME="pretooluse-bash-guard"
 _PBG_SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || _PBG_SELF_DIR=""
+# Raiz do projeto-alvo, resolvida por _pbg_precheck_active_scope a partir
+# do `.cwd` do payload (que pode estar num subdiretorio). Todo consumidor
+# de caminho do projeto — state-dir, whitelist, enforcement-log, catalogo
+# `project` — usa ESTA variavel, nunca `_PBG_CWD` cru.
+_PBG_SCOPE=""
 
 # Bootstrap: localizar+sourcear `_resolve-root.sh` (feature
 # claude-plugin-packaging, task 3.2.1). Ordem B (sibling -> plugin ->
@@ -104,8 +109,8 @@ _pbg_resolve_dep() {
     printf '%s' "$_PBG_SELF_DIR/../$_pbg_rel"
     return 0
   fi
-  if [ -n "${_PBG_CWD:-}" ] && [ -x "$_PBG_CWD/.claude/skills/agente-00c-runtime/$_pbg_rel" ]; then
-    printf '%s' "$_PBG_CWD/.claude/skills/agente-00c-runtime/$_pbg_rel"
+  if [ -n "${_PBG_SCOPE:-}" ] && [ -x "$_PBG_SCOPE/.claude/skills/agente-00c-runtime/$_pbg_rel" ]; then
+    printf '%s' "$_PBG_SCOPE/.claude/skills/agente-00c-runtime/$_pbg_rel"
     return 0
   fi
   # Plugin (${CLAUDE_PLUGIN_ROOT}) -> classico ($HOME), via helper
@@ -142,34 +147,105 @@ _pbg_resolve_dep_hae() {
     printf '%s' "$_pbg_root/$_pbg_rel"
     return 0
   fi
-  if [ -n "${_PBG_CWD:-}" ] && [ -r "$_PBG_CWD/.claude/skills/agente-00c-runtime/$_pbg_rel" ]; then
-    printf '%s' "$_PBG_CWD/.claude/skills/agente-00c-runtime/$_pbg_rel"
+  if [ -n "${_PBG_SCOPE:-}" ] && [ -r "$_PBG_SCOPE/.claude/skills/agente-00c-runtime/$_pbg_rel" ]; then
+    printf '%s' "$_PBG_SCOPE/.claude/skills/agente-00c-runtime/$_pbg_rel"
     return 0
   fi
   return 1
 }
 
-# _pbg_precheck_active_scope -> 0 (existe escopo a checar) se ao menos um
-# `state.json` OU `state.db` existe sob
-# `$_PBG_CWD/.claude/agente-00c-state/` ou
-# `$_PBG_CWD/.claude/feature-00c-state/*/` (SEC-H1, spec.md FR-008).
-# Usa EXCLUSIVAMENTE builtins do shell (`[ -f ]`, `[ -d ]`) — nenhuma
-# resolucao de dependencia nem sourcing acontece antes desta checagem.
-_pbg_precheck_active_scope() {
-  _pbg_pa_agente="$_PBG_CWD/.claude/agente-00c-state"
-  if [ -f "$_pbg_pa_agente/state.json" ] || [ -f "$_pbg_pa_agente/state.db" ]; then
+# _pbg_scope_has_state DIR -> 0 se DIR abriga o state de uma execucao 00c
+# (`state.json` OU `state.db` sob `agente-00c-state/` ou
+# `feature-00c-state/*/`). Usa EXCLUSIVAMENTE builtins do shell
+# (`[ -f ]`, `[ -d ]`) — nenhuma resolucao de dependencia nem sourcing
+# acontece dentro nem antes desta checagem (SEC-H1, spec.md FR-008).
+_pbg_scope_has_state() {
+  _pbg_sh_dir=$1
+  [ -n "$_pbg_sh_dir" ] || return 1
+
+  _pbg_sh_agente="$_pbg_sh_dir/.claude/agente-00c-state"
+  if [ -f "$_pbg_sh_agente/state.json" ] || [ -f "$_pbg_sh_agente/state.db" ]; then
     return 0
   fi
 
-  _pbg_pa_froot="$_PBG_CWD/.claude/feature-00c-state"
-  if [ -d "$_pbg_pa_froot" ]; then
-    for _pbg_pa_d in "$_pbg_pa_froot"/*/; do
-      [ -d "$_pbg_pa_d" ] || continue
-      if [ -f "${_pbg_pa_d}state.json" ] || [ -f "${_pbg_pa_d}state.db" ]; then
+  _pbg_sh_froot="$_pbg_sh_dir/.claude/feature-00c-state"
+  if [ -d "$_pbg_sh_froot" ]; then
+    for _pbg_sh_d in "$_pbg_sh_froot"/*/; do
+      [ -d "$_pbg_sh_d" ] || continue
+      if [ -f "${_pbg_sh_d}state.json" ] || [ -f "${_pbg_sh_d}state.db" ]; then
         return 0
       fi
     done
   fi
+  return 1
+}
+
+# _pbg_precheck_active_scope -> 0 (existe escopo a checar) assinalando
+# `_PBG_SCOPE` com a RAIZ do projeto-alvo; 1 se nenhum candidato abriga
+# state (100% das sessoes manuais do operador, FR-006). Substitui o
+# pre-check que testava exclusivamente `$_PBG_CWD`.
+#
+# MOTIVO (bug de deriva de cwd): o `.cwd` do payload NAO e a raiz do
+# projeto — e o diretorio corrente do shell da sessao, que gruda em
+# qualquer subdiretorio assim que o agente roda um `cd sub && ...` (o cwd
+# do Bash persiste entre tool calls). Observado em campo: uma sessao ficou
+# ~25h com `.cwd` num subdiretorio do projeto-alvo; o pre-check saiu 1 em
+# TODAS as tool calls e a guarda fail-closed ficou inerte justamente
+# enquanto o agente mexia em codigo (a metrica de tool_calls, que usa o
+# mesmo pre-check, zerou junto — sintoma visivel do mesmo defeito).
+#
+# Cadeia de candidatos, primeiro que abrigar state vence:
+#   1. `$_PBG_CWD` exato — comportamento historico, custo O(1);
+#   2. ancestrais de `$_PBG_CWD`, subindo ate a primeira fronteira:
+#      `$CLAUDE_PROJECT_DIR` (quando definido), diretorio com `.git`,
+#      `/`, ou o teto de 16 niveis;
+#   3. `$CLAUDE_PROJECT_DIR` direto — resgata o caso do cwd ter saido da
+#      arvore do projeto (ex.: `cd /tmp`), onde subir nao alcanca a raiz.
+#
+# ORDEM DELIBERADA (seguranca): `$CLAUDE_PROJECT_DIR` e consultado por
+# ULTIMO como candidato. Havendo state real alcancavel por cwd/ancestrais,
+# a env var nao consegue sombreá-lo — ela so amplia o alcance, nunca
+# redireciona a deteccao para outro state (o que, numa guarda fail-closed,
+# seria um vetor de bypass: apontar para uma execucao de status terminal
+# faria o helper responder "inativa" e a guarda sair 0). Como fronteira
+# superior do passo 2, a mesma variavel so RESTRINGE o alcance.
+_pbg_precheck_active_scope() {
+  if _pbg_scope_has_state "$_PBG_CWD"; then
+    _PBG_SCOPE="$_PBG_CWD"
+    return 0
+  fi
+
+  _pbg_pa_cur="$_PBG_CWD"
+  _pbg_pa_depth=0
+  while [ "$_pbg_pa_depth" -lt 16 ]; do
+    # Fronteira superior: nunca subir acima da raiz do projeto da sessao.
+    # Comparacao por igualdade literal (nunca `case`/glob) — um
+    # `CLAUDE_PROJECT_DIR` com `*`/`?`/`[` seria interpretado como padrao.
+    if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ "$_pbg_pa_cur" = "$CLAUDE_PROJECT_DIR" ]; then
+      break
+    fi
+
+    _pbg_pa_parent="${_pbg_pa_cur%/*}"
+    [ -n "$_pbg_pa_parent" ] || _pbg_pa_parent="/"
+    [ "$_pbg_pa_parent" = "$_pbg_pa_cur" ] && break
+    _pbg_pa_cur="$_pbg_pa_parent"
+
+    if _pbg_scope_has_state "$_pbg_pa_cur"; then
+      _PBG_SCOPE="$_pbg_pa_cur"
+      return 0
+    fi
+
+    # Raiz de repositorio sem state: parar (nao vazar para o projeto-pai).
+    [ -e "$_pbg_pa_cur/.git" ] && break
+    [ "$_pbg_pa_cur" = "/" ] && break
+    _pbg_pa_depth=$((_pbg_pa_depth + 1))
+  done
+
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && _pbg_scope_has_state "$CLAUDE_PROJECT_DIR"; then
+    _PBG_SCOPE="$CLAUDE_PROJECT_DIR"
+    return 0
+  fi
+
   return 1
 }
 
@@ -262,8 +338,12 @@ _pbg_write_log() {
       detected_execution_path: (if $dpath == "" then null else $dpath end)}' \
     2>/dev/null) || return 0
 
-  mkdir -p "$_PBG_CWD/.claude" 2>/dev/null || :
-  printf '%s\n' "$_pbg_line" >>"$_PBG_CWD/.claude/enforcement-log.jsonl" 2>/dev/null \
+  # Raiz de escopo resolvida (nunca o cwd cru): sem isso, uma tool call
+  # disparada de um subdiretorio criaria um `.claude/enforcement-log.jsonl`
+  # paralelo la dentro, fatiando a trilha de auditoria da execucao.
+  _pbg_log_root="${_PBG_SCOPE:-$_PBG_CWD}"
+  mkdir -p "$_pbg_log_root/.claude" 2>/dev/null || :
+  printf '%s\n' "$_pbg_line" >>"$_pbg_log_root/.claude/enforcement-log.jsonl" 2>/dev/null \
     || printf '%s: aviso - falha ao gravar enforcement-log.jsonl\n' "$_PBG_NAME" >&2
   return 0
 }
@@ -330,7 +410,7 @@ export HAE_BUSY_TIMEOUT_MS
 # padrao ja usado neste arquivo em L189/L269): sob `set -e`, uma atribuicao
 # simples cujo command substitution falha aborta o script inteiro — aqui
 # exit 1/2 do helper sao caminhos de controle legitimos, nao erros.
-if _PBG_HAE_OUT=$(hook_active_exec "$_PBG_CWD"); then
+if _PBG_HAE_OUT=$(hook_active_exec "$_PBG_SCOPE"); then
   _PBG_HAE_RC=0
 else
   _PBG_HAE_RC=$?
@@ -377,9 +457,9 @@ fi
 # Whitelist file (Decision 8 — dois nomes legados coexistem no codebase;
 # tenta ambos, primeiro que existir vence; nenhum -> bash-guard.sh trata
 # como whitelist vazia, comportamento ja existente).
-_pbg_wl="$_PBG_CWD/.claude/agente-00c-whitelist"
+_pbg_wl="$_PBG_SCOPE/.claude/agente-00c-whitelist"
 if [ ! -f "$_pbg_wl" ]; then
-  _pbg_wl_alt="$_PBG_CWD/.agente-00c-whitelist.txt"
+  _pbg_wl_alt="$_PBG_SCOPE/.agente-00c-whitelist.txt"
   [ -f "$_pbg_wl_alt" ] && _pbg_wl="$_pbg_wl_alt"
 fi
 

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/_state-ondas-db.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/_state-ondas-db.sh
@@ -251,16 +251,35 @@ _so_db_end() {
 
   # Consumo OTel — sidecares TSV, backend-agnosticos.
   _so_otel_snapshot "$_e_sdir" end
-  _e_otel=$(_so_otel_delta "$_e_sdir")
+  # Arquivo de motivo criado AQUI (fora do `$( )`) — ver _so_otel_delta.
+  _e_otel_rf=$(mktemp 2>/dev/null) || _e_otel_rf=""
+  _e_otel=$(_so_otel_delta "$_e_sdir" "$_e_otel_rf")
   case "$_e_otel" in ''|null) _e_otel="null" ;; esac
+  _e_otel_reason=$(_so_otel_reason_read "$_e_otel_rf")
+  [ -n "$_e_otel_rf" ] && rm -f -- "$_e_otel_rf" 2>/dev/null
 
   _e_spawns_sql="NULL"; [ "$_e_spawns" != "[]" ] && [ -n "$_e_spawns" ] && _e_spawns_sql=$(_sr_sql_quote "$_e_spawns")
   _e_au_sql="NULL"; [ "$_e_au" != "null" ] && _e_au_sql=$(_sr_sql_quote "$_e_au")
   _e_otel_sql="NULL"; [ "$_e_otel" != "null" ] && _e_otel_sql=$(_sr_sql_quote "$_e_otel")
 
+  # Motivo da ausencia de medicao OTel -> catch-all `extra_fields` (o
+  # equivalente sob SQLite da chave achatada que o path JSON grava na
+  # onda). MERGE, nunca overwrite: `extra_fields` e compartilhado com
+  # outros produtores (ex.: touched_key_aspects). So escreve quando ha
+  # motivo — onda medida nao ganha chave nenhuma.
+  _e_extra_sql=""
+  if [ "$_e_otel" = "null" ] && [ -n "$_e_otel_reason" ]; then
+    _e_extra_cur=$(_state_db_exec "$_e_db" \
+      "SELECT coalesce(extra_fields,'{}') FROM wave WHERE id=$(_sr_sql_quote "$_e_wid");")
+    case "$_e_extra_cur" in '') _e_extra_cur='{}' ;; esac
+    _e_extra_new=$(printf '%s' "$_e_extra_cur" \
+      | jq -c --arg r "$_e_otel_reason" '. + {otel_absent_reason: $r}' 2>/dev/null) || _e_extra_new=""
+    [ -n "$_e_extra_new" ] && _e_extra_sql=", extra_fields=$(_sr_sql_quote "$_e_extra_new")"
+  fi
+
   # C4: fechamento da onda + atualizacao de next_instruction na MESMA
   # transacao (paridade com o write atomico unico do path JSON).
-  _e_sql="BEGIN IMMEDIATE; UPDATE wave SET finished_at=$(_sr_sql_quote "$_e_now"), wallclock_seconds=$_e_wc, tool_calls=$_e_tc, termination_reason=$(_sr_sql_quote "$_e_motivo"), next_wave_scheduled_for=$_e_proxima_sql, executed_stages=$(_sr_sql_quote "$_e_stages_merged"), agent_usage=$_e_au_sql, agent_spawns=$_e_spawns_sql, otel_usage=$_e_otel_sql WHERE id=$(_sr_sql_quote "$_e_wid");"
+  _e_sql="BEGIN IMMEDIATE; UPDATE wave SET finished_at=$(_sr_sql_quote "$_e_now"), wallclock_seconds=$_e_wc, tool_calls=$_e_tc, termination_reason=$(_sr_sql_quote "$_e_motivo"), next_wave_scheduled_for=$_e_proxima_sql, executed_stages=$(_sr_sql_quote "$_e_stages_merged"), agent_usage=$_e_au_sql, agent_spawns=$_e_spawns_sql, otel_usage=$_e_otel_sql$_e_extra_sql WHERE id=$(_sr_sql_quote "$_e_wid");"
   if [ "$_e_next_set" = 1 ]; then
     _e_sql="$_e_sql UPDATE execution SET next_instruction=$_e_next_instr_sql WHERE id=$(_sr_sql_quote "$_e_exec_id");"
   fi

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/otel-usage.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/otel-usage.sh
@@ -70,13 +70,17 @@
 #         `type` = "cost" na linha de custo). Best-effort: endpoint fora
 #         do ar -> exit 0 sem escrever, a onda segue normal.
 #
-#   otel-usage.sh delta --state-dir DIR
+#   otel-usage.sh delta --state-dir DIR [--reason-file PATH]
 #       — end - start por chave (session, source, model, type), duplicatas
 #         SOMADAS, resultado atribuido a UNICA sessao que cresceu (ver
 #         bloco MULTIPLAS SESSOES). JSON no stdout. Sem os dois snapshots,
 #         mais de uma sessao ativa, processo trocado ou snapshot em
 #         formato antigo: imprime `null` e sai 0 (metrica ausente NUNCA e
 #         zero fabricado — Principio VI).
+#       — `--reason-file`: quando o resultado e `null`, grava nesse arquivo
+#         UM slug estavel explicando a ausencia (ver `_ou_reason`). Sem a
+#         flag, nada muda para o chamador. O arquivo NAO e tocado quando a
+#         medicao da certo — ausencia de conteudo significa "foi medido".
 #
 # MULTIPLAS SESSOES NO MESMO EXPORTER (bug real, 2026-07-28)
 # ----------------------------------------------------------
@@ -132,6 +136,36 @@ _OU_PII_LABELS="user_id user_email user_account_uuid user_account_id organizatio
 _ou_die_usage() { printf '%s: %s\n' "$_OU_NAME" "$1" >&2; exit 2; }
 _ou_die()       { printf '%s: %s\n' "$_OU_NAME" "$1" >&2; exit "${2:-1}"; }
 _ou_warn()      { printf '%s: %s\n' "$_OU_NAME" "$1" >&2; }
+
+# _ou_reason SLUG -> grava o motivo da AUSENCIA de medicao no arquivo
+# indicado por `--reason-file` (no-op quando a flag nao foi passada, o que
+# preserva byte-a-byte o comportamento de todo chamador antigo).
+#
+# Por que existe: o motivo do `null` sempre foi conhecido aqui e sempre foi
+# perdido — `_so_otel_delta` (state-ondas.sh) invoca este script com
+# `2>/dev/null`, entao o aviso em prosa morria no fechamento da onda. O
+# operador ficava com "s/ dado" no painel e nenhuma pista, apesar de o
+# sistema saber a resposta. Slug (kebab-case, estavel) em vez do texto do
+# aviso: prosa e para humano, motivo persistido e contrato de dado —
+# mesmo racional do `status=<estado>` do subcomando `preflight`.
+#
+# Vocabulario fechado (todo caminho de `null` do delta tem o seu):
+#   sem-snapshot      um dos TSV (start/end) ausente
+#   jq-ausente        dependencia opcional indisponivel
+#   formato-antigo    snapshot de 4 colunas, sem session_id por linha
+#   exporter-trocou   sessao do start sumiu no end (processo dono da porta
+#                     trocou — tipicamente restart do Claude Code no MEIO
+#                     da onda; contador cumulativo nunca some sozinho)
+#   sessoes-ambiguas  mais de uma sessao cresceu no mesmo exporter
+#   sem-crescimento   nenhuma sessao cresceu entre os snapshots
+#   falha-join        rc inesperado do awk
+# Falha de escrita e ignorada: isto e diagnostico best-effort e NUNCA pode
+# derrubar o fechamento de uma onda.
+_ou_reason() {
+  [ -n "${_ou_reason_file:-}" ] || return 0
+  printf '%s\n' "$1" > "$_ou_reason_file" 2>/dev/null || :
+  return 0
+}
 
 _ou_have_curl() { command -v curl >/dev/null 2>&1; }
 
@@ -284,10 +318,13 @@ _ou_cmd_snapshot() {
 
 _ou_cmd_delta() {
   _ou_sdir=""
+  _ou_reason_file=""
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --state-dir) [ "$#" -ge 2 ] || _ou_die_usage "delta: --state-dir exige valor"
                    _ou_sdir=$2; shift 2 ;;
+      --reason-file) [ "$#" -ge 2 ] || _ou_die_usage "delta: --reason-file exige valor"
+                   _ou_reason_file=$2; shift 2 ;;
       *) _ou_die_usage "delta: flag desconhecida: $1" ;;
     esac
   done
@@ -297,11 +334,12 @@ _ou_cmd_delta() {
   _ou_e="$_ou_sdir/otel-end.tsv"
   # Ausencia de qualquer um dos lados => metrica INDISPONIVEL, nao zero.
   if [ ! -f "$_ou_s" ] || [ ! -f "$_ou_e" ]; then
+    _ou_reason "sem-snapshot"
     printf 'null\n'
     return 0
   fi
 
-  command -v jq >/dev/null 2>&1 || { _ou_warn "delta: jq ausente"; printf 'null\n'; return 0; }
+  command -v jq >/dev/null 2>&1 || { _ou_warn "delta: jq ausente"; _ou_reason "jq-ausente"; printf 'null\n'; return 0; }
 
   # Join por chave COMPLETA (session, source, model, type), SOMANDO
   # duplicatas nos dois lados — o exporter emite linhas separadas por
@@ -355,15 +393,26 @@ _ou_cmd_delta() {
   case "$_ou_rc" in
     0) : ;;
     3) _ou_warn "delta: snapshot em formato antigo (sem session_id por linha) — delta descartado nesta onda"
+       _ou_reason "formato-antigo"
        rm -f -- "$_ou_rows"; printf 'null\n'; return 0 ;;
     4) _ou_warn "delta: sessao do snapshot inicial ausente no snapshot final — processo do exporter trocou, delta descartado"
+       _ou_reason "exporter-trocou"
        rm -f -- "$_ou_rows"; printf 'null\n'; return 0 ;;
     5) _ou_amb=$(awk -F'\t' '/^# ambiguous/{print $2; exit}' "$_ou_rows")
        _ou_warn "delta: mais de uma sessao ativa no exporter ($_ou_amb) — atribuicao ambigua, delta descartado"
+       _ou_reason "sessoes-ambiguas"
        rm -f -- "$_ou_rows"; printf 'null\n'; return 0 ;;
     *) _ou_warn "delta: falha inesperada no join (rc=$_ou_rc) — delta descartado"
+       _ou_reason "falha-join"
        rm -f -- "$_ou_rows"; printf 'null\n'; return 0 ;;
   esac
+
+  # rc=0 com `_ou_rows` sem nenhuma linha de dado = nenhuma sessao cresceu
+  # entre os snapshots (n==0 no awk). E ausencia legitima — a onda nao
+  # consumiu nada de medivel — mas continua sendo ausencia, nao zero.
+  if ! grep -qv '^#' "$_ou_rows" 2>/dev/null; then
+    _ou_reason "sem-crescimento"
+  fi
 
   _ou_sid=$(awk -F'\t' '/^# session_id/{print $2; exit}' "$_ou_rows")
   grep -v '^#' "$_ou_rows" \

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -543,20 +543,57 @@ _so_otel_snapshot() {
   return 0
 }
 
-# _so_otel_delta DIR -> stdout: JSON do consumo da onda, ou `null`.
-# `null` significa AUSENTE (telemetria desligada, snapshot faltando,
-# processo trocou no meio) — nunca zero fabricado.
+# _so_otel_delta DIR [REASON_FILE] -> stdout: JSON do consumo da onda, ou
+# `null`. `null` significa AUSENTE (telemetria desligada, snapshot
+# faltando, processo trocou no meio) — nunca zero fabricado.
+#
+# REASON_FILE (opcional): caminho onde o motivo da ausencia e depositado
+# como slug de uma linha (vazio/intocado quando a onda foi medida). O
+# motivo sempre existiu, mas so no aviso em prosa que o `2>/dev/null`
+# abaixo descarta — o operador ficava com um "s/ dado" mudo no painel.
+#
+# O ARQUIVO E DO CHAMADOR, de proposito: `end` invoca esta funcao dentro de
+# `$( )`, ou seja, num SUBSHELL — qualquer variavel global assinalada aqui
+# morreria junto com ele. Arquivo atravessa a fronteira; variavel nao.
 _so_otel_delta() {
+  _od_dir=$1
+  _od_rf=${2:-}
+  [ -n "$_od_rf" ] && : > "$_od_rf" 2>/dev/null
+
+  # _od_reason SLUG -> deposita o motivo (no-op sem REASON_FILE).
+  _od_reason() { [ -n "$_od_rf" ] && printf '%s\n' "$1" > "$_od_rf" 2>/dev/null; return 0; }
+
   _ots=$(_so_otel_script)
-  [ -f "$_ots" ] || { printf 'null\n'; return 0; }
-  _od=$(sh "$_ots" delta --state-dir "$1" 2>/dev/null) || _od=""
+  [ -f "$_ots" ] || { _od_reason "sem-script"; printf 'null\n'; return 0; }
+
+  if [ -n "$_od_rf" ]; then
+    _od=$(sh "$_ots" delta --state-dir "$_od_dir" --reason-file "$_od_rf" 2>/dev/null) || _od=""
+  else
+    _od=$(sh "$_ots" delta --state-dir "$_od_dir" 2>/dev/null) || _od=""
+  fi
+
   # Valida como JSON com jq. NAO usar glob de printaveis (`*[!\ -~]*`):
   # ele casa newline, entao qualquer JSON multi-linha virava `null`.
   if [ -z "$_od" ] || ! printf '%s' "$_od" | jq -e . >/dev/null 2>&1; then
+    # `null` legitimo do delta ja depositou o slug; aqui cobrimos so a
+    # saida invalida (contrato quebrado), que o delta nao classifica.
+    [ -n "$_od_rf" ] && [ ! -s "$_od_rf" ] && _od_reason "saida-invalida"
     printf 'null\n'
-  else
-    printf '%s\n' "$_od"
+    return 0
   fi
+
+  case "$_od" in
+    null) [ -n "$_od_rf" ] && [ ! -s "$_od_rf" ] && _od_reason "nao-classificado" ;;
+    *) [ -n "$_od_rf" ] && : > "$_od_rf" 2>/dev/null ;;
+  esac
+  printf '%s\n' "$_od"
+}
+
+# _so_otel_reason_read FILE -> slug depositado (vazio se nao ha motivo).
+_so_otel_reason_read() {
+  [ -n "${1:-}" ] || return 0
+  [ -s "$1" ] || return 0
+  head -n 1 "$1" 2>/dev/null | tr -d '[:space:]'
 }
 
 # _so_otel_reset DIR — descarta os snapshots da onda encerrada para nao
@@ -766,8 +803,20 @@ $2"; shift 2 ;;
   # write — e enquanto o processo Claude Code ainda vive, ja que o exporter
   # Prometheus e in-process e some junto com ele.
   _so_otel_snapshot "$_sdir" end
-  _otel_json=$(_so_otel_delta "$_sdir")
+  # Arquivo de motivo criado AQUI (fora do `$( )`): a funcao roda em
+  # subshell e nao consegue devolver o slug por variavel.
+  _otel_rf=$(mktemp 2>/dev/null) || _otel_rf=""
+  _otel_json=$(_so_otel_delta "$_sdir" "$_otel_rf")
   case "$_otel_json" in ''|null) _otel_json="null" ;; esac
+  # Motivo da ausencia (vazio quando medido). Chave achatada na onda,
+  # mesmo padrao ja usado por `.waves[-1].touched_key_aspects` (drift.sh)
+  # — sob backend SQLite o equivalente vai para a coluna `extra_fields`.
+  _otel_reason=$(_so_otel_reason_read "$_otel_rf")
+  [ -n "$_otel_rf" ] && rm -f -- "$_otel_rf" 2>/dev/null
+  _otel_reason_json="null"
+  if [ "$_otel_json" = "null" ] && [ -n "$_otel_reason" ]; then
+    _otel_reason_json=$(printf '%s' "$_otel_reason" | jq -Rs .) || _otel_reason_json="null"
+  fi
 
   # .next_instruction gravado DENTRO do mesmo write atomico do fechamento
   # da onda. Antes exigia um `state-rw.sh set` separado, e como `end`
@@ -783,6 +832,7 @@ $2"; shift 2 ;;
   _new=$(mktemp) || _so_die "mktemp falhou" 1
   jq \
     --argjson otel "$_otel_json" \
+    --argjson otel_reason "$_otel_reason_json" \
     --argjson next_instr "$_next_instr_json" \
     --arg now "$_now" \
     --arg motivo "$_motivo" \
@@ -820,6 +870,7 @@ $2"; shift 2 ;;
         | .agent_usage = $au
         | .agent_spawns = $sp
         | .otel_usage = $otel
+        | (if $otel_reason != null then .otel_absent_reason = $otel_reason else . end)
       ))
       | .accumulated_metrics.waves_total = ((.accumulated_metrics.waves_total // 0) + 1)
       | .accumulated_metrics.tool_calls_total = ((.accumulated_metrics.tool_calls_total // 0) + $tc)

--- a/tests/test_otel-usage.sh
+++ b/tests/test_otel-usage.sh
@@ -518,5 +518,118 @@ scenario_preflight_flag_desconhecida_exit2() {
   return 0
 }
 
+# ==== --reason-file: motivo da ausencia deixa de ser perdido ====
+#
+# O motivo do `null` sempre foi conhecido aqui e sempre morreu no aviso em
+# prosa (o chamador invoca este script com `2>/dev/null`). Cada caminho de
+# `null` MUST depositar seu slug; onda medida MUST NOT deixar motivo.
+
+# _reason_of FILE -> conteudo do reason-file, sem espacos (vazio se nao ha).
+_reason_of() {
+  [ -s "$1" ] || { printf ''; return 0; }
+  tr -d '[:space:]' < "$1"
+}
+
+scenario_reason_exporter_trocou() {
+  _sd="$TMPDIR_TEST/r-troca"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/r1-start.txt"; _fe="$TMPDIR_TEST/r1-end.txt"
+  _fixture "$_fs" "sess-AAA" 1.0 1.0 10 5
+  _fixture "$_fe" "sess-BBB" 9.0 9.0 90 50
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  _rf="$TMPDIR_TEST/r1.reason"
+  capture sh "$SCRIPT" delta --state-dir "$_sd" --reason-file "$_rf"
+  [ "$(printf '%s' "$_CAPTURED_STDOUT" | tr -d '[:space:]')" = "null" ] \
+    || { _fail "null" "esperado null"; return 1; }
+  [ "$(_reason_of "$_rf")" = "exporter-trocou" ] \
+    || { _fail "reason" "esperado exporter-trocou, obtido: $(_reason_of "$_rf")"; return 1; }
+  return 0
+}
+
+scenario_reason_sem_snapshot() {
+  _sd="$TMPDIR_TEST/r-sem"; mkdir -p "$_sd"
+  _fe="$TMPDIR_TEST/r2-end.txt"
+  _fixture "$_fe" "sess-AAA" 1.0 1.0 10 5
+  _snap "$_sd" end "$_fe"
+  _rf="$TMPDIR_TEST/r2.reason"
+  capture sh "$SCRIPT" delta --state-dir "$_sd" --reason-file "$_rf"
+  [ "$(_reason_of "$_rf")" = "sem-snapshot" ] \
+    || { _fail "reason" "esperado sem-snapshot, obtido: $(_reason_of "$_rf")"; return 1; }
+  return 0
+}
+
+scenario_reason_sessoes_ambiguas() {
+  _sd="$TMPDIR_TEST/r-amb"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/r3-start.txt"; _fe="$TMPDIR_TEST/r3-end.txt"
+  { _cost_line "sess-A" main "claude-opus-5[1m]" 1.0
+    _cost_line "sess-B" main "claude-opus-5[1m]" 1.0; } > "$_fs"
+  { _cost_line "sess-A" main "claude-opus-5[1m]" 5.0
+    _cost_line "sess-B" main "claude-opus-5[1m]" 7.0; } > "$_fe"
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  _rf="$TMPDIR_TEST/r3.reason"
+  capture sh "$SCRIPT" delta --state-dir "$_sd" --reason-file "$_rf"
+  [ "$(_reason_of "$_rf")" = "sessoes-ambiguas" ] \
+    || { _fail "reason" "esperado sessoes-ambiguas, obtido: $(_reason_of "$_rf")"; return 1; }
+  return 0
+}
+
+scenario_reason_sem_crescimento() {
+  _sd="$TMPDIR_TEST/r-parado"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/r4.txt"
+  _fixture "$_fs" "sess-AAA" 1.0 1.0 10 5
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fs"
+  _rf="$TMPDIR_TEST/r4.reason"
+  capture sh "$SCRIPT" delta --state-dir "$_sd" --reason-file "$_rf"
+  [ "$(_reason_of "$_rf")" = "sem-crescimento" ] \
+    || { _fail "reason" "esperado sem-crescimento, obtido: $(_reason_of "$_rf")"; return 1; }
+  return 0
+}
+
+scenario_reason_formato_antigo() {
+  _sd="$TMPDIR_TEST/r-legado"; mkdir -p "$_sd"
+  # Snapshot legado: 4 colunas (sem session_id por linha).
+  printf 'main\tclaude-opus-5[1m]\tcost\t1.0\n' > "$_sd/otel-start.tsv"
+  printf 'main\tclaude-opus-5[1m]\tcost\t9.0\n' > "$_sd/otel-end.tsv"
+  _rf="$TMPDIR_TEST/r5.reason"
+  capture sh "$SCRIPT" delta --state-dir "$_sd" --reason-file "$_rf"
+  [ "$(_reason_of "$_rf")" = "formato-antigo" ] \
+    || { _fail "reason" "esperado formato-antigo, obtido: $(_reason_of "$_rf")"; return 1; }
+  return 0
+}
+
+scenario_reason_vazio_quando_medido() {
+  _sd="$TMPDIR_TEST/r-ok"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/r6-start.txt"; _fe="$TMPDIR_TEST/r6-end.txt"
+  _fixture "$_fs" "sess-AAA" 1.0 1.0 10 5
+  _fixture "$_fe" "sess-AAA" 3.0 3.0 40 25
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  _rf="$TMPDIR_TEST/r6.reason"
+  capture sh "$SCRIPT" delta --state-dir "$_sd" --reason-file "$_rf"
+  printf '%s' "$_CAPTURED_STDOUT" | jq -e '.total_tokens > 0' >/dev/null 2>&1 \
+    || { _fail "delta" "esperado delta medido, obtido: $_CAPTURED_STDOUT"; return 1; }
+  [ -z "$(_reason_of "$_rf")" ] \
+    || { _fail "reason" "onda medida NAO deve deixar motivo, obtido: $(_reason_of "$_rf")"; return 1; }
+  return 0
+}
+
+# Sem a flag, byte-a-byte o comportamento antigo (nenhum chamador legado
+# muda de contrato so porque a capacidade passou a existir).
+scenario_reason_file_ausente_nao_altera_saida() {
+  _sd="$TMPDIR_TEST/r-compat"; mkdir -p "$_sd"
+  _fs="$TMPDIR_TEST/r7-start.txt"; _fe="$TMPDIR_TEST/r7-end.txt"
+  _fixture "$_fs" "sess-AAA" 1.0 1.0 10 5
+  _fixture "$_fe" "sess-BBB" 9.0 9.0 90 50
+  _snap "$_sd" start "$_fs"
+  _snap "$_sd" end   "$_fe"
+  capture sh "$SCRIPT" delta --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ "$(printf '%s' "$_CAPTURED_STDOUT" | tr -d '[:space:]')" = "null" ] \
+    || { _fail "stdout" "esperado null sem a flag"; return 1; }
+  return 0
+}
+
 run_all_scenarios
 exit $?

--- a/tests/test_posttooluse-agent-usage.sh
+++ b/tests/test_posttooluse-agent-usage.sh
@@ -517,5 +517,22 @@ scenario_plugin_root_resolve_hae_via_claude_plugin_root() {
   [ "$(_lines_count "$_side")" = 1 ] || { _fail "sidecar" "esperado 1 linha (hae resolvido via plugin root), obtido $(_lines_count "$_side")"; return 1; }
 }
 
+# ==== Regressao: deriva de cwd (bug de campo) ====
+#
+# `.cwd` gruda em subdiretorio apos `cd sub && ...` do agente e nao volta
+# sozinho; enquanto durar, o spawn nao e contabilizado e a onda perde a
+# metrica de tokens por subagente. Cadeia de resolucao identica a dos
+# demais hooks (ver _pbg_precheck_active_scope).
+
+scenario_cwd_em_subdiretorio_resolve_raiz_do_projeto() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  mkdir -p "$TMPDIR_TEST/host"
+  _tr='{"status":"completed","agentId":"a1b598e5d8f9a0318","resolvedModel":"claude-sonnet-5","totalTokens":131692,"totalDurationMs":681768,"totalToolUseCount":45,"usage":{"input_tokens":2,"output_tokens":1097,"cache_read_input_tokens":130176,"cache_creation_input_tokens":417}}'
+  _run_hook "$(_payload "$TMPDIR_TEST/host" "Agent" "$_tr")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _side=$(_sidecar_for "$TMPDIR_TEST" "minha-feat")
+  [ "$(_lines_count "$_side")" = 1 ] || { _fail "sidecar" "spawn deveria ser contabilizado no state-dir da RAIZ mesmo com cwd em subdiretorio; obtido $(_lines_count "$_side")"; return 1; }
+}
+
 run_all_scenarios
 exit $?

--- a/tests/test_posttooluse-loose-usage.sh
+++ b/tests/test_posttooluse-loose-usage.sh
@@ -316,5 +316,51 @@ scenario_plugin_root_resolve_otel_usage_via_claude_plugin_root() {
   [ -n "$_meta" ] || { _fail "sidecar" "esperado meta.tsv (otel-usage.sh resolvido via plugin root)"; return 1; }
 }
 
+# ==== Regressao: deriva de cwd (bug de campo) ====
+
+# Sob POLARIDADE INVERTIDA a deriva de cwd e pior que perda de metrica: o
+# pre-check falha, o hook conclui "sem execucao ativa" e CAPTURA consumo
+# que pertence a uma onda 00c — dupla contagem justamente do que
+# `cstk usage compare` promete separar.
+scenario_execucao_ativa_detectada_com_cwd_em_subdiretorio() {
+  _require_jq || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  export CSTK_LOOSE_USAGE_INTERVAL_S=0
+  _proj="$TMPDIR_TEST/proj"
+  _active_agente_json "$_proj" "em_andamento"
+  mkdir -p "$_proj/host"
+
+  _run_hook "$(_json_for "$_proj/host" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _meta=$(_find_meta_files)
+  [ -z "$_meta" ] || { _fail "captura indevida" "execucao 00c ativa na raiz deveria suprimir a captura mesmo com cwd em subdiretorio; meta=$_meta"; return 1; }
+  return 0
+}
+
+# Identidade (process_key + project_path) ancorada em CLAUDE_PROJECT_DIR:
+# ancora DIFERENTE da deteccao 00c — consumo avulso ocorre justamente em
+# projeto sem state nenhum, entao subir-ate-achar-state nao serve aqui.
+scenario_identidade_ancorada_em_claude_project_dir() {
+  _require_jq || return 2
+  export CSTK_OTEL_ENDPOINT="$_FAKE_ENDPOINT"
+  export CSTK_LOOSE_USAGE_INTERVAL_S=0
+  _proj="$TMPDIR_TEST/proj"
+  mkdir -p "$_proj/host"
+
+  _json=$(_json_for "$_proj/host" "Bash")
+  capture env HOME="$TMPDIR_TEST" CLAUDE_PROJECT_DIR="$_proj" \
+    sh -c 'printf "%s" "$1" | "$2"' _ "$_json" "$SCRIPT"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _meta=$(_find_meta_files)
+  [ -n "$_meta" ] || { _fail "sidecar" "esperado meta.tsv criado"; return 1; }
+  _pp=$(_meta_get "$_meta" project_path)
+  [ "$_pp" = "$_proj" ] || { _fail "project_path" "esperado a RAIZ ($_proj), obtido: $_pp"; return 1; }
+  case "$(dirname "$_meta")" in
+    */proj-*) : ;;
+    *) _fail "process_key" "key deveria derivar do basename da raiz (proj-*), obtido: $(basename "$(dirname "$_meta")")"; return 1 ;;
+  esac
+  return 0
+}
+
 run_all_scenarios
 exit $?

--- a/tests/test_posttooluse-tool-call-tick.sh
+++ b/tests/test_posttooluse-tool-call-tick.sh
@@ -406,5 +406,85 @@ scenario_plugin_root_resolve_hae_via_claude_plugin_root() {
   [ "$(_ticks_count "$_side")" = 1 ] || { _fail "sidecar" "esperado 1 linha (hae resolvido via plugin root), obtido $(_ticks_count "$_side")"; return 1; }
 }
 
+# ==== Regressao: deriva de cwd (bug de campo) ====
+#
+# O `.cwd` do payload e o diretorio corrente do shell da sessao, nao a raiz
+# do projeto: um `cd sub && ...` do agente gruda nele e nao volta sozinho.
+# Antes do fix, TODA tool call subsequente era descartada pelo pre-check e a
+# onda fechava com `tool_calls=0` (observado em campo por ~25h seguidas).
+
+scenario_cwd_em_subdiretorio_resolve_raiz_do_projeto() {
+  _active_feature "$TMPDIR_TEST" "minha-feat" "em_andamento"
+  mkdir -p "$TMPDIR_TEST/host"
+  _run_hook "$(_json_for "$TMPDIR_TEST/host" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _side="$TMPDIR_TEST/.claude/feature-00c-state/minha-feat/tool-call-ticks.log"
+  [ "$(_ticks_count "$_side")" = 1 ] || { _fail "sidecar" "tick deveria pousar no state-dir da RAIZ mesmo com cwd em subdiretorio; obtido $(_ticks_count "$_side") linha(s) em $_side"; return 1; }
+}
+
+scenario_cwd_em_subdiretorio_profundo_resolve_raiz() {
+  _active_agente "$TMPDIR_TEST" "em_andamento"
+  mkdir -p "$TMPDIR_TEST/a/b/c/d"
+  _run_hook "$(_json_for "$TMPDIR_TEST/a/b/c/d" "Read")"
+  _side="$TMPDIR_TEST/.claude/agente-00c-state/tool-call-ticks.log"
+  [ "$(_ticks_count "$_side")" = 1 ] || { _fail "sidecar" "esperado 1 tick apos subir 4 niveis, obtido $(_ticks_count "$_side")"; return 1; }
+}
+
+# Fronteira superior: CLAUDE_PROJECT_DIR delimita ate onde subir. State num
+# diretorio ACIMA da raiz da sessao nao pode ser adotado (seria contabilizar
+# tool call de um projeto na execucao de outro).
+scenario_nao_sobe_acima_de_claude_project_dir() {
+  _active_agente "$TMPDIR_TEST" "em_andamento"
+  _proj="$TMPDIR_TEST/proj"
+  mkdir -p "$_proj/sub"
+  _json=$(_json_for "$_proj/sub" "Bash")
+  capture env CLAUDE_PROJECT_DIR="$_proj" \
+    sh -c 'printf "%s" "$1" | "$2"' _ "$_json" "$SCRIPT"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _side="$TMPDIR_TEST/.claude/agente-00c-state/tool-call-ticks.log"
+  [ "$(_ticks_count "$_side")" = 0 ] || { _fail "sidecar" "NAO deveria adotar state acima de CLAUDE_PROJECT_DIR; obtido $(_ticks_count "$_side") tick(s)"; return 1; }
+}
+
+# Ultimo recurso: cwd fora da arvore do projeto (ex.: agente foi para /tmp);
+# subir nao alcanca a raiz, entao CLAUDE_PROJECT_DIR resgata.
+scenario_cwd_fora_da_arvore_resgatado_por_claude_project_dir() {
+  _proj="$TMPDIR_TEST/proj"
+  _active_feature "$_proj" "minha-feat" "em_andamento"
+  _fora="$TMPDIR_TEST/fora/daqui"
+  mkdir -p "$_fora"
+  _json=$(_json_for "$_fora" "Bash")
+  capture env CLAUDE_PROJECT_DIR="$_proj" \
+    sh -c 'printf "%s" "$1" | "$2"' _ "$_json" "$SCRIPT"
+  _side="$_proj/.claude/feature-00c-state/minha-feat/tool-call-ticks.log"
+  [ "$(_ticks_count "$_side")" = 1 ] || { _fail "sidecar" "esperado 1 tick via CLAUDE_PROJECT_DIR, obtido $(_ticks_count "$_side")"; return 1; }
+}
+
+# Precedencia de seguranca: havendo state alcancavel por cwd, a env var NAO
+# pode sombreá-lo (no guard fail-closed isso seria vetor de bypass —
+# apontar para execucao terminal faria a guarda sair 0).
+scenario_claude_project_dir_nao_sombreia_state_alcancavel_por_cwd() {
+  _proj="$TMPDIR_TEST/proj"
+  _active_feature "$_proj" "real" "em_andamento"
+  _outro="$TMPDIR_TEST/outro"
+  _active_feature "$_outro" "isca" "concluida"
+  _json=$(_json_for "$_proj" "Bash")
+  capture env CLAUDE_PROJECT_DIR="$_outro" \
+    sh -c 'printf "%s" "$1" | "$2"' _ "$_json" "$SCRIPT"
+  _side="$_proj/.claude/feature-00c-state/real/tool-call-ticks.log"
+  [ "$(_ticks_count "$_side")" = 1 ] || { _fail "sidecar" "state do cwd deve vencer CLAUDE_PROJECT_DIR; obtido $(_ticks_count "$_side")"; return 1; }
+}
+
+# Fronteira de repositorio: sem CLAUDE_PROJECT_DIR, um diretorio com `.git`
+# encerra a subida — nao vazar para o state de um projeto-pai.
+scenario_fronteira_git_nao_vaza_para_projeto_pai() {
+  _active_agente "$TMPDIR_TEST" "em_andamento"
+  _filho="$TMPDIR_TEST/filho"
+  mkdir -p "$_filho/.git" "$_filho/sub"
+  _run_hook "$(_json_for "$_filho/sub" "Bash")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _side="$TMPDIR_TEST/.claude/agente-00c-state/tool-call-ticks.log"
+  [ "$(_ticks_count "$_side")" = 0 ] || { _fail "sidecar" "subida deveria parar na raiz de repositorio; obtido $(_ticks_count "$_side") tick(s)"; return 1; }
+}
+
 run_all_scenarios
 exit $?

--- a/tests/test_pretooluse-bash-guard.sh
+++ b/tests/test_pretooluse-bash-guard.sh
@@ -595,5 +595,62 @@ scenario_sibling_beats_claude_plugin_root_env_shadow() {
   assert_stdout_contains "REGRA_VIOLADA" || return 1
 }
 
+# ==== Regressao: deriva de cwd (bug de campo) ====
+#
+# O `.cwd` do payload gruda em qualquer subdiretorio apos um `cd sub && ...`
+# do agente (cwd do Bash persiste entre tool calls) e nao volta sozinho.
+# Antes do fix, o pre-check saia 1 e a guarda fail-closed ficava INERTE —
+# nao e so perda de metrica: e a guarda desligada justamente enquanto o
+# agente mexe em codigo, sem nenhuma linha no enforcement-log denunciando.
+
+scenario_cwd_em_subdiretorio_guarda_permanece_ativa() {
+  _active_feature "$TMPDIR_TEST" "enforced-guards" "em_andamento"
+  mkdir -p "$TMPDIR_TEST/host"
+  _json='{"cwd":"'"$TMPDIR_TEST/host"'","tool_name":"Bash","tool_input":{"command":"git push origin main"}}'
+  _run_hook "$_json"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 (Decision 1), obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains '"permissionDecision": "deny"' || return 1
+  assert_stdout_contains "REGRA_VIOLADA" || return 1
+}
+
+# O enforcement-log e a trilha de auditoria da execucao: precisa pousar na
+# RAIZ, nunca fatiado num `.claude/` criado dentro do subdiretorio.
+scenario_enforcement_log_gravado_na_raiz_com_cwd_em_subdiretorio() {
+  _active_feature "$TMPDIR_TEST" "enforced-guards" "em_andamento"
+  mkdir -p "$TMPDIR_TEST/host"
+  _json='{"cwd":"'"$TMPDIR_TEST/host"'","tool_name":"Bash","tool_input":{"command":"git push origin main"}}'
+  _run_hook "$_json"
+
+  _log=$(_enforcement_log "$TMPDIR_TEST")
+  case "$_log" in
+    *'"outcome":"blocked-by-rule"'*) : ;;
+    *) _fail "log raiz" "enforcement-log da RAIZ deveria registrar o bloqueio; log=$_log"; return 1 ;;
+  esac
+  [ -e "$TMPDIR_TEST/host/.claude" ] \
+    && { _fail "log paralelo" "NAO deveria criar .claude/ dentro do subdiretorio"; return 1; }
+  return 0
+}
+
+# A whitelist do operador vive na raiz: com cwd derivado, a guarda precisa
+# continuar enxergando-a, senao passa a negar URL que o operador liberou.
+scenario_whitelist_da_raiz_respeitada_com_cwd_em_subdiretorio() {
+  _active_feature "$TMPDIR_TEST" "enforced-guards" "em_andamento"
+  mkdir -p "$TMPDIR_TEST/host"
+  # Padrao com `**` (match ancorado em ^...$ — ver bash-guard.sh::
+  # _bg_url_matches_pattern; host cru nao casa URL com path).
+  printf 'https://api.example.com/**\n' > "$TMPDIR_TEST/.claude/agente-00c-whitelist"
+  _json='{"cwd":"'"$TMPDIR_TEST/host"'","tool_name":"Bash","tool_input":{"command":"curl https://api.example.com/v1/ping"}}'
+  _run_hook "$_json"
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "URL na whitelist da raiz nao deveria gerar decisao; obtido: $_CAPTURED_STDOUT"; return 1; }
+
+  # Prova de que a guarda REALMENTE avaliou (e nao apenas saiu cedo pelo
+  # pre-check, como fazia antes do fix): ha linha `allowed` no log da raiz.
+  _log=$(_enforcement_log "$TMPDIR_TEST")
+  case "$_log" in
+    *'"outcome":"allowed"'*) : ;;
+    *) _fail "log allowed" "esperado registro allowed na raiz (guarda ativa + whitelist lida); log=$_log"; return 1 ;;
+  esac
+}
+
 run_all_scenarios
 exit $?

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -1295,6 +1295,77 @@ scenario_end_otel_usage_null_sem_telemetria() {
   return 0
 }
 
+# ==== Motivo da ausencia de medicao OTel persistido na onda ====
+#
+# `otel_usage: null` sozinho e mudo: o painel mostra "s/ dado" e o operador
+# nao tem como saber se a telemetria estava desligada, se o processo do
+# exporter trocou no meio da onda, ou se havia duas sessoes disputando. O
+# motivo SEMPRE foi conhecido no fechamento — e sempre foi descartado pelo
+# `2>/dev/null` de _so_otel_delta.
+
+# _otel_fixture_sess FILE SESSION COST -> fixture com session_id explicito
+# (o _otel_fixture padrao fixa "sess-w"; aqui o ponto e trocar a sessao).
+_otel_fixture_sess() {
+  printf 'claude_code_cost_usage_total{session_id="%s",terminal_type="ghostty",model="claude-opus-5[1m]",query_source="main"} %s\n' \
+    "$2" "$3" > "$1"
+}
+
+scenario_end_otel_absent_reason_exporter_trocou() {
+  _sd="$TMPDIR_TEST/otel-reason-troca"
+  _init_state "$_sd"
+  _fx="$TMPDIR_TEST/otel-troca.txt"
+  CSTK_OTEL_ENDPOINT="file://$_fx"; export CSTK_OTEL_ENDPOINT
+
+  _otel_fixture_sess "$_fx" "sess-antiga" 1.0
+  capture "$SCRIPT" start --state-dir "$_sd"
+  # Restart do Claude Code no MEIO da onda: exporter novo, sessao outra.
+  _otel_fixture_sess "$_fx" "sess-nova" 0.2
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  _e=$_CAPTURED_EXIT; _err=$_CAPTURED_STDERR
+  unset CSTK_OTEL_ENDPOINT
+  [ "$_e" = 0 ] || { _fail "end" "$_err"; return 1; }
+
+  _got=$(jq -r '.waves[-1].otel_usage' "$_sd/state.json")
+  [ "$_got" = "null" ] || { _fail "otel_usage" "esperado null, obtido '$_got'"; return 1; }
+  _reason=$(jq -r '.waves[-1].otel_absent_reason // ""' "$_sd/state.json")
+  [ "$_reason" = "exporter-trocou" ] \
+    || { _fail "otel_absent_reason" "esperado exporter-trocou, obtido '$_reason'"; return 1; }
+  return 0
+}
+
+scenario_end_otel_absent_reason_sem_telemetria() {
+  _sd="$TMPDIR_TEST/otel-reason-off"
+  _init_state "$_sd"
+  CSTK_OTEL_ENDPOINT="http://127.0.0.1:59999/metrics"; export CSTK_OTEL_ENDPOINT
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  unset CSTK_OTEL_ENDPOINT
+  _reason=$(jq -r '.waves[-1].otel_absent_reason // ""' "$_sd/state.json")
+  [ "$_reason" = "sem-snapshot" ] \
+    || { _fail "otel_absent_reason" "esperado sem-snapshot (telemetria off), obtido '$_reason'"; return 1; }
+  return 0
+}
+
+# Onda medida NAO ganha a chave — motivo so existe onde ha ausencia.
+scenario_end_onda_medida_nao_grava_motivo() {
+  _sd="$TMPDIR_TEST/otel-reason-ok"
+  _init_state "$_sd"
+  _fx="$TMPDIR_TEST/otel-ok.txt"
+  CSTK_OTEL_ENDPOINT="file://$_fx"; export CSTK_OTEL_ENDPOINT
+  _otel_fixture "$_fx" 1.0 0.5
+  capture "$SCRIPT" start --state-dir "$_sd"
+  _otel_fixture "$_fx" 4.0 3.5
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  unset CSTK_OTEL_ENDPOINT
+  _has=$(jq -r 'has("otel_absent_reason") | tostring' <<EOF
+$(jq -c '.waves[-1]' "$_sd/state.json")
+EOF
+)
+  [ "$_has" = "false" ] \
+    || { _fail "otel_absent_reason" "onda medida NAO deve carregar motivo"; return 1; }
+  return 0
+}
+
 scenario_end_otel_usage_captura_delta_da_onda() {
   _sd="$TMPDIR_TEST/state-otel"
   _init_state "$_sd"
@@ -1972,6 +2043,63 @@ scenario_c2_state_json_coexistente_ignorado_quando_state_db_presente() {
   _stale_now=$(cat "$_sd/state.json")
   [ "$_stale_now" = '{"waves":[]}' ] \
     || { _fail "c2: state.json coexistente foi modificado" "obtido: $_stale_now"; return 1; }
+}
+
+# ---- Motivo da ausencia OTel sob backend SQLite (paridade C1) ----
+#
+# Equivalente da chave achatada do path JSON: sob SQLite o motivo vai para
+# o catch-all `extra_fields`, que a view materializa como
+# `.waves[i].extra_fields`.
+
+scenario_sqlite_end_otel_absent_reason_exporter_trocou() {
+  _sd="$TMPDIR_TEST/sqlite-otel-reason"
+  _seed_sqlite_backend "$_sd" || return 1
+  _fx="$TMPDIR_TEST/otel-sqlite-troca.txt"
+  CSTK_OTEL_ENDPOINT="file://$_fx"; export CSTK_OTEL_ENDPOINT
+
+  _otel_fixture_sess "$_fx" "sess-antiga" 1.0
+  capture "$SCRIPT" start --state-dir "$_sd"
+  _otel_fixture_sess "$_fx" "sess-nova" 0.2
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  _e=$_CAPTURED_EXIT; _err=$_CAPTURED_STDERR
+  unset CSTK_OTEL_ENDPOINT
+  [ "$_e" = 0 ] || { _fail "sqlite end" "$_err"; return 1; }
+
+  _reason=$(sqlite3 "$_sd/state.db" \
+    "SELECT json_extract(extra_fields,'\$.otel_absent_reason') FROM wave WHERE seq=1;")
+  [ "$_reason" = "exporter-trocou" ] \
+    || { _fail "extra_fields" "esperado exporter-trocou em extra_fields, obtido '$_reason'"; return 1; }
+  _otel=$(sqlite3 "$_sd/state.db" "SELECT coalesce(otel_usage,'null') FROM wave WHERE seq=1;")
+  [ "$_otel" = "null" ] || { _fail "otel_usage" "esperado NULL, obtido '$_otel'"; return 1; }
+  return 0
+}
+
+# MERGE, nunca overwrite: `extra_fields` e catch-all compartilhado (ex.:
+# touched_key_aspects). Gravar o motivo NAO pode apagar o vizinho.
+scenario_sqlite_end_otel_reason_preserva_extra_fields() {
+  _sd="$TMPDIR_TEST/sqlite-otel-merge"
+  _seed_sqlite_backend "$_sd" || return 1
+  _fx="$TMPDIR_TEST/otel-sqlite-merge.txt"
+  CSTK_OTEL_ENDPOINT="file://$_fx"; export CSTK_OTEL_ENDPOINT
+
+  _otel_fixture_sess "$_fx" "sess-antiga" 1.0
+  capture "$SCRIPT" start --state-dir "$_sd"
+  sqlite3 "$_sd/state.db" \
+    "UPDATE wave SET extra_fields='{\"touched_key_aspects\":[\"auth\"]}' WHERE seq=1;" \
+    || { unset CSTK_OTEL_ENDPOINT; _fail "fixture" "UPDATE extra_fields falhou"; return 1; }
+  _otel_fixture_sess "$_fx" "sess-nova" 0.2
+  capture "$SCRIPT" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  unset CSTK_OTEL_ENDPOINT
+
+  _asp=$(sqlite3 "$_sd/state.db" \
+    "SELECT json_extract(extra_fields,'\$.touched_key_aspects[0]') FROM wave WHERE seq=1;")
+  [ "$_asp" = "auth" ] \
+    || { _fail "merge" "extra_fields pre-existente foi sobrescrito (touched_key_aspects='$_asp')"; return 1; }
+  _reason=$(sqlite3 "$_sd/state.db" \
+    "SELECT json_extract(extra_fields,'\$.otel_absent_reason') FROM wave WHERE seq=1;")
+  [ "$_reason" = "exporter-trocou" ] \
+    || { _fail "merge" "motivo nao gravado junto do vizinho, obtido '$_reason'"; return 1; }
+  return 0
 }
 
 fi # sqlite3 disponivel


### PR DESCRIPTION
Dois defeitos observados em campo no mesmo projeto-alvo (`esp32-c6`), ambos com o mesmo sintoma visivel — numero que some do painel — e causas totalmente distintas.

## 1. Hooks cegos por deriva de cwd

O `.cwd` do payload do harness nao e a raiz do projeto: e o diretorio corrente do shell da sessao, que gruda em qualquer subdiretorio assim que o agente roda `cd sub && ...` (o cwd do Bash persiste entre tool calls) e nao volta sozinho.

Evidencia: a sessao entrou em `host/` as `2026-08-07T23:29:15Z` e ficou ~25h la. Na janela seguinte, 68 de 68 tool calls tinham `cwd = <projeto>/host`.

O impacto grave nao e a metrica:

- o **`pretooluse-bash-guard` e fail-closed por desenho** e ficou **inerte** justamente enquanto o agente mexia em codigo — sem nenhuma linha no `enforcement-log` denunciando (ultimo registro: `23:29:19Z`, 4s depois da virada de cwd);
- as ondas fecharam com `tool_calls=0` apesar de dezenas de calls reais.

O pre-check inline vira resolvedor de raiz (builtins puros, preserva SEC-H1): cwd exato -> ancestrais -> para na primeira fronteira (`$CLAUDE_PROJECT_DIR`, diretorio com `.git`, `/`, teto de 16 niveis).

`$CLAUDE_PROJECT_DIR` entra como candidato **por ultimo**, de proposito: havendo state alcancavel por cwd/ancestrais a env var nao consegue sombrea-lo — numa guarda fail-closed isso seria vetor de bypass (apontar para execucao terminal faria o helper responder "inativa" e a guarda sair 0). Como fronteira superior, a mesma variavel so restringe.

Todos os consumidores de caminho passam a usar a raiz: state-dir, whitelist do operador, `enforcement-log` e resolucao do catalogo `project`. No `loose-usage`, a identidade (`process_key`/`project_path`) usa ancora **separada** (`$CLAUDE_PROJECT_DIR`) — consumo avulso ocorre justamente onde nao ha state 00c, entao subir-ate-achar-state nao serve la.

**Mudanca de comportamento declarada**: a guarda passa a valer em subdiretorios do projeto-alvo. Comando que viola regra rodado de `host/` agora e negado. E o conserto, mas aparece como "ficou mais rigido".

## 2. `otel_usage: null` mudo

`null` sozinho nao distingue "telemetria desligada" de "processo do exporter trocou" de "duas sessoes disputando". O motivo sempre foi conhecido no fechamento e sempre foi descartado pelo `2>/dev/null` de `_so_otel_delta`.

Caso real (onda-004): o Claude Code reiniciou **no meio da onda** (inicio `01:12:21Z`, processo novo `01:26:03Z`, fim `01:48:31Z`). A baseline tinha a sessao antiga, o snapshot final so a nova, e o delta caiu no ramo `exit 4` — corretamente, por Principio VI. Diagnosticar exigiu `state.db` + `lsof` + `ps` para uma informacao que o sistema ja possuia.

`delta` ganha `--reason-file PATH` (sem a flag, nada muda para chamador algum) e `end` persiste o slug: `.waves[-1].otel_absent_reason` no backend JSON, catch-all `extra_fields` sob SQLite — sempre por **merge**, nunca overwrite (o campo e compartilhado com `touched_key_aspects`).

Detalhe que quase virou falha silenciosa: `end` chama `_so_otel_delta` dentro de `$( )`, um **subshell** — variavel global assinalada la dentro morreria junto com ele. Por isso o arquivo de motivo e criado pelo chamador.

### Escopo deliberadamente parado no state

Levar o motivo ate o painel exige coluna nova na `knowledge.db` (`RECALL_SCHEMA_VERSION` 13 -> 14), e o painel tem allowlist **rigida** (`DEFAULT_SCHEMA_VERSIONS` termina em `'13'`): bumpar aqui derrubaria o painel inteiro com `schema-mismatch` ate uma release coordenada, painel primeiro. Fica para PR separado, se e quando o painel aceitar `'14'`.

## Verificacao

- Suite completa: **2630 PASS, 0 FAIL, 0 ERROR, 0 ORPHANS** (1282s).
- 24 cenarios novos. **19 verificados falhando contra o codigo anterior** (restaurando cada script pre-fix e rodando a suite). Os outros 5 sao guarda-corpo de fronteira e compatibilidade — passam nos dois lados por construcao, e estao listados como tal.
- End-to-end no harness real: sessao que executa `cd host` gera os ticks no state-dir da **raiz**, sem `.claude/` parasita no subdiretorio.

CHANGELOG e bump dos manifestos de plugin ficaram de fora por serem propriedade da skill `release-wave` (ETAPA 2 e gate MP-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa