### PR TITLE
feat(hooks): remover registro classico duplicado no hooks install (v7.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "7.0.1",
+      "version": "7.1.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [7.1.0] - 2026-08-09
+
+O dedup entre o caminho classico e o plugin era PASSIVO: `cstk hooks
+install` pulava o provisionamento ("plugin vence") e mandava o operador
+remover o registro classico na mao. Projeto que ja tinha esse registro
+seguia com AS DUAS camadas ativas, e desfazer isso significava editar
+`settings.json` a mao — arriscando levar junto hook de terceiro.
+
+### Added
+
+- **`cstk hooks install` remove o registro classico duplicado.** Quando o
+  plugin `cstk` ja prove os hooks E o projeto ainda tem registro classico
+  em `.claude/settings.json`, o comando detecta a duplicidade e PERGUNTA
+  se pode remover. Remove APENAS as entradas dos 4 hooks do runtime 00c
+  (casadas pelo caminho do comando): hooks de terceiros no mesmo bloco e
+  todas as demais chaves do arquivo (`permissions`, `env`, ...) sao
+  preservados; grupos que ficam sem hook nenhum sao podados e `.hooks` so
+  e removido se ficar vazio. Backup obrigatorio em
+  `settings.json.bak-pre-dedup` antes de qualquer escrita — falha ao
+  gravar o backup ABORTA a remocao. Escrita atomica (`mktemp` + `mv`).
+- **Flag `--remove-classic`** em `cstk hooks install`: remove sem
+  perguntar, para script/CI. Sem TTY e sem a flag, o bloco e MANTIDO com
+  aviso citando a flag — `settings.json` e do operador e nao e reescrito
+  sem consentimento explicito. Resposta vazia (Enter) tambem mantem: acao
+  destrutiva nunca e o default, mesmo padrao de `_setup_prompt_yn`.
+
+### Changed
+
+- **Remediacao de `duplicated-hooks` no `cstk doctor`** deixa de mandar
+  editar `settings.json` a mao e passa a apontar `cstk hooks install`
+  (com `--remove-classic` para o modo nao-interativo).
+
+### Nao alterado (deliberado)
+
+- **Plugin habilitado porem incompleto** (sem `hooks/hooks.json`
+  materializado) continua provisionando o caminho classico e NAO tem o
+  registro removido — remover ali deixaria o projeto sem guarda nenhuma,
+  o pior resultado possivel do dedup (achado F4 / dec-027 da feature
+  `claude-plugin-packaging`). Coberto por cenario dedicado.
+
 ## [7.0.1] - 2026-08-09
 
 Dois defeitos observados em campo no mesmo projeto-alvo, com o mesmo
@@ -5345,6 +5385,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[7.1.0]: https://github.com/JotJunior/cstk/releases/tag/v7.1.0
 [7.0.1]: https://github.com/JotJunior/cstk/releases/tag/v7.0.1
 [7.0.0]: https://github.com/JotJunior/cstk/releases/tag/v7.0.0
 [6.8.0]: https://github.com/JotJunior/cstk/releases/tag/v6.8.0

--- a/README.md
+++ b/README.md
@@ -324,7 +324,18 @@ cd ~/projects/my-target-project
 cstk hooks install                    # touches .claude/hooks/ + settings.json only
 cstk hooks install --dry-run          # show the plan without writing
 cstk hooks install --project-path ../other-project
+cstk hooks install --remove-classic   # de-duplicate against the plugin, no prompt
 ```
+
+When the plugin already provides the hooks, `cstk hooks install` skips the
+classic provisioning (plugin wins) and, if the project **still** carries a
+classic registration in `settings.json`, both layers would fire. In that
+case it asks whether to remove the classic block, deleting only the 00c
+hook entries — third-party hooks and every other key in the file are
+preserved — and writing a backup to `settings.json.bak-pre-dedup`. Use
+`--remove-classic` to skip the prompt (scripts/CI). Without a TTY and
+without the flag the block is **kept**, with a warning: `settings.json`
+belongs to the operator and is never rewritten without explicit consent.
 
 Without this step the Bash guard is inert and `tool_calls`/`agent_usage`
 stay at zero for every wave. To check the current state without writing

--- a/cli/lib/doctor.sh
+++ b/cli/lib/doctor.sh
@@ -493,8 +493,10 @@ _doctor_distribution_paths() {
       printf '\n==> Distribution Paths (plugin cstk)\n'
       printf '  [duplicated-hooks] plugin habilitado E registro classico de hooks\n'
       printf '                     presente em %s\n' "$_dp_project_settings"
-      printf '  remediacao: remova o bloco de hooks do cstk de %s\n' "$_dp_project_settings"
-      printf '              (o plugin ja os provê — mesma regra de "cstk hooks install").\n'
+      printf '  remediacao: rode `cstk hooks install` no projeto — ele oferece remover\n'
+      printf '              o registro classico (ou `--remove-classic` para nao perguntar).\n'
+      printf '              Remove apenas as entradas dos hooks 00c, preserva hooks de\n'
+      printf '              terceiros e grava backup em settings.json.bak-pre-dedup.\n'
     } >&2
     return 1
   fi

--- a/cli/lib/hooks.sh
+++ b/cli/lib/hooks.sh
@@ -535,13 +535,138 @@ apply_guard_hooks() {
 #   1  falha de I/O, catalogo sem hooks, ou --project-path invalido
 #   2  uso incorreto
 
+# ---------------------------------------------------------------------------
+# Dedup ATIVO do registro classico quando o plugin ja proveu os hooks.
+#
+# Ate aqui o dedup era so PASSIVO: `hooks install` pulava o provisionamento
+# ("plugin vence") e mandava o operador remover o bloco classico na mao. Um
+# projeto que ja tinha o registro classico continuava com AS DUAS camadas
+# ativas — o `cstk doctor` reportava `duplicated-hooks` e a remocao ficava
+# como licao de casa manual, propensa a erro (editar settings.json a mao
+# arrisca levar junto hook de terceiro).
+#
+# REGRA DURA — remover APENAS o que e do cstk: `settings.json` e do
+# operador, nao do toolkit. O filtro casa exclusivamente os 4 hooks do
+# runtime 00c pelo caminho do comando; qualquer outra entrada (hook proprio
+# do time, telemetria da empresa, lint) e preservada, assim como todas as
+# demais chaves do arquivo (permissions, env, ...). Grupos que ficarem sem
+# nenhum hook sao podados, e `.hooks` inteiro so some se ficar vazio.
+_HOOKS_CLASSIC_RE='/\.claude/hooks/(pretooluse-bash-guard|posttooluse-tool-call-tick|posttooluse-agent-usage|posttooluse-loose-usage)\.sh$'
+
+# _hooks_classic_count SETTINGS -> imprime quantas entradas de hook do
+# runtime 00c existem no arquivo (0 se ausente/ilegivel/JSON invalido).
+_hooks_classic_count() {
+  [ -f "$1" ] || { printf '0'; return 0; }
+  jq --arg re "$_HOOKS_CLASSIC_RE" -r '
+    [ (.hooks // {}) | to_entries[] | .value[]? | .hooks[]?
+      | select((.command // "") | test($re)) ] | length
+  ' "$1" 2>/dev/null || printf '0'
+}
+
+# _hooks_strip_classic SETTINGS -> stdout: JSON sem as entradas do cstk.
+_hooks_strip_classic() {
+  jq --arg re "$_HOOKS_CLASSIC_RE" '
+    def is_cstk: (.command // "") | test($re);
+    if has("hooks") then
+      .hooks |= ( with_entries(
+                    .value |= ( map(.hooks |= map(select(is_cstk | not)))
+                              | map(select((.hooks | length) > 0)) ) )
+                | with_entries(select((.value | length) > 0)) )
+      | if (.hooks | length) == 0 then del(.hooks) else . end
+    else . end
+  ' "$1" 2>/dev/null
+}
+
+# _hooks_prompt_yn PERGUNTA -> 0 se y/Y/yes/sim; 1 caso contrario (inclusive
+# vazio/EOF). Mesmo padrao de _setup_prompt_yn / _session_prompt_yn — vazio
+# NAO remove: a acao destrutiva nunca e o default de um Enter distraido.
+_hooks_prompt_yn() {
+  printf '%s ' "$1" >&2
+  read -r _hpy_ans 2>/dev/null || _hpy_ans=""
+  case "$_hpy_ans" in
+    y | Y | yes | YES | sim | SIM) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# _hooks_dedup_classic DEST DRY_RUN AUTO_REMOVE -> best-effort; SEMPRE
+# retorna 0. Nenhuma falha desta rotina pode alterar o exit de
+# `hooks install`: o provisionamento (ou o skip dele) ja aconteceu, e o
+# dedup e higiene, nao pre-requisito.
+#
+# AUTO_REMOVE=1 (`--remove-classic`) remove sem perguntar — caminho para
+# script/CI. Sem ele: pergunta SE houver TTY; sem TTY, mantem e avisa
+# (jamais mutar settings.json de alguem sem confirmacao explicita).
+_hooks_dedup_classic() {
+  _hdc_dest=$1
+  _hdc_dry=$2
+  _hdc_auto=$3
+  _hdc_settings="$_hdc_dest/settings.json"
+
+  [ -f "$_hdc_settings" ] || return 0
+
+  if ! detect_jq; then
+    log_warn "hooks install: jq ausente — nao da para editar settings.json com seguranca."
+    log_warn "hooks install: se houver registro classico em $_hdc_settings, remova-o a mao (duplicidade com o plugin)."
+    return 0
+  fi
+
+  _hdc_n=$(_hooks_classic_count "$_hdc_settings")
+  case "$_hdc_n" in ''|0|*[!0-9]*) return 0 ;; esac
+
+  log_warn "hooks install: $_hdc_settings ainda registra $_hdc_n hook(s) 00c pelo caminho classico — duplicidade com o plugin."
+
+  if [ "$_hdc_dry" = 1 ]; then
+    log_info "hooks install: [dry-run] removeria $_hdc_n entrada(s) do bloco classico (hooks de terceiros e demais chaves preservados)"
+    return 0
+  fi
+
+  if [ "$_hdc_auto" != 1 ]; then
+    if [ ! -t 0 ] && [ "${CSTK_FORCE_INTERACTIVE:-0}" != 1 ]; then
+      log_warn "hooks install: sem TTY para confirmar — bloco classico MANTIDO."
+      log_warn "hooks install: rode 'cstk hooks install --remove-classic' para remove-lo sem prompt."
+      return 0
+    fi
+    if ! _hooks_prompt_yn "hooks install: remover o registro classico de $_hdc_settings? (y/N)"; then
+      log_info "hooks install: bloco classico mantido a pedido — 'cstk doctor' seguira reportando duplicated-hooks"
+      return 0
+    fi
+  fi
+
+  _hdc_new=$(_hooks_strip_classic "$_hdc_settings")
+  if [ -z "$_hdc_new" ]; then
+    log_warn "hooks install: falha ao reescrever $_hdc_settings — bloco classico MANTIDO (arquivo intacto)"
+    return 0
+  fi
+
+  # Backup antes de escrever, com o mesmo nome que o dedup manual ja usava.
+  if ! cp -- "$_hdc_settings" "$_hdc_settings.bak-pre-dedup" 2>/dev/null; then
+    log_warn "hooks install: nao consegui gravar backup — bloco classico MANTIDO (nada e removido sem backup)"
+    return 0
+  fi
+
+  _hdc_tmp=$(mktemp 2>/dev/null) || {
+    log_warn "hooks install: mktemp indisponivel — bloco classico MANTIDO"
+    return 0
+  }
+  printf '%s\n' "$_hdc_new" > "$_hdc_tmp" 2>/dev/null \
+    && mv -- "$_hdc_tmp" "$_hdc_settings" 2>/dev/null || {
+      rm -f -- "$_hdc_tmp" 2>/dev/null || :
+      log_warn "hooks install: escrita atomica falhou — bloco classico MANTIDO"
+      return 0
+    }
+
+  log_info "hooks install: registro classico removido de $_hdc_settings ($_hdc_n entrada(s)); backup em $_hdc_settings.bak-pre-dedup"
+  return 0
+}
+
 _hooks_print_help() {
   cat >&2 <<'HELP'
 cstk hooks — provisiona os hooks do runtime 00c num projeto-alvo.
 
 USO:
   cstk hooks install [--project-path PATH] [--catalog DIR] [--dry-run]
-                      [--with-loose-usage]
+                      [--with-loose-usage] [--remove-classic]
 
 Copia pretooluse-bash-guard.sh + posttooluse-tool-call-tick.sh +
 posttooluse-agent-usage.sh para <PATH>/.claude/hooks/ e mescla o bloco de
@@ -552,6 +677,17 @@ para colagem manual).
 posttooluse-loose-usage.sh, hook que captura consumo avulso (fora de
 execucoes agente-00c/feature-00c) num sidecar local. Sem a flag,
 comportamento identico a antes desta opcao existir.
+
+Quando o plugin 'cstk' ja prove os hooks, o provisionamento classico e
+pulado (dedup, plugin vence). Se AINDA houver registro classico no
+settings.json do projeto, os dois caminhos ficam ativos ao mesmo tempo;
+o comando entao PERGUNTA se pode remover o registro classico. Remove
+apenas as entradas dos hooks 00c — hooks de terceiros e demais chaves do
+arquivo sao preservados — e grava backup em settings.json.bak-pre-dedup.
+
+--remove-classic: remove sem perguntar (script/CI). Sem TTY e sem essa
+flag, o bloco e MANTIDO com aviso: settings.json e do operador e nao e
+alterado sem confirmacao explicita.
 
 Diferenca para `cstk install --scope project agente-00c-runtime`: aquele
 comando tambem duplica skill+commands+agents dentro do repo; este toca
@@ -583,6 +719,7 @@ hooks_main() {
   _hooks_catalog="${HOME:?HOME nao setado}/.claude"
   _hooks_dry_run=0
   _hooks_with_loose=0
+  _hooks_remove_classic=0
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -596,6 +733,7 @@ hooks_main() {
       --catalog=*) _hooks_catalog=${1#--catalog=}; shift ;;
       --dry-run) _hooks_dry_run=1; shift ;;
       --with-loose-usage) _hooks_with_loose=1; shift ;;
+      --remove-classic) _hooks_remove_classic=1; shift ;;
       -h|--help) _hooks_print_help; return 0 ;;
       *) log_error "hooks install: flag desconhecida: $1"; return 2 ;;
     esac
@@ -636,7 +774,9 @@ hooks_main() {
   if plugin_enabled cstk; then
     if plugin_hooks_present cstk; then
       log_warn "hooks install: plugin 'cstk' habilitado e ja provê hooks/hooks.json — pulando provisionamento classico (dedup, plugin vence)"
-      log_warn "hooks install: se houver registro classico pre-existente em $_hooks_dest/settings.json, remova-o (cstk doctor reporta 'duplicated-hooks' com a mesma remediacao)"
+      # Dedup ATIVO: havendo registro classico pre-existente, oferece a
+      # remocao em vez de so mandar o operador editar settings.json a mao.
+      _hooks_dedup_classic "$_hooks_dest" "$_hooks_dry_run" "$_hooks_remove_classic"
       return 0
     else
       log_warn "hooks install: plugin 'cstk' habilitado mas hooks/hooks.json NAO encontrado no install path — instalacao do plugin parece incompleta"

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "7.0.1",
+  "version": "7.1.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/tests/cstk/test_hooks.sh
+++ b/tests/cstk/test_hooks.sh
@@ -710,4 +710,196 @@ EOF
   return 0
 }
 
+# ==== Dedup ATIVO: remocao do registro classico quando o plugin cobre ====
+#
+# Antes, o dedup era so passivo (pular + avisar) e o registro classico
+# pre-existente ficava ativo junto com o do plugin — efeito duplo que o
+# operador tinha de desfazer editando settings.json a mao.
+
+# _settings_com_classico FILE -> settings.json com o bloco 00c classico E
+# hooks de TERCEIROS no mesmo arquivo (o caso que a remocao pode estragar).
+_settings_com_classico() {
+  mkdir -p "$(dirname "$1")"
+  cat > "$1" <<'EOF'
+{
+  "permissions": {"allow": ["Bash(ls:*)"]},
+  "hooks": {
+    "PreToolUse": [
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pretooluse-bash-guard.sh", "timeout": 5}]},
+      {"matcher": "Bash", "hooks": [{"type": "command", "command": "/opt/hook-do-time.sh"}]}
+    ],
+    "PostToolUse": [
+      {"matcher": "*", "hooks": [
+        {"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/posttooluse-tool-call-tick.sh"},
+        {"type": "command", "command": "/usr/local/bin/telemetria.sh"}
+      ]},
+      {"matcher": "Agent", "hooks": [{"type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/posttooluse-agent-usage.sh"}]}
+    ]
+  }
+}
+EOF
+}
+
+# _n_hooks_cstk FILE -> quantas entradas 00c restam no settings.json.
+_n_hooks_cstk() {
+  jq '[ (.hooks // {}) | to_entries[] | .value[]? | .hooks[]?
+        | select((.command // "") | test("/\\.claude/hooks/(pretooluse-bash-guard|posttooluse-tool-call-tick|posttooluse-agent-usage|posttooluse-loose-usage)\\.sh$")) ] | length' "$1" 2>/dev/null
+}
+
+scenario_dedup_remove_classic_sem_prompt() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _home=$(_plugin_home_fixture enabled-with-hooks)
+  _proj="$TMPDIR_TEST/proj-dedup-remove"
+  _settings_com_classico "$_proj/.claude/settings.json"
+
+  _hooks_main_run_home "$_home" install --project-path "$_proj" --catalog "$_cat" --remove-classic
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.json")" = "0" ] \
+    || { _fail "remocao" "entradas 00c deveriam ter sumido, restaram $(_n_hooks_cstk "$_proj/.claude/settings.json")"; return 1; }
+  [ -f "$_proj/.claude/settings.json.bak-pre-dedup" ] \
+    || { _fail "backup" "backup nao foi gravado"; return 1; }
+  return 0
+}
+
+# O ponto mais perigoso da feature: settings.json e do operador.
+scenario_dedup_preserva_hooks_de_terceiros_e_demais_chaves() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _home=$(_plugin_home_fixture enabled-with-hooks)
+  _proj="$TMPDIR_TEST/proj-dedup-preserva"
+  _settings_com_classico "$_proj/.claude/settings.json"
+
+  _hooks_main_run_home "$_home" install --project-path "$_proj" --catalog "$_cat" --remove-classic
+  _s="$_proj/.claude/settings.json"
+  grep -q "hook-do-time.sh" "$_s" || { _fail "terceiros" "hook de terceiro foi removido junto"; return 1; }
+  grep -q "telemetria.sh" "$_s" || { _fail "terceiros" "hook de telemetria foi removido junto"; return 1; }
+  [ "$(jq -r '.permissions.allow[0]' "$_s" 2>/dev/null)" = "Bash(ls:*)" ] \
+    || { _fail "chaves" "chave permissions foi perdida"; return 1; }
+  # Grupo que ficou sem nenhum hook (matcher Agent) deve ser podado.
+  [ "$(jq -r '[.hooks.PostToolUse[]? | select(.matcher=="Agent")] | length' "$_s" 2>/dev/null)" = "0" ] \
+    || { _fail "poda" "grupo vazio deveria ter sido podado"; return 1; }
+  return 0
+}
+
+scenario_dedup_prompt_negado_mantem_bloco() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _home=$(_plugin_home_fixture enabled-with-hooks)
+  _proj="$TMPDIR_TEST/proj-dedup-nao"
+  _settings_com_classico "$_proj/.claude/settings.json"
+
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" CSTK_FORCE_INTERACTIVE=1 sh -c \
+    'printf "n\n" | { . "$CSTK_LIB/hooks.sh" && hooks_main "$@"; }' _ \
+    install --project-path "$_proj" --catalog "$_cat"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.json")" = "3" ] \
+    || { _fail "recusa" "resposta 'n' NAO pode remover nada"; return 1; }
+  [ -f "$_proj/.claude/settings.json.bak-pre-dedup" ] \
+    && { _fail "backup" "recusa nao deveria gerar backup"; return 1; }
+  return 0
+}
+
+scenario_dedup_prompt_aceito_remove() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _home=$(_plugin_home_fixture enabled-with-hooks)
+  _proj="$TMPDIR_TEST/proj-dedup-sim"
+  _settings_com_classico "$_proj/.claude/settings.json"
+
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" CSTK_FORCE_INTERACTIVE=1 sh -c \
+    'printf "y\n" | { . "$CSTK_LIB/hooks.sh" && hooks_main "$@"; }' _ \
+    install --project-path "$_proj" --catalog "$_cat"
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.json")" = "0" ] \
+    || { _fail "aceite" "resposta 'y' deveria remover as entradas 00c"; return 1; }
+  return 0
+}
+
+# Enter distraido NAO pode disparar acao destrutiva.
+scenario_dedup_resposta_vazia_mantem_bloco() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _home=$(_plugin_home_fixture enabled-with-hooks)
+  _proj="$TMPDIR_TEST/proj-dedup-vazio"
+  _settings_com_classico "$_proj/.claude/settings.json"
+
+  capture env HOME="$_home" CSTK_LIB="$CSTK_LIB" CSTK_FORCE_INTERACTIVE=1 sh -c \
+    'printf "\n" | { . "$CSTK_LIB/hooks.sh" && hooks_main "$@"; }' _ \
+    install --project-path "$_proj" --catalog "$_cat"
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.json")" = "3" ] \
+    || { _fail "default" "Enter vazio NAO pode remover"; return 1; }
+  return 0
+}
+
+# Sem TTY e sem --remove-classic: mantem e ensina a flag (nunca muta
+# settings.json de alguem sem confirmacao).
+scenario_dedup_sem_tty_mantem_e_orienta() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _home=$(_plugin_home_fixture enabled-with-hooks)
+  _proj="$TMPDIR_TEST/proj-dedup-sem-tty"
+  _settings_com_classico "$_proj/.claude/settings.json"
+
+  _hooks_main_run_home "$_home" install --project-path "$_proj" --catalog "$_cat"
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.json")" = "3" ] \
+    || { _fail "sem tty" "sem TTY nada pode ser removido"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"--remove-classic"*) ;;
+    *) _fail "orientacao" "stderr deveria citar --remove-classic: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  return 0
+}
+
+scenario_dedup_dry_run_nao_toca_arquivo() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _home=$(_plugin_home_fixture enabled-with-hooks)
+  _proj="$TMPDIR_TEST/proj-dedup-dry"
+  _settings_com_classico "$_proj/.claude/settings.json"
+  _antes=$(cat "$_proj/.claude/settings.json")
+
+  _hooks_main_run_home "$_home" install --project-path "$_proj" --catalog "$_cat" --dry-run --remove-classic
+  [ "$(cat "$_proj/.claude/settings.json")" = "$_antes" ] \
+    || { _fail "dry-run" "arquivo foi modificado em --dry-run"; return 1; }
+  [ -f "$_proj/.claude/settings.json.bak-pre-dedup" ] \
+    && { _fail "dry-run" "dry-run nao deveria gerar backup"; return 1; }
+  return 0
+}
+
+# Projeto sem registro classico: nada a remover, nenhum ruido, nenhum backup.
+scenario_dedup_sem_registro_classico_e_noop() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _home=$(_plugin_home_fixture enabled-with-hooks)
+  _proj="$TMPDIR_TEST/proj-dedup-limpo"
+  mkdir -p "$_proj/.claude"
+  printf '{"permissions":{"allow":[]}}\n' > "$_proj/.claude/settings.json"
+
+  _hooks_main_run_home "$_home" install --project-path "$_proj" --catalog "$_cat" --remove-classic
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -f "$_proj/.claude/settings.json.bak-pre-dedup" ] \
+    && { _fail "backup" "nao ha nada a remover: nao deveria gerar backup"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"caminho classico"*) _fail "ruido" "nao deveria avisar duplicidade em projeto limpo"; return 1 ;;
+  esac
+  return 0
+}
+
+# Plugin incompleto (hooks.json ausente): o classico e provisionado de
+# proposito (F4) — remover seria deixar o projeto SEM guarda nenhuma.
+scenario_dedup_nao_remove_quando_plugin_incompleto() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture)
+  _home=$(_plugin_home_fixture enabled-without-hooks)
+  _proj="$TMPDIR_TEST/proj-dedup-incompleto"
+  _settings_com_classico "$_proj/.claude/settings.json"
+
+  _hooks_main_run_home "$_home" install --project-path "$_proj" --catalog "$_cat" --remove-classic
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _n=$(_n_hooks_cstk "$_proj/.claude/settings.json")
+  [ "$_n" -ge 3 ] \
+    || { _fail "F4" "plugin incompleto NAO pode perder o registro classico (restaram $_n)"; return 1; }
+  return 0
+}
+
 run_all_scenarios


### PR DESCRIPTION
O dedup entre o caminho classico e o plugin era **passivo**: `cstk hooks install` pulava o provisionamento ("plugin vence") e mandava o operador remover o registro classico na mao. Projeto que ja tinha esse registro seguia com **as duas camadas ativas** — `cstk doctor` reportava `duplicated-hooks` e a remocao virava licao de casa manual, propensa a erro.

Agora, quando o plugin cobre os hooks E o projeto ainda tem registro classico, o comando detecta e pergunta se pode remover.

## Regra dura: `settings.json` e do operador, nao do toolkit

O filtro casa **exclusivamente** os 4 hooks do runtime 00c pelo caminho do comando. Preservados: hooks de terceiros no mesmo bloco, `permissions`, `env` e qualquer outra chave. Grupos que ficam sem hook nenhum sao podados; `.hooks` so e removido se ficar vazio.

Cenario de teste dedicado usa um `settings.json` com `/opt/hook-do-time.sh` e `/usr/local/bin/telemetria.sh` convivendo com os hooks 00c — ambos sobrevivem a remocao.

**Backup obrigatorio** em `settings.json.bak-pre-dedup` (mesmo nome que o dedup manual ja usava) ANTES de qualquer escrita: se o backup falhar, a remocao e abortada. Escrita atomica (`mktemp` + `mv`).

## Consentimento explicito em todo caminho

| situacao | comportamento |
|---|---|
| `--remove-classic` | remove sem perguntar (script/CI) |
| TTY, resposta `y` | remove |
| TTY, resposta `n` | mantem |
| TTY, **Enter vazio** | **mantem** — acao destrutiva nunca e o default |
| sem TTY, sem flag | **mantem** + aviso citando a flag |
| `--dry-run` | so relata; nao escreve, nao gera backup |

## Nao alterado, de proposito

Plugin habilitado porem **incompleto** (sem `hooks/hooks.json` materializado) continua provisionando o classico e NAO tem o registro removido — remover ali deixaria o projeto sem guarda nenhuma, o pior resultado possivel do dedup (achado F4 / dec-027 da feature `claude-plugin-packaging`). Ha cenario cobrindo isso.

## Verificacao

- Suite completa sobre a arvore final (codigo + changelog + manifests + README): **2639 PASS, 0 FAIL, 0 ERROR, 0 ORPHANS** (819s).
- 9 cenarios novos; **6 verificados falhando contra o codigo anterior**. Os 3 restantes sao casos "nao deve remover" — trivialmente verdadeiros quando a remocao nao existe, e estao listados como tal.
- `validate-plugin-manifests.sh --version 7.1.0 --strict` => OK.

## Nota de distribuicao

Esta release toca `cli/lib/` (runtime), entao **`cstk update` nao a entrega** — exige `cstk self-update`. E como `cstk hooks install` e subcomando do binario, que **nao** e empacotado no plugin (FR-006), `/plugin update` tambem nao traz esta feature. Ela alcanca apenas quem tem o bootstrap classico instalado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DKbARJETWZ1TgDxkmEUJa