### PR TITLE
fix(cli): cstk serve nao sobe no Windows (links de workspace quebrados apos o mv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [7.0.1] - 2026-08-09
+
+Corrige o `cstk serve` no Windows, onde o painel nunca chegava a subir: o
+build morria com `TS2307: Cannot find module '@cstk-panel/shared-types'`
+em 17 arquivos de `apps/server`. Mesma familia da #77 — codigo POSIX
+correto que assume semantica de link do Unix e encontra outra no Windows.
+
+### Fixed
+
+- **`cstk serve` reconcilia os links de workspace no destino final.** O
+  `npm install` da instalacao roda dentro do tmpdir e a arvore e movida
+  para `~/.local/share/cstk/panel` depois. Em POSIX o npm materializa os
+  workspaces como symlinks **relativos**, que sobrevivem intactos ao `mv`;
+  no Windows materializa como junctions de caminho **absoluto** apontando
+  para o tmpdir — que e removido em seguida, deixando `node_modules/
+  @cstk-panel/*` pendurado e o `tsc` sem os tipos compartilhados. A
+  instalacao agora reexecuta o install ja em `panel_dir`, reescrevendo os
+  links com o caminho real; se essa etapa falhar, o `panel_dir` e removido
+  para preservar a invariante de que instalacao detectada e instalacao
+  utilizavel. Em POSIX o passo extra e praticamente no-op (`node_modules`
+  ja populado) e roda uma vez por instalacao, nao por execucao.
+
 ## [7.0.0] - 2026-08-08
 
 **BREAKING** — feature `claude-plugin-packaging`. O catalogo do toolkit
@@ -5284,6 +5306,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[7.0.1]: https://github.com/JotJunior/cstk/releases/tag/v7.0.1
 [7.0.0]: https://github.com/JotJunior/cstk/releases/tag/v7.0.0
 [6.8.0]: https://github.com/JotJunior/cstk/releases/tag/v6.8.0
 [6.7.0]: https://github.com/JotJunior/cstk/releases/tag/v6.7.0

--- a/cli/lib/serve.sh
+++ b/cli/lib/serve.sh
@@ -237,7 +237,8 @@ _serve_write_integrity_log() {
 # Extraido de _serve_install (ate a extracao) para ser reusado por DOIS
 # callers sem duplicar o mecanismo de download/verificacao (FR-007):
 #   (a) _serve_install (modo nativo, abaixo): apos extrair, roda `npm
-#       install` dentro de DEST_DIR e move atomicamente para PANEL_DIR.
+#       install` dentro de DEST_DIR, move atomicamente para PANEL_DIR e
+#       reconcilia os links de workspace ja no destino.
 #   (b) o ponto de entrada do modo alternativo baseado em container (vive
 #       no arquivo confinado pelo carve-out do Principio II condicao b,
 #       FASE 2 do backlog correspondente): apos extrair, usa DEST_DIR
@@ -441,7 +442,10 @@ _serve_download_verify_extract() {
 
 # _serve_install PANEL_DIR [ALLOW_UNVERIFIED] [BYPASS_METHOD]
 # Realiza o download e instalacao do painel em PANEL_DIR.
-# Usa tmpdir privado; move atomicamente para PANEL_DIR apos sucesso.
+# Usa tmpdir privado; move atomicamente para PANEL_DIR apos sucesso e entao
+# reconcilia os links de workspace no destino (necessario no Windows, onde o
+# npm materializa workspaces como junctions de caminho absoluto — ver o
+# comentario no ponto da reconciliacao).
 # ALLOW_UNVERIFIED: "1" bypassa o bloqueio fail-closed quando a integridade
 #   nao pode ser confirmada (default "0" — bloqueia). NUNCA bypassa
 #   divergencia de checksum (mismatch — regressao FR-010, task 3.4).
@@ -493,6 +497,26 @@ _serve_install() {
 
   # .panel-version ja foi escrito por _serve_download_verify_extract dentro
   # de _si_extract, que agora VIVE em _si_panel_dir (o mv leva o arquivo).
+
+  # Reconciliar os links de workspace no destino DEFINITIVO (portabilidade
+  # Windows). O `npm install` acima rodou dentro do tmpdir: em POSIX o npm
+  # cria symlinks RELATIVOS para os workspaces, que sobrevivem intactos ao
+  # mv; no Windows cria junctions com caminho ABSOLUTO para o tmpdir — que
+  # e removido logo abaixo. O resultado sao links pendurados e um build que
+  # morre com `TS2307: Cannot find module '@cstk-panel/shared-types'`.
+  # Reexecutar o install ja em _si_panel_dir reescreve os links apontando
+  # para o caminho real. Custo: em POSIX e praticamente no-op (node_modules
+  # ja esta populado) e roda uma vez por INSTALACAO, nao por execucao.
+  # Falha aqui remove o panel_dir para preservar a invariante do caller
+  # (`_serve_is_installed` verdadeiro => instalacao completa e utilizavel).
+  printf 'cstk serve: reconciliando workspaces em %s...\n' "$_si_panel_dir"
+  if ! (cd "$_si_panel_dir" && npm install) 2>&1; then
+    printf 'cstk serve: erro: reconciliacao dos workspaces falhou\n' >&2
+    [ -n "$_si_panel_dir" ] && rm -rf -- "$_si_panel_dir"
+    rm -rf -- "$_si_wrapper_tmp"
+    trap - EXIT INT TERM
+    return 1
+  fi
 
   # Limpar tmpdir (trap cuida de EXIT mas chamamos explicitamente aqui)
   rm -rf -- "$_si_wrapper_tmp"

--- a/tests/cstk/test_serve.sh
+++ b/tests/cstk/test_serve.sh
@@ -273,6 +273,22 @@ STUB
   chmod +x "$_sno_bin/npm"
 }
 
+# _stub_npm_logs_cwd: npm que aceita tudo (exit 0) e registra "<subcomando>
+# <cwd>" por invocacao no arquivo de log. Permite ao scenario afirmar ONDE o
+# install rodou — o que importa porque os links de workspace criados pelo npm
+# carregam o diretorio em que ele foi executado.
+# $1 = bin dir, $2 = arquivo de log
+_stub_npm_logs_cwd() {
+  _snlc_bin="$1"
+  _snlc_log="$2"
+  cat > "$_snlc_bin/npm" <<STUB
+#!/bin/sh
+printf '%s %s\n' "\$1" "\$(pwd)" >> "${_snlc_log}"
+exit 0
+STUB
+  chmod +x "$_snlc_bin/npm"
+}
+
 # _stub_npm_exit_code: npm que sai com o exit code especificado para `run
 # <script>` (ex.: `run dev`), aceitando `install` com 0 — simula saida
 # espontanea do painel.
@@ -999,6 +1015,75 @@ STUB
   _run_serve
   if [ "$_CAPTURED_EXIT" != "1" ]; then
     _fail "npm_install_falha" "esperado exit 1, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+}
+
+# Regressao de portabilidade Windows: o `npm install` da instalacao roda no
+# tmpdir e a arvore e movida depois. Em POSIX os links de workspace sao
+# relativos e sobrevivem ao mv; no Windows sao junctions de caminho ABSOLUTO
+# para o tmpdir removido, e o build morre com TS2307. O contrato observavel —
+# testavel em qualquer plataforma — e que algum `npm install` roda com cwd no
+# panel_dir DEFINITIVO, deixando os links apontando para o caminho real.
+scenario_install_reconcilia_workspaces_no_destino() {
+  _setup_serve_env
+  _make_bin_dir
+  _stub_curl_ok "$_STUB_BIN"
+  _sirw_log="$TMPDIR_TEST/npm-calls.log"
+  _stub_npm_logs_cwd "$_STUB_BIN" "$_sirw_log"
+  _run_serve
+
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "reconcilia_workspaces" "esperado exit 0, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  if [ ! -f "$_sirw_log" ]; then
+    _fail "reconcilia_workspaces" "stub npm nao registrou nenhuma invocacao"
+    return 1
+  fi
+  # Normalizar o path esperado pelo mesmo caminho que o stub usa (`pwd` apos
+  # cd), para nao quebrar onde o tmpdir passa por symlink (ex.: /tmp no macOS).
+  _sirw_expected=$(cd "$CSTK_PANEL_DIR" 2>/dev/null && pwd)
+  if [ -z "$_sirw_expected" ]; then
+    _fail "reconcilia_workspaces" "panel_dir nao existe apos a instalacao: $CSTK_PANEL_DIR"
+    return 1
+  fi
+  if ! grep -q "^install ${_sirw_expected}$" "$_sirw_log"; then
+    _fail "reconcilia_workspaces" \
+      "nenhum 'npm install' rodou em ${_sirw_expected}; invocacoes: $(tr '\n' ';' < "$_sirw_log")"
+    return 1
+  fi
+}
+
+# Contrapartida do scenario acima: se a reconciliacao falhar, o panel_dir NAO
+# pode sobreviver pela metade — senao `_serve_is_installed` fica verdadeiro
+# para uma arvore com links quebrados e a execucao seguinte falha no build com
+# uma mensagem que nao aponta para a causa.
+scenario_reconciliacao_falha_remove_panel_dir() {
+  _setup_serve_env
+  _make_bin_dir
+  _stub_curl_ok "$_STUB_BIN"
+  # npm que aceita o primeiro install (no tmpdir) e falha no segundo (destino).
+  cat > "$_STUB_BIN/npm" <<STUB
+#!/bin/sh
+if [ "\$1" = "install" ]; then
+  if [ -f "${TMPDIR_TEST}/.first-install-done" ]; then
+    exit 1
+  fi
+  : > "${TMPDIR_TEST}/.first-install-done"
+fi
+exit 0
+STUB
+  chmod +x "$_STUB_BIN/npm"
+  _run_serve
+
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "reconciliacao_falha" "esperado exit 1, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  if [ -e "$CSTK_PANEL_DIR" ]; then
+    _fail "reconciliacao_falha" \
+      "panel_dir sobreviveu a falha da reconciliacao: $CSTK_PANEL_DIR"
     return 1
   fi
 }


### PR DESCRIPTION
## Problema

No Windows o `cstk serve` não chega a subir o painel. O download e a
verificação de integridade passam, o `npm install` passa, e o build morre com
17 erros iguais em `apps/server`:

```
src/db/freshness.ts(14,32): error TS2307: Cannot find module '@cstk-panel/shared-types' or its corresponding type declarations.
src/db/open.ts(26,37): error TS2307: Cannot find module '@cstk-panel/shared-types' or its corresponding type declarations.
... (17 arquivos)
cstk serve: erro: npm run build falhou; tente --reinstall
```

`--reinstall` não resolve — reproduz o mesmo estado.

## Causa raiz

`_serve_install` roda `npm install` dentro do tmpdir de extração e só depois
move a árvore para o `panel_dir`:

```sh
if ! (cd "$_si_extract" && npm install) 2>&1; then ...   # tmpdir
if ! mv -- "$_si_extract" "$_si_panel_dir"; then ...     # destino final
```

Em POSIX o npm materializa os workspaces como **symlinks relativos**, que
sobrevivem intactos ao `mv`. No Windows ele materializa como **junctions de
caminho absoluto** — e o alvo é o tmpdir, removido logo em seguida. O que
sobra no destino são links pendurados:

```
$ dir /al ~/.local/share/cstk/panel/node_modules/@cstk-panel
<JUNCTION>  server        [C:\Users\...\Temp\tmp.TYNhKGM6Dn\extracted\apps\server]
<JUNCTION>  shared-types  [C:\Users\...\Temp\tmp.TYNhKGM6Dn\extracted\packages\shared-types]
<JUNCTION>  web           [C:\Users\...\Temp\tmp.TYNhKGM6Dn\extracted\apps\web]
```

O `tsc` então não acha os tipos compartilhados. Mesma família da #77: código
POSIX correto que assume semântica de link do Unix e encontra outra no
Windows.

## Fix

Reexecutar o install já no `panel_dir`, depois do `mv`, reescrevendo os links
com o caminho real. Considerei mover antes de instalar (um único `npm
install`), mas isso abre uma janela em que `panel_dir` existe sem
`node_modules` — e como `_serve_is_installed` só checa `package.json`, uma
interrupção ali deixaria a próxima execução falhando no build em **todas** as
plataformas. A reconciliação depois do `mv` preserva integralmente o desenho
atual: se ela falhar, o `panel_dir` é removido, mantendo a invariante de que
instalação detectada é instalação utilizável.

Custo em POSIX: praticamente no-op (o `node_modules` já está populado — aqui
saiu `changed 3 packages in 5s`), e roda **uma vez por instalação**, não por
execução.

Verificado na máquina afetada: com o patch, o build completa e o Fastify sobe
em `http://127.0.0.1:5173` (HTTP 200).

## Testes

Dois scenarios novos em `tests/cstk/test_serve.sh`, ambos verificando o
contrato **observável em qualquer plataforma** (não dependem de rodar no
Windows):

- `scenario_install_reconcilia_workspaces_no_destino` — stub de `npm` registra
  o `cwd` de cada invocação; assere que algum `npm install` rodou com cwd no
  `panel_dir` definitivo.
- `scenario_reconciliacao_falha_remove_panel_dir` — se a reconciliação falhar,
  o `panel_dir` não pode sobreviver pela metade.

Resultado no meu ambiente (Windows + Git Bash), comparado com o baseline da
mesma máquina **sem** o patch:

| | `test_serve.sh` |
|---|---|
| baseline (sem patch) | PASS 55 · FAIL 5 |
| com o patch | PASS 57 · FAIL 5 |

Os 5 FAILs são idênticos nos dois lados e ambientais, não têm relação com a
mudança: 3 de `--docker` (Docker não instalado no host) e 2 de "prereq
ausente", que dependem de um stub de `sh` que o Git Bash não consegue
executar. `test_serve-docker.sh` fica em PASS 51 · FAIL 2, também só por
Docker ausente. `./tests/run.sh --check-coverage` reporta **zero órfãos**.

Transparência sobre o que **não** consegui rodar aqui: a suíte completa em
Linux, e o `shellcheck` (não está instalado nesta máquina) — vale conferir no
CI.

## Notas

- **Manifests não foram bumpados de propósito.** O `CHANGELOG.md` ganhou a
  seção `[7.0.1]`, mas deixei `.claude-plugin/marketplace.json` e os dois
  `plugin.json` intocados: pelo `test_validate-plugin-manifests.sh` o lockstep
  MP-5 é validado contra a tag (`--version`), e o histórico mostra o bump como
  passo separado de release. Se preferirem que o PR já inclua, é só falar.
- O único efeito visível para o usuário é uma linha nova de progresso
  (`cstk serve: reconciliando workspaces em ...`) durante a instalação.

## Checklist

- [x] Código/identificadores em inglês; comentários e mensagens em pt-br.
- [x] Script alterado tem teste 1:1 no diretório certo (`cli/lib/serve.sh` →
      `tests/cstk/test_serve.sh`), com scenarios novos.
- [x] `--check-coverage` com zero órfãos.
- [x] `CHANGELOG.md` atualizado; PATCH coerente (correção, sem mudança de
      contrato).
- [ ] `cstk doctor` sem drift — não aplicável: a mudança é no `cli/`, não em
      skill instalada, e o `cstk` não está instalado nesta máquina.
- [ ] Suíte completa verde em Linux — ver a seção Testes acima.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
