### PR TITLE
feat: captura do gauge de uso do plano via statusLine (7.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "7.1.1",
+      "version": "7.2.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "7.1.1",
+      "version": "7.2.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5508,6 +5508,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[7.2.0]: https://github.com/JotJunior/cstk/releases/tag/v7.2.0
 [7.1.1]: https://github.com/JotJunior/cstk/releases/tag/v7.1.1
 [7.1.0]: https://github.com/JotJunior/cstk/releases/tag/v7.1.0
 [7.0.1]: https://github.com/JotJunior/cstk/releases/tag/v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,51 @@ IV, 100% local).
 Detalhes de contrato/schema: `docs/specs/plan-usage-capture/contracts/`
 e `docs/specs/plan-usage-capture/data-model.md`.
 
+### Fixed
+
+- **`tool_calls` era contado em DOBRO em projeto com o cstk instalado
+  como plugin.** `guard-hooks-status.sh` so procurava os hooks na copia
+  classica (`<projeto>/.claude/hooks/` + `settings.json`) e era cego ao
+  `hooks/hooks.json` do plugin — o caminho que a propria v7 tornou
+  canonico, e que `cstk hooks install` ja privilegia ao pular o
+  provisionamento classico por dedup ("plugin vence"). Consequencia
+  funcional: `tick-mode` devolvia `manual`, o orquestrador tickava na
+  mao, o hook do plugin tickava tambem, e `state-ondas.sh end` soma as
+  duas fontes (ticks manuais + linhas do sidecar). Toda onda fechava com
+  ~2x o numero real de tool calls, e o budget de onda disparava com
+  metade do trabalho feito. O `check` tambem acusava "3 de 3 hooks NAO
+  estao ativos" e mandava rodar `cstk hooks install`, que respondia
+  "plugin ja prove — pulando": um loop de remediacao que nao remediava
+  nada. Agora o script consulta o registro nativo (`CLAUDE_PLUGIN_ROOT`,
+  ou `installed_plugins.json` + `enabledPlugins` de `settings.json`,
+  espelhando `cli/lib/plugin-detect.sh`), reporta
+  `present/registered/current` para hook provido pelo plugin e devolve
+  `hook` no `tick-mode`. Degradacao assimetrica preservada: `jq` ausente,
+  registro ilegivel ou plugin desabilitado => "plugin nao prove", que e o
+  comportamento anterior byte-a-byte — nunca se afirma cobertura sem ter
+  lido o `hooks.json`. Novo alerta quando plugin E copia classica estao
+  ativos ao mesmo tempo (o hook roda duas vezes de verdade).
+  **Nao ha correcao retroativa**: `tool_calls` ja gravado na
+  `knowledge.db` de execucoes anteriores permanece inflado — nao ha como
+  separar tick manual de tick de hook depois do fato, e estimar seria
+  inventar dado.
+- **`test_setup.sh` reprovava por causa desta propria versao.** O cenario
+  `scenario_dispatch_setup_wiring` verificava o wiring de `setup` no case
+  generico de `cli/cstk` com a regex `\|setup\)$` — ancorada no FIM da
+  linha, o que exigia que `setup` fosse a ULTIMA alternativa. Isso nunca
+  foi invariante: bastou esta versao acrescentar `plan-usage` depois dela
+  para o cenario reprovar com o dispatch perfeitamente intacto. A regex
+  passa a aceitar `setup` em qualquer posicao (`\|setup[|)]`). Achado ao
+  rodar a suite completa antes do release — a pipeline da feature tinha
+  rodado `test_cstk-main.sh`, que nao cobre este cenario.
+- **`test_recall.sh` reprovava com `state_backend=sqlite`.** Os cenarios
+  `ctx_15`/`ctx_15b` chamavam `state-rw.sh init` e liam o resultado com
+  `jq` direto em `state.json` — arquivo que nao existe no backend SQLite,
+  default desde a v6. Passam a ler via `state-rw.sh read` (agnostico a
+  backend). O `ctx_15b` era o caso mais insidioso: o `jq` falhava, um
+  `|| _ndec=0` engolia o erro e a assercao `= 0` passava TRIVIALMENTE —
+  verde sem ter verificado nada. Falha de leitura agora reprova.
+
 ## [7.1.1] - 2026-08-09
 
 `~/.claude/skills/` e espaco COMPARTILHADO — plugins da Anthropic, skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [7.2.0] - 2026-08-10
+
+Captura do gauge de uso do plano (`/usage`) sem credencial OAuth: o
+harness ja envia `rate_limits.five_hour`/`seven_day` no payload da
+`statusLine.command` a cada render — a feature so precisava ler o que
+ja estava passando, persistir localmente e expor consulta (Constitution
+IV, 100% local).
+
+### Added
+
+- **`cstk statusline install`/`status`** (`cli/lib/statusline.sh`,
+  NOVO). `install` escreve/atualiza `statusLine.command` em
+  `${HOME}/.claude/settings.json` apontando para
+  `<catalog>/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh`;
+  se ja existir um comando customizado, o valor original e preservado
+  em `CSTK_STATUSLINE_INNER_COMMAND` (nunca sobrescrito
+  silenciosamente) e encadeado como pass-through obrigatorio do
+  stdout. Idempotente — rodar `install` 2x nao aninha wrapper sobre
+  wrapper.
+- **`cstk plan-usage`** (`cli/lib/plan-usage.sh`, NOVO): uso mais
+  recente capturado, por escopo (`five_hour`/`seven_day`), com
+  `--json`/`--db PATH`. Campo sem medicao imprime `nao medido`
+  (texto) / `null` (JSON) — nunca `0` fabricado (Principio VI/dec-029).
+- **`cstk plan-usage history`** (mesmo arquivo): serie temporal por
+  escopo, reusando literalmente `--scope`/`--limit`/`--since` de `cstk
+  usage` (dec-014 — sem convencao nova de paginacao/cursor).
+- **Tabela `plan_usage`** no `knowledge.db` (migracao aditiva
+  `RECALL_SCHEMA_VERSION` 13→14, `cli/lib/recall.sh`): grava uma linha
+  por escopo (`five_hour`/`seven_day`) quando o hook novo
+  `statusline-plan-usage.sh` observa `rate_limits` no payload da
+  statusline. Ausencia TOTAL de `rate_limits` nunca gera linha
+  (dec-029); ausencia PARCIAL de um campo dentro de um escopo presente
+  grava `NULL` explicito, nunca `0`. Throttle descarta persistencia
+  redundante comparando sempre contra o ULTIMO registro persistido
+  daquele escopo, com tolerancia de 2 casas decimais em
+  `used_percentage` (ruido de ponto flutuante do harness nao gera
+  linha nova) — FR-010.
+
+Detalhes de contrato/schema: `docs/specs/plan-usage-capture/contracts/`
+e `docs/specs/plan-usage-capture/data-model.md`.
+
 ## [7.1.1] - 2026-08-09
 
 `~/.claude/skills/` e espaco COMPARTILHADO — plugins da Anthropic, skills

--- a/cli/cstk
+++ b/cli/cstk
@@ -147,6 +147,9 @@ COMANDOS:
   mcp           Servidor MCP de estado das execucoes 00c (mcp status)
   hooks         Provisiona os hooks do runtime 00c num projeto-alvo
                 (so hooks + settings.json; nao duplica skill/commands/agents)
+  statusline    Instala/inspeciona a captura de uso do plano via
+                statusLine.command (install/status); preserva customizacao
+                previa em CSTK_STATUSLINE_INNER_COMMAND
   usage         Consulta o consumo avulso (fora de execucoes 00c); tambem
                 `usage compare` (avulso vs pipeline) e `usage prune` (TTL)
   setup         Wizard guiado das 4 areas de configuracao recomendadas
@@ -184,6 +187,11 @@ HELP
     mcp)
       printf 'cstk help mcp: consulte docs/specs/state-mcp-server/contracts/mcp-session-lifecycle.md\n'
       printf 'Para help inline, rode: cstk mcp --help\n'
+      exit "$CSTK_EXIT_OK"
+      ;;
+    statusline)
+      printf 'cstk help statusline: consulte docs/specs/plan-usage-capture/contracts/statusline-hook.md\n'
+      printf 'Para help inline, rode: cstk statusline --help\n'
       exit "$CSTK_EXIT_OK"
       ;;
     install|update|self-update|list|doctor|session|serve)
@@ -267,7 +275,7 @@ TELHELP
       ;;
     *)
       printf 'cstk: comando desconhecido para help: %s\n' "$_sub" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, setup, 00c, telemetry\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, statusline, state, mcp, usage, setup, 00c, telemetry\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac
@@ -300,7 +308,7 @@ _dispatch() {
       . "$_lib_file"
       serve_main "$@"
       ;;
-    install|update|self-update|list|doctor|session|recall|show-tip|hooks|state|mcp|usage|setup|plan-usage)
+    install|update|self-update|list|doctor|session|recall|show-tip|hooks|statusline|state|mcp|usage|setup|plan-usage)
       # Boot-check para todos exceto self-update (que e o caminho de recovery
       # da janela transiente — bloquea-lo aqui causaria deadlock).
       case "$_cmd" in
@@ -349,7 +357,7 @@ _dispatch() {
       ;;
     *)
       printf 'cstk: comando desconhecido: %s\n' "$_cmd" >&2
-      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, state, mcp, usage, setup, 00c, help, --version\n' >&2
+      printf 'Comandos validos: install, update, self-update, list, doctor, session, recall, show-tip, serve, hooks, statusline, state, mcp, usage, setup, 00c, help, --version\n' >&2
       exit "$CSTK_EXIT_USAGE"
       ;;
   esac

--- a/cli/cstk
+++ b/cli/cstk
@@ -300,7 +300,7 @@ _dispatch() {
       . "$_lib_file"
       serve_main "$@"
       ;;
-    install|update|self-update|list|doctor|session|recall|show-tip|hooks|state|mcp|usage|setup)
+    install|update|self-update|list|doctor|session|recall|show-tip|hooks|state|mcp|usage|setup|plan-usage)
       # Boot-check para todos exceto self-update (que e o caminho de recovery
       # da janela transiente — bloquea-lo aqui causaria deadlock).
       case "$_cmd" in

--- a/cli/lib/plan-usage.sh
+++ b/cli/lib/plan-usage.sh
@@ -20,12 +20,13 @@
 # ausencia PARCIAL (escopo presente mas campo ausente dentro dele) ->
 # INSERT com NULL explicito, nunca 0 fabricado (Principio VI).
 #
-# `cstk plan-usage` (sem args) e `cstk plan-usage history` (consulta
-# publica, FASE 4.1/4.2) AINDA NAO IMPLEMENTADOS nesta onda — apenas o
-# subcomando interno `ingest --stdin` necessario para desbloquear FASE 2
-# (statusline-plan-usage.sh so consegue persistir via este subcomando,
-# research.md Decision 6 — o hook roda fora do processo `cstk` e nao tem
-# acesso direto a `cli/lib/recall.sh`).
+# `plan_usage_cmd_show` (task 4.1) e `plan_usage_cmd_history` (task 4.2)
+# sao a consulta PUBLICA (`cstk plan-usage` / `cstk plan-usage history`,
+# FASE 4.1/4.2) — leitura pura via recall_query_sql, sem sqlite3 direto
+# (Constitution II). NULL vira "nao medido" no texto e `null` JSON, nunca
+# `0` fabricado (Principio VI/dec-029/SC-002). `history` reusa
+# literalmente `--limit`/`--since` de `cstk usage` (dec-014, sem
+# convencao nova de paginacao).
 #
 # Despachado por cli/cstk: `cstk plan-usage ...` -> plan_usage_main "$@".
 #
@@ -179,10 +180,289 @@ cstk plan-usage — consulta o gauge de uso do plano (rate_limits/five_hour,
 seven_day) capturado via statusline (FASE 2, plan-usage-capture).
 
 USO:
-  cstk plan-usage                 uso mais recente por escopo [FASE 4 — pendente]
-  cstk plan-usage history         serie temporal por escopo   [FASE 4 — pendente]
+  cstk plan-usage [--json] [--db PATH]
+  cstk plan-usage history [--scope five_hour|seven_day] [--limit N]
+                           [--since ISO] [--json] [--db PATH]
   cstk plan-usage ingest --stdin  uso interno do hook statusline-plan-usage.sh
+
+  --json    saida maquina-legivel
+  --db PATH indice (default $CSTK_KNOWLEDGE_DB ou ~/.claude/cstk/knowledge.db)
 USAGE
+}
+
+# ==========================================================================
+# Task 4.1 — `cstk plan-usage` (uso mais recente)
+# ==========================================================================
+
+# _pu_local_time EPOCH -> horario local formatado (apresentacao apenas — a
+# persistencia continua epoch INTEGER, FR-003/Cenario 5). `date -r` e
+# BSD/macOS-first (ambiente-alvo desta feature); sem fallback GNU (`date -d
+# @EPOCH`) porque o CLI so precisa rodar no ambiente do operador (macOS/zsh,
+# Constitution). Se a conversao falhar (comando indisponivel/erro), imprime
+# o epoch cru — nunca fabrica um formato (Principio VI).
+_pu_local_time() {
+  [ -n "$1" ] || { printf ''; return 0; }
+  date -r "$1" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || printf '%s' "$1"
+}
+
+# _pu_row_field ROW INDEX -> campo INDEX (1-based) de uma linha
+# "used|resets|captured" (separador `|`, recall_query_sql .separator |).
+_pu_row_field() {
+  printf '%s' "$1" | awk -F '|' -v i="$2" '{print $i}'
+}
+
+# _pu_scope_text_line SCOPE ROW -> linha de texto para um escopo. ROW vazio
+# (sem captura) ou used_percentage vazio -> "nao medido" (nunca 0,
+# dec-029/SC-002).
+_pu_scope_text_line() {
+  _pstl_scope="$1"
+  _pstl_row="$2"
+  if [ -z "$_pstl_row" ]; then
+    printf '%s: nao medido\n' "$_pstl_scope"
+    return 0
+  fi
+  _pstl_used=$(_pu_row_field "$_pstl_row" 1)
+  _pstl_resets=$(_pu_row_field "$_pstl_row" 2)
+  if [ -z "$_pstl_used" ]; then
+    printf '%s: nao medido\n' "$_pstl_scope"
+    return 0
+  fi
+  _pstl_resets_disp="nao medido"
+  [ -n "$_pstl_resets" ] && _pstl_resets_disp=$(_pu_local_time "$_pstl_resets")
+  printf '%s: %s%% usado (reset: %s)\n' "$_pstl_scope" "$_pstl_used" "$_pstl_resets_disp"
+}
+
+# _pu_scope_json ROW -> objeto JSON {used_percentage,resets_at,captured_at}
+# para um escopo, com null explicito quando o campo/linha estiver ausente
+# (nunca 0 fabricado — SC-002).
+_pu_scope_json() {
+  _psj_row="$1"
+  if [ -z "$_psj_row" ]; then
+    printf '{"used_percentage":null,"resets_at":null,"captured_at":null}'
+    return 0
+  fi
+  _psj_used=$(_pu_row_field "$_psj_row" 1)
+  _psj_resets=$(_pu_row_field "$_psj_row" 2)
+  _psj_captured=$(_pu_row_field "$_psj_row" 3)
+  jq -n \
+    --arg used "$_psj_used" --arg resets "$_psj_resets" --arg captured "$_psj_captured" \
+    '{
+      used_percentage: (if $used == "" then null else ($used | tonumber) end),
+      resets_at: (if $resets == "" then null else ($resets | tonumber) end),
+      captured_at: (if $captured == "" then null else $captured end)
+    }' 2>/dev/null
+}
+
+plan_usage_cmd_show() {
+  _pcs_json=0
+  _pcs_db_flag=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --json) _pcs_json=1 ;;
+      --db) shift; _pcs_db_flag="${1:-}" ;;
+      -h|--help) _plan_usage_usage_text; return 0 ;;
+      *)
+        log_error "cstk plan-usage: flag desconhecida: $1"
+        return 2
+        ;;
+    esac
+    shift || break
+  done
+
+  if ! recall_have_sqlite3 2>/dev/null; then
+    log_warn "cstk plan-usage: sqlite3 nao instalado; consulta indisponivel"
+    return 1
+  fi
+
+  _pcs_db=$(recall_resolve_db "$_pcs_db_flag")
+
+  _pcs_row_5h=""
+  _pcs_row_7d=""
+  _pcs_have_data=0
+  if [ -f "$_pcs_db" ]; then
+    _pcs_row_5h=$(recall_query_sql "$_pcs_db" ".mode list
+.separator |
+SELECT used_percentage, resets_at, captured_at FROM plan_usage WHERE scope='five_hour' ORDER BY id DESC LIMIT 1;") || _pcs_row_5h=""
+    _pcs_row_7d=$(recall_query_sql "$_pcs_db" ".mode list
+.separator |
+SELECT used_percentage, resets_at, captured_at FROM plan_usage WHERE scope='seven_day' ORDER BY id DESC LIMIT 1;") || _pcs_row_7d=""
+    [ -n "$_pcs_row_5h" ] || [ -n "$_pcs_row_7d" ] && _pcs_have_data=1
+  else
+    log_warn "cstk plan-usage: indice ausente ($_pcs_db); nenhuma captura registrada ainda"
+  fi
+
+  if [ "$_pcs_json" -eq 1 ]; then
+    if recall_have_jq 2>/dev/null; then
+      _pcs_json_5h=$(_pu_scope_json "$_pcs_row_5h")
+      _pcs_json_7d=$(_pu_scope_json "$_pcs_row_7d")
+      [ -n "$_pcs_json_5h" ] || _pcs_json_5h='{"used_percentage":null,"resets_at":null,"captured_at":null}'
+      [ -n "$_pcs_json_7d" ] || _pcs_json_7d='{"used_percentage":null,"resets_at":null,"captured_at":null}'
+      jq -n --argjson five_hour "$_pcs_json_5h" --argjson seven_day "$_pcs_json_7d" \
+        '{five_hour: $five_hour, seven_day: $seven_day}'
+    else
+      log_warn "cstk plan-usage: jq ausente; --json indisponivel, usando texto"
+      if [ -f "$_pcs_db" ] && [ "$_pcs_have_data" -eq 0 ]; then
+        printf 'nao medido — nenhuma captura registrada ainda\n'
+      else
+        _pu_scope_text_line "five_hour" "$_pcs_row_5h"
+        _pu_scope_text_line "seven_day" "$_pcs_row_7d"
+      fi
+    fi
+  else
+    if [ -f "$_pcs_db" ] && [ "$_pcs_have_data" -eq 0 ]; then
+      printf 'nao medido — nenhuma captura registrada ainda\n'
+    else
+      _pu_scope_text_line "five_hour" "$_pcs_row_5h"
+      _pu_scope_text_line "seven_day" "$_pcs_row_7d"
+    fi
+  fi
+  return 0
+}
+
+# ==========================================================================
+# Task 4.2 — `cstk plan-usage history` (serie temporal)
+# ==========================================================================
+
+# _pu_history_rows DB SCOPE LIMIT SINCE -> ate LIMIT linhas
+# "used|resets|captured" das capturas MAIS RECENTES do escopo (respeitando
+# --since), em ORDEM CRONOLOGICA (a mais antiga primeiro). A query busca as
+# LIMIT mais recentes (ORDER BY id DESC LIMIT N) e entao inverte via o idioma
+# POSIX sed classico de reverse ('1!G;h;$!d') — portavel BSD/GNU, sem `tac`
+# (nao existe no macOS). DB ausente -> nenhuma linha (caller decide a
+# mensagem, paridade 4.1.5).
+_pu_history_rows() {
+  _phr_db="$1"; _phr_scope="$2"; _phr_limit="$3"; _phr_since="$4"
+  [ -f "$_phr_db" ] || return 0
+  _phr_where="WHERE scope='$(sql_escape "$_phr_scope")'"
+  [ -n "$_phr_since" ] && _phr_where="$_phr_where AND captured_at >= '$(sql_escape "$_phr_since")'"
+  recall_query_sql "$_phr_db" ".mode list
+.separator |
+SELECT used_percentage, resets_at, captured_at FROM plan_usage $_phr_where ORDER BY id DESC LIMIT $_phr_limit;" \
+    | sed '1!G;h;$!d'
+}
+
+# _pu_rows_to_json_array ROWS -> array JSON [{used_percentage,resets_at,
+# captured_at}]. ROWS vazio -> "[]" (array vazio, NUNCA null — contrato
+# 4.2.3: a chave do escopo pedido sempre existe, o array e que fica vazio
+# quando nao ha captura no filtro).
+_pu_rows_to_json_array() {
+  _prtja_rows="$1"
+  if [ -z "$_prtja_rows" ]; then
+    printf '[]'
+    return 0
+  fi
+  printf '%s\n' "$_prtja_rows" \
+    | awk -F '|' '{print $1"\t"$2"\t"$3}' \
+    | jq -R -s '
+        [ split("\n")[] | select(length>0) | split("\t")
+          | {used_percentage: (if .[0]=="" then null else (.[0]|tonumber) end),
+             resets_at: (if .[1]=="" then null else (.[1]|tonumber) end),
+             captured_at: (if .[2]=="" then null else .[2] end)}
+        ]
+      ' 2>/dev/null
+}
+
+# _pu_history_render_text DB SCOPES LIMIT SINCE DB_EXISTS -> uma secao de
+# texto por escopo (SCOPES separado por espaco), ate LIMIT linhas em ordem
+# cronologica. Mesma tabela de comportamento sem dados de 4.1.5/4.1.6
+# (4.2.4): DB_EXISTS=0 -> "nao medido" por escopo (paridade 4.1.5); DB
+# presente mas sem linha no filtro -> "nao medido — nenhuma captura
+# registrada ainda" por escopo (paridade 4.1.6).
+_pu_history_render_text() {
+  _phrt_db="$1"; _phrt_scopes="$2"; _phrt_limit="$3"; _phrt_since="$4"; _phrt_db_exists="$5"
+  for _phrt_s in $_phrt_scopes; do
+    printf '== %s ==\n' "$_phrt_s"
+    if [ "$_phrt_db_exists" -eq 0 ]; then
+      printf '  nao medido\n'
+      continue
+    fi
+    _phrt_rows=$(_pu_history_rows "$_phrt_db" "$_phrt_s" "$_phrt_limit" "$_phrt_since")
+    if [ -z "$_phrt_rows" ]; then
+      printf '  nao medido — nenhuma captura registrada ainda\n'
+      continue
+    fi
+    printf '%s\n' "$_phrt_rows" | while IFS= read -r _phrt_line; do
+      [ -n "$_phrt_line" ] || continue
+      _phrt_used=$(_pu_row_field "$_phrt_line" 1)
+      _phrt_captured=$(_pu_row_field "$_phrt_line" 3)
+      if [ -n "$_phrt_used" ]; then
+        printf '  %s  %s%%\n' "$_phrt_captured" "$_phrt_used"
+      else
+        printf '  %s  nao medido\n' "$_phrt_captured"
+      fi
+    done
+  done
+}
+
+plan_usage_cmd_history() {
+  _pch_scope=""
+  _pch_limit="20"
+  _pch_since=""
+  _pch_json=0
+  _pch_db_flag=""
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --scope) shift; _pch_scope="${1:-}" ;;
+      --limit) shift; _pch_limit="${1:-}" ;;
+      --since) shift; _pch_since="${1:-}" ;;
+      --json) _pch_json=1 ;;
+      --db) shift; _pch_db_flag="${1:-}" ;;
+      -h|--help) _plan_usage_usage_text; return 0 ;;
+      *)
+        log_error "cstk plan-usage history: flag desconhecida: $1"
+        return 2
+        ;;
+    esac
+    shift || break
+  done
+
+  case "$_pch_scope" in
+    ''|five_hour|seven_day) ;;
+    *)
+      log_error "cstk plan-usage history: --scope invalido (esperado five_hour|seven_day, recebido: '$_pch_scope')"
+      return 2
+      ;;
+  esac
+
+  if ! validate_limit "$_pch_limit"; then
+    log_error "cstk plan-usage history: --limit deve ser inteiro positivo (recebido: '$_pch_limit')"
+    return 2
+  fi
+
+  if ! recall_have_sqlite3 2>/dev/null; then
+    log_warn "cstk plan-usage history: sqlite3 nao instalado; consulta indisponivel"
+    return 1
+  fi
+
+  _pch_db=$(recall_resolve_db "$_pch_db_flag")
+  _pch_db_exists=0
+  [ -f "$_pch_db" ] && _pch_db_exists=1
+  [ "$_pch_db_exists" -eq 1 ] || log_warn "cstk plan-usage history: indice ausente ($_pch_db); nenhuma captura registrada ainda"
+
+  _pch_scopes="five_hour seven_day"
+  [ -n "$_pch_scope" ] && _pch_scopes="$_pch_scope"
+
+  if [ "$_pch_json" -eq 1 ]; then
+    if recall_have_jq 2>/dev/null; then
+      _pch_json_out="{}"
+      for _pch_s in $_pch_scopes; do
+        _pch_rows=""
+        [ "$_pch_db_exists" -eq 1 ] && _pch_rows=$(_pu_history_rows "$_pch_db" "$_pch_s" "$_pch_limit" "$_pch_since")
+        _pch_arr=$(_pu_rows_to_json_array "$_pch_rows")
+        [ -n "$_pch_arr" ] || _pch_arr="[]"
+        _pch_json_out=$(printf '%s' "$_pch_json_out" | jq --arg k "$_pch_s" --argjson v "$_pch_arr" '. + {($k): $v}' 2>/dev/null) || _pch_json_out="{}"
+      done
+      printf '%s\n' "$_pch_json_out"
+    else
+      log_warn "cstk plan-usage history: jq ausente; --json indisponivel, usando texto"
+      _pu_history_render_text "$_pch_db" "$_pch_scopes" "$_pch_limit" "$_pch_since" "$_pch_db_exists"
+    fi
+  else
+    _pu_history_render_text "$_pch_db" "$_pch_scopes" "$_pch_limit" "$_pch_since" "$_pch_db_exists"
+  fi
+  return 0
 }
 
 plan_usage_main() {
@@ -205,14 +485,14 @@ plan_usage_main() {
       _plan_usage_usage_text
       return 0
       ;;
-    '')
-      log_error "cstk plan-usage: consulta publica ainda nao implementada (FASE 4 desta feature)"
-      _plan_usage_usage_text
-      return 1
+    ''|--*)
+      plan_usage_cmd_show "$@"
+      return $?
       ;;
     history)
-      log_error "cstk plan-usage history: ainda nao implementada (FASE 4 desta feature)"
-      return 1
+      shift
+      plan_usage_cmd_history "$@"
+      return $?
       ;;
     *)
       log_error "cstk plan-usage: subcomando desconhecido: $_pum_sub"

--- a/cli/lib/plan-usage.sh
+++ b/cli/lib/plan-usage.sh
@@ -1,0 +1,223 @@
+#!/bin/sh
+# plan-usage.sh — subcomando `cstk plan-usage` (feature plan-usage-capture).
+#
+# Camada SQL do gauge de uso do plano (rate_limits do payload da
+# statusline), delegada integralmente a `cli/lib/recall.sh` (unico arquivo
+# autorizado a `sqlite3` — Constitution II / research.md Decision 6).
+#
+# `plan_usage_cmd_ingest_stdin` (task 4.3) e o subcomando INTERNO
+# `cstk plan-usage ingest --stdin`, consumido exclusivamente por
+# `plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh`
+# (research.md Decision 6): recebe o payload BRUTO da statusline via stdin,
+# extrai `rate_limits.<scope>.*` via `jq`, aplica o throttle de FR-010
+# (research.md Decision 4: compara contra o ULTIMO registro persistido do
+# escopo, sem cache auxiliar) e delega o INSERT a
+# `recall_plan_usage_insert()` (cli/lib/recall.sh). Exit SEMPRE 0, mesmo em
+# erro interno (task 4.3.3) — nunca propaga falha para a sessao do
+# operador que renderiza a statusline (Principio IV).
+#
+# Ausencia total de `rate_limits` no payload -> NENHUM INSERT (dec-029);
+# ausencia PARCIAL (escopo presente mas campo ausente dentro dele) ->
+# INSERT com NULL explicito, nunca 0 fabricado (Principio VI).
+#
+# `cstk plan-usage` (sem args) e `cstk plan-usage history` (consulta
+# publica, FASE 4.1/4.2) AINDA NAO IMPLEMENTADOS nesta onda — apenas o
+# subcomando interno `ingest --stdin` necessario para desbloquear FASE 2
+# (statusline-plan-usage.sh so consegue persistir via este subcomando,
+# research.md Decision 6 — o hook roda fora do processo `cstk` e nao tem
+# acesso direto a `cli/lib/recall.sh`).
+#
+# Despachado por cli/cstk: `cstk plan-usage ...` -> plan_usage_main "$@".
+#
+# POSIX sh puro. Deps OPCIONAIS: sqlite3, jq (ausencia degrada gracioso,
+# mesma disciplina de usage.sh/recall.sh).
+
+if [ -n "${_CSTK_PLAN_USAGE_LOADED:-}" ]; then
+  return 0 2>/dev/null
+fi
+_CSTK_PLAN_USAGE_LOADED=1
+
+if [ -n "${CSTK_LIB:-}" ] && [ -f "$CSTK_LIB/common.sh" ]; then
+  # shellcheck source=./common.sh
+  . "$CSTK_LIB/common.sh"
+fi
+
+# recall.sh concentra sql_escape, a camada de conexao
+# (recall_have_sqlite3/recall_have_jq/recall_resolve_db/
+# recall_ensure_db_dir/recall_apply_schema/recall_normalize_db_perms/
+# recall_apply_sql_with_retry), recall_real_or_null/recall_int_or_null e
+# recall_plan_usage_insert (task 1.2) — plan-usage.sh reusa tudo isso em
+# vez de reimplementar (Constitution II).
+if [ -n "${CSTK_LIB:-}" ] && [ -f "$CSTK_LIB/recall.sh" ]; then
+  # shellcheck source=./recall.sh
+  . "$CSTK_LIB/recall.sh"
+fi
+
+if ! command -v log_warn >/dev/null 2>&1; then
+  log_info() { printf '[info] %s\n' "$*" >&2; }
+  log_warn() { printf '[warn] %s\n' "$*" >&2; }
+  log_error() { printf '[error] %s\n' "$*" >&2; }
+fi
+
+_pu_now_iso() {
+  date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || printf '1970-01-01T00:00:00Z'
+}
+
+# _pu_last_scope_row DB SCOPE -> "used_percentage|resets_at" do ULTIMO
+# registro persistido daquele escopo. Confinamento sqlite3 (Constitution
+# II / task 2.5.2): delega a recall_plan_usage_last_scope_row
+# (cli/lib/recall.sh) — este arquivo NUNCA invoca `sqlite3` diretamente.
+_pu_last_scope_row() {
+  recall_plan_usage_last_scope_row "$1" "$2"
+}
+
+# _pu_2dp VALOR -> valor TRUNCADO (nao arredondado) a 2 casas decimais
+# (string). Truncar, nao arredondar: quickstart.md Cenario 3 exige que
+# 7.001 E 7.009 (3a casa decimal variando) comparem IGUAIS a 7.00 — sob
+# arredondamento padrao 7.009 viraria 7.01 (falharia o teste). Manipulacao
+# de string pura (POSIX sh, sem awk/bc) evita ruido de ponto-flutuante que
+# `int(v*100)/100` teria (ex.: 7.05*100 pode virar 704.999... e truncar
+# errado para 704). Entrada vazia/nao-numerica -> "" (NULL-vs-NULL,
+# dec-050, comparado por igualdade de string a jusante).
+_pu_2dp() {
+  case "$1" in
+    ''|*[!0-9.-]*) printf '' ; return 0 ;;
+  esac
+  case "$1" in
+    *.*)
+      _p2_int=${1%%.*}
+      _p2_frac=${1#*.}
+      _p2_frac=$(printf '%s' "$_p2_frac" | cut -c1-2)
+      while [ "${#_p2_frac}" -lt 2 ]; do _p2_frac="${_p2_frac}0"; done
+      printf '%s.%s' "$_p2_int" "$_p2_frac"
+      ;;
+    *)
+      printf '%s.00' "$1"
+      ;;
+  esac
+}
+
+# _pu_throttle_discard DB SCOPE NEW_USED NEW_RESETS -> 0 (descarta, repete
+# o ultimo registro dentro da tolerancia) ou 1 (persiste — mudou alem de 2
+# casas decimais OU resets_at mudou OU nao ha registro anterior).
+#
+# NULL-vs-NULL (dec-050, residual CHK010/tasks.md 2.3.4): comparado via
+# igualdade de string apos normalizacao (ambos "" = ambos NULL = identico
+# -> descarta), extensao natural da regra geral sem caso especial.
+_pu_throttle_discard() {
+  _ptd_db="$1"
+  _ptd_scope="$2"
+  _ptd_new_used="$3"
+  _ptd_new_resets="$4"
+
+  _ptd_last=$(_pu_last_scope_row "$_ptd_db" "$_ptd_scope") || return 1
+  [ -n "$_ptd_last" ] || return 1
+
+  _ptd_last_used=${_ptd_last%%|*}
+  _ptd_last_resets=${_ptd_last#*|}
+
+  _ptd_new_used_r=$(_pu_2dp "$_ptd_new_used")
+  _ptd_last_used_r=$(_pu_2dp "$_ptd_last_used")
+
+  if [ "$_ptd_new_used_r" = "$_ptd_last_used_r" ] && [ "$_ptd_new_resets" = "$_ptd_last_resets" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# plan_usage_cmd_ingest_stdin -> le payload bruto da statusline via stdin,
+# extrai rate_limits.<scope>.*, aplica throttle e insere via
+# recall_plan_usage_insert. Exit SEMPRE 0 (task 4.3.3) — qualquer falha
+# interna (jq/sqlite3 ausente, JSON malformado, INSERT falho) e best-effort
+# silencioso, nunca propaga para o caller (o hook da statusline).
+plan_usage_cmd_ingest_stdin() {
+  _pis_payload=$(cat 2>/dev/null) || return 0
+  [ -n "$_pis_payload" ] || return 0
+
+  recall_have_jq 2>/dev/null || return 0
+  printf '%s' "$_pis_payload" | jq empty >/dev/null 2>&1 || return 0
+
+  # Ausencia TOTAL de rate_limits -> nenhum INSERT (dec-029).
+  _pis_has_rl=$(printf '%s' "$_pis_payload" | jq -r 'has("rate_limits")' 2>/dev/null) || return 0
+  [ "$_pis_has_rl" = "true" ] || return 0
+
+  recall_have_sqlite3 2>/dev/null || return 0
+
+  _pis_session_id=$(printf '%s' "$_pis_payload" | jq -r '.session_id // ""' 2>/dev/null) || _pis_session_id=""
+  _pis_project_path=$(printf '%s' "$_pis_payload" | jq -r '.workspace.current_dir // .workspace.project_dir // ""' 2>/dev/null) || _pis_project_path=""
+  [ -n "$_pis_project_path" ] || return 0
+  _pis_project=$(basename -- "$_pis_project_path" 2>/dev/null) || return 0
+
+  _pis_db=$(recall_resolve_db "") || return 0
+  recall_ensure_db_dir "$_pis_db" >/dev/null 2>&1 || return 0
+  recall_apply_schema "$_pis_db" >/dev/null 2>&1 || return 0
+
+  _pis_now=$(_pu_now_iso)
+
+  for _pis_scope in five_hour seven_day; do
+    _pis_has_scope=$(printf '%s' "$_pis_payload" | jq -r --arg s "$_pis_scope" 'has("rate_limits") and (.rate_limits | has($s))' 2>/dev/null) || _pis_has_scope="false"
+    [ "$_pis_has_scope" = "true" ] || continue
+
+    _pis_used=$(printf '%s' "$_pis_payload" | jq -r --arg s "$_pis_scope" '.rate_limits[$s].used_percentage // ""' 2>/dev/null) || _pis_used=""
+    _pis_resets=$(printf '%s' "$_pis_payload" | jq -r --arg s "$_pis_scope" '.rate_limits[$s].resets_at // ""' 2>/dev/null) || _pis_resets=""
+
+    if _pu_throttle_discard "$_pis_db" "$_pis_scope" "$_pis_used" "$_pis_resets"; then
+      continue
+    fi
+
+    recall_plan_usage_insert "$_pis_db" "$_pis_project" "$_pis_project_path" \
+      "$_pis_session_id" "$_pis_scope" "$_pis_used" "$_pis_resets" \
+      "$_pis_now" "$_pis_now" >/dev/null 2>&1 || :
+  done
+
+  return 0
+}
+
+_plan_usage_usage_text() {
+  cat <<'USAGE'
+cstk plan-usage — consulta o gauge de uso do plano (rate_limits/five_hour,
+seven_day) capturado via statusline (FASE 2, plan-usage-capture).
+
+USO:
+  cstk plan-usage                 uso mais recente por escopo [FASE 4 — pendente]
+  cstk plan-usage history         serie temporal por escopo   [FASE 4 — pendente]
+  cstk plan-usage ingest --stdin  uso interno do hook statusline-plan-usage.sh
+USAGE
+}
+
+plan_usage_main() {
+  _pum_sub="${1:-}"
+  case "$_pum_sub" in
+    ingest)
+      shift
+      case "${1:-}" in
+        --stdin)
+          plan_usage_cmd_ingest_stdin
+          return 0
+          ;;
+        *)
+          log_error "cstk plan-usage ingest: flag desconhecida (esperado --stdin)"
+          return 2
+          ;;
+      esac
+      ;;
+    -h|--help)
+      _plan_usage_usage_text
+      return 0
+      ;;
+    '')
+      log_error "cstk plan-usage: consulta publica ainda nao implementada (FASE 4 desta feature)"
+      _plan_usage_usage_text
+      return 1
+      ;;
+    history)
+      log_error "cstk plan-usage history: ainda nao implementada (FASE 4 desta feature)"
+      return 1
+      ;;
+    *)
+      log_error "cstk plan-usage: subcomando desconhecido: $_pum_sub"
+      _plan_usage_usage_text
+      return 2
+      ;;
+  esac
+}

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -2512,6 +2512,26 @@ recall_plan_usage_insert() {
   return 0
 }
 
+# recall_plan_usage_last_scope_row DB SCOPE -> "used_percentage|resets_at"
+# do ULTIMO registro persistido daquele escopo (qualquer projeto —
+# rate_limits e gauge da CONTA, nao por-projeto; research.md Decision 4 da
+# feature plan-usage-capture), ou string vazia (+ exit 1) se nao houver
+# nenhum registro ainda. Colunas NULL viram string vazia no output do
+# sqlite3, distinguivel de "0" (nunca confundido com valor real zero).
+#
+# Confinamento sqlite3 (Constitution II / research.md Decision 6): unico
+# ponto de LEITURA do throttle de FR-010, usado por `cli/lib/plan-usage.sh`
+# (task 4.3), que NAO pode invocar `sqlite3` diretamente.
+recall_plan_usage_last_scope_row() {
+  _plsr_db="$1"
+  _plsr_scope="$2"
+  recall_have_sqlite3 || return 1
+  [ -f "$_plsr_db" ] || return 1
+  sqlite3 -separator '|' -- "$_plsr_db" \
+    "SELECT used_percentage, resets_at FROM plan_usage WHERE scope='$(sql_escape "$_plsr_scope")' ORDER BY id DESC LIMIT 1;" \
+    2>/dev/null
+}
+
 # ==========================================================================
 # FASE memories — Ingestao de arquivos .md de auto-memoria (recall-memory-mirror)
 # Aditivo ao recall_mode_ingest existente (CQ2). Lê arquivos .md do diretório

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -133,7 +133,17 @@ RECALL_EXIT_USAGE=2
 # de `wave_model_usage` na v11->v12 (linhas 810-811 acima), CREATE TABLE IF
 # NOT EXISTS coberto pelo DDL. `cost_usd`/`total_tokens`/`model` NULL quando
 # nao medido, nunca 0 (Principio VI; data-model.md §Entity LooseUsageRecord).
-RECALL_SCHEMA_VERSION=13
+# v14 (plan-usage-capture): tabela nova `plan_usage` (grao escopo x momento
+# de captura; origem: hook `statusLine.command`, via `cstk plan-usage
+# ingest --stdin` — consumo AVULSO fora do fluxo state.json/onda, mesma
+# familia de `loose_usage`). Migracao v13->v14 e puramente aditiva: sem
+# ALTER TABLE, sem DROP — mesmo precedente literal de `loose_usage` acima.
+# Append-only, sem UNIQUE de chave natural (data-model.md §Entity Captura
+# de Uso do Plano). `used_percentage`/`resets_at` NULL quando ausentes
+# dentro de escopo presente, nunca 0/fabricado (Principio VI, dec-029) —
+# ausencia TOTAL de `rate_limits` nao gera nenhuma linha (decidido no
+# caller, nao no schema).
+RECALL_SCHEMA_VERSION=14
 # Enum interno (canonico): valores EN. 'bloqueio' permanece aceito como ALIAS
 # DEPRECADO em --type (normalizado para 'block' com aviso) — ver recall_normalize_type.
 RECALL_TYPE_ENUM="decision block retro skill memory suggestion"
@@ -657,6 +667,17 @@ CREATE TABLE IF NOT EXISTS loose_usage (
   captured_at TEXT NOT NULL,
   ingested_at TEXT NOT NULL,
   UNIQUE(process_key, segment_id, model)
+);
+CREATE TABLE IF NOT EXISTS plan_usage (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  project TEXT NOT NULL,
+  project_path TEXT,
+  session_id TEXT NOT NULL,
+  scope TEXT NOT NULL CHECK (scope IN ('five_hour','seven_day')),
+  used_percentage REAL,
+  resets_at INTEGER,
+  captured_at TEXT NOT NULL,
+  ingested_at TEXT NOT NULL
 );
 CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_fts USING fts5 (
   body,
@@ -2454,6 +2475,40 @@ recall_prune_loose_usage() {
   recall_apply_sql_with_retry "$_plu_db" "DELETE FROM loose_usage WHERE captured_at < '$_plu_cutoff';" || return 1
   recall_normalize_db_perms "$_plu_db"
   printf '%s\n' "$_plu_n"
+  return 0
+}
+
+# recall_plan_usage_insert DB PROJECT PROJECT_PATH SESSION_ID SCOPE
+#   USED_PERCENTAGE RESETS_AT CAPTURED_AT INGESTED_AT
+# -> INSERT append-only em `plan_usage` (task 1.2, plan-usage-capture,
+# schema v14). Paridade com o INSERT de `loose_usage` dentro de
+# usage_map_sidecar_to_db() (cli/lib/usage.sh) — mesmo caminho de escrita
+# (sql_escape + recall_apply_sql_with_retry), sem UPSERT/UNIQUE (append-only
+# por design, data-model.md §Entity Captura de Uso do Plano).
+#
+# USED_PERCENTAGE/RESETS_AT: string vazia OU "null" (jq tostring de um
+# campo ausente/JSON null) viram literal SQL `NULL` via
+# recall_real_or_null/recall_int_or_null — NUNCA `0` fabricado
+# (Constitution VI, dec-029). CAPTURED_AT/INGESTED_AT sao TEXT NOT NULL
+# (FR-014): calculados pelo CALLER (`cstk plan-usage ingest --stdin`, task
+# 4.3.2) via `date -u +%Y-%m-%dT%H:%M:%SZ` — este helper NAO os infere.
+#
+# Retorna 0 em sucesso (via recall_apply_sql_with_retry), 1 em falha de
+# escrita apos esgotar retries. Best-effort pelo caller: nunca deve abortar
+# a captura da statusline (FR-011/Principio IV).
+recall_plan_usage_insert() {
+  _pui_db="$1"
+  _pui_project="$2"
+  _pui_project_path="$3"
+  _pui_session_id="$4"
+  _pui_scope="$5"
+  _pui_used_pct=$(recall_real_or_null "$6")
+  _pui_resets_at=$(recall_int_or_null "$7")
+  _pui_captured_at="$8"
+  _pui_ingested_at="$9"
+  _pui_sql="INSERT INTO plan_usage(project,project_path,session_id,scope,used_percentage,resets_at,captured_at,ingested_at) VALUES('$(sql_escape "$_pui_project")','$(sql_escape "$_pui_project_path")','$(sql_escape "$_pui_session_id")','$(sql_escape "$_pui_scope")',$_pui_used_pct,$_pui_resets_at,'$(sql_escape "$_pui_captured_at")','$(sql_escape "$_pui_ingested_at")');"
+  recall_apply_sql_with_retry "$_pui_db" "$_pui_sql" || return 1
+  recall_normalize_db_perms "$_pui_db"
   return 0
 }
 

--- a/cli/lib/statusline.sh
+++ b/cli/lib/statusline.sh
@@ -1,0 +1,265 @@
+#!/bin/sh
+# statusline.sh — subcomando `cstk statusline` (feature plan-usage-capture,
+# FASE 3 / tasks.md 3.1.1-3.1.6, dec-042).
+#
+# Provisiona a chave UNICA `statusLine.command` do settings.json do
+# harness (research.md Decision 2, plan.md linha 17-24) apontando para
+# `statusline-plan-usage.sh` (o entry-point de captura da FASE 2).
+#
+# Escopo: SEMPRE ${HOME}/.claude/settings.json — statusLine.command e uma
+# preferencia de UI por operador (nao por projeto), paralelo ao que o
+# proprio harness Claude Code trata como setting de usuario. Diferente de
+# `cstk hooks install`, que e por-projeto (`--project-path`).
+#
+# Preservacao de customizacao previa (task 3.1.2, mitigacao do risco
+# documentado em plan.md §Riscos conhecidos): se `statusLine.command` ja
+# apontar para outro comando, o valor original e movido para a variavel
+# de ambiente `CSTK_STATUSLINE_INNER_COMMAND`, e a nova chave passa a
+# exportar essa variavel antes de invocar o script desta feature — o
+# proprio script (`statusline-plan-usage.sh`, research.md Decision 2) le
+# essa variavel e repassa o stdout do comando original verbatim
+# (pass-through obrigatorio). NUNCA sobrescreve silenciosamente.
+#
+# Idempotencia (task 3.1.3): reinstalar detecta os dois formatos ja
+# instalados (com ou sem customizacao previa) e e no-op — nunca aninha
+# wrapper sobre wrapper.
+#
+# POSIX sh puro. Dep OPCIONAL: jq (carve-out ja vigente, research.md
+# Decision 3) — ausente, aborta a escrita com orientacao de colagem
+# manual (mesma disciplina de `cli/lib/hooks.sh` merge_settings).
+
+if [ -n "${_CSTK_STATUSLINE_LOADED:-}" ]; then
+  return 0 2>/dev/null
+fi
+_CSTK_STATUSLINE_LOADED=1
+
+if [ -n "${CSTK_LIB:-}" ] && [ -f "$CSTK_LIB/common.sh" ]; then
+  # shellcheck source=./common.sh
+  . "$CSTK_LIB/common.sh"
+fi
+
+if ! command -v log_warn >/dev/null 2>&1; then
+  log_info() { printf '[info] %s\n' "$*" >&2; }
+  log_warn() { printf '[warn] %s\n' "$*" >&2; }
+  log_error() { printf '[error] %s\n' "$*" >&2; }
+fi
+
+# _sl_detect_jq: exit 0 se jq disponivel, 1 se nao. Reusa detect_jq de
+# hooks.sh quando ja carregado (mesmo processo `cstk`); senao checa
+# diretamente — este arquivo pode ser sourceado standalone em teste.
+_sl_detect_jq() {
+  if command -v detect_jq >/dev/null 2>&1; then
+    detect_jq
+    return $?
+  fi
+  command -v jq >/dev/null 2>&1
+}
+
+# _sl_script_path CATALOG -> stdout: path do entry-point de captura sob o
+# catalogo informado (default: ${HOME}/.claude).
+_sl_script_path() {
+  printf '%s/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh' "$1"
+}
+
+# _sl_escape_single_quotes VALOR -> stdout: VALOR com toda aspas simples
+# escapada para uso seguro dentro de aspas simples num comando de shell
+# (' -> '\'').
+_sl_escape_single_quotes() {
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+}
+
+_statusline_print_help() {
+  cat >&2 <<'HELP'
+cstk statusline — instala/inspeciona a captura de uso do plano via
+statusLine.command (feature plan-usage-capture).
+
+USO:
+  cstk statusline install [--catalog DIR] [--dry-run]
+  cstk statusline status  [--catalog DIR]
+
+install:
+  Escreve/atualiza a chave `statusLine.command` de
+  ${HOME}/.claude/settings.json apontando para
+  <catalog>/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh
+  (catalog default: ${HOME}/.claude).
+
+  Se ja existir `statusLine.command` customizado (e distinto do script
+  desta feature), o valor original e preservado movendo-o para a
+  variavel de ambiente CSTK_STATUSLINE_INNER_COMMAND — NUNCA sobrescrito
+  silenciosamente. Idempotente: rodar 2x seguidas nao aninha wrapper
+  sobre wrapper.
+
+status:
+  Reporta se a captura esta instalada e ativa em
+  ${HOME}/.claude/settings.json, sem escrever nada.
+
+--catalog DIR: raiz do catalogo cstk (default: ${HOME}/.claude). Use para
+apontar a um catalogo alternativo (ex: fixture de teste).
+--dry-run: mostra o que seria escrito sem alterar settings.json.
+HELP
+}
+
+# statusline_cmd_install [--catalog DIR] [--dry-run]
+statusline_cmd_install() {
+  _si_home="${HOME:?HOME nao setado}"
+  _si_catalog="${_si_home}/.claude"
+  _si_dry_run=0
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --catalog)
+        [ "$#" -ge 2 ] || { log_error "statusline install: --catalog exige valor"; return 2; }
+        _si_catalog=$2; shift 2 ;;
+      --catalog=*) _si_catalog=${1#--catalog=}; shift ;;
+      --dry-run) _si_dry_run=1; shift ;;
+      -h|--help) _statusline_print_help; return 0 ;;
+      *) log_error "statusline install: flag desconhecida: $1"; return 2 ;;
+    esac
+  done
+
+  _si_script=$(_sl_script_path "$_si_catalog")
+  if [ ! -f "$_si_script" ]; then
+    log_error "statusline install: script nao encontrado: $_si_script"
+    log_error "statusline install: rode 'cstk install' (ou 'cstk update') antes, ou passe --catalog DIR."
+    return 1
+  fi
+
+  _si_settings="${_si_home}/.claude/settings.json"
+  _si_settings_dir=$(dirname -- "$_si_settings")
+
+  if ! _sl_detect_jq; then
+    log_warn "statusline install: jq ausente — nao da para editar settings.json com seguranca."
+    log_warn "statusline install: cole manualmente esta chave em $_si_settings:"
+    printf '  "statusLine": { "command": "%s" }\n' "$_si_script" >&2
+    return 1
+  fi
+
+  _si_cur=""
+  if [ -f "$_si_settings" ]; then
+    _si_cur=$(jq -r '.statusLine.command // empty' -- "$_si_settings" 2>/dev/null) || _si_cur=""
+  fi
+
+  case "$_si_cur" in
+    "")
+      _si_new="$_si_script"
+      _si_msg="instalado (sem statusline previa)"
+      ;;
+    "$_si_script")
+      log_info "statusline install: ja instalado e atualizado em $_si_settings (nada a fazer)"
+      return 0
+      ;;
+    *"CSTK_STATUSLINE_INNER_COMMAND="*"$_si_script")
+      log_info "statusline install: ja instalado (customizacao preservada) em $_si_settings (nada a fazer)"
+      return 0
+      ;;
+    *)
+      _si_escaped=$(_sl_escape_single_quotes "$_si_cur")
+      _si_new="CSTK_STATUSLINE_INNER_COMMAND='${_si_escaped}' $_si_script"
+      _si_msg="customizacao previa preservada em CSTK_STATUSLINE_INNER_COMMAND"
+      ;;
+  esac
+
+  if [ "$_si_dry_run" = 1 ]; then
+    log_info "[dry-run] statusline install: statusLine.command <- $_si_new ($_si_msg) em $_si_settings"
+    return 0
+  fi
+
+  if [ ! -d "$_si_settings_dir" ]; then
+    mkdir -p -- "$_si_settings_dir" || { log_error "statusline install: nao consegui criar $_si_settings_dir"; return 1; }
+  fi
+
+  if [ -f "$_si_settings" ]; then
+    if ! cp -- "$_si_settings" "${_si_settings}.bak"; then
+      log_error "statusline install: backup de $_si_settings falhou — abortando sem escrever"
+      return 1
+    fi
+    _si_tmp=$(mktemp -- "${_si_settings_dir}/.cstk-statusline.XXXXXX") || {
+      log_error "statusline install: mktemp em $_si_settings_dir falhou"
+      return 1
+    }
+    if ! jq --arg cmd "$_si_new" '.statusLine.command = $cmd' -- "$_si_settings" > "$_si_tmp" 2>/dev/null; then
+      log_error "statusline install: jq falhou ao mesclar $_si_settings (JSON invalido?)"
+      rm -f -- "$_si_tmp"
+      return 1
+    fi
+    if ! mv -f -- "$_si_tmp" "$_si_settings"; then
+      log_error "statusline install: mv atomico falhou para $_si_settings"
+      rm -f -- "$_si_tmp"
+      return 1
+    fi
+  else
+    if ! jq -n --arg cmd "$_si_new" '{"statusLine": {"command": $cmd}}' > "$_si_settings" 2>/dev/null; then
+      log_error "statusline install: falha ao criar $_si_settings"
+      return 1
+    fi
+  fi
+
+  log_info "statusline install: $_si_msg ($_si_settings)"
+  return 0
+}
+
+# statusline_cmd_status [--catalog DIR]
+statusline_cmd_status() {
+  _ss_home="${HOME:?HOME nao setado}"
+  _ss_catalog="${_ss_home}/.claude"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --catalog)
+        [ "$#" -ge 2 ] || { log_error "statusline status: --catalog exige valor"; return 2; }
+        _ss_catalog=$2; shift 2 ;;
+      --catalog=*) _ss_catalog=${1#--catalog=}; shift ;;
+      -h|--help) _statusline_print_help; return 0 ;;
+      *) log_error "statusline status: flag desconhecida: $1"; return 2 ;;
+    esac
+  done
+
+  _ss_script=$(_sl_script_path "$_ss_catalog")
+  _ss_settings="${_ss_home}/.claude/settings.json"
+
+  if [ ! -f "$_ss_settings" ]; then
+    printf 'statusline: nao instalado (settings.json ausente: %s)\n' "$_ss_settings"
+    return 1
+  fi
+
+  if ! _sl_detect_jq; then
+    printf 'statusline: jq ausente — nao consigo inspecionar %s\n' "$_ss_settings"
+    return 1
+  fi
+
+  _ss_cur=$(jq -r '.statusLine.command // empty' -- "$_ss_settings" 2>/dev/null) || _ss_cur=""
+  if [ -z "$_ss_cur" ]; then
+    printf 'statusline: nao instalado (statusLine.command ausente em %s)\n' "$_ss_settings"
+    return 1
+  fi
+
+  case "$_ss_cur" in
+    "$_ss_script")
+      printf 'statusline: ativo (sem customizacao previa) -> %s\n' "$_ss_cur"
+      return 0
+      ;;
+    *"CSTK_STATUSLINE_INNER_COMMAND="*"$_ss_script")
+      printf 'statusline: ativo (customizacao previa preservada) -> %s\n' "$_ss_cur"
+      return 0
+      ;;
+    *)
+      printf 'statusline: statusLine.command aponta para outro comando (captura desta feature NAO ativa): %s\n' "$_ss_cur"
+      return 1
+      ;;
+  esac
+}
+
+statusline_main() {
+  _sl_sub="${1:-}"
+  [ "$#" -ge 1 ] && shift || :
+
+  case "$_sl_sub" in
+    install) statusline_cmd_install "$@" ;;
+    status) statusline_cmd_status "$@" ;;
+    ''|-h|--help|help) _statusline_print_help; [ -z "$_sl_sub" ] && return 2 || return 0 ;;
+    *)
+      log_error "statusline: subcomando desconhecido: $_sl_sub (use: install, status)"
+      return 2
+      ;;
+  esac
+}

--- a/docs/specs/plan-usage-capture/checklists/requirements.md
+++ b/docs/specs/plan-usage-capture/checklists/requirements.md
@@ -1,0 +1,228 @@
+# Requirements Checklist: Plan Usage Capture
+
+**Purpose**: Quality gate dos requisitos (spec.md + plan.md + data-model.md +
+contracts/*.md + quickstart.md) antes de `create-tasks`. Domain generico
+("requirements") — a feature mistura CLI (`api`-like) e schema de dados, sem
+um dominio unico dominante.
+**Created**: 2026-08-10
+**Feature**: [spec.md](../spec.md)
+
+## Completude de Requisitos
+
+- [x] CHK001 - Cada campo do payload consumido (`session_id`,
+  `workspace.current_dir`/`project_dir`, `rate_limits.five_hour.*`,
+  `rate_limits.seven_day.*`) tem requisito funcional + coluna de destino
+  definidos? [Completude, Spec §FR-001/FR-009, Data-Model tabela `plan_usage`,
+  Contract statusline-hook.md linhas 26-32] {auto}
+- [ ] CHK002 - O texto literal de FR-006 (MUST NOT capturar
+  `seven_day_opus`/`seven_day_sonnet`/`extra_usage`) cobre TODOS os campos
+  que `contracts/statusline-hook.md` (linhas 34-36) e `plan.md` §Constitution
+  Check (linha ~93, principio VI) citam como excluidos "por FR-006"
+  (`.model`, `.cost`, `.context_window`, `.exceeds_200k_tokens`, `.thinking`,
+  `.effort`, `.output_style`, `.version`)? **Nao** — FR-006 so menciona
+  literalmente os 3 campos que exigem OAuth; os demais 8 campos citados no
+  contrato nunca aparecem no texto de FR-006 nem em nenhum outro FR/Edge
+  Case de `spec.md`. [Ambiguity, Spec §FR-006 vs Contract statusline-hook.md
+  §linha 34-36] {auto}
+- [ ] CHK003 - Existe requisito funcional ou Edge Case cobrindo o
+  comportamento de instalacao quando o operador ja possui um
+  `statusLine.command` customizado no `settings.json` (risco de sobrescrita
+  documentado APENAS em `plan.md` §Riscos conhecidos, nunca em `spec.md`)?
+  **Nao** — a mitigacao (`CSTK_STATUSLINE_INNER_COMMAND`, research.md
+  Decision 2) ja esta desenhada no nivel de plano, mas nunca virou FR/Edge
+  Case rastreavel em `spec.md`. [Gap, Spec §Edge Cases (ausente) vs
+  Plan.md §Riscos conhecidos linha ~230] {auto}
+- [ ] CHK004 - O comportamento de resiliencia best-effort/fail-open
+  (`jq` ausente, `sqlite3`/`knowledge.db` indisponivel, payload malformado,
+  nunca atrasar/bloquear a renderizacao da statusline) esta declarado como
+  requisito testavel em `spec.md`, ou so em `contracts/statusline-hook.md`
+  §Comportamento de captura (linhas 56-70) e `quickstart.md` Cenario 7?
+  **So no plano/contrato** — `spec.md` nao tem FR/Edge Case equivalente,
+  apesar de este comportamento ser parte do "Independent Test" implicito da
+  User Story 1 (a statusline continuar funcionando mesmo com falha de
+  captura). [Gap, Spec §Requirements (ausente)] {auto}
+- [x] CHK005 - As colunas deliberadamente ausentes do schema (`feature`,
+  `wave`, `execution_id`) tem racional citavel e auditavel? [Completude,
+  Data-Model §Colunas deliberadamente ausentes linhas 43-48] {auto}
+- [x] CHK006 - O gap de numeracao FR-012 → FR-014 (com `FR-013-INFRA-SCHED`
+  no lugar de `FR-013`) tem explicacao textual que evita parecer erro de
+  digitacao? [Completude, Spec § linhas 204-213 "Decisoes de
+  infraestrutura"] {auto}
+
+## Clareza de Requisitos
+
+- [x] CHK007 - FR-010 (throttle) define precisamente a tolerancia numerica
+  (2 casas decimais) e a base de comparacao (ULTIMO registro persistido do
+  escopo, sem janela temporal)? [Clareza, Spec §FR-010 + Clarifications
+  linhas 11-12] {auto}
+- [x] CHK008 - FR-002/FR-003/FR-004 distinguem claramente ausencia (`NULL`)
+  de valor real, sem depender de termo vago tipo "indisponivel" sem
+  definicao operacional? [Clareza, Spec §FR-002/FR-003/FR-004, Edge Cases
+  linhas 113-125] {auto}
+- [ ] CHK009 - **[CRITICAL]** O comportamento para "rate_limits ausente do
+  payload" e o MESMO em todos os artefatos que o descrevem? **Nao —
+  CONFLITO real entre artefatos**:
+  - `spec.md` FR-002 (linhas 147-150): "MUST persistir `NULL`... **nunca**
+    `0`" — linguagem MUST de persistencia, implica um registro E gravado.
+  - `spec.md` SC-002 (linha 238-240): "o dado persistido e explicitamente
+    ausente (NULL)" — de novo, implica que algo FOI persistido.
+  - `spec.md` User Story 3, Acceptance Scenario 2 (linhas 103-107): espera
+    que o historico contenha "capturas sem dado" distinguiveis das com
+    dado real — so faz sentido se essas capturas viram linhas na tabela.
+  - `data-model.md` linhas 69-80 (tabela "Ausencia explicita vs valor
+    real"): explicito — "o segundo caso [ausencia de `rate_limits`] gera
+    uma linha com `NULL` explicito".
+  - **CONTRADIZ** `contracts/statusline-hook.md` linha 60: "`.rate_limits`
+    ausente no payload → Pass-through normal; **NENHUM INSERT** (nao e
+    'captura com NULL' — e 'sessao sem nenhuma resposta de API')".
+  - **CONTRADIZ** `quickstart.md` Cenario 2, passo 2 (linha 22): "**nenhuma
+    linha nova** em `plan_usage`" apos processar payload sem `rate_limits`.
+
+  4 referencias em `spec.md`+`data-model.md` dizem "insere linha com NULL";
+  2 referencias em `contracts/`+`quickstart.md` dizem "nao insere nada".
+  Isto NAO e um caso trivial de "spec vence, corrigir o plano" — inserir
+  uma linha NULL a CADA render antes da 1a resposta de API (statusline
+  renderiza por evento, nao por polling — research.md Decision 1, ~2x/2min)
+  colide com FR-010 (ver CHK010): sem regra de comparacao NULL-vs-NULL, o
+  throttle nao dedupe essas linhas e a tabela cresce sem limite ate a
+  1a resposta de API completar. E plausivel que a escolha do plano
+  ("nenhum INSERT quando ausente") tenha sido deliberada para evitar esse
+  flooding, mas isso contradiz o texto MUST de FR-002/SC-002 sem
+  documentar a excecao em lugar nenhum. [Conflict, Spec §FR-002/SC-002/
+  User-Story-3 vs Contract statusline-hook.md §linha 60 vs Quickstart.md
+  §Cenario 2] {auto}
+- [ ] CHK010 - FR-010 (throttle) define o comportamento de comparacao
+  quando o ULTIMO registro persistido do escopo tem `used_percentage`/
+  `resets_at` = `NULL` e a nova captura tambem chega com `rate_limits`
+  ausente (NULL vs NULL)? **Nao** — o texto de FR-010 so define a
+  tolerancia para valores numericos reais ("bate ate a 2a casa decimal");
+  nao ha clausula para o caso NULL. Diretamente relevante para resolver
+  CHK009: se a decisao for "sempre inserir NULL" (lado spec.md), falta
+  aqui a regra que evita flooding. [Gap, Spec §FR-010] {auto}
+
+## Consistencia de Requisitos
+
+- [x] CHK011 - As 5 respostas da secao `## Clarifications` (Session
+  2026-08-10) estao todas refletidas em FRs correspondentes (throttle
+  tolerancia/janela → FR-010; dimensao projeto/sessao → FR-009; formato
+  `captured_at`/`ingested_at` → FR-014; flags de historico → FR-008)?
+  [Consistencia, Spec §Clarifications linhas 9-15 vs FR-008/009/010/014]
+  {auto}
+- [x] CHK012 - O `CHECK IN ('five_hour','seven_day')` de `data-model.md`
+  (linha 28) e consistente com FR-005 (escopos tratados como series
+  distintas) e com o default `--scope` (ambos, separados) de
+  `contracts/cli-plan-usage.md` (linha 71)? [Consistencia, Spec §FR-005,
+  Data-Model linha 28, Contract cli-plan-usage.md linha 71] {auto}
+- [x] CHK013 - `plan.md` §Constitution Check (linha ~89) confirma que os
+  carve-outs de `jq`/`sqlite3` sao REUSO de carve-outs ja vigentes
+  (`loose-usage-capture`/`cstk-cli`), nao uma excecao nova ao Principio II
+  (POSIX puro)? [Consistencia, Plan.md §Constitution Check linha 89,
+  Research.md Decision 3/6] {auto}
+
+## Qualidade de Criterios de Aceite / Mensurabilidade
+
+- [x] CHK014 - Cada Success Criterion (SC-001..SC-005) e objetivamente
+  verificavel sem instrumentacao adicional (ex.: "ausencia de chamada de
+  rede" para SC-005, "100% dos horarios interpretaveis como epoch" para
+  SC-004)? [Mensurabilidade, Spec §Success Criteria linhas 234-249] {auto}
+- [x] CHK015 - Os 7 cenarios de `quickstart.md` cobrem 1:1 os SC-001..
+  SC-005 (Cenario 1→SC-001, Cenario 2→SC-002, Cenario 4→SC-003, Cenario
+  5→SC-004, Cenario 6→SC-005) mais 2 cenarios adicionais de robustez
+  (Cenario 3 throttle/FR-010, Cenario 7 deps ausentes)? [Traceability,
+  Quickstart.md linhas 7-74] {auto}
+- [ ] CHK016 - O Cenario 2 do `quickstart.md`, que e o teste de aceite de
+  SC-002, esta escrito de forma consistente com a redacao de SC-002 (ver
+  CHK009 — mesmo conflito, agora do lado "teste de aceite")? **Nao** —
+  mesma raiz do CHK009: o passo 2 do Cenario 2 ("nenhuma linha nova") nao
+  bate com "o dado persistido e explicitamente ausente (NULL)" de SC-002.
+  [Conflict, Quickstart.md §Cenario 2 vs Spec §SC-002] {auto}
+
+## Cobertura de Cenarios / Edge Cases
+
+- [x] CHK017 - Happy path (User Story 1, captura + consulta) e Edge Cases
+  de ausencia/formato/ruido de float/throttle estao todos cobertos por
+  Acceptance Scenarios ou Edge Cases dedicados? [Cobertura, Spec §User
+  Story 1 + Edge Cases linhas 111-138] {auto}
+- [x] CHK018 - O gate deterministico `requirement-coverage.sh` confirma que
+  todos os 13 requisitos numerados (`FR-001..FR-012`, `FR-014`) tem pelo
+  menos um cenario associado? [Cobertura] {auto} — evidencia:
+  `RESULT|.../spec.md|requirements=13|covered=13|errors=0`, exit=0.
+- [x] CHK019 - Testabilidade sem sessao interativa real (`claude -p` nao
+  dispara a statusline) esta coberta tanto como requisito (FR-012) quanto
+  como mecanismo concreto de teste (`quickstart.md`, todos os 7 cenarios
+  via fixture stdin)? [Cobertura, Spec §FR-012, Research.md Decision 8]
+  {auto}
+- [ ] CHK020 - Existe cenario cobrindo concorrencia (duas invocacoes do
+  script de statusline em paralelo, ex.: renders simultaneos de duas
+  janelas do terminal na mesma sessao) escrevendo no `knowledge.db` ao
+  mesmo tempo? **Nao** — nenhum FR/Edge Case/cenario de `quickstart.md`
+  aborda concorrencia de escrita; `plan.md`/`research.md` tambem nao
+  mencionam locking/retry para este caminho especifico (so
+  `recall_apply_sql_with_retry`, citado no gate de seguranca do plan.md,
+  sem cenario de teste dedicado). [Gap, Spec §Edge Cases (ausente)] {auto}
+
+## Requisitos Nao-Funcionais
+
+- [x] CHK021 - Requisito de zero coleta remota (Principio IV) e testavel e
+  tem cenario dedicado? [NFR, Spec §FR-011, Quickstart.md §Cenario 6] {auto}
+- [ ] CHK022 - Ha requisito ou budget explicito de latencia/overhead
+  aceitavel adicionado pela captura por render da statusline (ex.: "captura
+  MUST adicionar no maximo Xms por render")? **Nao** — `contracts/
+  statusline-hook.md` linha 69 menciona "nenhuma chamada de rede, throttle
+  O(1)" como caracteristica de design, mas nao ha numero/threshold
+  verificavel em nenhum artefato. [Gap, Plan.md/Contract (sem numero)] {auto}
+- [x] CHK023 - Persistencia local exclusiva (Principio IV) e migracao
+  aditiva de schema (sem `ALTER`/`DROP`) estao ambas evidenciadas com
+  comando/linha real, nao suposicao? [Mensurabilidade, Data-Model
+  §Migracao linhas 61-67 — `RECALL_SCHEMA_VERSION` 13→14 medido via
+  `grep -n RECALL_SCHEMA_VERSION cli/lib/recall.sh`] {auto}
+
+## Dependencias e Premissas
+
+- [x] CHK024 - As dependencias opcionais confinadas (`jq`, `sqlite3`) tem
+  fallback definido para quando estao ausentes (captura pulada, pass-through
+  intacto, exit sempre 0)? [Completude, Contract statusline-hook.md §linhas
+  63-64, Quickstart.md §Cenario 7] {auto}
+- [x] CHK025 - A premissa de que `statusLine.command` e uma chave UNICA no
+  `settings.json` (nao um array, ao contrario de `hooks.PostToolUse[]`) foi
+  verificada empiricamente, nao suposta? [Assumption, Research.md Decision
+  1 linhas 10-25 — `grep -n statusLine` no repo inteiro = zero ocorrencias
+  previas] {auto}
+
+## Ambiguidades e Conflitos — Decisao do Dono do Produto
+
+- [ ] CHK026 - **[Escopo / regressao de rascunho original]** A exclusao de
+  `.cost` e `.context_window` do payload (fora de escopo desde FR-006, sem
+  coluna equivalente no schema — `data-model.md` nao lista nenhuma coluna
+  `session_cost_usd`/`session_input_tokens`/etc.) e uma reducao deliberada
+  frente ao rascunho de schema que o operador produziu ANTES desta feature
+  comecar, que continha as colunas: `session_cost_usd`,
+  `session_input_tokens`, `session_output_tokens`,
+  `cache_read_input_tokens`, `cache_creation_input_tokens` e `model_id`.
+  Consequencia colateral verificada: a regra nao-negociavel do plano de
+  onda "(d) rate_limits e gauge da CONTA; cost/context_window sao
+  cumulativos da SESSAO — agregar com MAX, jamais SUM" ficou sem objeto nos
+  artefatos (nenhuma coluna cumulativa de custo/contexto e persistida por
+  esta feature). **Pergunta ao dono do produto**: a exclusao de `.cost`/
+  `.context_window` (e das 5 colunas correlatas do rascunho original) foi
+  intencional para esta feature, ficando reservada para uma feature futura
+  dedicada a custo/tokens de sessao? Ou deveria ser reincluida agora,
+  antes de `create-tasks` gerar o backlog de schema? Se confirmado o corte:
+  a regra (d) fica formalmente N/A para `plan-usage-capture` (documentar
+  isso explicitamente evita reabrir a duvida numa proxima revisao). [Spec
+  §FR-006, Data-Model.md (colunas ausentes), fora do rascunho original do
+  operador] {humano}
+
+## Notes
+
+- Items `{auto}` ja vem resolvidos pelo agente (`[x]` com citacao, ou
+  marcador `[Gap]`/`[Ambiguity]`/`[Conflict]`).
+- Items `{humano}` ficam `[ ]` aguardando decisao do dono do produto.
+- **Achado mais critico desta rodada**: CHK009/CHK010/CHK016 descrevem o
+  MESMO conflito sob 3 angulos (requisito, throttle, cenario de teste) — o
+  comportamento de "rate_limits ausente" diverge entre `spec.md`/
+  `data-model.md` (inserir linha com NULL) e `contracts/statusline-hook.md`/
+  `quickstart.md` (nao inserir nada). Isto precisa ser resolvido via
+  `/clarify` (ou correcao direta do plano, se o operador confirmar qual
+  lado esta certo) ANTES de `create-tasks` decompor a tarefa de ingestao —
+  as duas leituras geram implementacoes e testes de aceite incompativeis.

--- a/docs/specs/plan-usage-capture/checklists/requirements.md
+++ b/docs/specs/plan-usage-capture/checklists/requirements.md
@@ -59,7 +59,17 @@ um dominio unico dominante.
   de valor real, sem depender de termo vago tipo "indisponivel" sem
   definicao operacional? [Clareza, Spec §FR-002/FR-003/FR-004, Edge Cases
   linhas 113-125] {auto}
-- [ ] CHK009 - **[CRITICAL]** O comportamento para "rate_limits ausente do
+- [x] CHK009 - **RESOLVIDO (dec-029, onda-005)**: sistema MUST NOT
+  inserir linha quando `rate_limits` ausente por completo; ausencia de
+  linha E o estado "nao medido" (leitura, nao escrita). `spec.md`
+  FR-002/SC-002/User Story 3 (Independent Test + Acceptance Scenarios
+  1-2) corrigidos para alinhar a `contracts/statusline-hook.md` e
+  `quickstart.md` Cenario 2, que ja estavam certos. `data-model.md`
+  atualizado (tabela "Ausencia explicita vs valor real" agora tripla:
+  sem-linha-por-throttle / sem-linha-por-ausencia-total / NULL-por-
+  ausencia-parcial-dentro-de-escopo-presente). `plan.md` (linhas
+  Fio condutor, Constitution Check VI, Re-check, Riscos) tambem
+  corrigido. **[CRITICAL]** O comportamento para "rate_limits ausente do
   payload" e o MESMO em todos os artefatos que o descrevem? **Nao —
   CONFLITO real entre artefatos**:
   - `spec.md` FR-002 (linhas 147-150): "MUST persistir `NULL`... **nunca**
@@ -91,7 +101,23 @@ um dominio unico dominante.
   documentar a excecao em lugar nenhum. [Conflict, Spec §FR-002/SC-002/
   User-Story-3 vs Contract statusline-hook.md §linha 60 vs Quickstart.md
   §Cenario 2] {auto}
-- [ ] CHK010 - FR-010 (throttle) define o comportamento de comparacao
+- [x] CHK010 - **RESOLVIDO (dec-029, onda-005)**: pergunta ficou sem
+  objeto no caminho principal — como a ausencia TOTAL de `rate_limits`
+  nunca gera INSERT (CHK009), o throttle de FR-010 nunca precisa comparar
+  `used_percentage`/`resets_at` = `NULL` contra `NULL` no fluxo normal.
+  Resta um caso residual NAO coberto por dec-029 nem observado
+  empiricamente (memoria `reference_statusline_usage_payload.md` mostra
+  os dois campos sempre juntos quando o escopo esta presente): se um
+  escopo ja tiver uma linha com `NULL` persistido por ausencia PARCIAL
+  (defensivo) e a proxima captura do MESMO escopo repetir esse `NULL`,
+  o comportamento exato do throttle para esse par NULL-vs-NULL fica
+  indefinido — nenhuma implementacao concreta foi escrita ainda (feature
+  em `plan`/`checklist`). Marcado resolvido porque deixou de ser
+  CRITICAL/bloqueante (o caminho dominante — ausencia total — esta
+  coberto); `create-tasks` DEVE incluir uma task explicita para decidir e
+  implementar essa comparacao residual quando escrever
+  `cli/lib/plan-usage.sh` (nao inventar aqui, sem codigo, qual e o
+  comportamento certo). FR-010 (throttle) define o comportamento de comparacao
   quando o ULTIMO registro persistido do escopo tem `used_percentage`/
   `resets_at` = `NULL` e a nova captura tambem chega com `rate_limits`
   ausente (NULL vs NULL)? **Nao** — o texto de FR-010 so define a
@@ -130,7 +156,10 @@ um dominio unico dominante.
   5→SC-004, Cenario 6→SC-005) mais 2 cenarios adicionais de robustez
   (Cenario 3 throttle/FR-010, Cenario 7 deps ausentes)? [Traceability,
   Quickstart.md linhas 7-74] {auto}
-- [ ] CHK016 - O Cenario 2 do `quickstart.md`, que e o teste de aceite de
+- [x] CHK016 - **RESOLVIDO (dec-029, onda-005)**: `quickstart.md` Cenario
+  2 estava CERTO desde a onda-003; era `spec.md` (SC-002 + FR-002 + User
+  Story 3) que estava fora de linha, agora corrigida para "nenhuma linha
+  inserida" (mesmo texto do CHK009). O Cenario 2 do `quickstart.md`, que e o teste de aceite de
   SC-002, esta escrito de forma consistente com a redacao de SC-002 (ver
   CHK009 — mesmo conflito, agora do lado "teste de aceite")? **Nao** —
   mesma raiz do CHK009: o passo 2 do Cenario 2 ("nenhuma linha nova") nao
@@ -191,7 +220,17 @@ um dominio unico dominante.
 
 ## Ambiguidades e Conflitos — Decisao do Dono do Produto
 
-- [ ] CHK026 - **[Escopo / regressao de rascunho original]** A exclusao de
+- [x] CHK026 - **RESOLVIDO (dec-030, onda-005 — decisao consciente do
+  dono do produto)**: corte CONFIRMADO. Condicao do operador ("reincluir
+  so se houver perda de dado existente ou de funcionalidade do painel")
+  verificada empiricamente como FALSA nos dois lados: `plan_usage` e
+  tabela NOVA (`SELECT name FROM sqlite_master WHERE name='plan_usage'`
+  -> vazio, nada a perder) e a migracao e aditiva pura (`CREATE TABLE IF
+  NOT EXISTS`, v13->v14, sem `ALTER`/`DROP`); o dado de custo/token que o
+  painel consome vive em `waves` (1176 linhas), `wave_model_usage` (109)
+  e `loose_usage` (1), todas intocadas por esta feature. `data-model.md`
+  §Colunas deliberadamente AUSENTES agora documenta explicitamente o
+  corte e a regra (d) N/A. [Escopo / regressao de rascunho original] A exclusao de
   `.cost` e `.context_window` do payload (fora de escopo desde FR-006, sem
   coluna equivalente no schema — `data-model.md` nao lista nenhuma coluna
   `session_cost_usd`/`session_input_tokens`/etc.) e uma reducao deliberada
@@ -226,3 +265,21 @@ um dominio unico dominante.
   `/clarify` (ou correcao direta do plano, se o operador confirmar qual
   lado esta certo) ANTES de `create-tasks` decompor a tarefa de ingestao —
   as duas leituras geram implementacoes e testes de aceite incompativeis.
+- **Update onda-005**: CHK009/CHK010/CHK016 (conflito) e CHK026 ({humano})
+  RESOLVIDOS — ver dec-029/dec-030 e as citacoes `[x]` acima. Artefatos
+  corrigidos: `spec.md` (FR-002/FR-007/SC-002/User Story 3/Edge Case/
+  Clarifications), `data-model.md` (tabela de ausencia + colunas
+  ausentes), `plan.md` (Constitution Check/Re-check/Riscos/Fio condutor).
+  `contracts/statusline-hook.md` e `quickstart.md` nao precisaram de
+  mudanca — ja estavam corretos.
+- **Reavaliacao dos demais items abertos (onda-005)**: CHK002 (Ambiguity,
+  FR-006 nao lista literalmente os 8 campos excluidos que o contrato
+  cita), CHK003 (Gap, risco de sobrescrita de `statusLine.command`
+  customizado so no plan.md), CHK004 (Gap, fail-open best-effort so no
+  contrato/quickstart), CHK020 (Gap, concorrencia de escrita nao
+  coberta), CHK022 (Gap, sem budget numerico de latencia) permanecem
+  `[ ]` — nao afetados pelas duas decisoes desta onda (dec-029/dec-030),
+  todos sao gaps de completude de documentacao, nenhum e CRITICAL nem
+  {humano}, nenhum bloqueia `create-tasks` por si so. Ficam como debt
+  documentado; `create-tasks` PODE gerar tasks dedicadas para fecha-los
+  (ex.: adicionar FR/Edge Case faltante) a seu criterio.

--- a/docs/specs/plan-usage-capture/contracts/cli-plan-usage.md
+++ b/docs/specs/plan-usage-capture/contracts/cli-plan-usage.md
@@ -1,0 +1,122 @@
+# Contracts: `cstk plan-usage` `[PROPOSTA — a validar na implementacao]`
+
+Superficie de consulta do uso do plano (FR-007/FR-008). Subcomando NOVO —
+**nao existe hoje**. Lista atual de subcomandos do dispatch em `cli/cstk`
+(`grep -n 'case "\$1"' -A40 cli/cstk`, verificado nesta onda): `install |
+update | self-update | list | doctor | session | serve | recall |
+show-tip | hooks | state | mcp | usage` — `plan-usage` esta livre.
+
+Convencoes herdadas do CLI existente: mensagens de erro em stderr, dados
+em stdout, exit `0` sucesso / `1` erro geral / `2` uso incorreto
+(Constitution II).
+
+---
+
+## `cstk plan-usage` (uso mais recente — FR-007)
+
+**Comando**: `cstk plan-usage [--json] [--db PATH]`
+
+Retorna a captura mais recente de `five_hour` e `seven_day`, sem
+credencial OAuth.
+
+### Parametros
+
+| Flag | Type | Required | Validation |
+|------|------|----------|------------|
+| `--json` | flag | nao | Saida maquina-legivel em vez de texto |
+| `--db` | path | nao | Override do `knowledge.db` (paridade com `cstk usage --db`) |
+
+### Saida (texto, exit 0)
+
+Duas linhas, uma por escopo: percentual usado + horario de reset
+(convertido para local time na apresentacao — a persistencia continua
+epoch, FR-003). Campo sem medicao imprime **`nao medido`**, nunca `0`
+(FR-002/SC-002).
+
+### Saida (`--json`, exit 0)
+
+```json
+{
+  "five_hour": {"used_percentage": 7.000000000000001, "resets_at": 1786372200, "captured_at": "2026-08-10T13:00:00Z"},
+  "seven_day": {"used_percentage": null, "resets_at": null, "captured_at": null}
+}
+```
+
+`used_percentage`/`resets_at`/`captured_at` sao `null` JSON quando o
+escopo nunca teve nenhuma captura com `rate_limits` presente — a ausencia
+e representada por `null`, nunca por `0` (SC-002).
+
+### Comportamento sem dados
+
+| Situacao | Saida | Exit |
+|----------|-------|------|
+| `knowledge.db` ausente | Aviso em stderr + `nao medido` para os 2 escopos | 0 |
+| Tabela `plan_usage` vazia | `nao medido — nenhuma captura registrada ainda` | 0 |
+| `sqlite3` ausente | Aviso em stderr explicando a dep | 1 |
+| Flag desconhecida | Uso em stderr | 2 |
+
+---
+
+## `cstk plan-usage history` (serie temporal — FR-008)
+
+**Comando**: `cstk plan-usage history [--scope five_hour|seven_day] [--limit N] [--since ISO] [--json] [--db PATH]`
+
+Atende FR-008/User Story 2: evolucao do uso ao longo do tempo, por
+escopo, em ordem cronologica.
+
+### Parametros
+
+| Flag | Type | Required | Validation |
+|------|------|----------|------------|
+| `--scope` | enum `five_hour`\|`seven_day` | nao | Default: ambos os escopos, series separadas (FR-005) |
+| `--limit` | int | nao | Inteiro positivo; default `20` — **reusa literalmente a mesma convencao de `cstk usage --limit`** (dec-014/Q5, resolvida via bloqueio `block-002`) |
+| `--since` | ISO 8601 | nao | Filtra por `captured_at >= valor` — **reusa a mesma flag de `cstk usage --since`** (dec-014) |
+| `--json` | flag | nao | Saida maquina-legivel |
+| `--db` | path | nao | Override do `knowledge.db` |
+
+**Sem convencao nova de paginacao**: dec-014 e explicita — nao inventar
+cursor/offset novo; `--limit`/`--since` sao os UNICOS controles, ja
+existentes em `cstk usage` e agora reusados aqui verbatim.
+
+### Saida (texto, exit 0)
+
+Uma secao por escopo (quando `--scope` omitido, as duas secoes aparecem,
+nunca misturadas — FR-005), cada uma com ate `--limit` linhas em ordem
+cronologica: timestamp (`captured_at`) + percentual usado.
+
+### Saida (`--json`, exit 0)
+
+```json
+{
+  "five_hour": [
+    {"used_percentage": 6.5, "resets_at": 1786372200, "captured_at": "2026-08-10T12:00:00Z"},
+    {"used_percentage": 7.0, "resets_at": 1786372200, "captured_at": "2026-08-10T13:00:00Z"}
+  ]
+}
+```
+
+Chave presente so para o(s) escopo(s) pedido(s); array vazio (nao `null`)
+quando o escopo existe mas nao tem captura no filtro pedido.
+
+### Comportamento sem dados
+
+Mesma tabela de `cstk plan-usage` acima (`knowledge.db` ausente / tabela
+vazia / `sqlite3` ausente / flag desconhecida).
+
+---
+
+## `cstk plan-usage ingest --stdin` (uso interno, NAO documentado como
+superficie publica)
+
+Consumido exclusivamente por
+`plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh`
+(research.md Decision 6) — recebe o payload bruto da statusline via stdin,
+aplica o throttle (FR-010) e insere em `plan_usage` quando aplicavel.
+Sem flags de usuario, sem entrada na tabela de help publica de
+`cstk plan-usage --help` (mesmo tratamento que outros subcomandos internos
+do dispatch, se existirem precedentes — a decomposicao exata fica para
+`create-tasks`).
+
+Exit sempre `0` mesmo em erro interno (o hook que o invoca NUNCA pode
+propagar falha para a sessao do operador — FR-011/Principio IV, mesma
+disciplina fail-open de `posttooluse-loose-usage.sh`).

--- a/docs/specs/plan-usage-capture/contracts/statusline-hook.md
+++ b/docs/specs/plan-usage-capture/contracts/statusline-hook.md
@@ -1,0 +1,81 @@
+# Contract: `statusline-plan-usage.sh` `[PROPOSTA — a validar na implementacao]`
+
+Ponto de entrada de captura, configurado via `statusLine.command` no
+`settings.json` do harness (research.md Decision 1). Nao existe hoje —
+`grep -rn statusLine` no repo inteiro nao retorna nenhuma ocorrencia
+anterior a esta feature.
+
+## Invocacao
+
+O harness Claude Code invoca o comando configurado em
+`statusLine.command`, alimentando o JSON completo do estado da sessao no
+**stdin** do processo, e espera o texto a ser renderizado na UI no
+**stdout** (memoria `reference_statusline_usage_payload.md`, schema
+completo).
+
+```
+<statusLine.command> < payload.json > texto_renderizado
+```
+
+## Contrato de entrada (payload — schema OBSERVADO, nao inferido)
+
+Ver memoria `reference_statusline_usage_payload.md` para o schema completo
+verificado empiricamente (Claude Code 2.1.226, macOS, 2026-08-10). Campos
+consumidos por esta feature:
+
+| Campo | Presenca | Uso |
+|-------|----------|-----|
+| `.session_id` | sempre | `plan_usage.session_id` |
+| `.workspace.current_dir` / `.workspace.project_dir` | sempre | `plan_usage.project_path` (basename -> `project`) |
+| `.rate_limits.five_hour.used_percentage` | so apos 1a resposta de API completar na sessao | `plan_usage.used_percentage` (scope=`five_hour`) |
+| `.rate_limits.five_hour.resets_at` | idem | `plan_usage.resets_at` (scope=`five_hour`) |
+| `.rate_limits.seven_day.*` | idem | mesma logica, scope=`seven_day` |
+
+Campos NAO consumidos por esta feature (fora de escopo, FR-006):
+`.model`, `.cost`, `.context_window`, `.exceeds_200k_tokens`,
+`.thinking`, `.effort`, `.output_style`, `.version`.
+
+## Contrato de saida (obrigatorio — research.md Decision 2)
+
+O script MUST imprimir em stdout o texto que a UI deve renderizar,
+independente de a captura ter sucesso ou falha:
+
+1. Se `CSTK_STATUSLINE_INNER_COMMAND` estiver definida: reencaminhar o
+   payload original (stdin, sem modificacao) para o comando dela e
+   repassar o stdout verbatim.
+2. Senao: imprimir fallback minimo de 1 linha, construido so a partir de
+   `model.display_name` e (quando presente nesta mesma captura)
+   `rate_limits.five_hour.used_percentage`.
+
+**Nunca** imprimir erro de diagnostico da captura (jq ausente, sqlite3
+ausente, `knowledge.db` sem permissao de escrita) em stdout — isso
+contaminaria a UI. Erros de captura, se logados, vao para stderr
+(consistente com Constitution II) ou sao descartados silenciosamente
+(fail-open, mesma disciplina de `posttooluse-loose-usage.sh`).
+
+## Comportamento de captura (best-effort, nunca bloqueante)
+
+| Situacao | Comportamento |
+|----------|----------------|
+| `.rate_limits` ausente no payload | Pass-through normal; NENHUM INSERT (nao e "captura com NULL" — e "sessao sem nenhuma resposta de API", Edge Case da spec); throttle nao se aplica porque nao ha valor novo a comparar |
+| `.rate_limits` presente, `used_percentage` identico ao ultimo registro do escopo ate 2 casas decimais E `resets_at` igual | Pass-through normal; captura descartada pelo throttle (FR-010), nenhum INSERT |
+| `.rate_limits` presente, valor mudou alem de 2 casas decimais OU `resets_at` mudou | Pass-through normal + INSERT em `plan_usage` (via `cstk plan-usage ingest --stdin`) |
+| `jq` ausente | Pass-through normal; captura pulada (Decision 3 do research.md) |
+| `sqlite3`/`knowledge.db` indisponivel | Pass-through normal; captura pulada |
+| Payload malformado (JSON invalido) | Pass-through normal (best-effort — tenta repassar stdin cru); captura pulada |
+
+Em NENHUM cenario o script sai com codigo diferente de `0`, nem atrasa a
+renderizacao da UI de forma perceptivel (mesmo teto implicito de
+`posttooluse-loose-usage.sh`: nenhuma chamada de rede, throttle O(1) no
+caminho de leitura).
+
+## Teste (FR-012 — sem sessao interativa real)
+
+```sh
+printf '%s' "$FIXTURE_PAYLOAD" | statusline-plan-usage.sh
+```
+
+`$FIXTURE_PAYLOAD` e um JSON fixture estatico (variantes: com
+`rate_limits`, sem `rate_limits`, com `rate_limits` repetido dentro da
+tolerancia de throttle) — nunca uma sessao `claude` real (GOTCHA: a
+statusline nao dispara em `claude -p`).

--- a/docs/specs/plan-usage-capture/contracts/statusline-hook.md
+++ b/docs/specs/plan-usage-capture/contracts/statusline-hook.md
@@ -65,9 +65,23 @@ contaminaria a UI. Erros de captura, se logados, vao para stderr
 | Payload malformado (JSON invalido) | Pass-through normal (best-effort — tenta repassar stdin cru); captura pulada |
 
 Em NENHUM cenario o script sai com codigo diferente de `0`, nem atrasa a
-renderizacao da UI de forma perceptivel (mesmo teto implicito de
-`posttooluse-loose-usage.sh`: nenhuma chamada de rede, throttle O(1) no
-caminho de leitura).
+renderizacao da UI de forma perceptivel — nenhuma chamada de rede,
+throttle O(1) no caminho de leitura (`SELECT ... ORDER BY id DESC LIMIT 1`
+por escopo, mesmo custo de `recall_apply_sql_with_retry`).
+
+**Threshold verificavel (CHK022, politica de design — nao medicao
+empirica)**: a captura completa (parse do payload + throttle + INSERT,
+quando aplicavel) MUST adicionar no maximo **50ms** de latencia por
+render em relacao ao pass-through puro (sem captura). Este e um orcamento
+de design, na mesma ordem de grandeza do teto de 5s de timeout de hook do
+harness (`docs/specs/_archived/2026-08-08-loose-usage-capture/contracts/hook-loose-usage.md`,
+linha 22) dividido por um fator
+de folga generoso para uma operacao sincrona e visivel ao operador a cada
+render — nao uma medicao ja realizada nesta feature. FASE 5 (task 5.1)
+MUST validar esse orcamento empiricamente com `time` sobre o script com
+fixtures reais antes de declarar o requisito atendido; se a medicao real
+exceder 50ms de forma consistente, o numero MUST ser revisto via Decisao
+auditavel (nao silenciosamente ignorado).
 
 ## Teste (FR-012 — sem sessao interativa real)
 

--- a/docs/specs/plan-usage-capture/contracts/statusline-hook.md
+++ b/docs/specs/plan-usage-capture/contracts/statusline-hook.md
@@ -13,7 +13,7 @@ O harness Claude Code invoca o comando configurado em
 **stdout** (memoria `reference_statusline_usage_payload.md`, schema
 completo).
 
-```
+```text
 <statusLine.command> < payload.json > texto_renderizado
 ```
 

--- a/docs/specs/plan-usage-capture/data-model.md
+++ b/docs/specs/plan-usage-capture/data-model.md
@@ -86,16 +86,31 @@ literal de `loose_usage` na migracao v12->v13 (research.md Decision 7).
 | `rate_limits.<scope>` presente com uso genuinamente `0%` (hipotetico, nunca observado) | Sim | `0.0` (valor real medido) | epoch real |
 | Throttle descarta a captura (repeticao dentro de 2 casas decimais) | Nao — nenhuma linha nova e inserida | (idem) | (idem) |
 
-A distincao agora e tripla (dec-029, resolve CHK009/CHK010/CHK016):
+A distincao agora e tripla (dec-029, resolve CHK009/CHK016):
 "sem linha nova por throttle" (repeticao redundante, by design), "sem
 linha por ausencia TOTAL de `rate_limits`" (nenhuma resposta de API
 completou — a ausencia de linha E o estado "nao medido"; a leitura via
 CLI MUST mostrar "nao medido", nunca `0%`) e "linha com `NULL` explicito
 por ausencia PARCIAL" (escopo presente mas um dos dois campos veio
 ausente/nulo dentro dele — caso defensivo, coluna permanece NULLABLE).
-Isto tambem resolve o gap de FR-010 (NULL-vs-NULL no throttle): como a
-ausencia total nunca gera INSERT, nao ha comparacao NULL-vs-NULL a fazer
-no caminho de throttle.
+
+**Residual CHK010 — NULL-vs-NULL no throttle (dec-050, corrige F4/dec-043
+do gate analyze)**: o paragrafo acima resolve so a ausencia TOTAL (nenhum
+INSERT candidato existe, logo nao ha comparacao a fazer). Existe um
+segundo caso, distinto: o ULTIMO registro persistido do escopo tem
+`used_percentage`/`resets_at` = `NULL` (ausencia PARCIAL ja persistida,
+linha 85) e a NOVA captura do MESMO escopo TAMBEM chega com o campo
+ausente dentro do escopo presente (mesma condicao defensiva/malformada
+se repetindo). Decisao (dec-050): **NULL-vs-NULL conta como "identico"
+e a captura e descartada pelo throttle** — extensao natural da regra
+geral de 2.3.2 (compara via SQL `IS` em vez de `=`, de forma que
+`NULL IS NULL` avalie verdadeiro sem caso especial no codigo). A
+alternativa ("sempre persiste" ausencia) foi descartada porque geraria
+crescimento ilimitado da tabela caso a API mantenha o mesmo estado
+malformado a cada render — o que contraria o proprio proposito do
+FR-010. Nao ha fabricacao de dado envolvida: a ausencia ja foi
+persistida uma vez (`NULL` verdadeiro); repetir a mesma ausencia nao
+carrega informacao nova.
 
 ### Concorrencia (CHK020)
 

--- a/docs/specs/plan-usage-capture/data-model.md
+++ b/docs/specs/plan-usage-capture/data-model.md
@@ -1,0 +1,80 @@
+# Data Model: Plan Usage Capture
+
+Camada unica de persistencia (ao contrario de `loose-usage-capture`, que
+tem sidecar + indice): o dado ja chega pronto no stdin da statusline a
+cada render (research.md Decision 4), entao nao ha necessidade de uma
+camada de captura intermediaria em arquivo — a tabela `plan_usage` do
+`knowledge.db` **e** a fonte persistida.
+
+Schema marcado `[PROPOSTA — a validar na implementacao]` ainda nao existe
+no codigo. Citado com arquivo e linha o que ja existe hoje.
+
+---
+
+## Entity: Captura de Uso do Plano (tabela `plan_usage`) `[PROPOSTA]`
+
+Grao: uma linha por (escopo, momento de captura) — apos o throttle de
+FR-010 ja ter descartado repeticoes identicas. Append-only (nunca UPDATE
+nem UPSERT — ao contrario de `loose_usage`, nao ha chave natural
+mutavel a atualizar; cada linha e um ponto imutavel da serie temporal,
+FR-008/User Story 2).
+
+| Field | Type | Constraints | Notes |
+|-------|------|-------------|-------|
+| `id` | INTEGER | PK AUTOINCREMENT | Padrao das demais tabelas do `knowledge.db` |
+| `project` | TEXT | NOT NULL | Basename de `project_path`; paridade com `loose_usage.project` |
+| `project_path` | TEXT | — | `workspace.current_dir` ou `workspace.project_dir` do payload (memoria linha 21) |
+| `session_id` | TEXT | NOT NULL | Copiado verbatim de `session_id` no topo do payload (memoria linha 19) — ver research.md Decision 5 para o porque do nome divergir de `session` |
+| `scope` | TEXT | NOT NULL, CHECK IN ('five_hour','seven_day') | FR-005: escopos tratados como series distintas, nunca mesclados |
+| `used_percentage` | REAL | — | **NULL quando `rate_limits` ausente** — jamais `0` fabricado (FR-002/FR-004/Principio VI). Persistido sem arredondar (FR-004), inclusive com ruido de float (`7.000000000000001`, memoria linha 32) |
+| `resets_at` | INTEGER | — | Epoch em SEGUNDOS (FR-003), **NULL quando `rate_limits` ausente**. Distinto de `captured_at`/`ingested_at` (ver abaixo) |
+| `captured_at` | TEXT | NOT NULL | ISO 8601 (`2026-08-07T04:38:14Z`) — momento em que o hook processou o render (FR-014) |
+| `ingested_at` | TEXT | NOT NULL | ISO 8601 — momento da escrita no `knowledge.db` (FR-014); pode ser identico a `captured_at` porque nao ha camada intermediaria de sidecar (diferente de `loose_usage`, onde `captured_at` vem do sidecar e `ingested_at` do momento de leitura posterior) |
+
+**Sem `UNIQUE` de chave natural** — ao contrario de `loose_usage`
+(`UNIQUE(process_key, segment_id, model)`), nao ha upsert aqui: o throttle
+(FR-010, research.md Decision 4) e uma leitura **antes** do INSERT
+(`SELECT ... ORDER BY id DESC LIMIT 1 WHERE scope = ?`), nao uma
+constraint de banco. A escolha e deliberada — a chave natural candidata
+(`scope` + `captured_at`) colidiria em testes que geram fixtures no mesmo
+segundo, e o requisito real (FR-010) e sobre o VALOR anterior, nao sobre
+timestamp duplicado.
+
+**Colunas deliberadamente AUSENTES**: `feature`, `wave`, `execution_id`
+(mesma logica de `loose_usage` — a captura acontece fora de qualquer
+execucao `agente-00c`/`feature-00c`, preencher esses campos seria
+fabricar dado, Constitution VI); `seven_day_opus`, `seven_day_sonnet`,
+`extra_usage` (FR-006 — exigem OAuth, fora de escopo; nenhuma coluna e
+criada para campos que a fonte nunca emite).
+
+### Relationships
+
+- Sem FK declarada para `executions`/`waves`/`loose_usage` — `plan_usage`
+  e um indice independente, capturado fora de qualquer execucao de
+  pipeline (mesmo racional de independencia de `loose_usage`, ver plan.md
+  arquivado de `loose-usage-capture` §Relationships).
+- `plan_usage.project_path` pode coincidir com `loose_usage.project_path`
+  ou `executions.target_project_path` (mesmo projeto), mas a comparacao —
+  se algum dia existir — seria agregacao lado a lado, nunca JOIN linha a
+  linha (granularidades e cadencias de captura diferentes).
+
+### Migracao
+
+`RECALL_SCHEMA_VERSION`: `13` -> `14` (valor real medido nesta onda via
+`grep -n RECALL_SCHEMA_VERSION cli/lib/recall.sh`: `13`). Aditiva pura:
+`CREATE TABLE IF NOT EXISTS plan_usage (...)` no corpo de
+`recall_schema_ddl`, sem `ALTER TABLE` e sem `DROP` — mesmo precedente
+literal de `loose_usage` na migracao v12->v13 (research.md Decision 7).
+
+### Ausencia explicita vs valor real (SC-002, FR-002)
+
+| Situacao | `used_percentage` | `resets_at` |
+|----------|--------------------|-------------|
+| `rate_limits` ausente do payload (nenhuma resposta de API completou) | `NULL` | `NULL` |
+| `rate_limits.<scope>` presente com uso genuinamente `0%` (hipotetico, nunca observado) | `0.0` (valor real medido) | epoch real |
+| Throttle descarta a captura (repeticao dentro de 2 casas decimais) | (nenhuma linha nova é inserida) | (idem) |
+
+A distincao entre "sem linha nova por throttle" e "sem dado por
+ausencia de `rate_limits`" e estrutural: o primeiro caso nao gera INSERT
+algum (nenhuma linha, redundante por design); o segundo gera uma linha com
+`NULL` explicito (User Story 3 — nunca confundir "nao medido" com "zero").

--- a/docs/specs/plan-usage-capture/data-model.md
+++ b/docs/specs/plan-usage-capture/data-model.md
@@ -96,3 +96,30 @@ ausente/nulo dentro dele — caso defensivo, coluna permanece NULLABLE).
 Isto tambem resolve o gap de FR-010 (NULL-vs-NULL no throttle): como a
 ausencia total nunca gera INSERT, nao ha comparacao NULL-vs-NULL a fazer
 no caminho de throttle.
+
+### Concorrencia (CHK020)
+
+`statusline-plan-usage.sh` e invocado pelo harness a cada render de UI —
+em teoria, duas invocacoes podem sobrepor (ex.: dois panes/sessoes do
+mesmo operador renderizando quase simultaneamente) e tentar `INSERT` em
+`plan_usage` ao mesmo tempo. `recall_apply_sql_with_retry()`
+(`cli/lib/recall.sh`) ja cobre esse caso: ate 4 tentativas com backoff +
+jitter por-PID em `SQLITE_BUSY`/`SQLITE_LOCKED` (mesmo mecanismo usado
+por TODAS as demais tabelas do `knowledge.db`, incluindo `loose_usage`).
+Isso e considerado SUFICIENTE para `plan_usage` sem mecanismo adicional,
+porque:
+
+- Append-only sem `UNIQUE`/`UPSERT` — nao ha janela de leitura-modificacao-
+  escrita a proteger (ao contrario de um contador ou upsert), so um
+  `INSERT` isolado por captura.
+- O throttle (FR-010) le o ultimo registro ANTES do `INSERT` (nao dentro
+  da mesma transacao) — na pior hipotese de corrida entre duas invocacoes
+  concorrentes, o resultado e no maximo uma linha redundante extra
+  persistida (nao um dado corrompido nem uma linha perdida), o que e
+  aceitavel para uma serie de observabilidade local de baixo volume.
+- Falha apos esgotar os 4 retries e fail-open (FR-015): a captura e
+  descartada silenciosamente, a statusline segue renderizando normalmente.
+
+Nenhum mutex/lock adicional (ex.: `state-lock.sh`) e introduzido para
+esta feature — seria over-engineering para um indice derivado de baixo
+volume onde a pior consequencia de corrida e uma linha redundante.

--- a/docs/specs/plan-usage-capture/data-model.md
+++ b/docs/specs/plan-usage-capture/data-model.md
@@ -26,8 +26,8 @@ FR-008/User Story 2).
 | `project_path` | TEXT | — | `workspace.current_dir` ou `workspace.project_dir` do payload (memoria linha 21) |
 | `session_id` | TEXT | NOT NULL | Copiado verbatim de `session_id` no topo do payload (memoria linha 19) — ver research.md Decision 5 para o porque do nome divergir de `session` |
 | `scope` | TEXT | NOT NULL, CHECK IN ('five_hour','seven_day') | FR-005: escopos tratados como series distintas, nunca mesclados |
-| `used_percentage` | REAL | — | **NULL quando `rate_limits` ausente** — jamais `0` fabricado (FR-002/FR-004/Principio VI). Persistido sem arredondar (FR-004), inclusive com ruido de float (`7.000000000000001`, memoria linha 32) |
-| `resets_at` | INTEGER | — | Epoch em SEGUNDOS (FR-003), **NULL quando `rate_limits` ausente**. Distinto de `captured_at`/`ingested_at` (ver abaixo) |
+| `used_percentage` | REAL | — | `NULL` quando o campo esta ausente/nulo dentro de um escopo PRESENTE (caso defensivo/malformado) — jamais `0` fabricado (FR-002/FR-004/Principio VI). Quando `rate_limits` esta ausente por completo, NENHUMA linha e inserida (dec-029) — este campo so existe em linhas ja inseridas. Persistido sem arredondar (FR-004), inclusive com ruido de float (`7.000000000000001`, memoria linha 32) |
+| `resets_at` | INTEGER | — | Epoch em SEGUNDOS (FR-003). `NULL` quando ausente/nulo dentro de um escopo presente (dec-029) — ausencia TOTAL de `rate_limits` nao gera linha. Distinto de `captured_at`/`ingested_at` (ver abaixo) |
 | `captured_at` | TEXT | NOT NULL | ISO 8601 (`2026-08-07T04:38:14Z`) — momento em que o hook processou o render (FR-014) |
 | `ingested_at` | TEXT | NOT NULL | ISO 8601 — momento da escrita no `knowledge.db` (FR-014); pode ser identico a `captured_at` porque nao ha camada intermediaria de sidecar (diferente de `loose_usage`, onde `captured_at` vem do sidecar e `ingested_at` do momento de leitura posterior) |
 
@@ -45,7 +45,18 @@ timestamp duplicado.
 execucao `agente-00c`/`feature-00c`, preencher esses campos seria
 fabricar dado, Constitution VI); `seven_day_opus`, `seven_day_sonnet`,
 `extra_usage` (FR-006 — exigem OAuth, fora de escopo; nenhuma coluna e
-criada para campos que a fonte nunca emite).
+criada para campos que a fonte nunca emite); `.cost`/`.context_window` e
+as colunas de custo/tokens de sessao correlatas (`session_cost_usd`,
+`session_input_tokens`, `session_output_tokens`,
+`cache_read_input_tokens`, `cache_creation_input_tokens`, `model_id` —
+presentes no rascunho de schema original do operador, anterior a esta
+feature) — corte de escopo CONFIRMADO (dec-030, CHK026): `plan_usage`
+cobre exclusivamente o gauge `rate_limits` da CONTA; custo/tokens de
+SESSAO ficam reservados para uma feature futura dedicada. Consequencia
+formal: a regra "cost/context_window sao cumulativos da SESSAO — agregar
+com MAX, jamais SUM" (memoria `reference_statusline_usage_payload.md`)
+fica **N/A para esta feature**, por ausencia de qualquer coluna
+cumulativa persistida por `plan_usage`.
 
 ### Relationships
 
@@ -66,15 +77,22 @@ criada para campos que a fonte nunca emite).
 `recall_schema_ddl`, sem `ALTER TABLE` e sem `DROP` — mesmo precedente
 literal de `loose_usage` na migracao v12->v13 (research.md Decision 7).
 
-### Ausencia explicita vs valor real (SC-002, FR-002)
+### Ausencia explicita vs valor real (SC-002, FR-002, dec-029)
 
-| Situacao | `used_percentage` | `resets_at` |
-|----------|--------------------|-------------|
-| `rate_limits` ausente do payload (nenhuma resposta de API completou) | `NULL` | `NULL` |
-| `rate_limits.<scope>` presente com uso genuinamente `0%` (hipotetico, nunca observado) | `0.0` (valor real medido) | epoch real |
-| Throttle descarta a captura (repeticao dentro de 2 casas decimais) | (nenhuma linha nova é inserida) | (idem) |
+| Situacao | Linha inserida? | `used_percentage` | `resets_at` |
+|----------|------------------|--------------------|-------------|
+| `rate_limits` ausente do payload inteiro (nenhuma resposta de API completou) | **Nao** — nenhum INSERT (dec-029) | n/a (sem linha) | n/a (sem linha) |
+| `rate_limits.<scope>` presente mas `used_percentage`/`resets_at` ausente dentro do escopo (defensivo/malformado) | Sim | `NULL` (se ausente) | `NULL` (se ausente) |
+| `rate_limits.<scope>` presente com uso genuinamente `0%` (hipotetico, nunca observado) | Sim | `0.0` (valor real medido) | epoch real |
+| Throttle descarta a captura (repeticao dentro de 2 casas decimais) | Nao — nenhuma linha nova e inserida | (idem) | (idem) |
 
-A distincao entre "sem linha nova por throttle" e "sem dado por
-ausencia de `rate_limits`" e estrutural: o primeiro caso nao gera INSERT
-algum (nenhuma linha, redundante por design); o segundo gera uma linha com
-`NULL` explicito (User Story 3 — nunca confundir "nao medido" com "zero").
+A distincao agora e tripla (dec-029, resolve CHK009/CHK010/CHK016):
+"sem linha nova por throttle" (repeticao redundante, by design), "sem
+linha por ausencia TOTAL de `rate_limits`" (nenhuma resposta de API
+completou — a ausencia de linha E o estado "nao medido"; a leitura via
+CLI MUST mostrar "nao medido", nunca `0%`) e "linha com `NULL` explicito
+por ausencia PARCIAL" (escopo presente mas um dos dois campos veio
+ausente/nulo dentro dele — caso defensivo, coluna permanece NULLABLE).
+Isto tambem resolve o gap de FR-010 (NULL-vs-NULL no throttle): como a
+ausencia total nunca gera INSERT, nao ha comparacao NULL-vs-NULL a fazer
+no caminho de throttle.

--- a/docs/specs/plan-usage-capture/plan.md
+++ b/docs/specs/plan-usage-capture/plan.md
@@ -28,10 +28,12 @@ caro — aqui o dado ja chega de graca a cada render):
    (unico arquivo autorizado a `sqlite3` — mesmo confinamento de
    `loose-usage-capture`).
 
-Fio condutor: **ausencia de `rate_limits` e sempre `NULL`, nunca `0`**
-(Constitution VI / User Story 3) — e toda ponta (captura sem `jq`,
-sem `sqlite3`, payload malformado) degrada em pass-through silencioso,
-jamais bloqueando a sessao do operador.
+Fio condutor: **ausencia TOTAL de `rate_limits` nunca gera linha em
+`plan_usage` (dec-029) — a ausencia de linha E o estado "nao medido",
+apresentado assim na leitura, nunca fabricado como `0`** (Constitution VI
+/ User Story 3) — e toda ponta (captura sem `jq`, sem `sqlite3`, payload
+malformado) degrada em pass-through silencioso, jamais bloqueando a
+sessao do operador.
 
 ## Technical Context
 
@@ -95,7 +97,7 @@ Constitution: `docs/constitution.md` **v1.3.0**.
 | III. Formato canonico de skill | N/A (com dever de doc) | Nao cria skill nova. Toca a skill interna `agente-00c-runtime` (script novo em `hooks/`) — documentado em `contracts/statusline-hook.md`, sem `SKILL.md` novo a produzir. |
 | IV. Zero coleta remota (MUST) | PASS — caso mais simples que `loose-usage-capture` | A fonte e o **stdin do proprio processo local** alimentado pelo harness — nao ha sequer um scrape loopback (`otel-usage.sh` le HTTP `127.0.0.1`; esta feature nao faz nenhuma chamada de rede, nem local). Nenhum artefato sai do filesystem local (`~/.claude/cstk/knowledge.db`). |
 | V. Profundidade sobre adocao (SHOULD) | PASS | Fecha o ponto cego de "quando vou bater o limite do plano" sem exigir OAuth — nenhum requisito de visibilidade externa. |
-| VI. Veracidade de dados / zero fabricacao (MUST) | PASS | Ausencia de `rate_limits` e SEMPRE `NULL` (FR-002); `resets_at` nunca reinterpretado como string (FR-003); `used_percentage` persistido sem arredondar (FR-004); nenhum campo alem de `five_hour`/`seven_day` e capturado (FR-006) — os campos que exigem OAuth simplesmente nao tem coluna. |
+| VI. Veracidade de dados / zero fabricacao (MUST) | PASS | Ausencia TOTAL de `rate_limits` nunca gera linha (dec-029, FR-002) — nenhum `0`/`NULL` fabricado; leitura mostra "nao medido". `resets_at` nunca reinterpretado como string (FR-003); `used_percentage` persistido sem arredondar (FR-004); nenhum campo alem de `five_hour`/`seven_day` e capturado (FR-006) — os campos que exigem OAuth simplesmente nao tem coluna. |
 
 **GATE**: nenhum FAIL em principio MUST. Prosseguir autorizado.
 
@@ -184,7 +186,7 @@ configuracao nova desta feature usa o prefixo `CSTK_`.
 |----------|----------|
 | O design introduziu complexidade nao justificada? | Nao. Zero servico novo, zero daemon, zero diretorio de topo, zero sidecar (mais simples que `loose-usage-capture` porque o dado ja chega pronto no stdin). |
 | Algum MUST deixou de ser respeitado apos o design? | Nao. O ponto de risco era `sqlite3`/`jq` escaparem do confinamento — resolvido pela delegacao a `recall.sh` e pelo confinamento por arquivo (research.md Decisions 3 e 6). |
-| O design criou caminho que fabrica dado? | Nao. `rate_limits` ausente ⇒ `NULL` em `used_percentage`/`resets_at`; nenhum campo fora de `five_hour`/`seven_day` ganha coluna. |
+| O design criou caminho que fabrica dado? | Nao. `rate_limits` ausente por completo ⇒ nenhuma linha inserida (dec-029); nenhum campo fora de `five_hour`/`seven_day` ganha coluna. |
 | O design mantem a sessao do operador intocada? | Sim — MAS com uma condicao nova em relacao ao molde `PostToolUse`: o pass-through obrigatorio de stdout (research.md Decision 2) e o mecanismo que garante isso aqui, porque `statusLine.command` (diferente de um hook) tem OUTPUT visivel ao operador a cada render; falhar em pass-through quebraria a UI, nao so a captura. |
 
 **Veredito do re-check**: PASS. Nenhuma linha de Complexity Tracking
@@ -229,5 +231,5 @@ respeitando um padrao ja existente, em vez de so reusar algo pronto).
 | Risco | Origem | Mitigacao no design |
 |-------|--------|-----------------------|
 | `statusLine.command` e uma chave UNICA no `settings.json` — instalar esta feature sem cuidado apaga a statusline customizada de quem ja tem uma | Observado nesta onda (nenhum precedente de codigo; so o GOTCHA da memoria) | Pass-through obrigatorio via `CSTK_STATUSLINE_INNER_COMMAND` (research.md Decision 2); mecanismo de instalacao exato fica para `create-tasks` decompor, mas o contrato de pass-through ja esta fixado aqui |
-| `rate_limits` so aparece apos 1a resposta de API completar — feature instalada numa sessao nova pode parecer "sem dado" por um tempo | Memoria, GOTCHA 1 | Documentado em `contracts/statusline-hook.md` e no Cenario 2 do `quickstart.md`; comportamento correto (NULL), nao um bug |
+| `rate_limits` so aparece apos 1a resposta de API completar — feature instalada numa sessao nova pode parecer "sem dado" por um tempo | Memoria, GOTCHA 1 | Documentado em `contracts/statusline-hook.md` e no Cenario 2 do `quickstart.md`; comportamento correto (nenhuma linha ate a 1a resposta completar, leitura mostra "nao medido"), nao um bug |
 | Testar exige fixture via stdin, nao sessao real (`claude -p` nao dispara statusline) | Memoria, GOTCHA 4 | research.md Decision 8; `tests/test_statusline-plan-usage.sh` segue o precedente de `test_posttooluse-loose-usage.sh` |

--- a/docs/specs/plan-usage-capture/plan.md
+++ b/docs/specs/plan-usage-capture/plan.md
@@ -1,0 +1,233 @@
+# Implementation Plan: Captura de Uso do Plano via Statusline (Plan Usage Capture)
+
+**Feature**: `plan-usage-capture` | **Date**: 2026-08-10 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+Dar ao operador visibilidade do quanto do limite de plano (`/usage`, janelas
+`five_hour`/`seven_day`) ja foi consumido, **sem exigir credencial OAuth** —
+a unica via observada que expoe esse dado sem token e o payload que o
+harness Claude Code alimenta no stdin do comando de `statusLine`
+(memoria `reference_statusline_usage_payload.md`, campo `rate_limits`).
+
+Abordagem tecnica, em duas camadas (mais enxuta que `loose-usage-capture`,
+que precisa de sidecar intermediario porque a fonte la e um scrape HTTP
+caro — aqui o dado ja chega de graca a cada render):
+
+1. **Captura**: script novo `statusline-plan-usage.sh`, configurado como
+   `statusLine.command` no `settings.json` do harness — mecanismo distinto
+   do array `hooks.PostToolUse[]` ja gerenciado por `cli/lib/hooks.sh`.
+   Le o payload do stdin, extrai `rate_limits.five_hour`/`seven_day`,
+   aplica throttle (2 casas decimais contra o ultimo registro do escopo) e
+   insere direto em `plan_usage` — sem sidecar intermediario. Pass-through
+   obrigatorio do stdout (research.md Decision 2) para nao apagar a UI de
+   quem ja tem statusline customizada.
+2. **Persistencia + Consulta**: tabela nova `plan_usage` no `knowledge.db`
+   (migracao aditiva v13 -> v14) + subcomando novo `cstk plan-usage`
+   (+ `history`), com a camada SQL delegada a `cli/lib/recall.sh`
+   (unico arquivo autorizado a `sqlite3` — mesmo confinamento de
+   `loose-usage-capture`).
+
+Fio condutor: **ausencia de `rate_limits` e sempre `NULL`, nunca `0`**
+(Constitution VI / User Story 3) — e toda ponta (captura sem `jq`,
+sem `sqlite3`, payload malformado) degrada em pass-through silencioso,
+jamais bloqueando a sessao do operador.
+
+## Technical Context
+
+**Language/Version**: POSIX `sh` (shebang `#!/bin/sh`), Constitution
+Principio II. Sem Bash-isms.
+**Primary Dependencies**:
+- `jq` — dep OPCIONAL com fallback fail-open (research.md Decision 3),
+  reuso do carve-out ja vigente em `cli/lib/recall.sh`/`cli/lib/usage.sh`;
+- `sqlite3` — confinado a `cli/lib/recall.sh` (research.md Decision 6);
+  OPCIONAL na captura (fail-open), a consulta via `cstk plan-usage`
+  segue a mesma degradacao ja documentada em `contracts/cli-usage.md`
+  para `cstk usage`.
+**Storage**: `~/.claude/cstk/knowledge.db` (SQLite, indice) — versao real
+verificada nesta onda: `RECALL_SCHEMA_VERSION = 13` (`grep -n
+RECALL_SCHEMA_VERSION cli/lib/recall.sh`). Sem arquivo sidecar
+intermediario (diferenca deliberada vs `loose-usage-capture` — ver
+research.md Decision 4).
+**Testing**: harness POSIX proprio (`tests/run.sh`). Convencao: hook em
+`plugins/cstk/skills/agente-00c-runtime/hooks/` -> `tests/test_<n>.sh`
+(precedente: `tests/test_posttooluse-loose-usage.sh`); lib em `cli/lib/`
+-> `tests/cstk/test_<n>.sh` (precedente: `tests/cstk/test_usage.sh`).
+**Target Platform**: macOS e Linux, ambiente local do operador. Sem
+servidor, sem container, sem rede externa (o dado ja chega no stdin do
+proprio processo local — nem sequer um scrape loopback como
+`otel-usage.sh`).
+**Project Type**: CLI + entry-point de statusline (single-process, local).
+**Performance Goals**: caminho quente (render sem mudanca de
+`rate_limits`) sem I/O de rede; teto implicito e o de qualquer
+`statusLine.command` do harness (nao documentado numericamente pelo
+harness; o design nao introduz nenhuma chamada bloqueante — 1 query SQL
+condicional no maximo).
+**Constraints**: `statusline-plan-usage.sh` NUNCA sai com codigo != 0;
+stdout SEMPRE contem o texto a renderizar (research.md Decision 2) — o
+unico dos dois requisitos de nao-regressao desta feature que nao vem
+diretamente de um FR da spec, e sim de uma condicao de viabilidade de
+instalacao (ver research.md Decision 2 para o racional completo).
+**Scale/Scope**: um operador, N sessoes simultaneas. Volume de linhas em
+`plan_usage` proporcional a (renders com `rate_limits` presente x
+mudancas reais alem do throttle) — ordem de grandeza de dezenas por
+sessao longa, muito menor que `loose_usage` (que grana por modelo x
+segmento).
+
+Nenhum `NEEDS CLARIFICATION` remanescente: os 5 pontos abertos foram
+fechados na etapa `clarify` (dec-008, dec-009, dec-013, dec-014, dec-015 —
+dec-015 corrigiu dec-010 de epoch para TEXT ISO em `captured_at`/
+`ingested_at`; registrados em `spec.md` §Clarifications) e as decisoes de
+design puramente tecnicas (sem impacto em requisito visivel ao operador)
+foram fechadas no Phase 0 ([research.md](./research.md), Decisions 1-8).
+
+## Constitution Check
+
+*GATE: Deve passar antes do Phase 0. Re-checado apos Phase 1 — ver
+§Re-check.*
+
+Constitution: `docs/constitution.md` **v1.3.0**.
+
+| Principio | Status | Notas |
+|-----------|--------|-------|
+| I. SDD recursivo (MUST) | PASS | Feature entra pela pipeline completa: `spec.md` + `clarify` + este `plan.md`; `tasks.md` na proxima etapa. Contrato de CLI novo (`cstk plan-usage`) exige nota no CHANGELOG (MINOR — capacidade nova). |
+| II. POSIX sh puro, zero dep externa (MUST) | PASS **com carve-outs ja vigentes, nao novos** | `jq` (research.md Decision 3) e `sqlite3` (research.md Decision 6) reusam carve-outs ja declarados em `loose-usage-capture`/`cstk-cli` — nenhuma dep obrigatoria nova introduzida. |
+| III. Formato canonico de skill | N/A (com dever de doc) | Nao cria skill nova. Toca a skill interna `agente-00c-runtime` (script novo em `hooks/`) — documentado em `contracts/statusline-hook.md`, sem `SKILL.md` novo a produzir. |
+| IV. Zero coleta remota (MUST) | PASS — caso mais simples que `loose-usage-capture` | A fonte e o **stdin do proprio processo local** alimentado pelo harness — nao ha sequer um scrape loopback (`otel-usage.sh` le HTTP `127.0.0.1`; esta feature nao faz nenhuma chamada de rede, nem local). Nenhum artefato sai do filesystem local (`~/.claude/cstk/knowledge.db`). |
+| V. Profundidade sobre adocao (SHOULD) | PASS | Fecha o ponto cego de "quando vou bater o limite do plano" sem exigir OAuth — nenhum requisito de visibilidade externa. |
+| VI. Veracidade de dados / zero fabricacao (MUST) | PASS | Ausencia de `rate_limits` e SEMPRE `NULL` (FR-002); `resets_at` nunca reinterpretado como string (FR-003); `used_percentage` persistido sem arredondar (FR-004); nenhum campo alem de `five_hour`/`seven_day` e capturado (FR-006) — os campos que exigem OAuth simplesmente nao tem coluna. |
+
+**GATE**: nenhum FAIL em principio MUST. Prosseguir autorizado.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+docs/specs/plan-usage-capture/
+├── spec.md
+├── plan.md          # This file
+├── research.md      # Phase 0 output
+├── data-model.md     # Phase 1 output
+├── quickstart.md      # Phase 1 output
+└── contracts/          # Phase 1 output
+    ├── cli-plan-usage.md
+    └── statusline-hook.md
+```
+
+### Source Code (repository root)
+
+Arvore real do repositorio (`ls cli/lib/`, `ls
+plugins/cstk/skills/agente-00c-runtime/hooks/` verificados nesta onda),
+com marcacao do que muda:
+
+```
+cli/
+├── cstk                                      # MODIFICA: dispatch + help do subcomando `plan-usage`
+└── lib/
+    ├── recall.sh                             # MODIFICA: RECALL_SCHEMA_VERSION 13->14 + DDL de `plan_usage`
+    └── plan-usage.sh                         # NOVO: logica de `cstk plan-usage` (+ `history` + `ingest --stdin`), SQL delegado a recall.sh
+plugins/cstk/skills/agente-00c-runtime/
+└── hooks/
+    ├── posttooluse-loose-usage.sh            # INTACTO (molde de referencia — disciplina fail-open/throttle)
+    ├── posttooluse-tool-call-tick.sh         # INTACTO
+    ├── settings.snippet.json                 # INTACTO
+    └── statusline-plan-usage.sh              # NOVO: entry-point de statusLine.command
+tests/
+├── test_statusline-plan-usage.sh             # NOVO (convencao de hooks/entry-points)
+└── cstk/
+    ├── test_plan-usage.sh                    # NOVO (convencao cli/lib)
+    └── test_recall.sh                        # ESTENDE: migracao v14
+```
+
+**Structure Decision**: nenhum diretorio novo de topo. A feature se
+encaixa em duas superficies existentes (lib do CLI, indice
+`knowledge.db`) e adiciona um unico ponto de entrada novo
+(`statusline-plan-usage.sh`) porque o mecanismo `statusLine.command` nao
+tem overlap com nenhum hook ja registrado — nao ha como reusar
+`posttooluse-*.sh` sem inventar um payload que o harness nunca emite ali.
+Ao contrario de `loose-usage-capture`, nao ha diretorio de sidecar novo:
+o dado ja chega pronto no stdin a cada render, entao a captura escreve
+direto no indice.
+
+## Convencoes de Borda
+
+A feature atravessa 2 fronteiras (payload da statusline -> hook ->
+CLI/DB), logo a secao se aplica.
+
+| Camada | Case style | Validacao | Fonte da verdade |
+|--------|------------|-----------|-------------------|
+| Payload da statusline (JSON) | `snake_case` (`session_id`, `rate_limits`, `used_percentage`, `resets_at`) | Schema observado, nao inferido | Memoria `reference_statusline_usage_payload.md` |
+| Colunas SQLite (`plan_usage`) | `snake_case` | DDL; sem `UNIQUE` de chave natural (append-only, research.md Decision 4) | `cli/lib/recall.sh` (DDL), `data-model.md` |
+| Flags de CLI | `kebab-case` (`--scope`, `--limit`, `--since`, `--json`, `--db`) | Parser explicito com `*)` ⇒ exit 2 | `contracts/cli-plan-usage.md` |
+| Saida `--json` | `snake_case` nas chaves, `null` para ausencia | — | `contracts/cli-plan-usage.md` |
+| Variaveis de ambiente | `SCREAMING_SNAKE_CASE` com prefixo `CSTK_` | — | `CSTK_STATUSLINE_INNER_COMMAND` `[PROPOSTA]` (research.md Decision 2) |
+
+**Mapper layer (payload ↔ DB)**: `statusline-plan-usage.sh` `[PROPOSTA]`
+e o unico tradutor — extrai os 3 campos consumidos do payload
+(`session_id`, `workspace.*`, `rate_limits.*`) e chama `cstk plan-usage
+ingest --stdin` (que delega o INSERT a `cli/lib/recall.sh`). Sem ORM;
+SQL escrito a mao, como todo `recall.sh`.
+
+**Validacao de payload**: sem Zod (projeto shell). Equivalente e a
+checagem estrutural feita por `jq -e '.rate_limits'` — ausencia da chave
+(`jq` retorna erro/null) e tratada como "sem `rate_limits`", nao como
+erro fatal (Edge Case da spec, User Story 3).
+
+**Prefixo `CSTK_`**: mesma disciplina de `loose-usage-capture`
+(`research.md` daquela feature, Decision 3) — qualquer variavel de
+configuracao nova desta feature usa o prefixo `CSTK_`.
+
+## Re-check de Constitution (pos-Phase 1)
+
+| Pergunta | Resposta |
+|----------|----------|
+| O design introduziu complexidade nao justificada? | Nao. Zero servico novo, zero daemon, zero diretorio de topo, zero sidecar (mais simples que `loose-usage-capture` porque o dado ja chega pronto no stdin). |
+| Algum MUST deixou de ser respeitado apos o design? | Nao. O ponto de risco era `sqlite3`/`jq` escaparem do confinamento — resolvido pela delegacao a `recall.sh` e pelo confinamento por arquivo (research.md Decisions 3 e 6). |
+| O design criou caminho que fabrica dado? | Nao. `rate_limits` ausente ⇒ `NULL` em `used_percentage`/`resets_at`; nenhum campo fora de `five_hour`/`seven_day` ganha coluna. |
+| O design mantem a sessao do operador intocada? | Sim — MAS com uma condicao nova em relacao ao molde `PostToolUse`: o pass-through obrigatorio de stdout (research.md Decision 2) e o mecanismo que garante isso aqui, porque `statusLine.command` (diferente de um hook) tem OUTPUT visivel ao operador a cada render; falhar em pass-through quebraria a UI, nao so a captura. |
+
+**Veredito do re-check**: PASS. Nenhuma linha de Complexity Tracking
+necessaria.
+
+## Complexity Tracking
+
+> Preencher APENAS se Constitution Check tem violacoes que precisam
+> justificativa
+
+Nao aplicavel — Constitution Check e re-check passaram sem violacao. Os
+dois carve-outs invocados (`jq` opcional; confinamento de `sqlite3`) sao
+reuso de mecanismos ja declarados por features anteriores
+(`loose-usage-capture`, `cstk-cli`), nao excecoes novas que exijam sunset.
+
+## Revisao de Seguranca (gate `owasp-security`)
+
+Revisao de design (nao ha codigo ainda — gate roda sobre `plan.md` +
+`contracts/*.md`). Superficie analisada: (1) parse de JSON arbitrario do
+stdin da statusline via `jq`; (2) INSERT em `plan_usage` via
+`cli/lib/recall.sh`; (3) subcomando CLI `cstk plan-usage` local.
+
+| Vetor (OWASP) | Achado | Mitigacao MANDATORIA no design |
+|----------------|--------|----------------------------------|
+| A05 Injection (SQL) | O payload da statusline e, em ultima instancia, controlado pelo processo do harness — mas `session_id`/`project_path` sao strings de origem externa ao script e NAO devem ser concatenadas cru em SQL | `statusline-plan-usage.sh`/`cli/lib/plan-usage.sh` MUST escapar todo valor extraido do payload via `sql_escape` (`cli/lib/recall.sh` linha 223, `s/'/''/g`) antes de compor qualquer `INSERT INTO plan_usage`, e MUST usar `recall_apply_sql_with_retry` (linha 2393) — **mesmo caminho ja usado por `usage.sh` para `loose_usage`**, nao um novo |
+| A05 Injection (comando, `jq` parse) | `jq` e um parser JSON seguro por construcao (nao interpreta o conteudo como codigo); risco residual so existe se um valor extraido for reusado depois em `eval`/interpolação de shell sem aspas | Nenhum valor extraido do payload MUST ser passado a `eval`, `sh -c`, ou interpolado sem aspas duplas em comando algum — regra ja coberta pela disciplina POSIX geral do Principio II (variaveis sempre entre aspas) |
+| A02 Security Misconfiguration / exposicao de dado local | `session_id`/`project_path` ficam em texto plano em `plan_usage`, no mesmo `knowledge.db` que ja guarda dado equivalente (`loose_usage.project_path`, `executions.session`) | Nenhuma mitigacao NOVA necessaria — `recall_normalize_db_perms` (linha 691, `chmod 600`) ja se aplica ao arquivo `knowledge.db` inteiro, cobrindo `plan_usage` automaticamente por ser a mesma base; nenhuma tabela tem permissao por-tabela em SQLite |
+| A09 Logging Failures | Erros de captura (jq/sqlite3 ausente, INSERT falho) nao devem vazar para stdout (contaminaria a UI da statusline) nem para logs persistentes com dado sensivel | `statusline-plan-usage.sh` MUST descartar erros de captura silenciosamente ou envia-los so a stderr (nunca stdout) — ja coberto pelo contrato de pass-through (`contracts/statusline-hook.md` §Contrato de saida) |
+| Principio IV (Zero Coleta Remota) | Nenhum ponto do design faz requisicao de rede — fonte e o stdin do proprio processo local | PASS sem mitigacao adicional (mais simples que `loose-usage-capture`, que ao menos faz scrape loopback) |
+| LLM01/ASI09 (dado nao-confiavel tratado como instrucao) | N/A neste design — o payload da statusline e consumido apenas como DADO (campos JSON especificos extraidos por caminho fixo), nunca interpretado como instrucao/prompt para um LLM | N/A |
+
+**Veredito**: nenhum achado `critical`/`high` — todos os vetores tem
+mitigacao ja disponivel por reuso de helper existente (`sql_escape`,
+`recall_apply_sql_with_retry`, `recall_normalize_db_perms`), sem
+necessidade de mecanismo novo. `create-tasks` MUST incluir uma task
+explicita para o uso de `sql_escape` no INSERT de `plan_usage` (nao e
+opcional — e o unico ponto do design que precisa de codigo novo
+respeitando um padrao ja existente, em vez de so reusar algo pronto).
+
+## Riscos conhecidos
+
+| Risco | Origem | Mitigacao no design |
+|-------|--------|-----------------------|
+| `statusLine.command` e uma chave UNICA no `settings.json` — instalar esta feature sem cuidado apaga a statusline customizada de quem ja tem uma | Observado nesta onda (nenhum precedente de codigo; so o GOTCHA da memoria) | Pass-through obrigatorio via `CSTK_STATUSLINE_INNER_COMMAND` (research.md Decision 2); mecanismo de instalacao exato fica para `create-tasks` decompor, mas o contrato de pass-through ja esta fixado aqui |
+| `rate_limits` so aparece apos 1a resposta de API completar — feature instalada numa sessao nova pode parecer "sem dado" por um tempo | Memoria, GOTCHA 1 | Documentado em `contracts/statusline-hook.md` e no Cenario 2 do `quickstart.md`; comportamento correto (NULL), nao um bug |
+| Testar exige fixture via stdin, nao sessao real (`claude -p` nao dispara statusline) | Memoria, GOTCHA 4 | research.md Decision 8; `tests/test_statusline-plan-usage.sh` segue o precedente de `test_posttooluse-loose-usage.sh` |

--- a/docs/specs/plan-usage-capture/plan.md
+++ b/docs/specs/plan-usage-capture/plan.md
@@ -105,7 +105,7 @@ Constitution: `docs/constitution.md` **v1.3.0**.
 
 ### Documentation (this feature)
 
-```
+```text
 docs/specs/plan-usage-capture/
 ├── spec.md
 ├── plan.md          # This file
@@ -123,7 +123,7 @@ Arvore real do repositorio (`ls cli/lib/`, `ls
 plugins/cstk/skills/agente-00c-runtime/hooks/` verificados nesta onda),
 com marcacao do que muda:
 
-```
+```text
 cli/
 ├── cstk                                      # MODIFICA: dispatch + help dos subcomandos `plan-usage` e `statusline`
 └── lib/

--- a/docs/specs/plan-usage-capture/plan.md
+++ b/docs/specs/plan-usage-capture/plan.md
@@ -125,10 +125,11 @@ com marcacao do que muda:
 
 ```
 cli/
-├── cstk                                      # MODIFICA: dispatch + help do subcomando `plan-usage`
+├── cstk                                      # MODIFICA: dispatch + help dos subcomandos `plan-usage` e `statusline`
 └── lib/
     ├── recall.sh                             # MODIFICA: RECALL_SCHEMA_VERSION 13->14 + DDL de `plan_usage`
-    └── plan-usage.sh                         # NOVO: logica de `cstk plan-usage` (+ `history` + `ingest --stdin`), SQL delegado a recall.sh
+    ├── plan-usage.sh                         # NOVO: logica de `cstk plan-usage` (+ `history` + `ingest --stdin`), SQL delegado a recall.sh
+    └── statusline.sh                         # NOVO (FASE 3, dec-042): logica de `cstk statusline install`/`status` — escreve/inspeciona `statusLine.command` em ${HOME}/.claude/settings.json (jq, mesmo carve-out de merge_settings em hooks.sh)
 plugins/cstk/skills/agente-00c-runtime/
 └── hooks/
     ├── posttooluse-loose-usage.sh            # INTACTO (molde de referencia — disciplina fail-open/throttle)
@@ -139,8 +140,19 @@ tests/
 ├── test_statusline-plan-usage.sh             # NOVO (convencao de hooks/entry-points)
 └── cstk/
     ├── test_plan-usage.sh                    # NOVO (convencao cli/lib)
+    ├── test_statusline.sh                    # NOVO (FASE 3, convencao cli/lib): cobre install/status/idempotencia via HOME sandbox
     └── test_recall.sh                        # ESTENDE: migracao v14
 ```
+
+**Resolucao dec-042 (gate `analyze`, HIGH F2/E2)**: footprint da FASE 3
+(`cli/lib/statusline.sh` + `tests/cstk/test_statusline.sh` + wiring em
+`cli/cstk`) documentado acima. Sem contrato dedicado novo — mecanismo de
+instalacao e infraestrutura de CLI (paralelo direto a `cli/lib/hooks.sh`,
+que tambem nao tem `contracts/*.md` proprio, apenas `--help` inline + este
+Project Structure), nao um comportamento observavel do payload/schema da
+feature (esse ja esta coberto por `contracts/statusline-hook.md`). Sem FR
+numerado novo em `spec.md` — anotado como infraestrutura (mesmo tratamento
+de `FR-013-INFRA-SCHED`), ver `spec.md` `FR-016-INFRA-INSTALL`.
 
 **Structure Decision**: nenhum diretorio novo de topo. A feature se
 encaixa em duas superficies existentes (lib do CLI, indice

--- a/docs/specs/plan-usage-capture/quickstart.md
+++ b/docs/specs/plan-usage-capture/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: Plan Usage Capture
+
+Cenarios de validacao — happy path + error cases. Todos alimentam payload
+fixture via stdin (FR-012); nenhum depende de sessao interativa real do
+Claude Code.
+
+## Cenario 1 — Captura basica (User Story 1 / SC-001)
+
+1. Alimentar `statusline-plan-usage.sh` com um payload fixture que contem
+   `rate_limits.five_hour` e `rate_limits.seven_day`.
+2. **Expected**: stdout contem o pass-through/fallback (nunca vazio);
+   `plan_usage` ganha 2 linhas novas (uma por escopo), com
+   `used_percentage`/`resets_at` iguais aos valores do fixture.
+3. Rodar `cstk plan-usage`.
+4. **Expected**: saida mostra os 2 escopos com os valores capturados, sem
+   qualquer credencial OAuth envolvida.
+
+## Cenario 2 — Ausencia de `rate_limits` nunca vira zero (User Story 3 / SC-002)
+
+1. Alimentar `statusline-plan-usage.sh` com um payload fixture SEM a
+   chave `rate_limits` (sessao aberta e fechada sem resposta de API).
+2. **Expected**: nenhuma linha nova em `plan_usage`; pass-through de
+   stdout normal.
+3. Rodar `cstk plan-usage` num banco onde NUNCA houve captura.
+4. **Expected**: saida mostra `nao medido` para os 2 escopos — nunca `0%`.
+
+## Cenario 3 — Throttle descarta repeticao (FR-010)
+
+1. Alimentar `statusline-plan-usage.sh` duas vezes em sequencia com o
+   MESMO `used_percentage` (ate a 2a casa decimal) e o mesmo `resets_at`
+   para `five_hour`.
+2. **Expected**: apenas 1 linha nova em `plan_usage` para `five_hour` (a
+   segunda captura e descartada pelo throttle).
+3. Alimentar uma 3a vez com `used_percentage` mudando na 3a casa decimal
+   apenas (ex.: `7.001` -> `7.009`, ambos arredondam para `7.00`).
+4. **Expected**: ainda descartada (dentro da tolerancia de 2 casas).
+5. Alimentar uma 4a vez com `used_percentage` mudando na 2a casa decimal
+   (ex.: `7.00` -> `7.05`).
+6. **Expected**: nova linha inserida (mudanca real).
+
+## Cenario 4 — Evolucao ao longo do tempo (User Story 2 / SC-003)
+
+1. Alimentar `statusline-plan-usage.sh` 3 vezes para `five_hour` com
+   `used_percentage` crescente (`5.0`, `12.0`, `20.0`) e mudanca real a
+   cada vez.
+2. Rodar `cstk plan-usage history --scope five_hour`.
+3. **Expected**: 3 linhas em ordem cronologica, sem precisar cruzar dados
+   de fontes separadas.
+
+## Cenario 5 — Formato de `resets_at` (SC-004)
+
+1. Alimentar `statusline-plan-usage.sh` com `resets_at: 1786372200`
+   (epoch segundos, exatamente como o payload real observado).
+2. **Expected**: `plan_usage.resets_at` persistido como `1786372200`
+   (INTEGER), interpretavel diretamente como epoch — sem tentativa de
+   parse como string ISO.
+
+## Cenario 6 — Zero coleta remota (SC-005 / Principio IV)
+
+1. Rodar toda a suite de testes desta feature com rede desabilitada
+   (ou instrumentada para falhar qualquer `curl`/`wget`).
+2. **Expected**: nenhum teste falha por dependencia de rede — a fonte e
+   exclusivamente o stdin do processo local, nunca uma chamada HTTP.
+
+## Cenario 7 — `jq`/`sqlite3` ausentes (Principio II carve-out)
+
+1. Simular ausencia de `jq` no PATH e alimentar
+   `statusline-plan-usage.sh` com um payload valido.
+2. **Expected**: pass-through de stdout ocorre normalmente; nenhuma
+   captura nova em `plan_usage`; exit `0`.
+3. Repetir simulando ausencia de `sqlite3`.
+4. **Expected**: mesmo comportamento — pass-through intacto, captura
+   pulada, exit `0`.

--- a/docs/specs/plan-usage-capture/research.md
+++ b/docs/specs/plan-usage-capture/research.md
@@ -1,0 +1,202 @@
+# Research: Captura de Uso do Plano via Statusline
+
+Nenhum `NEEDS CLARIFICATION` remanescente na spec — as 5 respostas de
+`clarify` (Q1/Q2/Q4 autonomas + Q3/Q5 via bloqueio humano) ja estao
+integradas em `spec.md` §Clarifications e nos FRs correspondentes
+(FR-008, FR-009, FR-010, FR-014). Este documento resolve as decisoes
+tecnicas de **como** implementar, ainda nao cobertas pelos FRs (que
+descrevem o **o que**).
+
+## Decision 1 — Ponto de captura: novo script de entrada, fora do
+sistema de hooks `PreToolUse`/`PostToolUse`
+
+**Decision**: introduzir um script novo,
+`plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh`,
+dedicado a processar o payload da statusline. Vive no mesmo diretorio dos
+demais hooks do runtime (`hooks/`) por convencao de local (scripts de
+instrumentacao do `agente-00c-runtime`), mas **nao e um hook
+`PreToolUse`/`PostToolUse`** — e configurado via o campo `statusLine.command`
+do `settings.json` do harness, um mecanismo de configuracao distinto do
+array `.hooks.PostToolUse[]` que `cli/lib/hooks.sh` ja gerencia
+(evidencia: `grep -n statusLine` no repo inteiro retorna zero ocorrencias
+antes desta feature — nao ha precedente de codigo a reusar, so o
+GOTCHA documentado na memoria `reference_statusline_usage_payload.md`).
+
+**Rationale**: `posttooluse-loose-usage.sh` (feature `loose-usage-capture`)
+e o molde mais proximo — mesma disciplina (fail-open, exit sempre `0`,
+throttle, sem bloquear a sessao) — mas o gatilho e diferente por natureza:
+`PostToolUse` dispara apos uma tool call; `statusLine.command` dispara a
+cada RENDER de UI (~2x/2min numa sessao minima, por observacao empirica),
+e o payload chega no **stdin** do processo, nao em variavel de ambiente ou
+argv. Reusar o array `hooks.PostToolUse` seria factualmente incorreto —
+`statusLine` e uma chave irma de `hooks` no `settings.json`, nao um membro
+dela.
+
+**Alternatives considered**:
+- Reusar `posttooluse-loose-usage.sh` como esta, adicionando deteccao de
+  `rate_limits` no payload de `PostToolUse` — REJEITADA: o payload de
+  `PostToolUse` (tool_name, tool_input, tool_response) nao contem
+  `rate_limits`; o campo so existe no payload da statusline (memoria,
+  linha 31). Fontes distintas, sem overlap.
+- Poll ativo via `GET /api/oauth/usage` — REJEITADA pela spec (FR-006 MUST
+  NOT depender de OAuth) e pelo Principio VI (fonte teria que ser
+  simulada/suposta sem credencial disponivel neste ambiente de dev).
+
+## Decision 2 — Pass-through obrigatorio do stdout da statusline
+
+**Decision**: o script `statusline-plan-usage.sh` MUST imprimir em stdout
+exatamente o mesmo texto que o comando de statusline anterior do operador
+produziria, encaminhando a chamada para um comando "interno" configuravel
+via variavel de ambiente `CSTK_STATUSLINE_INNER_COMMAND` (se definida) e
+repassando o stdout dele **verbatim**; se a variavel nao estiver definida,
+o script MUST imprimir apenas um fallback minimo de 1 linha (nao
+inventado — construido so a partir de campos ja capturados desta mesma
+sessao: `model.display_name` e, quando disponivel, o `used_percentage` de
+`five_hour`) em vez de string vazia, para nao apagar a UI de quem nunca
+configurou uma statusline customizada antes.
+
+**Rationale**: nao e um requisito funcional explicito da spec (a spec so
+cobre a captura, FR-001 a FR-014), mas e uma condicao de viabilidade de
+instalacao: `statusLine.command` e uma chave **unica** no `settings.json`
+— se este script simplesmente NAO reemitir a UI, qualquer operador que ja
+tenha uma statusline customizada perde a visualizacao ao instalar esta
+feature. Documentado aqui como decisao de design necessaria para um
+rollout seguro, nao como fabricacao de requisito.
+
+**Marcado `[PROPOSTA — a validar na implementacao]`**: o mecanismo exato
+de wiring/instalacao (extensao de `cstk hooks install` para tambem
+gerenciar `.statusLine.command`, ou um subcomando novo `cstk statusline
+install`) fica para a fase `create-tasks` decompor; este research.md fixa
+apenas a garantia comportamental (pass-through) que qualquer mecanismo de
+instalacao escolhido precisa preservar.
+
+## Decision 3 — `jq` como dependencia opcional confinada (reuso de carve-out
+ja vigente, nao um novo)
+
+**Decision**: `statusline-plan-usage.sh` usa `jq` para parsear o payload
+JSON do stdin, com fallback fail-open: `jq` ausente ⇒ script encaminha o
+pass-through (Decision 2) sem persistir nenhuma captura, exit `0`, nenhuma
+mensagem em stdout/stderr que contamine a UI.
+
+**Confinamento (condicao b do amendment 1.1.0)**: `jq` ja e dependencia
+opcional confinada, mas **espalhada por precedente ja existente** (nao
+introduzido por esta feature) em `cli/lib/recall.sh` (`recall_have_jq`,
+linha 367) e `cli/lib/usage.sh` (12 ocorrencias, todas atras de
+`recall_have_jq`). O carve-out original (`cstk-cli`, amendment 1.1.0) exige
+"um unico arquivo identificavel" por invocacao do carve-out, e cada arquivo
+novo desta feature (`statusline-plan-usage.sh`, `cli/lib/plan-usage.sh`)
+continua essa mesma disciplina — cada um encapsula sua propria checagem
+`command -v jq` e degrada individualmente. Precedente literal:
+`cli/lib/usage.sh` (feature `loose-usage-capture`) fez exatamente esse
+reuso sem reabrir o debate do carve-out.
+
+**Alternatives considered**: parsear o JSON com `sed`/`awk` (POSIX puro,
+sem `jq`) — REJEITADA: o payload tem aninhamento arbitrario
+(`rate_limits.five_hour.used_percentage`) e o Principio II ja aceita o
+carve-out de `jq` para exatamente este tipo de caso; reimplementar um
+parser JSON ad-hoc em `awk` seria a "complexidade nao justificada" que o
+Constitution Check re-check deve vetar.
+
+## Decision 4 — Throttle: comparacao contra o ultimo registro, sem cache
+auxiliar
+
+**Decision**: o throttle de FR-010 (tolerancia de 2 casas decimais,
+comparado contra o ULTIMO registro persistido do escopo — dec-008/dec-009)
+e implementado com uma leitura SQL simples (`SELECT used_percentage,
+resets_at FROM plan_usage WHERE scope = ? ORDER BY id DESC LIMIT 1`) antes
+de cada INSERT, delegada a `cli/lib/recall.sh` (ver Decision 6) — nao
+introduz nenhum arquivo de cache/estado auxiliar novo (paridade com o
+padrao de UPSERT natural-key do `loose_usage`, mas aqui e comparacao
+pre-INSERT porque `plan_usage` e append-only, nao upsert — ver
+data-model.md).
+
+**Rationale**: o volume de writes e baixissimo (~2 renders/2min por
+sessao, e cada render so gera captura nova se `rate_limits` estiver
+presente E o percentual mudar alem de 2 casas decimais) — uma query extra
+por candidate-write nao e hot path (contraste com o throttle O(1) de
+`posttooluse-tool-call-tick.sh`, que dispara a CADA tool call).
+
+**Alternatives considered**: throttle em arquivo sidecar local (mesmo
+padrao do `loose_usage`, `meta.tsv` com `updated_at`) — REJEITADA: o
+`loose_usage` precisa de sidecar porque a fonte (`otel-usage.sh`) e um
+scrape HTTP caro que precisa ser evitado no hot path do hook; aqui o dado
+ja chega de graca no stdin a cada render, entao o unico custo real e o
+INSERT condicional, e uma query SQL de leitura e mais simples/auditavel
+que introduzir uma segunda camada de arquivo.
+
+## Decision 5 — Nome da coluna de sessao: `session_id`, nao `session`
+
+**Decision**: a tabela `plan_usage` usa a coluna `session_id` (nao
+`session`, como em `executions`/`waves` — `cli/lib/recall.sh` linhas
+512/533), conforme a resolucao literal do bloqueio `block-001`
+(dec-013, respondida pelo operador).
+
+**Rationale registrada explicitamente** (a spec/dec-013 nomeou os 3 campos
+literalmente: `project`, `project_path`, `session_id`): o valor de origem
+para esta coluna e o campo `session_id` do TOPO do proprio payload da
+statusline (memoria, linha 19: `"session_id": "..."`) — copiado
+verbatim do payload, sem sintese. Chamar a coluna de `session_id` (em vez
+de normalizar para `session`, convencao de `executions`/`waves`) mantem o
+nome auto-descritivo do campo-fonte e evita ambiguidade de mapeamento na
+camada de ingestao (`statusline-plan-usage.sh` copia
+`.session_id -> session_id` 1:1, sem renomear).
+
+**Divergencia de convencao reconhecida, nao ignorada**: `executions`/
+`waves` usam `session` porque e um identificador SINTETICO derivado
+internamente pelo runtime `agente-00c`/`feature-00c` (nao um campo
+copiado de um payload externo). `plan_usage` e o primeiro caso de tabela
+que copia `session_id` diretamente de uma fonte externa — a divergencia de
+nome e intencional e documentada aqui para nao ser confundida com
+inconsistencia acidental numa revisao futura.
+
+## Decision 6 — `sqlite3` permanece confinado a `cli/lib/recall.sh`
+
+**Decision**: nem `statusline-plan-usage.sh` nem `cli/lib/plan-usage.sh`
+invocam `sqlite3` diretamente. `statusline-plan-usage.sh` (POSIX sh, sem
+acesso a helpers do CLI porque roda fora do processo `cstk`) grava a
+captura via uma chamada de subprocesso ao proprio `cstk plan-usage
+ingest --stdin` (novo subcomando interno, nao documentado como superficie
+publica em `contracts/`, usado so pelo hook), que por sua vez delega a
+`recall.sh` — mesma cadeia de confinamento que `posttooluse-loose-usage.sh`
+usa indiretamente (sidecar TSV -> ingest-on-read do `cstk usage`), adaptada
+porque aqui nao ha sidecar intermediario (Decision 4).
+
+**Rationale**: preserva o invariante grep-avel ja documentado no plan.md
+arquivado de `loose-usage-capture` (`grep -nE
+'(^|[^-[:alnum:]_])sqlite3[[:space:]]+(-cmd[[:space:]]|--[[:space:]])'
+cli/lib/*.sh` deve continuar retornando so `cli/lib/recall.sh`) —
+condicao (b) do carve-out de dependencia obrigatoria da camada
+transacional nao se aplica aqui (esta NAO e a camada `state.db` dos
+orquestradores), entao `sqlite3` aqui segue como dependencia OPCIONAL
+(fallback: sem `sqlite3`, a captura falha silenciosamente e o hook segue
+fazendo so o pass-through) confinada a um unico arquivo, disciplina
+identica ao `jq`.
+
+## Decision 7 — `RECALL_SCHEMA_VERSION`: 13 -> 14, tabela nova aditiva
+
+**Decision**: bump de `RECALL_SCHEMA_VERSION` (valor real medido nesta
+onda: `13`, `cli/lib/recall.sh` linha 136) para `14`, adicionando
+`CREATE TABLE IF NOT EXISTS plan_usage (...)` ao corpo de
+`recall_schema_ddl` — sem `ALTER TABLE`, sem `DROP`, mesmo precedente
+literal usado por `loose_usage` na migracao v12->v13.
+
+**Rationale**: tabela nova nao exige migracao de coluna aditiva (ao
+contrario do padrao `ALTER TABLE ... ADD COLUMN` usado quando uma tabela
+EXISTENTE ganha campo novo) — `CREATE TABLE IF NOT EXISTS` cobre tanto
+bases que ja tem v13 (ganham a tabela vazia na proxima escrita) quanto
+bases anteriores (que passam pela cadeia de migracao ja existente sem
+interferencia).
+
+## Decision 8 — Testabilidade sem sessao interativa (FR-012)
+
+**Decision**: a logica de parsing/throttle/persistencia de
+`statusline-plan-usage.sh` e fatorada numa funcao POSIX isolavel
+(`_splu_process_payload`), testada alimentando um payload fixture via
+`printf '%s' "$FIXTURE" | statusline-plan-usage.sh` no harness de testes —
+nunca dependendo de `claude --settings ./settings.json` real (GOTCHA da
+memoria: "Statusline NAO dispara em `claude -p`").
+
+**Rationale**: mesma tecnica ja usada por `test_posttooluse-loose-usage.sh`
+(alimentar JSON fixture via stdin em vez de invocar o harness real) —
+precedente direto no proprio repo, convencao de testes de hook ja
+estabelecida.

--- a/docs/specs/plan-usage-capture/spec.md
+++ b/docs/specs/plan-usage-capture/spec.md
@@ -14,6 +14,32 @@
 - Q: Qual o formato de `captured_at`/`ingested_at`? → A: TEXT ISO 8601 (ex.: `2026-08-07T04:38:14Z`), alinhado a convencao de toda a knowledge.db — nunca epoch segundos. Distinto de `resets_at` (FR-003), que permanece epoch segundos por ser assim que a statusline emite esse campo especifico; `captured_at`/`ingested_at` sao carimbos proprios da ingestao do cstk, nao um campo repassado do payload.
 - Q: A consulta de historico do FR-008 via CLI deve ter limite/janela padrao? → A: sim — reusar as flags ja existentes de `cstk usage` (`--limit N`, default 20; `--since ISO`), sem inventar convencao nova.
 
+### Session 2026-08-10 (integracao pos-checklist, dec-029/dec-030)
+
+- Q: Quando `rate_limits` esta AUSENTE do payload inteiro (sessao sem
+  nenhuma resposta de API completada), o sistema insere uma linha `NULL`
+  em `plan_usage` ou nao insere nada? → A: NAO insere linha (dec-029). A
+  ausencia de linha E o proprio estado "nao medido". O objetivo "nunca 0"
+  se cumpre na LEITURA (a CLI mostra "nao medido", nunca "0%"), nao
+  escrevendo uma linha `NULL` a cada render antes da 1a resposta de API
+  completar (o que tambem eliminaria o flooding da tabela e a
+  indefinicao de comparacao NULL-vs-NULL no throttle de FR-010). Ressalva:
+  a coluna `used_percentage`/`resets_at` continua NULLABLE — quando
+  `rate_limits` ESTA presente mas um campo especifico vem ausente/nulo
+  dentro de um escopo capturado (caso defensivo/malformado), a linha E
+  inserida com `NULL` nesse campo, nunca `0`.
+- Q: A feature deve incluir `.cost`/`.context_window` (e as colunas
+  correlatas de custo/tokens de sessao do rascunho original do operador
+  — `session_cost_usd`, `session_input_tokens`, `session_output_tokens`,
+  `cache_read_input_tokens`, `cache_creation_input_tokens`, `model_id`)
+  no escopo, alem de `rate_limits`? → A: NAO — corte confirmado
+  (dec-030). `plan_usage` cobre exclusivamente o gauge de uso do plano
+  (`rate_limits`); `.cost`/`.context_window` ficam fora de escopo,
+  reservados para uma feature futura dedicada a custo/tokens de sessao.
+  Consequencia formal: a regra "cost/context_window sao cumulativos da
+  SESSAO — agregar com MAX, jamais SUM" fica **N/A para esta feature**,
+  por ausencia de qualquer coluna cumulativa persistida por `plan_usage`.
+
 ## User Scenarios & Testing
 
 ### User Story 1 - Consultar o uso atual do plano sem credencial OAuth (Priority: P1)
@@ -93,26 +119,35 @@ Stories 1 e 2, testavel isoladamente simulando a ausencia do campo
 **Independent Test**: apresentar ao mecanismo de captura um payload de
 statusline em que a chave `rate_limits` esta ausente (sessao aberta e
 fechada sem nenhuma resposta de API) e verificar que a captura resultante
-grava ausencia explicita (NULL), nunca o valor `0`.
+NAO grava linha nova em `plan_usage` (dec-029) e que a consulta
+subsequente via CLI reporta "nao medido", nunca o valor `0`.
 
 **Acceptance Scenarios**:
 
 1. **Given** um payload de statusline sem a chave `rate_limits`, **When** a
-   captura processa esse payload, **Then** o registro persistido tem
-   percentual usado e horario de reset como ausentes (NULL), nao como zero.
-2. **Given** um historico com capturas mistas (algumas com dado real,
-   outras sem `rate_limits`), **When** o operador consulta o historico,
-   **Then** o sistema distingue visualmente/estruturalmente as capturas sem
-   dado das capturas com `0%` real (se algum dia existir esse valor
-   genuino).
+   captura processa esse payload, **Then** nenhuma linha nova e inserida em
+   `plan_usage` para aquela captura (dec-029) — a ausencia de linha e o
+   estado "nao medido", nunca uma linha com valor zero fabricado.
+2. **Given** um banco onde nenhuma captura de um escopo existe ainda
+   (nenhuma resposta de API completou em nenhuma sessao), **When** o
+   operador consulta o uso do plano via CLI, **Then** o sistema apresenta
+   esse escopo como "nao medido" explicito, distinto de qualquer `0%` real
+   que venha a existir no futuro.
 
 ---
 
 ### Edge Cases
 
 - O que acontece quando a chave `rate_limits` esta ausente do payload
-  (sessao sem nenhuma resposta de API completada)? O sistema MUST gravar
-  ausencia explicita (NULL), nunca `0` (Constitution VI; ver Story 3).
+  (sessao sem nenhuma resposta de API completada)? O sistema MUST NOT
+  inserir linha em `plan_usage` para aquela captura — a ausencia de linha
+  E o estado "nao medido" (dec-029). Na leitura (FR-007/FR-008), esse
+  estado MUST ser apresentado como "nao medido", nunca como `0`
+  (Constitution VI; ver Story 3). Ressalva: quando `rate_limits` estiver
+  presente mas um campo especifico (`used_percentage` ou `resets_at`)
+  vier ausente dentro de um escopo capturado, o sistema MUST persistir
+  `NULL` explicito somente para aquele campo — a coluna permanece
+  NULLABLE para esse caso defensivo.
 - Como o sistema trata `resets_at`, que chega como numero em epoch segundos
   na statusline mesmo o contrato do endpoint `/api/oauth/usage` declarando
   `string|null`? O sistema MUST tratar `resets_at` como epoch em segundos
@@ -145,9 +180,14 @@ grava ausencia explicita (NULL), nunca o valor `0`.
   comando de statusline e extrair `rate_limits.five_hour` e
   `rate_limits.seven_day` quando presentes.
 - **FR-002**: Quando a chave `rate_limits` estiver ausente do payload
-  (sessao sem nenhuma resposta de API completada), o sistema MUST persistir
-  `NULL` para percentual usado e horario de reset daquela captura — nunca
-  `0`.
+  (sessao sem nenhuma resposta de API completada), o sistema MUST NOT
+  inserir linha em `plan_usage` para aquela captura — a ausencia de linha
+  E o estado "nao medido" (dec-029); o sistema MUST NUNCA fabricar `0` nem
+  inserir uma linha `NULL` como substituta. Quando `rate_limits` estiver
+  presente mas `used_percentage` ou `resets_at` vier ausente/nulo dentro
+  de um escopo capturado (caso defensivo/malformado), o sistema MUST
+  persistir `NULL` explicito somente para o campo faltante (a coluna
+  permanece NULLABLE para esse caso), nunca `0`.
 - **FR-003**: O sistema MUST persistir `resets_at` como epoch em segundos
   (numero), sem reinterpretar ou converter como string ISO.
 - **FR-004**: O sistema MUST persistir `used_percentage` como valor real
@@ -161,7 +201,11 @@ grava ausencia explicita (NULL), nunca o valor `0`.
   (`extra_usage`), que exigem credencial OAuth e estao fora de escopo.
 - **FR-007**: Usuarios MUST ser capazes de consultar, via CLI `cstk`, a
   captura mais recente conhecida do uso do plano (percentual usado +
-  horario de reset) para `five_hour` e `seven_day`.
+  horario de reset) para `five_hour` e `seven_day`. Quando nao houver
+  nenhuma captura conhecida para um escopo (nenhuma linha em `plan_usage`
+  para ele, porque `rate_limits` nunca esteve presente numa resposta de
+  API completada), o sistema MUST apresentar esse escopo como "nao
+  medido" explicito, nunca como `0%` (Constitution VI; dec-029).
 - **FR-008**: Usuarios MUST ser capazes de consultar o historico de
   capturas de uso do plano ao longo do tempo (nao apenas a mais recente),
   em ordem cronologica, por escopo. A consulta MUST reusar as flags ja
@@ -235,9 +279,10 @@ grava ausencia explicita (NULL), nunca o valor `0`.
   a captura configurada, o operador consegue consultar via CLI o percentual
   mais recente de uso do plano para `five_hour` e `seven_day`, sem fornecer
   nenhuma credencial OAuth.
-- **SC-002**: Para 100% das capturas em que `rate_limits` estava ausente do
-  payload, o dado persistido e explicitamente ausente (NULL) — nenhuma
-  captura sem dado real e reportada como `0%`.
+- **SC-002**: Para 100% das capturas em que `rate_limits` esta ausente do
+  payload, nenhuma linha e inserida em `plan_usage` (dec-029) — e para
+  100% das consultas em que nao ha captura conhecida de um escopo, a
+  leitura via CLI reporta "nao medido", nunca `0%` nem um dado fabricado.
 - **SC-003**: A partir de pelo menos duas capturas consecutivas na mesma
   janela, o operador consegue visualizar a evolucao do uso do plano ao
   longo do tempo sem cruzar dados manualmente de fontes separadas.

--- a/docs/specs/plan-usage-capture/spec.md
+++ b/docs/specs/plan-usage-capture/spec.md
@@ -279,6 +279,18 @@ subsequente via CLI reporta "nao medido", nunca o valor `0`.
 > nao depende de token externo com TTL, e cada captura e um processo local
 > de vida curta (o comando de statusline) sem estado compartilhado entre
 > replicas.
+> **FR-016-INFRA-INSTALL** (dec-042, gate `analyze` HIGH F2/E2): o
+> mecanismo de instalacao do `statusLine.command` (Edge Case acima, linha
+> 174-183) e o subcomando `cstk statusline install`/`status`
+> (`cli/lib/statusline.sh`, ver `plan.md` Project Structure), paralelo de
+> infraestrutura de CLI a `cli/lib/hooks.sh` (`cstk hooks install`) — nao
+> um FR numerado porque nao introduz comportamento novo de captura, apenas
+> plumbing de escrita/inspecao de `${HOME}/.claude/settings.json`. O
+> requisito comportamental que este mecanismo PRECISA preservar
+> (pass-through via `CSTK_STATUSLINE_INNER_COMMAND`, nunca sobrescrever
+> customizacao previa) ja esta fixado em `research.md` Decision 2 e no
+> Edge Case acima; `cstk statusline install` e a implementacao MUST desse
+> requisito, testada em `tests/cstk/test_statusline.sh`.
 
 ### Key Entities
 

--- a/docs/specs/plan-usage-capture/spec.md
+++ b/docs/specs/plan-usage-capture/spec.md
@@ -1,0 +1,222 @@
+# Feature Specification: Captura de Uso do Plano via Statusline (Plan Usage Capture)
+
+**Feature**: `plan-usage-capture`
+**Created**: 2026-08-10
+**Status**: Draft
+
+## User Scenarios & Testing
+
+### User Story 1 - Consultar o uso atual do plano sem credencial OAuth (Priority: P1)
+
+Como operador do Claude Code, eu quero consultar quanto do meu limite de
+plano (`/usage`) ja foi consumido nas janelas de 5 horas e 7 dias, usando o
+`cstk`, sem precisar fornecer credencial OAuth, para saber o quao perto
+estou de ser limitado antes de continuar trabalhando.
+
+**Why this priority**: e a capacidade minima que entrega valor sozinha — sem
+ela, o operador so descobre que bateu o limite quando o Claude Code ja
+recusa a proxima resposta. A statusline e a unica via observada que expoe
+esse dado sem OAuth.
+
+**Independent Test**: com o comando de statusline configurado para
+alimentar a captura, completar pelo menos uma resposta de API numa sessao e,
+em seguida, consultar via CLI o percentual usado e o horario de reset das
+janelas `five_hour` e `seven_day`, sem qualquer intervencao manual de
+coleta.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma sessao em que ao menos uma resposta de API completou,
+   **When** o operador consulta o uso do plano via `cstk`, **Then** o
+   sistema retorna o percentual usado e o horario de reset para `five_hour`
+   e `seven_day` separadamente.
+2. **Given** que a statusline nunca expos `seven_day_opus`,
+   `seven_day_sonnet` ou dados de creditos (exigem OAuth), **When** o
+   operador consulta o uso do plano, **Then** o sistema nao apresenta esses
+   campos como se fossem dados capturados — apenas `five_hour` e
+   `seven_day`.
+
+---
+
+### User Story 2 - Acompanhar a evolucao do uso do plano ao longo do tempo (Priority: P2)
+
+Como operador que roda sessoes longas ou multiplas sessoes no mesmo dia, eu
+quero ver como o uso do plano evoluiu ao longo de uma janela (5h ou 7d), e
+nao apenas o ultimo valor, para conseguir antecipar quando vou atingir o
+limite e ajustar meu ritmo de trabalho.
+
+**Why this priority**: um unico valor pontual (Story 1) ja tem valor, mas
+nao revela tendencia — sem historico, o operador nao sabe se esta
+consumindo rapido ou devagar dentro da janela. Depende da captura basica da
+Story 1 existir, mas e verificavel isoladamente a partir de duas ou mais
+capturas.
+
+**Independent Test**: acumular pelo menos duas capturas de uso do plano
+(por exemplo, em dois momentos distintos de uma mesma sessao ou em sessoes
+diferentes) e verificar que o historico consultado via CLI mostra as
+capturas em ordem cronologica, cada uma com seu percentual e timestamp.
+
+**Acceptance Scenarios**:
+
+1. **Given** duas ou mais capturas de uso do plano registradas para a
+   janela `five_hour`, **When** o operador consulta o historico dessa
+   janela, **Then** o sistema apresenta as capturas em ordem cronologica com
+   percentual usado e timestamp de cada uma.
+2. **Given** capturas registradas tanto para `five_hour` quanto para
+   `seven_day`, **When** o operador consulta o historico, **Then** as duas
+   janelas sao apresentadas como series distintas, sem mistura de escopo.
+
+---
+
+### User Story 3 - Nunca confundir "nao medido" com "zero" (Priority: P3)
+
+Como operador que confia nos numeros que o `cstk` reporta, eu quero que uma
+sessao sem nenhuma resposta de API completada apareca como "uso nao
+disponivel para esta captura", e nunca como "0% usado", para nao tomar
+decisoes com base num dado fabricado que parece zero de verdade.
+
+**Why this priority**: um "0%" fabricado e pior que nenhum dado — sugere
+folga de limite que pode nao existir. Refinamento de integridade sobre as
+Stories 1 e 2, testavel isoladamente simulando a ausencia do campo
+`rate_limits` no payload.
+
+**Independent Test**: apresentar ao mecanismo de captura um payload de
+statusline em que a chave `rate_limits` esta ausente (sessao aberta e
+fechada sem nenhuma resposta de API) e verificar que a captura resultante
+grava ausencia explicita (NULL), nunca o valor `0`.
+
+**Acceptance Scenarios**:
+
+1. **Given** um payload de statusline sem a chave `rate_limits`, **When** a
+   captura processa esse payload, **Then** o registro persistido tem
+   percentual usado e horario de reset como ausentes (NULL), nao como zero.
+2. **Given** um historico com capturas mistas (algumas com dado real,
+   outras sem `rate_limits`), **When** o operador consulta o historico,
+   **Then** o sistema distingue visualmente/estruturalmente as capturas sem
+   dado das capturas com `0%` real (se algum dia existir esse valor
+   genuino).
+
+---
+
+### Edge Cases
+
+- O que acontece quando a chave `rate_limits` esta ausente do payload
+  (sessao sem nenhuma resposta de API completada)? O sistema MUST gravar
+  ausencia explicita (NULL), nunca `0` (Constitution VI; ver Story 3).
+- Como o sistema trata `resets_at`, que chega como numero em epoch segundos
+  na statusline mesmo o contrato do endpoint `/api/oauth/usage` declarando
+  `string|null`? O sistema MUST tratar `resets_at` como epoch em segundos
+  na via da statusline, sem reinterpretar como string ISO — a fonte de
+  verdade e o payload observado, nao o contrato do endpoint que a feature
+  nao consome.
+- Como o sistema trata o ruido de float em `used_percentage` (ex.:
+  `7.000000000000001`)? O sistema MUST persistir o valor como veio, sem
+  arredondar na ingestao — arredondamento e, se necessario, responsabilidade
+  exclusiva da camada de apresentacao.
+- O que acontece se a statusline renderizar o mesmo gauge repetidas vezes
+  em sucessao rapida (comportamento orientado a evento, nao a polling)? O
+  sistema MUST evitar persistir capturas redundantes identicas em sucessao
+  imediata (throttle), para nao inflar o historico com ruido sem
+  informacao nova.
+- Como testar esta feature, dado que a statusline nao dispara em `claude
+  -p`? O teste automatizado MUST alimentar a via de ingestao com um payload
+  fixture apresentado via stdin, nunca depender de uma sessao interativa
+  real.
+- O que acontece com campos que existem apenas na resposta de `GET
+  /api/oauth/usage` (`seven_day_opus`, `seven_day_sonnet`, creditos/
+  `extra_usage`)? Estao fora de escopo desta feature — o sistema MUST NOT
+  tentar captura-los a partir da statusline, que nunca os emite.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: O sistema MUST ingerir o payload JSON recebido via stdin do
+  comando de statusline e extrair `rate_limits.five_hour` e
+  `rate_limits.seven_day` quando presentes.
+- **FR-002**: Quando a chave `rate_limits` estiver ausente do payload
+  (sessao sem nenhuma resposta de API completada), o sistema MUST persistir
+  `NULL` para percentual usado e horario de reset daquela captura — nunca
+  `0`.
+- **FR-003**: O sistema MUST persistir `resets_at` como epoch em segundos
+  (numero), sem reinterpretar ou converter como string ISO.
+- **FR-004**: O sistema MUST persistir `used_percentage` como valor real
+  (ponto flutuante), exatamente como reportado pela statusline, sem
+  arredondar na ingestao.
+- **FR-005**: O sistema MUST tratar `five_hour` e `seven_day` como escopos/
+  series distintos, nunca mesclando ou derivando um a partir do outro.
+- **FR-006**: O sistema MUST restringir a captura aos campos `five_hour` e
+  `seven_day` emitidos pela statusline; MUST NOT tentar capturar
+  `seven_day_opus`, `seven_day_sonnet` ou dados de creditos
+  (`extra_usage`), que exigem credencial OAuth e estao fora de escopo.
+- **FR-007**: Usuarios MUST ser capazes de consultar, via CLI `cstk`, a
+  captura mais recente conhecida do uso do plano (percentual usado +
+  horario de reset) para `five_hour` e `seven_day`.
+- **FR-008**: Usuarios MUST ser capazes de consultar o historico de
+  capturas de uso do plano ao longo do tempo (nao apenas a mais recente),
+  em ordem cronologica, por escopo.
+- **FR-009**: O sistema MUST persistir cada captura numa tabela dedicada
+  (`plan_usage`) no repositorio de conhecimento local (mesmo indice ja
+  usado por outras features de uso, ex.: `cstk recall`), com o
+  correspondente bump de versao de schema e migracao.
+- **FR-010**: O sistema MUST evitar persistir capturas redundantes
+  identicas (mesmo escopo, mesmo percentual, mesmo horario de reset) em
+  sucessao imediata, dado que a statusline renderiza por evento e nao por
+  polling controlado.
+- **FR-011**: O sistema MUST permanecer 100% local — nenhuma captura de uso
+  do plano e transmitida para fora do ambiente do operador (Principio IV da
+  constitution do projeto).
+- **FR-012**: A suite de teste automatizado desta feature MUST validar o
+  comportamento de ingestao usando um payload fixture apresentado via
+  stdin, nunca dependendo de uma sessao interativa real (a statusline nao
+  dispara em modo nao-interativo).
+
+> Decisoes de infraestrutura: aplica-se apenas cadencia de captura —
+> **FR-013-INFRA-SCHED**: a cadencia de captura e determinada por eventos
+> do harness (o comando de statusline e invocado a cada render de UI, nao
+> por um agendador externo tipo cron); o throttle mencionado em FR-010 e
+> responsabilidade do proprio mecanismo de ingestao, nao de um scheduler
+> separado. Demais itens do checklist (rotacao de chave, refresh de token
+> externo, mutex multi-pod, backup) N/A — a feature nao persiste segredos,
+> nao depende de token externo com TTL, e cada captura e um processo local
+> de vida curta (o comando de statusline) sem estado compartilhado entre
+> replicas.
+
+### Key Entities
+
+- **Captura de Uso do Plano (Plan Usage Snapshot)**: um registro pontual do
+  gauge de uso da conta para um escopo de janela (`five_hour` ou
+  `seven_day`), com percentual usado (ou ausencia explicita) e horario de
+  reset (epoch segundos, ou ausencia explicita), capturado a partir de um
+  render do comando de statusline. Persistido na tabela dedicada
+  `plan_usage` do repositorio de conhecimento local.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Apos pelo menos uma resposta de API completar numa sessao com
+  a captura configurada, o operador consegue consultar via CLI o percentual
+  mais recente de uso do plano para `five_hour` e `seven_day`, sem fornecer
+  nenhuma credencial OAuth.
+- **SC-002**: Para 100% das capturas em que `rate_limits` estava ausente do
+  payload, o dado persistido e explicitamente ausente (NULL) — nenhuma
+  captura sem dado real e reportada como `0%`.
+- **SC-003**: A partir de pelo menos duas capturas consecutivas na mesma
+  janela, o operador consegue visualizar a evolucao do uso do plano ao
+  longo do tempo sem cruzar dados manualmente de fontes separadas.
+- **SC-004**: 100% dos horarios de reset persistidos sao interpretaveis
+  diretamente como epoch em segundos, sem erro de parsing por presumir
+  formato string.
+- **SC-005**: Nenhuma captura de uso do plano desta feature e transmitida
+  para fora do ambiente local do operador — verificavel pela ausencia de
+  qualquer chamada de rede na via de ingestao.
+
+## Delta Requirements
+
+**Skip**: feature adiciona uma capacidade inteiramente nova (captura de
+gauge de limite do plano via statusline); nao ha nenhuma capability
+documentada em `docs/specs/current/` referente a captura de uso do plano ou
+`rate_limits` a ser alterada, removida ou renomeada — o corpus canonico
+atual cobre apenas atomic-commit-staging, guards e gates de delta/spec, sem
+sobreposicao com este escopo — agente-00c-feature-orchestrator, 2026-08-10

--- a/docs/specs/plan-usage-capture/spec.md
+++ b/docs/specs/plan-usage-capture/spec.md
@@ -171,6 +171,16 @@ subsequente via CLI reporta "nao medido", nunca o valor `0`.
   /api/oauth/usage` (`seven_day_opus`, `seven_day_sonnet`, creditos/
   `extra_usage`)? Estao fora de escopo desta feature — o sistema MUST NOT
   tentar captura-los a partir da statusline, que nunca os emite.
+- O que acontece quando o operador ja tem uma statusline customizada
+  configurada (`statusLine.command` no `settings.json` do harness)? Como
+  essa chave e UNICA, instalar esta feature sem cuidado sobrescreveria a
+  customizacao existente. O sistema MUST preservar a customizacao previa
+  via pass-through: quando a variavel de ambiente
+  `CSTK_STATUSLINE_INNER_COMMAND` estiver definida, `statusline-plan-usage.sh`
+  MUST reencaminhar o payload original (stdin, sem modificacao) para o
+  comando nela referenciado e repassar o stdout dele verbatim, capturando
+  o uso do plano como efeito colateral best-effort — nunca substituindo o
+  texto renderizado pela statusline customizada do operador.
 
 ## Requirements
 
@@ -199,6 +209,11 @@ subsequente via CLI reporta "nao medido", nunca o valor `0`.
   `seven_day` emitidos pela statusline; MUST NOT tentar capturar
   `seven_day_opus`, `seven_day_sonnet` ou dados de creditos
   (`extra_usage`), que exigem credencial OAuth e estao fora de escopo.
+  MUST NOT tambem capturar os demais campos do payload que a statusline
+  emite mas que nao pertencem ao gauge `rate_limits`: `.model`, `.cost`,
+  `.context_window`, `.exceeds_200k_tokens`, `.thinking`, `.effort`,
+  `.output_style`, `.version` (ver `contracts/statusline-hook.md`
+  §Contrato de entrada, "Campos NAO consumidos por esta feature").
 - **FR-007**: Usuarios MUST ser capazes de consultar, via CLI `cstk`, a
   captura mais recente conhecida do uso do plano (percentual usado +
   horario de reset) para `five_hour` e `seven_day`. Quando nao houver
@@ -244,8 +259,17 @@ subsequente via CLI reporta "nao medido", nunca o valor `0`.
   comportamento de ingestao usando um payload fixture apresentado via
   stdin, nunca dependendo de uma sessao interativa real (a statusline nao
   dispara em modo nao-interativo).
-
-> Decisoes de infraestrutura: aplica-se apenas cadencia de captura —
+- **FR-015**: A captura MUST ser fail-open/best-effort em qualquer cenario
+  de degradacao — `jq` ausente, `sqlite3` ausente, `knowledge.db`
+  inacessivel (sem permissao de escrita), ou payload JSON malformado. Em
+  TODOS esses cenarios o sistema MUST: (a) pular a captura silenciosamente
+  (sem inserir linha em `plan_usage`); (b) imprimir em stdout o texto de
+  fallback/pass-through normal da statusline, exatamente como se a captura
+  nao existisse; (c) sair sempre com exit code `0`. O sistema MUST NUNCA
+  imprimir erro de diagnostico da captura em stdout (contaminaria a UI
+  renderizada) nem atrasar perceptivelmente a renderizacao — erros, se
+  logados, vao para stderr ou sao descartados silenciosamente (mesma
+  disciplina fail-open de `posttooluse-loose-usage.sh`).
 > **FR-013-INFRA-SCHED**: a cadencia de captura e determinada por eventos
 > do harness (o comando de statusline e invocado a cada render de UI, nao
 > por um agendador externo tipo cron); o throttle mencionado em FR-010 e

--- a/docs/specs/plan-usage-capture/spec.md
+++ b/docs/specs/plan-usage-capture/spec.md
@@ -4,6 +4,16 @@
 **Created**: 2026-08-10
 **Status**: Draft
 
+## Clarifications
+
+### Session 2026-08-10
+
+- Q: Qual a tolerancia de dedupe do throttle FR-010 para `used_percentage`? → A: tolerancia de 2 casas decimais — duas capturas so sao consideradas identicas (e descartaveis pelo throttle) se `used_percentage` bater ate a 2a casa decimal; alem disso conta como mudanca real.
+- Q: Qual a janela temporal do throttle FR-010 (ultimas N capturas ou so a ultima)? → A: sem janela temporal — o throttle compara sempre contra o ULTIMO registro persistido daquele escopo (`five_hour`/`seven_day`), nao uma janela de tempo.
+- Q: Qual a dimensao do schema `plan_usage` — global (so a conta) ou com dimensao de projeto/sessao? → A: manter dimensao de projeto/sessao (`project`, `project_path`, `session_id`), como as demais tabelas do knowledge.db (ex.: `loose_usage`); o gauge continua sendo da CONTA, a dimensao registra apenas DE ONDE a captura veio.
+- Q: Qual o formato de `captured_at`/`ingested_at`? → A: TEXT ISO 8601 (ex.: `2026-08-07T04:38:14Z`), alinhado a convencao de toda a knowledge.db — nunca epoch segundos. Distinto de `resets_at` (FR-003), que permanece epoch segundos por ser assim que a statusline emite esse campo especifico; `captured_at`/`ingested_at` sao carimbos proprios da ingestao do cstk, nao um campo repassado do payload.
+- Q: A consulta de historico do FR-008 via CLI deve ter limite/janela padrao? → A: sim — reusar as flags ja existentes de `cstk usage` (`--limit N`, default 20; `--since ISO`), sem inventar convencao nova.
+
 ## User Scenarios & Testing
 
 ### User Story 1 - Consultar o uso atual do plano sem credencial OAuth (Priority: P1)
@@ -154,15 +164,35 @@ grava ausencia explicita (NULL), nunca o valor `0`.
   horario de reset) para `five_hour` e `seven_day`.
 - **FR-008**: Usuarios MUST ser capazes de consultar o historico de
   capturas de uso do plano ao longo do tempo (nao apenas a mais recente),
-  em ordem cronologica, por escopo.
+  em ordem cronologica, por escopo. A consulta MUST reusar as flags ja
+  existentes de `cstk usage` (`--limit N`, default 20; `--since ISO`) para
+  limitar/janelar o resultado — sem introduzir uma convencao nova de
+  paginacao para esta feature.
 - **FR-009**: O sistema MUST persistir cada captura numa tabela dedicada
   (`plan_usage`) no repositorio de conhecimento local (mesmo indice ja
   usado por outras features de uso, ex.: `cstk recall`), com o
-  correspondente bump de versao de schema e migracao.
+  correspondente bump de versao de schema e migracao. A tabela MUST manter
+  dimensao de projeto/sessao (`project`, `project_path`, `session_id`),
+  na mesma convencao das demais tabelas do knowledge.db (ex.:
+  `loose_usage`) — o gauge medido continua sendo o da CONTA (nao do
+  projeto/sessao); a dimensao registra apenas a proveniencia da captura.
 - **FR-010**: O sistema MUST evitar persistir capturas redundantes
   identicas (mesmo escopo, mesmo percentual, mesmo horario de reset) em
   sucessao imediata, dado que a statusline renderiza por evento e nao por
-  polling controlado.
+  polling controlado. O throttle MUST comparar cada nova captura apenas
+  contra o ULTIMO registro persistido daquele escopo (`five_hour` ou
+  `seven_day`), sem janela temporal; duas capturas do mesmo escopo sao
+  consideradas identicas (e portanto descartadas) somente quando
+  `used_percentage` bate ate a 2a casa decimal e `resets_at` e igual —
+  qualquer diferenca alem da 2a casa decimal conta como mudanca real e
+  MUST ser persistida.
+- **FR-014**: O sistema MUST persistir `captured_at` (carimbo de quando a
+  captura foi processada) e `ingested_at` (carimbo de ingestao no
+  knowledge.db) como TEXT em formato ISO 8601 (ex.:
+  `2026-08-07T04:38:14Z`), na mesma convencao usada pelas demais tabelas
+  do knowledge.db — nunca como epoch. Isto e distinto de `resets_at`
+  (FR-003), que permanece epoch em segundos por ser o formato em que a
+  propria statusline emite esse campo.
 - **FR-011**: O sistema MUST permanecer 100% local — nenhuma captura de uso
   do plano e transmitida para fora do ambiente do operador (Principio IV da
   constitution do projeto).
@@ -189,7 +219,13 @@ grava ausencia explicita (NULL), nunca o valor `0`.
   `seven_day`), com percentual usado (ou ausencia explicita) e horario de
   reset (epoch segundos, ou ausencia explicita), capturado a partir de um
   render do comando de statusline. Persistido na tabela dedicada
-  `plan_usage` do repositorio de conhecimento local.
+  `plan_usage` do repositorio de conhecimento local, com dimensao de
+  proveniencia (`project`, `project_path`, `session_id`) na mesma
+  convencao das demais tabelas do knowledge.db — o gauge medido e sempre
+  da CONTA, a dimensao so registra a origem da captura. Carrega dois
+  carimbos de tempo proprios da ingestao, `captured_at` e `ingested_at`,
+  ambos TEXT em formato ISO 8601 — distintos de `resets_at`, que
+  permanece epoch em segundos por ser o formato emitido pela statusline.
 
 ## Success Criteria
 

--- a/docs/specs/plan-usage-capture/tasks.md
+++ b/docs/specs/plan-usage-capture/tasks.md
@@ -345,27 +345,52 @@ Ref: contracts/cli-plan-usage.md §`ingest --stdin`
 
 Ref: spec.md FR-012, research.md Decision 8, quickstart.md (7 cenarios)
 
-- [ ] 5.1.1 Criar `tests/test_statusline-plan-usage.sh` seguindo o
+- [x] 5.1.1 Criar `tests/test_statusline-plan-usage.sh` seguindo o
       precedente de `tests/test_posttooluse-loose-usage.sh` — alimenta
-      fixtures via stdin, nunca sessao `claude` real
-- [ ] 5.1.2 Cobrir os 7 cenarios de `quickstart.md` como casos de teste
+      fixtures via stdin, nunca sessao `claude` real <!-- criado onda-007;
+      `LC_ALL=C bash tests/test_statusline-plan-usage.sh`: 12/12 ok
+      (onda-010) -->
+- [x] 5.1.2 Cobrir os 7 cenarios de `quickstart.md` como casos de teste
       nomeados (1 captura basica, 2 ausencia-nunca-zero, 3 throttle, 4
       evolucao temporal, 5 formato resets_at, 6 zero coleta remota, 7
-      deps ausentes)
-- [ ] 5.1.3 Criar `tests/test_cli-plan-usage.sh` cobrindo `cstk
-      plan-usage`/`cstk plan-usage history` (FASE 4)
-- [ ] 5.1.4 Rodar a suite completa local e confirmar 0 regressao nos
+      deps ausentes) <!-- 1/2/3/7 em scenario_captura_basica_2_linhas /
+      scenario_ausencia_total_zero_linhas+scenario_ausencia_parcial_null_nunca_zero
+      / scenario_throttle_quickstart_cenario3 / scenario_jq_ausente+
+      scenario_cstk_ausente (tests/test_statusline-plan-usage.sh); 4/5/6
+      em scenario_09_historico_ordem_cronologica / scenario_04_json_com_dados
+      (resets_at=1786372200) / scenario_06_tabela_vazia
+      (tests/cstk/test_plan-usage.sh) -->
+- [x] 5.1.3 Criar `tests/cstk/test_plan-usage.sh` cobrindo `cstk
+      plan-usage`/`cstk plan-usage history` (FASE 4) <!-- path corrigido
+      de tests/test_cli-plan-usage.sh (divergencia do tasks.md original)
+      para tests/cstk/test_plan-usage.sh, alinhado a convencao cli/lib
+      ja declarada em plan.md §Testing e §Estrutura — dec-041 (gate
+      analyze, HIGH), resolvido nesta onda (onda-010); arquivo criado
+      onda-009, 14/14 ok -->
+- [x] 5.1.4 Rodar a suite completa local e confirmar 0 regressao nos
       testes existentes de `recall.sh`/`usage.sh` (migracao aditiva nao
-      quebra nada)
+      quebra nada) <!-- onda-010, LC_ALL=C: test_statusline-plan-usage.sh
+      12/12, tests/cstk/test_plan-usage.sh 14/14, tests/cstk/test_statusline.sh
+      12/12 (todos rodados ao vivo nesta onda); tests/cstk/test_recall.sh
+      148 ok / 1 not ok ja verificado pelo pai nesta sessao — unico
+      vermelho e scenario_ctx_15_auditabilidade_pre_decisao, falha
+      pre-existente do backend sqlite (dec-047), fora de escopo, zero
+      regressao introduzida por esta feature -->
 
 ### 5.2 Gates deterministicos pos-geracao `[M]`
 
 Ref: create-tasks/scripts/validate-tasks-template.sh, template canonico
 
-- [ ] 5.2.1 Rodar `validate-tasks-template.sh` sobre este `tasks.md` e
-      confirmar exit `0` (conformante ao template)
-- [ ] 5.2.2 Rodar `validate-docs-rendered` sobre os artefatos da feature
+- [x] 5.2.1 Rodar `validate-tasks-template.sh` sobre este `tasks.md` e
+      confirmar exit `0` (conformante ao template) <!-- onda-010:
+      `RESULT|.../tasks.md|critical=0|warning=0`, exit 0 -->
+- [x] 5.2.2 Rodar `validate-docs-rendered` sobre os artefatos da feature
       (Mermaid da Matriz de Dependencias, links internos, frontmatter)
+      <!-- onda-010: spec/plan/tasks/data-model/quickstart/contracts (9
+      arquivos) -> ERRO=0, AVISO 4->1 apos corrigir 3 code-blocks sem
+      linguagem (plan.md x2, statusline-hook.md); 1 AVISO residual
+      (cli-plan-usage.md:71, falso-positivo de pipe escapado \| dentro
+      de celula — ver dec-066) -->
 
 ---
 
@@ -376,11 +401,23 @@ Ref: create-tasks/scripts/validate-tasks-template.sh, template canonico
 Ref: plan.md §Constitution Check Principio I (SDD recursivo — "Contrato
 de CLI novo exige nota no CHANGELOG, MINOR")
 
-- [ ] 6.1.1 Adicionar entrada MINOR no CHANGELOG do `cstk` descrevendo a
+- [x] 6.1.1 Adicionar entrada MINOR no CHANGELOG do `cstk` descrevendo a
       capacidade nova (`cstk plan-usage`, captura via statusline)
-- [ ] 6.1.2 Atualizar contagem de subcomandos/docs afetados, se algum
+      <!-- onda-010: CHANGELOG.md secao [7.2.0] - 2026-08-10 adicionada
+      (cstk statusline install/status, cstk plan-usage, cstk plan-usage
+      history, tabela plan_usage v13->v14); bump de versao no
+      MANIFESTO (plugin.json/marketplace.json) e tag/release ficam para
+      o pipeline release-wave, publicacao exige autorizacao humana
+      (fora do escopo autorizado desta onda) -->
+- [x] 6.1.2 Atualizar contagem de subcomandos/docs afetados, se algum
       teste de contagem (`test_doc-counts.sh` ou equivalente) gateia
-      README/docs
+      README/docs <!-- onda-010: grep em test_doc-counts.sh e
+      test_build-release.sh confirma que os gates de contagem existentes
+      medem apenas pastas de skill (plugins/cstk/skills/*) e
+      profiles.txt.in — esta feature nao cria skill nova (so subcomandos
+      cli/lib novos sob a skill agente-00c-runtime ja existente), logo
+      nenhum contador precisa mudar; nenhum teste de contagem referencia
+      subcomandos cli individualmente -->
 
 ---
 

--- a/docs/specs/plan-usage-capture/tasks.md
+++ b/docs/specs/plan-usage-capture/tasks.md
@@ -231,26 +231,51 @@ Ref: contracts/statusline-hook.md linha 64, research.md Decision 6
 Ref: research.md Decision 2 (mecanismo exato deixado para esta fase),
 plan.md §Riscos conhecidos
 
-- [ ] 3.1.1 Decidir e implementar o mecanismo de instalacao: subcomando
+- [x] 3.1.1 Decidir e implementar o mecanismo de instalacao: subcomando
       novo `cstk statusline install` (paralelo a `cstk hooks install`,
       linha equivalente em `cli/cstk` dispatch) que escreve/atualiza a
       chave `statusLine.command` do `settings.json` do harness
-- [ ] 3.1.2 Se ja existir `statusLine.command` customizado: preservar o
+      <!-- cli/lib/statusline.sh (statusline_main/statusline_cmd_install);
+      cli/cstk dispatch registrado (COMANDOS, help switch, dispatch case,
+      2x "Comandos validos"); target = ${HOME}/.claude/settings.json
+      (statusLine e preferencia por-operador, nao por-projeto) -->
+- [x] 3.1.2 Se ja existir `statusLine.command` customizado: preservar o
       valor atual movendo-o para `CSTK_STATUSLINE_INNER_COMMAND` (nunca
       sobrescrever silenciosamente — mitigacao do risco documentado em
       `plan.md`)
-- [ ] 3.1.3 Idempotencia: rodar a instalacao 2x seguidas produz o mesmo
+      <!-- statusline_cmd_install: case "$_si_cur" com wrap
+      CSTK_STATUSLINE_INNER_COMMAND='<escaped>' <script>; escaping via
+      _sl_escape_single_quotes (' -> '\''); demais chaves do
+      settings.json preservadas via jq merge pontual (.statusLine.command
+      = $cmd) -->
+- [x] 3.1.3 Idempotencia: rodar a instalacao 2x seguidas produz o mesmo
       `settings.json` final (sem duplicar wrapper sobre wrapper)
-- [ ] 3.1.4 `cstk statusline status`/`--help` reportando se a captura
+      <!-- case "$_si_cur" detecta os 2 formatos ja instalados (script puro
+      OU wrapper com CSTK_STATUSLINE_INNER_COMMAND terminando no script) e
+      retorna no-op; testado em
+      scenario_install_idempotente_sem_customizacao +
+      scenario_install_idempotente_com_customizacao -->
+- [x] 3.1.4 `cstk statusline status`/`--help` reportando se a captura
       esta instalada e ativa (paridade com `cstk hooks status`, se
       existir precedente)
-- [ ] 3.1.5 Teste: instalacao em `settings.json` sem `statusLine.command`
+      <!-- sem precedente real (hooks_main so tem "install"); status
+      implementado do zero: statusline_cmd_status reporta nao-instalado
+      (exit 1), ativo sem/com customizacao previa (exit 0), ou apontando
+      p/ outro comando = captura NAO ativa (exit 1); --help via
+      _statusline_print_help -->
+- [x] 3.1.5 Teste: instalacao em `settings.json` sem `statusLine.command`
       previo -> chave criada apontando para
       `statusline-plan-usage.sh`
-- [ ] 3.1.6 Teste: instalacao em `settings.json` com `statusLine.command`
+      <!-- tests/cstk/test_statusline.sh ::
+      scenario_install_sem_statusline_previa_cria_chave -->
+- [x] 3.1.6 Teste: instalacao em `settings.json` com `statusLine.command`
       customizado previo -> valor original preservado em
       `CSTK_STATUSLINE_INNER_COMMAND`, nova chave aponta para o script
       desta feature
+      <!-- tests/cstk/test_statusline.sh ::
+      scenario_install_preserva_customizacao_previa +
+      scenario_install_preserva_customizacao_com_aspas (round-trip de
+      aspas duplas no comando original) -->
 
 ---
 

--- a/docs/specs/plan-usage-capture/tasks.md
+++ b/docs/specs/plan-usage-capture/tasks.md
@@ -289,41 +289,41 @@ Ref: contracts/cli-plan-usage.md §`cstk plan-usage`, spec.md FR-007
       (`case "$1"`), delegando a `plan_usage_main()` novo em
       `cli/lib/plan-usage.sh` (paridade com `usage_main()` de
       `cli/lib/usage.sh`)
-- [ ] 4.1.2 Flags `--json`, `--db PATH` (paridade `cstk usage --db`)
-- [ ] 4.1.3 Saida texto: percentual + horario de reset (local time na
+- [x] 4.1.2 Flags `--json`, `--db PATH` (paridade `cstk usage --db`)
+- [x] 4.1.3 Saida texto: percentual + horario de reset (local time na
       apresentacao; persistencia continua epoch) por escopo; campo sem
       medicao imprime `nao medido`, nunca `0` (FR-002/SC-002, dec-029)
-- [ ] 4.1.4 Saida `--json`: `used_percentage`/`resets_at`/`captured_at`
+- [x] 4.1.4 Saida `--json`: `used_percentage`/`resets_at`/`captured_at`
       como `null` JSON quando o escopo nunca teve captura com
       `rate_limits` presente
-- [ ] 4.1.5 `knowledge.db` ausente: aviso em stderr + `nao medido` para
+- [x] 4.1.5 `knowledge.db` ausente: aviso em stderr + `nao medido` para
       os 2 escopos, exit `0`
-- [ ] 4.1.6 Tabela `plan_usage` vazia: `nao medido — nenhuma captura
+- [x] 4.1.6 Tabela `plan_usage` vazia: `nao medido — nenhuma captura
       registrada ainda`, exit `0`
-- [ ] 4.1.7 `sqlite3` ausente: aviso em stderr explicando a dep, exit `1`
-- [ ] 4.1.8 Flag desconhecida: uso em stderr, exit `2`
-- [ ] 4.1.9 Teste: os 8 subitens acima como casos de teste automatizados
-      via fixture (sem sessao real — FR-012)
+- [x] 4.1.7 `sqlite3` ausente: aviso em stderr explicando a dep, exit `1`
+- [x] 4.1.8 Flag desconhecida: uso em stderr, exit `2`
+- [x] 4.1.9 Teste: os 8 subitens acima como casos de teste automatizados
+      via fixture (sem sessao real — FR-012) <!-- tests/cstk/test_plan-usage.sh, 8/8 ok -->
 
 ### 4.2 `cstk plan-usage history` (serie temporal) `[A]`
 
 Ref: contracts/cli-plan-usage.md §`cstk plan-usage history`, spec.md
 FR-008, dec-014
 
-- [ ] 4.2.1 Flags `--scope five_hour|seven_day` (default: ambos,
+- [x] 4.2.1 Flags `--scope five_hour|seven_day` (default: ambos,
       separados — FR-005), `--limit N` (default `20`, reuso literal de
       `cstk usage --limit`), `--since ISO` (reuso literal de `cstk usage
       --since`) — SEM inventar convencao nova de paginacao (dec-014)
-- [ ] 4.2.2 Saida texto: uma secao por escopo, ate `--limit` linhas em
+- [x] 4.2.2 Saida texto: uma secao por escopo, ate `--limit` linhas em
       ordem cronologica
-- [ ] 4.2.3 Saida `--json`: chave presente so para escopo(s) pedido(s);
+- [x] 4.2.3 Saida `--json`: chave presente so para escopo(s) pedido(s);
       array vazio (nao `null`) quando o escopo existe mas nao tem
       captura no filtro
-- [ ] 4.2.4 Mesma tabela de comportamento sem dados de 4.1.5-4.1.8
-- [ ] 4.2.5 Teste: 3 capturas crescentes -> historico em ordem
+- [x] 4.2.4 Mesma tabela de comportamento sem dados de 4.1.5-4.1.8
+- [x] 4.2.5 Teste: 3 capturas crescentes -> historico em ordem
       cronologica (paridade quickstart.md Cenario 4)
-- [ ] 4.2.6 Teste: `--since`/`--limit` filtram identico a `cstk usage`
-      (mesmo parsing de flag, reuso de codigo se possivel)
+- [x] 4.2.6 Teste: `--since`/`--limit` filtram identico a `cstk usage`
+      (mesmo parsing de flag, reuso de codigo se possivel) <!-- tests/cstk/test_plan-usage.sh cenarios 9-14, 14/14 ok -->
 
 ### 4.3 `cstk plan-usage ingest --stdin` (interno) `[A]`
 

--- a/docs/specs/plan-usage-capture/tasks.md
+++ b/docs/specs/plan-usage-capture/tasks.md
@@ -127,19 +127,19 @@ Ref: checklists/requirements.md CHK002, CHK003, CHK004, CHK020, CHK022
 Ref: contracts/statusline-hook.md §Contrato de entrada, research.md
 Decision 1/3
 
-- [ ] 2.1.1 Criar
+- [x] 2.1.1 Criar
       `plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh`
       (shebang `#!/bin/sh`, Constitution II) lendo o payload JSON do
       stdin
-- [ ] 2.1.2 Extrair `.session_id`, `.workspace.current_dir` /
+- [x] 2.1.2 Extrair `.session_id`, `.workspace.current_dir` /
       `.workspace.project_dir` (fallback conforme contrato linha 29),
       `.rate_limits.five_hour.*`, `.rate_limits.seven_day.*` via `jq`
-- [ ] 2.1.3 `jq` ausente: captura pulada, pass-through preservado, exit
+- [x] 2.1.3 `jq` ausente: captura pulada, pass-through preservado, exit
       sempre `0` (research.md Decision 3, reuso do carve-out de
       `cli/lib/recall.sh`/`cli/lib/usage.sh`)
-- [ ] 2.1.4 Payload malformado (JSON invalido): captura pulada,
+- [x] 2.1.4 Payload malformado (JSON invalido): captura pulada,
       pass-through best-effort do stdin cru, exit `0`
-- [ ] 2.1.5 Teste: fixture com `rate_limits` completo extrai os 4 valores
+- [x] 2.1.5 Teste: fixture com `rate_limits` completo extrai os 4 valores
       corretamente (paridade com o schema OBSERVADO na memoria
       `reference_statusline_usage_payload.md`)
 
@@ -149,21 +149,21 @@ Ref: spec.md FR-002/Edge-Case/User-Story-3, data-model.md §Ausencia
 explicita vs valor real, contracts/statusline-hook.md §Comportamento de
 captura, Constitution VI (Zero Fabricacao)
 
-- [ ] 2.2.1 Quando a chave `.rate_limits` esta AUSENTE do payload
+- [x] 2.2.1 Quando a chave `.rate_limits` esta AUSENTE do payload
       inteiro: **NAO chamar** `recall_plan_usage_insert()` para nenhum
       escopo — nenhuma linha inserida (dec-029)
-- [ ] 2.2.2 Quando `.rate_limits.<scope>` esta presente mas
+- [x] 2.2.2 Quando `.rate_limits.<scope>` esta presente mas
       `used_percentage`/`resets_at` vem ausente/nulo dentro do escopo:
       chamar `recall_plan_usage_insert()` para aquele escopo com `NULL`
       no(s) campo(s) faltante(s) — caso defensivo/malformado, nunca
       observado empiricamente mas a coluna permanece NULLABLE para isso
-- [ ] 2.2.3 Em NENHUM caminho persistir `0` como substituto de dado
+- [x] 2.2.3 Em NENHUM caminho persistir `0` como substituto de dado
       ausente (Constitution VI — validar com teste dedicado, nao so
       inspecao)
-- [ ] 2.2.4 Teste: fixture SEM `rate_limits` -> zero linhas novas em
+- [x] 2.2.4 Teste: fixture SEM `rate_limits` -> zero linhas novas em
       `plan_usage` apos a execucao (nao apenas "sem erro" — checar
       `SELECT COUNT(*)` antes/depois)
-- [ ] 2.2.5 Teste: fixture com `rate_limits.five_hour` presente e
+- [x] 2.2.5 Teste: fixture com `rate_limits.five_hour` presente e
       `rate_limits.seven_day` ausente -> uma linha nova so para
       `five_hour`, nenhuma para `seven_day`
 
@@ -172,14 +172,14 @@ captura, Constitution VI (Zero Fabricacao)
 Ref: spec.md FR-010, data-model.md §Migracao/Ausencia, checklists/
 requirements.md CHK010 (residual documentado nesta onda)
 
-- [ ] 2.3.1 Antes de cada INSERT candidato, consultar o ULTIMO registro
+- [x] 2.3.1 Antes de cada INSERT candidato, consultar o ULTIMO registro
       persistido daquele escopo (`SELECT ... ORDER BY id DESC LIMIT 1
       WHERE scope = ?`), sem janela temporal
-- [ ] 2.3.2 Descartar (nao inserir) quando `used_percentage` bate ate a
+- [x] 2.3.2 Descartar (nao inserir) quando `used_percentage` bate ate a
       2a casa decimal E `resets_at` e igual ao ultimo registro
-- [ ] 2.3.3 Persistir quando a diferenca ultrapassa a 2a casa decimal OU
+- [x] 2.3.3 Persistir quando a diferenca ultrapassa a 2a casa decimal OU
       `resets_at` mudou
-- [ ] 2.3.4 **Decisao residual CHK010**: definir e implementar o
+- [x] 2.3.4 **Decisao residual CHK010**: definir e implementar o
       comportamento quando o ULTIMO registro do escopo tem
       `used_percentage`/`resets_at` = `NULL` (ausencia parcial
       persistida, 2.2.2) e a nova captura do MESMO escopo TAMBEM chega
@@ -187,7 +187,7 @@ requirements.md CHK010 (residual documentado nesta onda)
       Decisao auditavel (nao inventar sem registro) se NULL-vs-NULL conta
       como "identico" (descarta) ou "sempre persiste" (nunca descarta
       ausencia); documentar a escolha em `data-model.md` apos decidir
-- [ ] 2.3.5 Teste: duas capturas identicas em sequencia -> so 1 linha
+- [x] 2.3.5 Teste: duas capturas identicas em sequencia -> so 1 linha
       nova; 3a captura com mudanca na 3a casa decimal apenas -> ainda
       descartada; 4a captura com mudanca na 2a casa decimal -> nova linha
       (paridade com quickstart.md Cenario 3)
@@ -197,16 +197,16 @@ requirements.md CHK010 (residual documentado nesta onda)
 Ref: contracts/statusline-hook.md §Contrato de saida, research.md
 Decision 2
 
-- [ ] 2.4.1 Se `CSTK_STATUSLINE_INNER_COMMAND` definida: reencaminhar o
+- [x] 2.4.1 Se `CSTK_STATUSLINE_INNER_COMMAND` definida: reencaminhar o
       payload original (stdin intacto) para o comando dela, repassar
       stdout verbatim
-- [ ] 2.4.2 Senao: imprimir fallback minimo de 1 linha construido so a
+- [x] 2.4.2 Senao: imprimir fallback minimo de 1 linha construido so a
       partir de `model.display_name` + (quando presente) `used_percentage`
       de `five_hour` desta mesma captura — nunca inventar outro campo
-- [ ] 2.4.3 Erros de captura (jq ausente, sqlite3 ausente, INSERT falho)
+- [x] 2.4.3 Erros de captura (jq ausente, sqlite3 ausente, INSERT falho)
       NUNCA vao para stdout — descartados silenciosamente ou enviados so
       a stderr
-- [ ] 2.4.4 Teste: em NENHUM cenario (dep ausente, payload malformado,
+- [x] 2.4.4 Teste: em NENHUM cenario (dep ausente, payload malformado,
       throttle, INSERT ok) o script sai com exit != `0`, nem imprime erro
       de diagnostico em stdout
 
@@ -214,12 +214,12 @@ Decision 2
 
 Ref: contracts/statusline-hook.md linha 64, research.md Decision 6
 
-- [ ] 2.5.1 `sqlite3` ausente OU `knowledge.db` sem permissao de escrita:
+- [x] 2.5.1 `sqlite3` ausente OU `knowledge.db` sem permissao de escrita:
       captura pulada, pass-through intacto, exit `0`
-- [ ] 2.5.2 Confinar toda chamada a `sqlite3` a `cli/lib/recall.sh` —
+- [x] 2.5.2 Confinar toda chamada a `sqlite3` a `cli/lib/recall.sh` —
       `statusline-plan-usage.sh` MUST NOT invocar `sqlite3` diretamente
       (mesmo confinamento de `loose-usage-capture`)
-- [ ] 2.5.3 Teste: simular `sqlite3` ausente no PATH -> pass-through
+- [x] 2.5.3 Teste: simular `sqlite3` ausente no PATH -> pass-through
       normal, captura pulada, exit `0` (paridade quickstart.md Cenario 7)
 
 ---
@@ -260,7 +260,7 @@ plan.md §Riscos conhecidos
 
 Ref: contracts/cli-plan-usage.md §`cstk plan-usage`, spec.md FR-007
 
-- [ ] 4.1.1 Registrar subcomando `plan-usage` no dispatch de `cli/cstk`
+- [x] 4.1.1 Registrar subcomando `plan-usage` no dispatch de `cli/cstk`
       (`case "$1"`), delegando a `plan_usage_main()` novo em
       `cli/lib/plan-usage.sh` (paridade com `usage_main()` de
       `cli/lib/usage.sh`)
@@ -304,12 +304,12 @@ FR-008, dec-014
 
 Ref: contracts/cli-plan-usage.md §`ingest --stdin`
 
-- [ ] 4.3.1 Subcomando interno (nao listado em `--help` publico,
+- [x] 4.3.1 Subcomando interno (nao listado em `--help` publico,
       paridade com outros internos do dispatch) consumido exclusivamente
       por `statusline-plan-usage.sh`
-- [ ] 4.3.2 Recebe payload bruto via stdin, aplica throttle (2.3) e
+- [x] 4.3.2 Recebe payload bruto via stdin, aplica throttle (2.3) e
       delega a `recall_plan_usage_insert()` (1.2) quando aplicavel
-- [ ] 4.3.3 Exit sempre `0` mesmo em erro interno — nunca propaga falha
+- [x] 4.3.3 Exit sempre `0` mesmo em erro interno — nunca propaga falha
       para a sessao do operador (FR-011/Principio IV)
 
 ---

--- a/docs/specs/plan-usage-capture/tasks.md
+++ b/docs/specs/plan-usage-capture/tasks.md
@@ -26,78 +26,94 @@ credencial OAuth, 100% local (Constitution IV).
 Ref: spec.md FR-009/FR-014, data-model.md (tabela `plan_usage`, §Migracao),
 plan.md §Summary item 2, research.md Decision 7
 
-- [ ] 1.1.1 Bump `RECALL_SCHEMA_VERSION` de `13` para `14` em
-      `cli/lib/recall.sh` (linha 136)
-- [ ] 1.1.2 Adicionar `CREATE TABLE IF NOT EXISTS plan_usage (...)` em
+- [x] 1.1.1 Bump `RECALL_SCHEMA_VERSION` de `13` para `14` em
+      `cli/lib/recall.sh` (linha 136) <!-- verificado: grep RECALL_SCHEMA_VERSION cli/lib/recall.sh -> RECALL_SCHEMA_VERSION=14 -->
+- [x] 1.1.2 Adicionar `CREATE TABLE IF NOT EXISTS plan_usage (...)` em
       `recall_schema_ddl`, seguindo o schema de data-model.md (colunas
       `id`, `project`, `project_path`, `session_id`, `scope` com
       `CHECK IN ('five_hour','seven_day')`, `used_percentage` REAL
       NULLABLE, `resets_at` INTEGER NULLABLE, `captured_at` TEXT NOT NULL,
       `ingested_at` TEXT NOT NULL) — sem `ALTER`/`DROP`, mesmo precedente
-      literal de `loose_usage` (linha 647)
-- [ ] 1.1.3 Sem `UNIQUE` de chave natural (data-model.md linhas 34-41) —
-      confirmar que a DDL nao introduz constraint indevida
-- [ ] 1.1.4 Teste: migracao aditiva pura — banco com schema v13 existente
+      literal de `loose_usage` (linha 647) <!-- verificado empiricamente: recall_apply_schema em DB novo gera sqlite_master.sql identico ao DDL declarado (ver evidencia da Decisao) -->
+- [x] 1.1.3 Sem `UNIQUE` de chave natural (data-model.md linhas 34-41) —
+      confirmar que a DDL nao introduz constraint indevida <!-- confirmado por leitura direta do DDL: nenhum UNIQUE presente -->
+- [x] 1.1.4 Teste: migracao aditiva pura — banco com schema v13 existente
       recebe a migracao e ganha a tabela `plan_usage` sem perder nenhuma
       linha das tabelas existentes (`waves`, `wave_model_usage`,
-      `loose_usage`)
-- [ ] 1.1.5 Teste: `schema_meta.schema_version` reflete `14` apos a
-      migracao
+      `loose_usage`) <!-- tests/cstk/test_recall.sh scenario_pu2_migracao_v13_v14_real_idempotente -->
+- [x] 1.1.5 Teste: `schema_meta.schema_version` reflete `14` apos a
+      migracao <!-- tests/cstk/test_recall.sh scenario_pu1_fresh_db_tabela_e_versao + scenario_pu2 -->
 
 ### 1.2 Helper de escrita `plan_usage` (INSERT seguro) `[C]`
 
 Ref: plan.md §Revisao de Seguranca (gate owasp-security, achado A05
 Injection/SQL — MANDATORIO), spec.md FR-002/FR-009
 
-- [ ] 1.2.1 Implementar `recall_plan_usage_insert()` em `cli/lib/recall.sh`
+- [x] 1.2.1 Implementar `recall_plan_usage_insert()` em `cli/lib/recall.sh`
       (paridade com o helper equivalente de `loose_usage`), recebendo
       `project`, `project_path`, `session_id`, `scope`, `used_percentage`
-      (pode ser vazio/NULL), `resets_at` (pode ser vazio/NULL)
-- [ ] 1.2.2 **MANDATORIO**: escapar `session_id`/`project_path`/`project`
+      (pode ser vazio/NULL), `resets_at` (pode ser vazio/NULL),
+      `captured_at`, `ingested_at` — os dois ultimos sao TEXT NOT NULL
+      em data-model.md (FR-014) e devem ser calculados pelo CALLER (`cstk
+      plan-usage ingest --stdin`, task 4.3.2) via `date -u
+      +%Y-%m-%dT%H:%M:%SZ` e passados explicitos, mesmo padrao de
+      `usage_map_sidecar_to_db()` em `cli/lib/usage.sh` (`_umd_captured`/
+      `_umd_now` computados pelo caller antes do INSERT de
+      `loose_usage`, linha ~255) — nao inferidos dentro do helper <!-- verificado empiricamente via chamada direta da funcao (ver evidencia da Decisao) -->
+- [x] 1.2.2 **MANDATORIO**: escapar `session_id`/`project_path`/`project`
       via `sql_escape()` (linha 223) antes de compor qualquer `INSERT INTO
       plan_usage` — nenhum valor extraido do payload entra em SQL sem
-      passar por `sql_escape`
-- [ ] 1.2.3 **MANDATORIO**: usar `recall_apply_sql_with_retry()` (linha
+      passar por `sql_escape` <!-- confirmado por leitura direta do codigo + teste de injecao (1.2.5) -->
+- [x] 1.2.3 **MANDATORIO**: usar `recall_apply_sql_with_retry()` (linha
       2393) para o INSERT — mesmo caminho ja usado por `usage.sh` para
-      `loose_usage`, nao um mecanismo novo
-- [ ] 1.2.4 `used_percentage`/`resets_at` ausentes (string vazia/nao
+      `loose_usage`, nao um mecanismo novo <!-- confirmado por leitura direta do codigo -->
+- [x] 1.2.4 `used_percentage`/`resets_at` ausentes (string vazia/nao
       fornecidos) viram literal `NULL` no SQL, nunca `0` ou string vazia
       (Constitution VI, dec-029 — caso de ausencia PARCIAL dentro de
       escopo presente; ver 2.2 para a decisao de NAO chamar este helper
-      quando `rate_limits` esta ausente por completo)
-- [ ] 1.2.5 Teste de seguranca: payload com `session_id`/`project_path`
+      quando `rate_limits` esta ausente por completo) <!-- verificado empiricamente: SELECT (used_percentage IS NULL)||'|'||(resets_at IS NULL) -> '1|1' -->
+- [x] 1.2.5 Teste de seguranca: payload com `session_id`/`project_path`
       contendo aspas simples, `;`, `--`, e fragmento tipo
       `'; DROP TABLE plan_usage; --` — confirmar que o INSERT nao quebra
-      e o valor literal e persistido escapado (nao interpretado como SQL)
-- [ ] 1.2.6 Teste: INSERT com `used_percentage`/`resets_at` NULL persiste
-      `NULL` real na coluna (nao string `"NULL"`, nao `0`)
+      e o valor literal e persistido escapado (nao interpretado como SQL) <!-- tests/cstk/test_recall.sh scenario_pu3_injecao_no_insert; verificado tambem manualmente, tabela sobrevive e valor literal preservado -->
+- [x] 1.2.6 Teste: INSERT com `used_percentage`/`resets_at` NULL persiste
+      `NULL` real na coluna (nao string `"NULL"`, nao `0`) <!-- tests/cstk/test_recall.sh scenario_pu4_null_vs_valor_presente -->
+
+**Nota de verificacao (task 1.2)**: cobertura automatizada adicionada em
+`tests/cstk/test_recall.sh` (scenarios `pu1`-`pu4`). Execucao completa da
+suite `test_recall.sh` (regressao + novos scenarios) iniciada em background
+durante esta onda; resultado literal citado no relatorio de conclusao —
+verificacao manual direta das funcoes (`recall_apply_schema`,
+`recall_plan_usage_insert`) ja confirmou o comportamento esperado com
+output literal (schema_version=14, tabela criada com DDL exato, INSERT
+normal/NULL/injecao todos corretos).
 
 ### 1.3 Fechar gaps de documentacao do checklist `[M]`
 
 Ref: checklists/requirements.md CHK002, CHK003, CHK004, CHK020, CHK022
 (gaps nao-bloqueantes reavaliados na onda-005, nenhum CRITICAL/{humano})
 
-- [ ] 1.3.1 CHK002: editar `spec.md` FR-006 para listar explicitamente
+- [x] 1.3.1 CHK002: editar `spec.md` FR-006 para listar explicitamente
       (ou referenciar `contracts/statusline-hook.md` §linhas 34-36) os 8
       campos excluidos (`.model`, `.cost`, `.context_window`,
       `.exceeds_200k_tokens`, `.thinking`, `.effort`, `.output_style`,
       `.version`), nao so os 3 que exigem OAuth
-- [ ] 1.3.2 CHK003: adicionar Edge Case em `spec.md` cobrindo o risco de
+- [x] 1.3.2 CHK003: adicionar Edge Case em `spec.md` cobrindo o risco de
       sobrescrita de `statusLine.command` customizado (hoje so em
       `plan.md` §Riscos conhecidos), citando a mitigacao
       `CSTK_STATUSLINE_INNER_COMMAND`
-- [ ] 1.3.3 CHK004: adicionar FR ou Edge Case em `spec.md` declarando o
+- [x] 1.3.3 CHK004: adicionar FR ou Edge Case em `spec.md` declarando o
       comportamento fail-open/best-effort (jq ausente, sqlite3 ausente,
       payload malformado, nunca atrasar a statusline) como requisito
       testavel, hoje so em `contracts/statusline-hook.md`/`quickstart.md`
-      Cenario 7
-- [ ] 1.3.4 CHK020: decidir e documentar (spec.md Edge Case ou NOTE em
+      Cenario 7 <!-- adicionado como FR-015 -->
+- [x] 1.3.4 CHK020: decidir e documentar (spec.md Edge Case ou NOTE em
       `data-model.md`) o comportamento de concorrencia — duas invocacoes
       simultaneas de `statusline-plan-usage.sh` escrevendo em
       `plan_usage` ao mesmo tempo; `recall_apply_sql_with_retry` ja
       cobre retry de `SQLITE_BUSY`, documentar que isso e suficiente (ou
-      justificar mecanismo adicional)
-- [ ] 1.3.5 CHK022: adicionar numero/threshold verificavel de latencia
+      justificar mecanismo adicional) <!-- data-model.md secao Concorrencia -->
+- [x] 1.3.5 CHK022: adicionar numero/threshold verificavel de latencia
       adicional por render (ex.: "captura MUST adicionar no maximo Xms")
       em `contracts/statusline-hook.md`, substituindo a caracterizacao
       qualitativa atual ("throttle O(1)")

--- a/docs/specs/plan-usage-capture/tasks.md
+++ b/docs/specs/plan-usage-capture/tasks.md
@@ -1,0 +1,400 @@
+# Tarefas Plan Usage Capture - Captura de uso do plano via statusline
+
+Escopo: implementar a captura do gauge `/usage` (`rate_limits.five_hour`/
+`seven_day`) a partir do payload da statusline do Claude Code, persistir em
+tabela nova `plan_usage` no `knowledge.db` (migracao aditiva v13->v14), e
+expor consulta via `cstk plan-usage`/`cstk plan-usage history` — sem
+credencial OAuth, 100% local (Constitution IV).
+
+**Legenda de status:**
+- `[ ]` Pendente
+- `[~]` Em andamento
+- `[x]` Concluido
+- `[!]` Bloqueado
+
+**Legenda de criticidade:**
+- `[C]` Critico - Impacto financeiro direto ou bloqueante (seguranca/injection, veracidade de dado)
+- `[A]` Alto - Funcionalidade essencial (captura, persistencia, consulta)
+- `[M]` Medio - Necessario mas sem urgencia imediata (docs, gaps de completude)
+
+---
+
+## FASE 1 - Fundacao: Schema e Camada de Persistencia
+
+### 1.1 Migracao de schema `plan_usage` `[A]`
+
+Ref: spec.md FR-009/FR-014, data-model.md (tabela `plan_usage`, §Migracao),
+plan.md §Summary item 2, research.md Decision 7
+
+- [ ] 1.1.1 Bump `RECALL_SCHEMA_VERSION` de `13` para `14` em
+      `cli/lib/recall.sh` (linha 136)
+- [ ] 1.1.2 Adicionar `CREATE TABLE IF NOT EXISTS plan_usage (...)` em
+      `recall_schema_ddl`, seguindo o schema de data-model.md (colunas
+      `id`, `project`, `project_path`, `session_id`, `scope` com
+      `CHECK IN ('five_hour','seven_day')`, `used_percentage` REAL
+      NULLABLE, `resets_at` INTEGER NULLABLE, `captured_at` TEXT NOT NULL,
+      `ingested_at` TEXT NOT NULL) — sem `ALTER`/`DROP`, mesmo precedente
+      literal de `loose_usage` (linha 647)
+- [ ] 1.1.3 Sem `UNIQUE` de chave natural (data-model.md linhas 34-41) —
+      confirmar que a DDL nao introduz constraint indevida
+- [ ] 1.1.4 Teste: migracao aditiva pura — banco com schema v13 existente
+      recebe a migracao e ganha a tabela `plan_usage` sem perder nenhuma
+      linha das tabelas existentes (`waves`, `wave_model_usage`,
+      `loose_usage`)
+- [ ] 1.1.5 Teste: `schema_meta.schema_version` reflete `14` apos a
+      migracao
+
+### 1.2 Helper de escrita `plan_usage` (INSERT seguro) `[C]`
+
+Ref: plan.md §Revisao de Seguranca (gate owasp-security, achado A05
+Injection/SQL — MANDATORIO), spec.md FR-002/FR-009
+
+- [ ] 1.2.1 Implementar `recall_plan_usage_insert()` em `cli/lib/recall.sh`
+      (paridade com o helper equivalente de `loose_usage`), recebendo
+      `project`, `project_path`, `session_id`, `scope`, `used_percentage`
+      (pode ser vazio/NULL), `resets_at` (pode ser vazio/NULL)
+- [ ] 1.2.2 **MANDATORIO**: escapar `session_id`/`project_path`/`project`
+      via `sql_escape()` (linha 223) antes de compor qualquer `INSERT INTO
+      plan_usage` — nenhum valor extraido do payload entra em SQL sem
+      passar por `sql_escape`
+- [ ] 1.2.3 **MANDATORIO**: usar `recall_apply_sql_with_retry()` (linha
+      2393) para o INSERT — mesmo caminho ja usado por `usage.sh` para
+      `loose_usage`, nao um mecanismo novo
+- [ ] 1.2.4 `used_percentage`/`resets_at` ausentes (string vazia/nao
+      fornecidos) viram literal `NULL` no SQL, nunca `0` ou string vazia
+      (Constitution VI, dec-029 — caso de ausencia PARCIAL dentro de
+      escopo presente; ver 2.2 para a decisao de NAO chamar este helper
+      quando `rate_limits` esta ausente por completo)
+- [ ] 1.2.5 Teste de seguranca: payload com `session_id`/`project_path`
+      contendo aspas simples, `;`, `--`, e fragmento tipo
+      `'; DROP TABLE plan_usage; --` — confirmar que o INSERT nao quebra
+      e o valor literal e persistido escapado (nao interpretado como SQL)
+- [ ] 1.2.6 Teste: INSERT com `used_percentage`/`resets_at` NULL persiste
+      `NULL` real na coluna (nao string `"NULL"`, nao `0`)
+
+### 1.3 Fechar gaps de documentacao do checklist `[M]`
+
+Ref: checklists/requirements.md CHK002, CHK003, CHK004, CHK020, CHK022
+(gaps nao-bloqueantes reavaliados na onda-005, nenhum CRITICAL/{humano})
+
+- [ ] 1.3.1 CHK002: editar `spec.md` FR-006 para listar explicitamente
+      (ou referenciar `contracts/statusline-hook.md` §linhas 34-36) os 8
+      campos excluidos (`.model`, `.cost`, `.context_window`,
+      `.exceeds_200k_tokens`, `.thinking`, `.effort`, `.output_style`,
+      `.version`), nao so os 3 que exigem OAuth
+- [ ] 1.3.2 CHK003: adicionar Edge Case em `spec.md` cobrindo o risco de
+      sobrescrita de `statusLine.command` customizado (hoje so em
+      `plan.md` §Riscos conhecidos), citando a mitigacao
+      `CSTK_STATUSLINE_INNER_COMMAND`
+- [ ] 1.3.3 CHK004: adicionar FR ou Edge Case em `spec.md` declarando o
+      comportamento fail-open/best-effort (jq ausente, sqlite3 ausente,
+      payload malformado, nunca atrasar a statusline) como requisito
+      testavel, hoje so em `contracts/statusline-hook.md`/`quickstart.md`
+      Cenario 7
+- [ ] 1.3.4 CHK020: decidir e documentar (spec.md Edge Case ou NOTE em
+      `data-model.md`) o comportamento de concorrencia — duas invocacoes
+      simultaneas de `statusline-plan-usage.sh` escrevendo em
+      `plan_usage` ao mesmo tempo; `recall_apply_sql_with_retry` ja
+      cobre retry de `SQLITE_BUSY`, documentar que isso e suficiente (ou
+      justificar mecanismo adicional)
+- [ ] 1.3.5 CHK022: adicionar numero/threshold verificavel de latencia
+      adicional por render (ex.: "captura MUST adicionar no maximo Xms")
+      em `contracts/statusline-hook.md`, substituindo a caracterizacao
+      qualitativa atual ("throttle O(1)")
+
+---
+
+## FASE 2 - Captura: `statusline-plan-usage.sh`
+
+### 2.1 Parse do payload e extracao de `rate_limits` `[A]`
+
+Ref: contracts/statusline-hook.md §Contrato de entrada, research.md
+Decision 1/3
+
+- [ ] 2.1.1 Criar
+      `plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh`
+      (shebang `#!/bin/sh`, Constitution II) lendo o payload JSON do
+      stdin
+- [ ] 2.1.2 Extrair `.session_id`, `.workspace.current_dir` /
+      `.workspace.project_dir` (fallback conforme contrato linha 29),
+      `.rate_limits.five_hour.*`, `.rate_limits.seven_day.*` via `jq`
+- [ ] 2.1.3 `jq` ausente: captura pulada, pass-through preservado, exit
+      sempre `0` (research.md Decision 3, reuso do carve-out de
+      `cli/lib/recall.sh`/`cli/lib/usage.sh`)
+- [ ] 2.1.4 Payload malformado (JSON invalido): captura pulada,
+      pass-through best-effort do stdin cru, exit `0`
+- [ ] 2.1.5 Teste: fixture com `rate_limits` completo extrai os 4 valores
+      corretamente (paridade com o schema OBSERVADO na memoria
+      `reference_statusline_usage_payload.md`)
+
+### 2.2 Semantica de ausencia — dec-029 (core da feature) `[C]`
+
+Ref: spec.md FR-002/Edge-Case/User-Story-3, data-model.md §Ausencia
+explicita vs valor real, contracts/statusline-hook.md §Comportamento de
+captura, Constitution VI (Zero Fabricacao)
+
+- [ ] 2.2.1 Quando a chave `.rate_limits` esta AUSENTE do payload
+      inteiro: **NAO chamar** `recall_plan_usage_insert()` para nenhum
+      escopo — nenhuma linha inserida (dec-029)
+- [ ] 2.2.2 Quando `.rate_limits.<scope>` esta presente mas
+      `used_percentage`/`resets_at` vem ausente/nulo dentro do escopo:
+      chamar `recall_plan_usage_insert()` para aquele escopo com `NULL`
+      no(s) campo(s) faltante(s) — caso defensivo/malformado, nunca
+      observado empiricamente mas a coluna permanece NULLABLE para isso
+- [ ] 2.2.3 Em NENHUM caminho persistir `0` como substituto de dado
+      ausente (Constitution VI — validar com teste dedicado, nao so
+      inspecao)
+- [ ] 2.2.4 Teste: fixture SEM `rate_limits` -> zero linhas novas em
+      `plan_usage` apos a execucao (nao apenas "sem erro" — checar
+      `SELECT COUNT(*)` antes/depois)
+- [ ] 2.2.5 Teste: fixture com `rate_limits.five_hour` presente e
+      `rate_limits.seven_day` ausente -> uma linha nova so para
+      `five_hour`, nenhuma para `seven_day`
+
+### 2.3 Throttle (FR-010, dec-029/CHK010) `[A]`
+
+Ref: spec.md FR-010, data-model.md §Migracao/Ausencia, checklists/
+requirements.md CHK010 (residual documentado nesta onda)
+
+- [ ] 2.3.1 Antes de cada INSERT candidato, consultar o ULTIMO registro
+      persistido daquele escopo (`SELECT ... ORDER BY id DESC LIMIT 1
+      WHERE scope = ?`), sem janela temporal
+- [ ] 2.3.2 Descartar (nao inserir) quando `used_percentage` bate ate a
+      2a casa decimal E `resets_at` e igual ao ultimo registro
+- [ ] 2.3.3 Persistir quando a diferenca ultrapassa a 2a casa decimal OU
+      `resets_at` mudou
+- [ ] 2.3.4 **Decisao residual CHK010**: definir e implementar o
+      comportamento quando o ULTIMO registro do escopo tem
+      `used_percentage`/`resets_at` = `NULL` (ausencia parcial
+      persistida, 2.2.2) e a nova captura do MESMO escopo TAMBEM chega
+      com o campo ausente dentro do escopo presente — decidir via
+      Decisao auditavel (nao inventar sem registro) se NULL-vs-NULL conta
+      como "identico" (descarta) ou "sempre persiste" (nunca descarta
+      ausencia); documentar a escolha em `data-model.md` apos decidir
+- [ ] 2.3.5 Teste: duas capturas identicas em sequencia -> so 1 linha
+      nova; 3a captura com mudanca na 3a casa decimal apenas -> ainda
+      descartada; 4a captura com mudanca na 2a casa decimal -> nova linha
+      (paridade com quickstart.md Cenario 3)
+
+### 2.4 Pass-through obrigatorio do stdout `[A]`
+
+Ref: contracts/statusline-hook.md §Contrato de saida, research.md
+Decision 2
+
+- [ ] 2.4.1 Se `CSTK_STATUSLINE_INNER_COMMAND` definida: reencaminhar o
+      payload original (stdin intacto) para o comando dela, repassar
+      stdout verbatim
+- [ ] 2.4.2 Senao: imprimir fallback minimo de 1 linha construido so a
+      partir de `model.display_name` + (quando presente) `used_percentage`
+      de `five_hour` desta mesma captura — nunca inventar outro campo
+- [ ] 2.4.3 Erros de captura (jq ausente, sqlite3 ausente, INSERT falho)
+      NUNCA vao para stdout — descartados silenciosamente ou enviados so
+      a stderr
+- [ ] 2.4.4 Teste: em NENHUM cenario (dep ausente, payload malformado,
+      throttle, INSERT ok) o script sai com exit != `0`, nem imprime erro
+      de diagnostico em stdout
+
+### 2.5 `sqlite3`/`knowledge.db` indisponivel `[A]`
+
+Ref: contracts/statusline-hook.md linha 64, research.md Decision 6
+
+- [ ] 2.5.1 `sqlite3` ausente OU `knowledge.db` sem permissao de escrita:
+      captura pulada, pass-through intacto, exit `0`
+- [ ] 2.5.2 Confinar toda chamada a `sqlite3` a `cli/lib/recall.sh` —
+      `statusline-plan-usage.sh` MUST NOT invocar `sqlite3` diretamente
+      (mesmo confinamento de `loose-usage-capture`)
+- [ ] 2.5.3 Teste: simular `sqlite3` ausente no PATH -> pass-through
+      normal, captura pulada, exit `0` (paridade quickstart.md Cenario 7)
+
+---
+
+## FASE 3 - Instalacao (`statusLine.command`)
+
+### 3.1 Wiring de instalacao `[A]`
+
+Ref: research.md Decision 2 (mecanismo exato deixado para esta fase),
+plan.md §Riscos conhecidos
+
+- [ ] 3.1.1 Decidir e implementar o mecanismo de instalacao: subcomando
+      novo `cstk statusline install` (paralelo a `cstk hooks install`,
+      linha equivalente em `cli/cstk` dispatch) que escreve/atualiza a
+      chave `statusLine.command` do `settings.json` do harness
+- [ ] 3.1.2 Se ja existir `statusLine.command` customizado: preservar o
+      valor atual movendo-o para `CSTK_STATUSLINE_INNER_COMMAND` (nunca
+      sobrescrever silenciosamente — mitigacao do risco documentado em
+      `plan.md`)
+- [ ] 3.1.3 Idempotencia: rodar a instalacao 2x seguidas produz o mesmo
+      `settings.json` final (sem duplicar wrapper sobre wrapper)
+- [ ] 3.1.4 `cstk statusline status`/`--help` reportando se a captura
+      esta instalada e ativa (paridade com `cstk hooks status`, se
+      existir precedente)
+- [ ] 3.1.5 Teste: instalacao em `settings.json` sem `statusLine.command`
+      previo -> chave criada apontando para
+      `statusline-plan-usage.sh`
+- [ ] 3.1.6 Teste: instalacao em `settings.json` com `statusLine.command`
+      customizado previo -> valor original preservado em
+      `CSTK_STATUSLINE_INNER_COMMAND`, nova chave aponta para o script
+      desta feature
+
+---
+
+## FASE 4 - Consulta CLI (`cstk plan-usage`)
+
+### 4.1 `cstk plan-usage` (uso mais recente) `[A]`
+
+Ref: contracts/cli-plan-usage.md §`cstk plan-usage`, spec.md FR-007
+
+- [ ] 4.1.1 Registrar subcomando `plan-usage` no dispatch de `cli/cstk`
+      (`case "$1"`), delegando a `plan_usage_main()` novo em
+      `cli/lib/plan-usage.sh` (paridade com `usage_main()` de
+      `cli/lib/usage.sh`)
+- [ ] 4.1.2 Flags `--json`, `--db PATH` (paridade `cstk usage --db`)
+- [ ] 4.1.3 Saida texto: percentual + horario de reset (local time na
+      apresentacao; persistencia continua epoch) por escopo; campo sem
+      medicao imprime `nao medido`, nunca `0` (FR-002/SC-002, dec-029)
+- [ ] 4.1.4 Saida `--json`: `used_percentage`/`resets_at`/`captured_at`
+      como `null` JSON quando o escopo nunca teve captura com
+      `rate_limits` presente
+- [ ] 4.1.5 `knowledge.db` ausente: aviso em stderr + `nao medido` para
+      os 2 escopos, exit `0`
+- [ ] 4.1.6 Tabela `plan_usage` vazia: `nao medido — nenhuma captura
+      registrada ainda`, exit `0`
+- [ ] 4.1.7 `sqlite3` ausente: aviso em stderr explicando a dep, exit `1`
+- [ ] 4.1.8 Flag desconhecida: uso em stderr, exit `2`
+- [ ] 4.1.9 Teste: os 8 subitens acima como casos de teste automatizados
+      via fixture (sem sessao real — FR-012)
+
+### 4.2 `cstk plan-usage history` (serie temporal) `[A]`
+
+Ref: contracts/cli-plan-usage.md §`cstk plan-usage history`, spec.md
+FR-008, dec-014
+
+- [ ] 4.2.1 Flags `--scope five_hour|seven_day` (default: ambos,
+      separados — FR-005), `--limit N` (default `20`, reuso literal de
+      `cstk usage --limit`), `--since ISO` (reuso literal de `cstk usage
+      --since`) — SEM inventar convencao nova de paginacao (dec-014)
+- [ ] 4.2.2 Saida texto: uma secao por escopo, ate `--limit` linhas em
+      ordem cronologica
+- [ ] 4.2.3 Saida `--json`: chave presente so para escopo(s) pedido(s);
+      array vazio (nao `null`) quando o escopo existe mas nao tem
+      captura no filtro
+- [ ] 4.2.4 Mesma tabela de comportamento sem dados de 4.1.5-4.1.8
+- [ ] 4.2.5 Teste: 3 capturas crescentes -> historico em ordem
+      cronologica (paridade quickstart.md Cenario 4)
+- [ ] 4.2.6 Teste: `--since`/`--limit` filtram identico a `cstk usage`
+      (mesmo parsing de flag, reuso de codigo se possivel)
+
+### 4.3 `cstk plan-usage ingest --stdin` (interno) `[A]`
+
+Ref: contracts/cli-plan-usage.md §`ingest --stdin`
+
+- [ ] 4.3.1 Subcomando interno (nao listado em `--help` publico,
+      paridade com outros internos do dispatch) consumido exclusivamente
+      por `statusline-plan-usage.sh`
+- [ ] 4.3.2 Recebe payload bruto via stdin, aplica throttle (2.3) e
+      delega a `recall_plan_usage_insert()` (1.2) quando aplicavel
+- [ ] 4.3.3 Exit sempre `0` mesmo em erro interno — nunca propaga falha
+      para a sessao do operador (FR-011/Principio IV)
+
+---
+
+## FASE 5 - Testes e Qualidade
+
+### 5.1 Suite de testes da feature `[A]`
+
+Ref: spec.md FR-012, research.md Decision 8, quickstart.md (7 cenarios)
+
+- [ ] 5.1.1 Criar `tests/test_statusline-plan-usage.sh` seguindo o
+      precedente de `tests/test_posttooluse-loose-usage.sh` — alimenta
+      fixtures via stdin, nunca sessao `claude` real
+- [ ] 5.1.2 Cobrir os 7 cenarios de `quickstart.md` como casos de teste
+      nomeados (1 captura basica, 2 ausencia-nunca-zero, 3 throttle, 4
+      evolucao temporal, 5 formato resets_at, 6 zero coleta remota, 7
+      deps ausentes)
+- [ ] 5.1.3 Criar `tests/test_cli-plan-usage.sh` cobrindo `cstk
+      plan-usage`/`cstk plan-usage history` (FASE 4)
+- [ ] 5.1.4 Rodar a suite completa local e confirmar 0 regressao nos
+      testes existentes de `recall.sh`/`usage.sh` (migracao aditiva nao
+      quebra nada)
+
+### 5.2 Gates deterministicos pos-geracao `[M]`
+
+Ref: create-tasks/scripts/validate-tasks-template.sh, template canonico
+
+- [ ] 5.2.1 Rodar `validate-tasks-template.sh` sobre este `tasks.md` e
+      confirmar exit `0` (conformante ao template)
+- [ ] 5.2.2 Rodar `validate-docs-rendered` sobre os artefatos da feature
+      (Mermaid da Matriz de Dependencias, links internos, frontmatter)
+
+---
+
+## FASE 6 - Documentacao e Release
+
+### 6.1 CHANGELOG e nota de release `[A]`
+
+Ref: plan.md §Constitution Check Principio I (SDD recursivo — "Contrato
+de CLI novo exige nota no CHANGELOG, MINOR")
+
+- [ ] 6.1.1 Adicionar entrada MINOR no CHANGELOG do `cstk` descrevendo a
+      capacidade nova (`cstk plan-usage`, captura via statusline)
+- [ ] 6.1.2 Atualizar contagem de subcomandos/docs afetados, se algum
+      teste de contagem (`test_doc-counts.sh` ou equivalente) gateia
+      README/docs
+
+---
+
+## Matriz de Dependencias
+
+```mermaid
+flowchart TD
+    F1[Fase 1 - Fundacao: Schema e Persistencia]
+    F2[Fase 2 - Captura: statusline-plan-usage.sh]
+    F3[Fase 3 - Instalacao statusLine.command]
+    F4[Fase 4 - Consulta CLI cstk plan-usage]
+    F5[Fase 5 - Testes e Qualidade]
+    F6[Fase 6 - Documentacao e Release]
+
+    F1 --> F2
+    F1 --> F4
+    F2 --> F3
+    F2 --> F4
+    F2 --> F5
+    F4 --> F5
+    F3 --> F5
+    F5 --> F6
+```
+
+## Resumo Quantitativo
+
+| Fase | Tarefas | Subtarefas | Criticidade |
+|------|---------|------------|-------------|
+| 1 - Fundacao: Schema e Persistencia | 3 | 16 | C/A/M |
+| 2 - Captura: statusline-plan-usage.sh | 5 | 22 | C/A |
+| 3 - Instalacao statusLine.command | 1 | 6 | A |
+| 4 - Consulta CLI cstk plan-usage | 3 | 18 | A |
+| 5 - Testes e Qualidade | 2 | 6 | A/M |
+| 6 - Documentacao e Release | 1 | 2 | A |
+| **Total** | **15** | **70** | - |
+
+## Escopo Coberto
+
+| Item | Descricao | Fase |
+|------|-----------|------|
+| Migracao de schema | `plan_usage` tabela nova, v13->v14 aditiva | 1 |
+| INSERT seguro | `sql_escape` + `recall_apply_sql_with_retry` (owasp mandatario) | 1 |
+| Captura via statusline | `statusline-plan-usage.sh`, pass-through obrigatorio | 2 |
+| Semantica dec-029 | Ausencia total = nenhum INSERT; ausencia parcial = NULL | 2 |
+| Throttle FR-010 | Comparacao contra ultimo registro, tolerancia 2 casas | 2 |
+| Instalacao | `cstk statusline install`, preserva customizacao previa | 3 |
+| Consulta CLI | `cstk plan-usage` + `history`, reuso de flags de `cstk usage` | 4 |
+| Testes fixture-based | Sem sessao interativa real (FR-012) | 5 |
+| Gaps de documentacao | CHK002/CHK003/CHK004/CHK020/CHK022 | 1 |
+
+## Escopo Excluido
+
+| Item | Descricao | Motivo |
+|------|-----------|--------|
+| `.cost`/`.context_window` e colunas correlatas (`session_cost_usd`, `session_input_tokens`, `session_output_tokens`, `cache_read_input_tokens`, `cache_creation_input_tokens`, `model_id`) | Custo/tokens de sessao do rascunho original do operador | Corte confirmado (dec-030, CHK026) — reservado para feature futura dedicada; regra MAX-nunca-SUM fica N/A |
+| `seven_day_opus`, `seven_day_sonnet`, `extra_usage` (creditos) | Campos que so existem em `GET /api/oauth/usage` | Exigem credencial OAuth (FR-006) — fora do objetivo "sem OAuth" desta feature |
+| Convencao de paginacao nova (cursor/offset) | Alternativa a `--limit`/`--since` | dec-014: reuso literal das flags ja existentes de `cstk usage`, sem inventar mecanismo novo |
+| Dashboard/painel dedicado a `plan_usage` | Visualizacao grafica do historico | Fora do escopo da CLI; `cstk-panel` fica para decisao futura, se houver demanda |

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "7.1.1",
+  "version": "7.2.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# statusline-plan-usage.sh — entry-point de `statusLine.command` (feature
+# plan-usage-capture, FASE 2). Configurado no `settings.json` do harness
+# via a chave IRMA `statusLine.command` (distinta do array
+# `.hooks.PostToolUse[]` que os demais hooks deste diretorio usam —
+# research.md Decision 1).
+#
+# Contrato: docs/specs/plan-usage-capture/contracts/statusline-hook.md
+# Research: docs/specs/plan-usage-capture/research.md (Decisions 1-6)
+# Fonte do schema OBSERVADO do payload: memoria
+# reference_statusline_usage_payload.md (Claude Code 2.1.226, macOS,
+# 2026-08-10) — NAO INVENTAR campo fora dela (Constitution VI).
+#
+# Disciplina fail-open (molde: posttooluse-loose-usage.sh): sem `set -e`,
+# cada passo trata a propria falha com no-op, exit SEMPRE 0, e o script
+# MUST sempre emitir ALGO em stdout (contrato de saida — nunca deixar a UI
+# da statusline em branco).
+#
+# `statusline-plan-usage.sh` roda FORA do processo `cstk` (invocado
+# diretamente pelo harness) e por isso NAO tem acesso direto a
+# `cli/lib/recall.sh` — a persistencia (extracao completa + throttle +
+# INSERT) e delegada via subprocesso a `cstk plan-usage ingest --stdin`
+# (research.md Decision 6, cli/lib/plan-usage.sh task 4.3). Este script
+# extrai localmente so os campos necessarios para (a) decidir se vale a
+# pena invocar o subprocesso (rate_limits ausente -> nem tenta) e (b)
+# construir o fallback minimo de stdout (2.4.2) — NUNCA toca `sqlite3`
+# diretamente (task 2.5.2).
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Passo 1: ler stdin UMA VEZ (necessario tanto para extracao quanto para
+# encaminhar ao comando interno / forward de payload bruto).
+# ---------------------------------------------------------------------------
+_SPU_INPUT=$(cat 2>/dev/null) || _SPU_INPUT=""
+
+# ---------------------------------------------------------------------------
+# Passo 2: jq disponivel? (dep opcional confinada, research.md Decision 3)
+# ---------------------------------------------------------------------------
+_SPU_HAVE_JQ=0
+command -v jq >/dev/null 2>&1 && _SPU_HAVE_JQ=1
+
+# ---------------------------------------------------------------------------
+# Passo 3: payload valido (JSON parseavel)? So tenta se jq disponivel e
+# stdin nao-vazio. JSON malformado -> extracao pulada (task 2.1.4).
+# ---------------------------------------------------------------------------
+_SPU_VALID_JSON=0
+if [ "$_SPU_HAVE_JQ" = 1 ] && [ -n "$_SPU_INPUT" ]; then
+  if printf '%s' "$_SPU_INPUT" | jq empty >/dev/null 2>&1; then
+    _SPU_VALID_JSON=1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Passo 4: extracao (task 2.1) — so quando jq+JSON validos. Campos NAO
+# consumidos por esta feature (fora de escopo, FR-006): .cost,
+# .context_window, .exceeds_200k_tokens, .thinking, .effort, .output_style,
+# .version.
+# ---------------------------------------------------------------------------
+_SPU_SESSION_ID=""
+_SPU_PROJECT_PATH=""
+_SPU_MODEL_NAME=""
+_SPU_HAS_RL="false"
+_SPU_FH_USED=""
+_SPU_FH_RESETS=""
+_SPU_SD_USED=""
+_SPU_SD_RESETS=""
+
+if [ "$_SPU_VALID_JSON" = 1 ]; then
+  _SPU_SESSION_ID=$(printf '%s' "$_SPU_INPUT" | jq -r '.session_id // ""' 2>/dev/null) || _SPU_SESSION_ID=""
+  _SPU_PROJECT_PATH=$(printf '%s' "$_SPU_INPUT" | jq -r '.workspace.current_dir // .workspace.project_dir // ""' 2>/dev/null) || _SPU_PROJECT_PATH=""
+  _SPU_MODEL_NAME=$(printf '%s' "$_SPU_INPUT" | jq -r '.model.display_name // ""' 2>/dev/null) || _SPU_MODEL_NAME=""
+  _SPU_HAS_RL=$(printf '%s' "$_SPU_INPUT" | jq -r 'has("rate_limits")' 2>/dev/null) || _SPU_HAS_RL="false"
+  if [ "$_SPU_HAS_RL" = "true" ]; then
+    _SPU_FH_USED=$(printf '%s' "$_SPU_INPUT" | jq -r '.rate_limits.five_hour.used_percentage // ""' 2>/dev/null) || _SPU_FH_USED=""
+    _SPU_FH_RESETS=$(printf '%s' "$_SPU_INPUT" | jq -r '.rate_limits.five_hour.resets_at // ""' 2>/dev/null) || _SPU_FH_RESETS=""
+    _SPU_SD_USED=$(printf '%s' "$_SPU_INPUT" | jq -r '.rate_limits.seven_day.used_percentage // ""' 2>/dev/null) || _SPU_SD_USED=""
+    _SPU_SD_RESETS=$(printf '%s' "$_SPU_INPUT" | jq -r '.rate_limits.seven_day.resets_at // ""' 2>/dev/null) || _SPU_SD_RESETS=""
+  fi
+fi
+
+# Introspeccao de teste (task 2.1.5) — NUNCA stdout (contaminaria a UI),
+# so stderr, e so quando explicitamente pedido via env var. Fixture de
+# teste consome isto para validar a extracao sem depender do pipeline de
+# persistencia (task 2.2) nem do contrato de pass-through (task 2.4).
+if [ "${CSTK_STATUSLINE_DEBUG:-}" = "1" ]; then
+  printf 'session_id=%s project_path=%s model=%s has_rate_limits=%s five_hour.used=%s five_hour.resets=%s seven_day.used=%s seven_day.resets=%s\n' \
+    "$_SPU_SESSION_ID" "$_SPU_PROJECT_PATH" "$_SPU_MODEL_NAME" "$_SPU_HAS_RL" \
+    "$_SPU_FH_USED" "$_SPU_FH_RESETS" "$_SPU_SD_USED" "$_SPU_SD_RESETS" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Passo 5 (task 2.2/2.3): persistencia — delegada via subprocesso a
+# `cstk plan-usage ingest --stdin` (research.md Decision 6). So tenta
+# quando rate_limits esta presente (dec-029: ausencia total nunca gera
+# INSERT, entao nem vale a pena invocar o subprocesso) e `cstk` esta
+# resolvivel no PATH (task 2.5.1: `cstk`/`sqlite3` indisponivel -> captura
+# pulada, sem erro). Payload BRUTO (nao os campos ja extraidos) e
+# reencaminhado — o subcomando faz sua propria extracao completa +
+# throttle + INSERT (4.3.2), este script so decide SE vale a pena chamar.
+# Saida do subprocesso e sempre descartada (nunca contamina stdout/stderr
+# da statusline — task 2.4.3).
+# ---------------------------------------------------------------------------
+if [ "$_SPU_VALID_JSON" = 1 ] && [ "$_SPU_HAS_RL" = "true" ]; then
+  if _SPU_CSTK_BIN=$(command -v cstk 2>/dev/null) && [ -n "$_SPU_CSTK_BIN" ]; then
+    printf '%s' "$_SPU_INPUT" | "$_SPU_CSTK_BIN" plan-usage ingest --stdin >/dev/null 2>&1 || :
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Passo 6 (task 2.4): pass-through obrigatorio do stdout (contrato de
+# saida — o script MUST sempre imprimir algo, nunca deixar a UI em branco;
+# NUNCA imprimir erro de diagnostico em stdout).
+# ---------------------------------------------------------------------------
+if [ -n "${CSTK_STATUSLINE_INNER_COMMAND:-}" ]; then
+  # Reencaminha o payload ORIGINAL (stdin intacto, inclusive se malformado
+  # — pass-through best-effort do stdin cru, task 2.1.4/2.4.1) para o
+  # comando interno e repassa o stdout dele verbatim.
+  printf '%s' "$_SPU_INPUT" | sh -c "$CSTK_STATUSLINE_INNER_COMMAND" 2>/dev/null
+  exit 0
+fi
+
+if [ "$_SPU_VALID_JSON" = 1 ]; then
+  # Fallback minimo de 1 linha (2.4.2) — nao inventado, so campos ja
+  # capturados desta mesma sessao (model.display_name + five_hour.used_percentage
+  # quando disponivel).
+  if [ -n "$_SPU_MODEL_NAME" ] && [ "$_SPU_MODEL_NAME" != "null" ]; then
+    _SPU_LABEL="$_SPU_MODEL_NAME"
+  else
+    _SPU_LABEL="claude"
+  fi
+  if [ -n "$_SPU_FH_USED" ] && [ "$_SPU_FH_USED" != "null" ]; then
+    printf '%s (%s%% used)\n' "$_SPU_LABEL" "$_SPU_FH_USED"
+  else
+    printf '%s\n' "$_SPU_LABEL"
+  fi
+else
+  # Sem jq, ou JSON invalido/vazio: nao ha campo algum disponivel para
+  # montar um fallback data-driven sem inventar (Principio VI) — 1 linha
+  # neutra, nunca vazia (preserva a UI de quem nao configurou nada antes).
+  printf 'claude\n'
+fi
+
+exit 0

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
@@ -172,6 +172,104 @@ _gh_registered() {
   grep -Fq -- "$2" "$_gh_settings" 2>/dev/null
 }
 
+# ---------------------------------------------------------------------------
+# TERCEIRO MODO DE FALHA DE CAMPO: o hook vem do PLUGIN, nao do projeto
+# ---------------------------------------------------------------------------
+# Desde a v7 (feature claude-plugin-packaging) o cstk pode ser instalado como
+# plugin nativo do Claude Code. Nesse modo os 3 hooks sao registrados pelo
+# `hooks/hooks.json` do plugin, via ${CLAUDE_PLUGIN_ROOT} — e NAO existe
+# copia em <PAP>/.claude/hooks/ nem registro em <PAP>/.claude/settings.json.
+# `cstk hooks install` inclusive PULA o provisionamento classico nesse caso
+# (dedup "plugin vence", cli/lib/hooks.sh).
+#
+# Sem as duas funcoes abaixo, `_gh_present`/`_gh_registered` respondem
+# missing/unregistered para hooks que estao PERFEITAMENTE ATIVOS. Duas
+# consequencias, uma cosmetica e uma FUNCIONAL:
+#   - `check` acusa "3 de 3 hooks NAO estao ativos" e manda rodar
+#     `cstk hooks install`, que responde "plugin ja prove — pulando". O
+#     operador fica num loop de remediacao que nao remedia nada.
+#   - `tick-mode` devolve "manual", o orquestrador ticka na mao, o hook do
+#     plugin ticka tambem, e `state-ondas.sh end` SOMA as duas fontes
+#     (ticks manuais + linhas do sidecar) => `tool_calls` contado em DOBRO
+#     em toda onda. O budget de onda dispara com metade do trabalho real.
+#     Este e exatamente o cenario que o comentario de `tick-mode` ja
+#     antecipava ("devolver manual ali produziria contagem DUPLA"), so que
+#     pelo caminho do plugin, que nao existia quando aquilo foi escrito.
+#
+# Degradacao (mesma assimetria de cli/lib/plugin-detect.sh): na duvida o
+# resultado e "plugin nao prove", que preserva byte-a-byte o comportamento
+# anterior. Nunca se afirma cobertura de plugin sem ter lido o hooks.json.
+
+# _gh_plugin_hooks_json -> stdout: path do hooks.json do plugin cstk ATIVO,
+# ou vazio. SEMPRE exit 0 (consumido em $(...) sob `set -e`). Memoizado: a
+# resolucao envolve jq e e chamada uma vez por hook.
+_GH_PLUGIN_HJ_MEMO=''
+_gh_plugin_hooks_json() {
+  if [ -n "$_GH_PLUGIN_HJ_MEMO" ]; then
+    [ "$_GH_PLUGIN_HJ_MEMO" = '-' ] || printf '%s' "$_GH_PLUGIN_HJ_MEMO"
+    return 0
+  fi
+  _GH_PLUGIN_HJ_MEMO='-'
+
+  # (a) Override de teste — mesma disciplina de CSTK_HOOKS_CATALOG_DIR.
+  if [ -n "${CSTK_PLUGIN_HOOKS_JSON:-}" ]; then
+    if [ -r "$CSTK_PLUGIN_HOOKS_JSON" ]; then
+      _GH_PLUGIN_HJ_MEMO="$CSTK_PLUGIN_HOOKS_JSON"
+      printf '%s' "$_GH_PLUGIN_HJ_MEMO"
+    fi
+    return 0
+  fi
+
+  # (b) Sinal mais forte: estamos rodando DENTRO do plugin. Nao exige jq.
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -r "${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json" ]; then
+    _GH_PLUGIN_HJ_MEMO="${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json"
+    printf '%s' "$_GH_PLUGIN_HJ_MEMO"
+    return 0
+  fi
+
+  # (c) Registro nativo do Claude Code. Espelha plugin_enabled +
+  # plugin_install_path de cli/lib/plugin-detect.sh (instalado E habilitado),
+  # sem sourcear aquele arquivo: ele exige CSTK_LIB + common.sh, que podem
+  # nao existir no projeto-alvo que estamos diagnosticando. jq ausente =>
+  # indeterminado => "nao prove" (degradacao, nunca falso-positivo).
+  command -v jq >/dev/null 2>&1 || return 0
+  [ -n "${HOME:-}" ] || return 0
+  _gh_pj_inst="$HOME/.claude/plugins/installed_plugins.json"
+  _gh_pj_set="$HOME/.claude/settings.json"
+  [ -f "$_gh_pj_inst" ] || return 0
+  [ -f "$_gh_pj_set" ] || return 0
+
+  _gh_pj_on=$(jq -r '
+    (.enabledPlugins // {}) | to_entries
+    | map(select((.key | startswith("cstk@")) and .value == true)) | length
+  ' -- "$_gh_pj_set" 2>/dev/null) || return 0
+  case "$_gh_pj_on" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$_gh_pj_on" -gt 0 ] || return 0
+
+  _gh_pj_path=$(jq -r '
+    (.plugins // {}) | to_entries
+    | map(select(.key | startswith("cstk@"))) | map(.value) | flatten(1)
+    | sort_by(.lastUpdated // .installedAt // "") | last
+    | .installPath // empty
+  ' -- "$_gh_pj_inst" 2>/dev/null) || return 0
+  [ -n "$_gh_pj_path" ] || return 0
+  [ -r "$_gh_pj_path/hooks/hooks.json" ] || return 0
+
+  _GH_PLUGIN_HJ_MEMO="$_gh_pj_path/hooks/hooks.json"
+  printf '%s' "$_GH_PLUGIN_HJ_MEMO"
+  return 0
+}
+
+# _gh_plugin_provides HOOK -> 0 se o plugin ATIVO registra esse hook.
+# Busca textual pelo basename, mesma justificativa de `_gh_registered`: o
+# hooks.json referencia o hook como fragmento de linha de comando
+# (${CLAUDE_PLUGIN_ROOT}/skills/agente-00c-runtime/hooks/X.sh).
+_gh_plugin_provides() {
+  _gh_pp_json=$(_gh_plugin_hooks_json)
+  [ -n "$_gh_pp_json" ] || return 1
+  grep -Fq -- "$1" "$_gh_pp_json" 2>/dev/null
+}
+
 # _gh_self_dir -> diretorio do proprio script (vazio se irresolvivel).
 _gh_self_dir() {
   (CDPATH='' cd -- "$(dirname -- "$0")" 2>/dev/null && pwd) || printf ''
@@ -324,6 +422,8 @@ _gh_cmd_check() {
   _guard_missing=0
   _guard_stale=0
   _guard_divergent=0
+  _plugin_hooks=0
+  _dup_hooks=0
   for _h in $_GH_HOOKS; do
     if _gh_present "$_pap" "$_h"; then
       _st_file="present"
@@ -338,6 +438,34 @@ _gh_cmd_check() {
     _st_fresh=$(_gh_freshness "$_pap" "$_h")
     if [ "$_verify_reg" = 1 ]; then
       _st_verify=$(_gh_verify_registration "$_pap" "$_h")
+    fi
+
+    # Hook provido pelo PLUGIN: roda de fato, independentemente de existir
+    # copia classica no projeto. As 3 dimensoes passam a descrever o que
+    # VAI EXECUTAR, que e o que o consumidor pergunta:
+    #   present   — o arquivo existe (no plugin)
+    #   registered— o hooks.json do plugin o registra
+    #   current   — e a propria copia do plugin; nao ha snapshot a envelhecer
+    #               (o plugin e versionado e atualizado como unidade)
+    # Os tokens NAO mudam: introduzir um valor novo quebraria consumidores
+    # que casam exatamente estes literais.
+    if _gh_plugin_provides "$_h"; then
+      _plugin_hooks=$((_plugin_hooks + 1))
+      # Copia classica registrada TAMBEM => o hook roda DUAS vezes (o mesmo
+      # caso que `cstk hooks install` ja alerta ao pular o provisionamento).
+      # Para metricas isso e contagem dupla; para a guarda de Bash, so custo.
+      if [ "$_st_file" = "present" ] && [ "$_st_reg" = "registered" ]; then
+        _dup_hooks=$((_dup_hooks + 1))
+      fi
+      _st_file="present"
+      _st_reg="registered"
+      _st_fresh="current"
+      if [ "$_verify_reg" = 1 ]; then
+        _st_verify="canonical"
+      fi
+    fi
+
+    if [ "$_verify_reg" = 1 ]; then
       printf '%s\t%s\t%s\t%s\t%s\n' "$_h" "$_st_file" "$_st_reg" "$_st_fresh" "$_st_verify"
     else
       printf '%s\t%s\t%s\t%s\n' "$_h" "$_st_file" "$_st_reg" "$_st_fresh"
@@ -381,6 +509,17 @@ _gh_cmd_check() {
     fi
   fi
 
+  # Origem plugin: informativo, nunca anomalia. Sem esta linha o operador ve
+  # "3/3 ativos" sem saber de onde vem, e nao entende por que nao ha nada em
+  # <PAP>/.claude/hooks/.
+  if [ "$_quiet" = 0 ] && [ "$_plugin_hooks" -gt 0 ]; then
+    _gh_err "$_plugin_hooks de 3 hooks 00c sao providos pelo PLUGIN cstk (hooks.json), nao pela copia classica em $_pap/.claude/hooks/ — ativos, nada a provisionar."
+  fi
+  if [ "$_quiet" = 0 ] && [ "$_dup_hooks" -gt 0 ]; then
+    _gh_err "ATENCAO: $_dup_hooks hook(s) registrados DUAS vezes (plugin + copia classica em $_pap/.claude/settings.json) — cada tool call e contado em dobro."
+    _gh_err "  Remediacao: remova o bloco classico de $_pap/.claude/settings.json (o plugin vence)."
+  fi
+
   [ "$_missing" -eq 0 ] && [ "$_stale" -eq 0 ] && [ "$_divergent" -eq 0 ] && return 0
 
   if [ "$_quiet" = 0 ]; then
@@ -420,6 +559,16 @@ _gh_cmd_tick_mode() {
     esac
   done
   [ -n "$_pap" ] || _gh_die_usage "tick-mode: --projeto-alvo-path obrigatorio"
+
+  # Provido pelo PLUGIN: o hook JA ticka. Devolver "manual" aqui faria o
+  # orquestrador tickar tambem, e `state-ondas.sh end` soma as duas fontes
+  # (ticks manuais + linhas do sidecar) => tool_calls em DOBRO. Este ramo vem
+  # ANTES do teste de copia classica porque no modo plugin ela nao existe —
+  # e a ausencia dela nao significa metrica ausente.
+  if _gh_plugin_provides "posttooluse-tool-call-tick.sh"; then
+    printf 'hook\n'
+    return 0
+  fi
 
   if ! _gh_present "$_pap" "posttooluse-tool-call-tick.sh" \
      || ! _gh_registered "$_pap" "posttooluse-tool-call-tick.sh"; then

--- a/tests/cstk/test_plan-usage.sh
+++ b/tests/cstk/test_plan-usage.sh
@@ -1,0 +1,309 @@
+#!/bin/sh
+# test_plan-usage.sh — cobre cli/lib/plan-usage.sh, consulta publica
+# `cstk plan-usage` / `cstk plan-usage history` (FASE 4.1/4.2, feature
+# plan-usage-capture).
+#
+# Contrato: docs/specs/plan-usage-capture/contracts/cli-plan-usage.md
+# secoes "cstk plan-usage" e "cstk plan-usage history".
+#
+# Cenarios `cstk plan-usage` (mapeados 1:1 aos subitens 4.1.2-4.1.8):
+#   1  --json/--db flags aceitas + saida texto com dados (4.1.2/4.1.3)
+#   2  texto: campo sem medicao imprime "nao medido", nunca "0" (4.1.3)
+#   3  --json: null explicito quando escopo nunca teve captura (4.1.4)
+#   4  --json e JSON parseavel com dados presentes (4.1.4)
+#   5  knowledge.db ausente -> aviso stderr + "nao medido" nos 2 escopos, exit 0 (4.1.5)
+#   6  tabela plan_usage vazia (db existe, sem linhas) -> mensagem dedicada, exit 0 (4.1.6)
+#   7  sqlite3 ausente -> aviso stderr, exit 1 (4.1.7)
+#   8  flag desconhecida -> uso em stderr, exit 2 (4.1.8)
+#
+# Cenarios `cstk plan-usage history` (mapeados aos subitens 4.2.1-4.2.6):
+#   9  3 capturas crescentes -> historico em ordem cronologica, --scope
+#      filtra (paridade quickstart.md Cenario 4) (4.2.1/4.2.2/4.2.5)
+#   10 --json: chave so do escopo pedido, array vazio (nao null) sem
+#      captura no filtro (4.2.3)
+#   11 --since filtra identico a `cstk usage --since` (4.2.1/4.2.6)
+#   12 --limit filtra e mantem ordem cronologica (4.2.1/4.2.6)
+#   13 --scope invalido -> exit 2 (4.2.1)
+#   14 knowledge.db ausente -> "nao medido" por escopo, exit 0 (4.2.4)
+#
+# DB de teste sempre via --db em $TMPDIR_TEST; HOME sempre isolado sob
+# $TMPDIR_TEST (nunca ~/.claude real). Sem sessao real: captura semeada via
+# `plan_usage_main ingest --stdin` (mesmo caminho de producao usado pelo
+# hook da statusline, research.md Decision 6) alimentado por payload
+# fixture — paridade com tests/test_statusline-plan-usage.sh.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+CSTK_LIB="$REPO_ROOT/cli/lib"
+export CSTK_LIB
+
+_have_deps() {
+  command -v sqlite3 >/dev/null 2>&1 && command -v jq >/dev/null 2>&1
+}
+
+# _pu_home HOME_DIR ARGS... -> roda plan_usage_main isolado sob HOME_DIR.
+_pu_home() {
+  _puh_home="$1"; shift
+  env HOME="$_puh_home" \
+    sh -c '. "$CSTK_LIB/plan-usage.sh"; plan_usage_main "$@"' _ "$@"
+}
+
+# _pu_fixture SCOPE USED RESETS -> payload minimo com rate_limits.<scope>
+# (mesmo formato do payload real observado, paridade
+# reference_statusline_usage_payload.md).
+_pu_fixture_scope() {
+  printf '{"session_id":"s","workspace":{"current_dir":"/tmp/proj"},"rate_limits":{"%s":{"used_percentage":%s,"resets_at":%s}}}' "$1" "$2" "$3"
+}
+
+# _pu_ingest HOME_DIR DB JSON -> semeia plan_usage via o caminho de producao
+# `ingest --stdin` (aplica schema + INSERT), nao INSERT SQL direto no teste.
+_pu_ingest() {
+  _pi_home="$1"; _pi_db="$2"; _pi_json="$3"
+  printf '%s' "$_pi_json" | env HOME="$_pi_home" CSTK_KNOWLEDGE_DB="$_pi_db" \
+    sh -c '. "$CSTK_LIB/plan-usage.sh"; plan_usage_main ingest --stdin'
+}
+
+# _pu_touch_empty_db DB -> cria o arquivo do indice com o schema aplicado
+# mas SEM nenhuma linha em plan_usage (cenario 4.1.6: tabela vazia, DB
+# presente). Distinto de "DB ausente" (cenario 4.1.5).
+_pu_touch_empty_db() {
+  _pted_db="$1"
+  sh -c '. "$CSTK_LIB/recall.sh"; recall_ensure_db_dir "$1" >/dev/null 2>&1; recall_apply_schema "$1" >/dev/null 2>&1' _ "$_pted_db"
+}
+
+# =========================================================================
+# Cenario 1 — flags --json/--db aceitas + saida texto com dados (4.1.2/4.1.3)
+# =========================================================================
+scenario_01_flags_e_texto_com_dados() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/k1.db"
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 7.50 1786372200)" >/dev/null 2>&1
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" --db "$_db" || return 1
+  assert_stdout_contains "five_hour: 7.5% usado" || return 1
+  # reset formatado em local time (data ISO-like na apresentacao) — nunca o
+  # epoch cru exposto ao usuario.
+  assert_stdout_match "reset: [0-9]{4}-[0-9]{2}-[0-9]{2}" || return 1
+  assert_stdout_not_contains "1786372200" || return 1
+}
+
+# =========================================================================
+# Cenario 2 — campo sem medicao imprime "nao medido", nunca "0" (4.1.3)
+# =========================================================================
+scenario_02_nao_medido_nunca_zero() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/k2.db"
+  # so five_hour recebe captura; seven_day nunca e alimentado.
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 3.00 1786372200)" >/dev/null 2>&1
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" --db "$_db" || return 1
+  assert_stdout_contains "seven_day: nao medido" || return 1
+  assert_stdout_not_contains "seven_day: 0" || return 1
+}
+
+# =========================================================================
+# Cenario 3 — --json: null explicito quando escopo nunca teve captura (4.1.4)
+# =========================================================================
+scenario_03_json_null_sem_captura() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/k3.db"
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 5.00 1786372200)" >/dev/null 2>&1
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" --json --db "$_db" || return 1
+  printf '%s' "$_CAPTURED_STDOUT" | jq -e . >/dev/null 2>&1 || {
+    _fail "json_valido" "saida --json nao e JSON parseavel"
+    return 1
+  }
+  _sd_used=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.seven_day.used_percentage')
+  _sd_resets=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.seven_day.resets_at')
+  _sd_captured=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.seven_day.captured_at')
+  [ "$_sd_used" = "null" ] || { _fail "seven_day_used_null" "esperado null, obtido $_sd_used"; return 1; }
+  [ "$_sd_resets" = "null" ] || { _fail "seven_day_resets_null" "esperado null, obtido $_sd_resets"; return 1; }
+  [ "$_sd_captured" = "null" ] || { _fail "seven_day_captured_null" "esperado null, obtido $_sd_captured"; return 1; }
+}
+
+# =========================================================================
+# Cenario 4 — --json e JSON parseavel com dados presentes nos 2 escopos (4.1.4)
+# =========================================================================
+scenario_04_json_com_dados() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/k4.db"
+  _pu_ingest "$TMPDIR_TEST" "$_db" \
+    '{"session_id":"s","workspace":{"current_dir":"/tmp/proj"},"rate_limits":{"five_hour":{"used_percentage":7.0,"resets_at":1786372200},"seven_day":{"used_percentage":19,"resets_at":1786802400}}}' \
+    >/dev/null 2>&1
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" --json --db "$_db" || return 1
+  printf '%s' "$_CAPTURED_STDOUT" | jq -e . >/dev/null 2>&1 || {
+    _fail "json_valido" "saida --json nao e JSON parseavel"
+    return 1
+  }
+  _fh_used=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.five_hour.used_percentage')
+  _sd_used=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.seven_day.used_percentage')
+  # SQLite armazena a coluna REAL (7 -> 7.0, 19 -> 19.0); jq preserva a
+  # representacao textual vinda da query (tonumber de "7.0"/"19.0").
+  [ "$_fh_used" = "7.0" ] || { _fail "five_hour_used" "esperado 7.0, obtido $_fh_used"; return 1; }
+  [ "$_sd_used" = "19.0" ] || { _fail "seven_day_used" "esperado 19.0, obtido $_sd_used"; return 1; }
+}
+
+# =========================================================================
+# Cenario 5 — knowledge.db ausente -> aviso stderr + "nao medido" nos 2
+# escopos, exit 0 (4.1.5)
+# =========================================================================
+scenario_05_db_ausente() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/nunca-existiu-5/k.db"
+  assert_exit 0 _pu_home "$TMPDIR_TEST" --db "$_db" || return 1
+  assert_stderr_contains "ausente" || return 1
+  assert_stdout_contains "five_hour: nao medido" || return 1
+  assert_stdout_contains "seven_day: nao medido" || return 1
+}
+
+# =========================================================================
+# Cenario 6 — tabela plan_usage vazia (DB existe, sem linhas) -> mensagem
+# dedicada, exit 0 (4.1.6)
+# =========================================================================
+scenario_06_tabela_vazia() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/k6.db"
+  _pu_touch_empty_db "$_db"
+  [ -f "$_db" ] || { _error "seed_db" "nao consegui criar DB vazio de fixture"; return 2; }
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" --db "$_db" || return 1
+  assert_stdout_contains "nao medido — nenhuma captura registrada ainda" || return 1
+}
+
+# =========================================================================
+# Cenario 7 — sqlite3 ausente -> aviso stderr, exit 1 (4.1.7)
+# =========================================================================
+scenario_07_sem_sqlite3() {
+  _bin="$TMPDIR_TEST/bin7"
+  mkdir -p "$_bin"
+  for _t in tr wc printf sed grep awk basename dirname date find mkdir rm cat head sleep cp jq stat mktemp sh env; do
+    _p=$(command -v "$_t" 2>/dev/null) && ln -sf "$_p" "$_bin/$_t"
+  done
+  # (sqlite3 deliberadamente ausente do PATH)
+  assert_exit 1 env PATH="$_bin" HOME="$TMPDIR_TEST" sh -c \
+    '. "'"$CSTK_LIB"'/plan-usage.sh"; plan_usage_main --db "'"$TMPDIR_TEST"'/k7.db"' || return 1
+  assert_stderr_contains "sqlite3" || return 1
+}
+
+# =========================================================================
+# Cenario 8 — flag desconhecida -> uso em stderr, exit 2 (4.1.8)
+# =========================================================================
+scenario_08_flag_desconhecida() {
+  assert_exit 2 _pu_home "$TMPDIR_TEST" --bogus || return 1
+}
+
+# =========================================================================
+# Cenario 9 — 3 capturas crescentes -> historico em ordem cronologica,
+# --scope filtra (paridade quickstart.md Cenario 4) (4.2.1/4.2.2/4.2.5)
+# =========================================================================
+scenario_09_historico_ordem_cronologica() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/k9.db"
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 5.0 1786372200)" >/dev/null 2>&1
+  sleep 1
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 12.0 1786372200)" >/dev/null 2>&1
+  sleep 1
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 20.0 1786372200)" >/dev/null 2>&1
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" history --scope five_hour --db "$_db" || return 1
+  assert_stdout_contains "== five_hour ==" || return 1
+  assert_stdout_not_contains "seven_day" || return 1
+
+  # ordem cronologica: 5.0 aparece ANTES de 12.0, que aparece ANTES de 20.0.
+  _pos5=$(printf '%s' "$_CAPTURED_STDOUT" | grep -n "5.0%" | head -1 | cut -d: -f1)
+  _pos12=$(printf '%s' "$_CAPTURED_STDOUT" | grep -n "12.0%" | head -1 | cut -d: -f1)
+  _pos20=$(printf '%s' "$_CAPTURED_STDOUT" | grep -n "20.0%" | head -1 | cut -d: -f1)
+  [ -n "$_pos5" ] && [ -n "$_pos12" ] && [ -n "$_pos20" ] || { _fail "3_linhas_presentes" "esperado 3 valores no historico"; return 1; }
+  [ "$_pos5" -lt "$_pos12" ] && [ "$_pos12" -lt "$_pos20" ] || {
+    _fail "ordem_cronologica" "esperado 5.0 < 12.0 < 20.0 na saida (linhas $_pos5/$_pos12/$_pos20)"
+    return 1
+  }
+}
+
+# =========================================================================
+# Cenario 10 — --json: chave so do escopo pedido, array vazio (nao null)
+# sem captura no filtro (4.2.3)
+# =========================================================================
+scenario_10_json_chave_escopo_array_vazio() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/k10.db"
+  _pu_touch_empty_db "$_db"
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" history --scope five_hour --json --db "$_db" || return 1
+  printf '%s' "$_CAPTURED_STDOUT" | jq -e . >/dev/null 2>&1 || {
+    _fail "json_valido" "saida --json de history nao e JSON parseavel"
+    return 1
+  }
+  assert_stdout_not_contains "seven_day" || return 1
+  _arr=$(printf '%s' "$_CAPTURED_STDOUT" | jq -c '.five_hour')
+  [ "$_arr" = "[]" ] || { _fail "array_vazio" "esperado [], obtido $_arr"; return 1; }
+}
+
+# =========================================================================
+# Cenario 11 — --since filtra identico a `cstk usage --since` (4.2.1/4.2.6)
+# =========================================================================
+scenario_11_since_filtra() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/k11.db"
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 5.0 1786372200)" >/dev/null 2>&1
+  sleep 1
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 12.0 1786372200)" >/dev/null 2>&1
+  sleep 1
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 20.0 1786372200)" >/dev/null 2>&1
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" history --scope five_hour --json --db "$_db" || return 1
+  _since=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.five_hour[1].captured_at')
+  [ -n "$_since" ] && [ "$_since" != "null" ] || { _fail "since_seed" "nao consegui extrair captured_at do 2o registro"; return 1; }
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" history --scope five_hour --since "$_since" --json --db "$_db" || return 1
+  _n=$(printf '%s' "$_CAPTURED_STDOUT" | jq '.five_hour | length')
+  [ "$_n" = "2" ] || { _fail "since_filtra" "esperado 2 linhas (>= 2o registro), obtido $_n"; return 1; }
+  assert_stdout_not_contains '"used_percentage": 5.0' || return 1
+}
+
+# =========================================================================
+# Cenario 12 — --limit filtra e mantem ordem cronologica (4.2.1/4.2.6)
+# =========================================================================
+scenario_12_limit_filtra() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/k12.db"
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 5.0 1786372200)" >/dev/null 2>&1
+  sleep 1
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 12.0 1786372200)" >/dev/null 2>&1
+  sleep 1
+  _pu_ingest "$TMPDIR_TEST" "$_db" "$(_pu_fixture_scope five_hour 20.0 1786372200)" >/dev/null 2>&1
+
+  assert_exit 0 _pu_home "$TMPDIR_TEST" history --scope five_hour --limit 2 --json --db "$_db" || return 1
+  _n=$(printf '%s' "$_CAPTURED_STDOUT" | jq '.five_hour | length')
+  [ "$_n" = "2" ] || { _fail "limit_2" "esperado 2 linhas, obtido $_n"; return 1; }
+  # --limit 2 mantem as 2 MAIS RECENTES (12.0, 20.0), nao as 2 mais antigas.
+  _first=$(printf '%s' "$_CAPTURED_STDOUT" | jq -r '.five_hour[0].used_percentage')
+  [ "$_first" = "12.0" ] || { _fail "limit_mais_recentes" "esperado 12.0 como primeiro apos --limit 2, obtido $_first"; return 1; }
+}
+
+# =========================================================================
+# Cenario 13 — --scope invalido -> exit 2 (4.2.1)
+# =========================================================================
+scenario_13_scope_invalido() {
+  assert_exit 2 _pu_home "$TMPDIR_TEST" history --scope bogus --db "$TMPDIR_TEST/k13.db" || return 1
+}
+
+# =========================================================================
+# Cenario 14 — knowledge.db ausente -> "nao medido" por escopo, exit 0 (4.2.4)
+# =========================================================================
+scenario_14_history_db_ausente() {
+  _have_deps || return 0
+  _db="$TMPDIR_TEST/nunca-existiu-14/k.db"
+  assert_exit 0 _pu_home "$TMPDIR_TEST" history --db "$_db" || return 1
+  assert_stderr_contains "ausente" || return 1
+  assert_stdout_contains "== five_hour ==" || return 1
+  assert_stdout_contains "== seven_day ==" || return 1
+  assert_stdout_contains "nao medido" || return 1
+}
+
+run_all_scenarios

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -606,9 +606,9 @@ SQL
   # Aplica schema v7 via funcao real (caminho de recall_apply_schema).
   sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_mdb" || {
     _fail "apply schema v7" "recall_apply_schema falhou"; return 1; }
-  # (a) schema_version virou a corrente (13 — v13 loose-usage-capture).
+  # (a) schema_version virou a corrente (14 — v14 plan-usage-capture).
   _sv=$(sqlite3 "$_mdb" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "13" ] || { _fail "schema_version" "esperado 13, obtido $_sv"; return 1; }
+  [ "$_sv" = "14" ] || { _fail "schema_version" "esperado 14, obtido $_sv"; return 1; }
   # (b) tabela bloqueios DROPADA; blocks (EN) criada no lugar.
   _hasbloq=$(sqlite3 "$_mdb" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='bloqueios'")
   [ "$_hasbloq" = "0" ] || { _fail "bloqueios dropada" "tabela pt-BR bloqueios sobreviveu"; return 1; }
@@ -653,7 +653,7 @@ scenario_m11b_v7_reindex_repopula() {
   _v7db="$TMPDIR_TEST/v7.db"
   _rc --reindex --states-root "$TMPDIR_TEST/rxv7" --db "$_v7db" >/dev/null 2>&1
   _sv=$(sqlite3 "$_v7db" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "13" ] || { _fail "reindex schema corrente" "esperado schema_version 13, obtido $_sv"; return 1; }
+  [ "$_sv" = "14" ] || { _fail "reindex schema corrente" "esperado schema_version 14, obtido $_sv"; return 1; }
   # decisions repopuladas em EN (2 decisoes do _write_state).
   _n=$(sqlite3 "$_v7db" "SELECT count(*) FROM decisions WHERE feature='featV7'")
   [ "$_n" = "2" ] || { _fail "reindex repopula" "esperado 2 decisoes, obtido $_n"; return 1; }
@@ -675,7 +675,7 @@ scenario_m12_ddl_idempotente() {
   sqlite3 "$_mdb" "INSERT INTO decisions(project,feature,wave,execution_id,source_ts,source_id,choice,ingested_at) VALUES('p','f','w','e','t','dec-keep','keep','now')"
   assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_mdb" || return 1
   _sv=$(sqlite3 "$_mdb" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "13" ] || { _fail "schema estavel" "esperado 13 apos 2x, obtido $_sv"; return 1; }
+  [ "$_sv" = "14" ] || { _fail "schema estavel" "esperado 14 apos 2x, obtido $_sv"; return 1; }
   _keep=$(sqlite3 "$_mdb" "SELECT count(*) FROM decisions WHERE source_id='dec-keep'")
   [ "$_keep" = "1" ] || { _fail "idempotente sem re-drop" "linha sumiu: 2o apply re-dropou ($_keep)"; return 1; }
 }
@@ -1913,7 +1913,7 @@ scenario_b11_ddl_tasks_events() {
   # v9 executions-target-path: coluna target_project_path em executions; v8
   # recall-worktree-identity: coluna session em executions/waves).
   _sv=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT value FROM schema_meta WHERE key='schema_version'")
-  [ "$_sv" = "13" ] || { _fail "schema_version" "esperado 13, obtido $_sv"; return 1; }
+  [ "$_sv" = "14" ] || { _fail "schema_version" "esperado 14, obtido $_sv"; return 1; }
   # tasks tem a coluna title (EN, DDL fresco).
   _hascol=$(sqlite3 "$TMPDIR_TEST/k.db" "SELECT count(*) FROM pragma_table_info('tasks') WHERE name='title'")
   [ "$_hascol" = "1" ] || { _fail "coluna title" "esperado 1, obtido $_hascol"; return 1; }
@@ -2229,7 +2229,7 @@ scenario_m1_schema_memories_table_exists() {
   # schema_version deve ser 10 (wave-token-metrics: colunas agent_* em waves)
   _ver=$(sqlite3 "$TMPDIR_TEST/m1.db" \
     "SELECT value FROM schema_meta WHERE key='schema_version';" 2>/dev/null)
-  [ "$_ver" = "13" ] || { _fail "schema_version errado" "esperado 13, obtido '$_ver'"; return 1; }
+  [ "$_ver" = "14" ] || { _fail "schema_version errado" "esperado 14, obtido '$_ver'"; return 1; }
 }
 
 # M1-enum — RECALL_TYPE_ENUM inclui 'memory' apos bump.
@@ -2319,7 +2319,7 @@ scenario_m1_migration_v3_to_current() {
   # session/target_project_path de executions e agent_* de waves vem do DDL
   # fresco pos-drop v7)
   _ver=$(sqlite3 "$_v3db" "SELECT value FROM schema_meta WHERE key='schema_version';" 2>/dev/null)
-  [ "$_ver" = "13" ] || { _fail "migration: schema_version errado" "esperado 13, obtido '$_ver'"; return 1; }
+  [ "$_ver" = "14" ] || { _fail "migration: schema_version errado" "esperado 14, obtido '$_ver'"; return 1; }
   # decisions repopuladas pelo ingest (>=1; o derivado v3 foi descartado, o
   # state.json o reconstroi em EN).
   _n=$(sqlite3 "$_v3db" "SELECT count(*) FROM decisions;" 2>/dev/null)
@@ -3069,7 +3069,7 @@ INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,stages,i
     *) _fail "W5 waves.session" "coluna session ausente em waves pos-migracao"; return 1 ;;
   esac
   _w5_ver=$(sqlite3 "$_w5_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_w5_ver" = "13" ] || { _fail "W5 schema_version" "esperado '13' (corrente pos-v13), obtido '$_w5_ver'"; return 1; }
+  [ "$_w5_ver" = "14" ] || { _fail "W5 schema_version" "esperado '14' (corrente pos-v14), obtido '$_w5_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/w5/sd" --db "$_w5_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "W5 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3195,7 +3195,7 @@ JSON
     *) _fail "TP1d shape v9" "coluna target_project_path ausente em executions"; return 1 ;;
   esac
   _tp1_ver=$(sqlite3 "$_tp1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_tp1_ver" = "13" ] || { _fail "TP1d schema_version" "esperado 13, obtido '$_tp1_ver'"; return 1; }
+  [ "$_tp1_ver" = "14" ] || { _fail "TP1d schema_version" "esperado 14, obtido '$_tp1_ver'"; return 1; }
 }
 
 # Cenario TP2 — re-ingestao idempotente + backfill: DB v8 preexistente com
@@ -3250,7 +3250,7 @@ INSERT INTO executions(project,feature,wave,execution_id,source_ts,source_id,ses
   _tp3_new=$(sqlite3 "$_tp3_db" "SELECT target_project_path FROM executions WHERE feature='feat-tp3';")
   [ "$_tp3_new" = "/nonexistent/tp3proj" ] || { _fail "TP3 linha nova" "esperado '/nonexistent/tp3proj', obtido '$_tp3_new'"; return 1; }
   _tp3_ver=$(sqlite3 "$_tp3_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_tp3_ver" = "13" ] || { _fail "TP3 schema_version" "esperado '13', obtido '$_tp3_ver'"; return 1; }
+  [ "$_tp3_ver" = "14" ] || { _fail "TP3 schema_version" "esperado '14', obtido '$_tp3_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada, sem duplicata)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/tp3/sd" --db "$_tp3_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "TP3 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3299,7 +3299,7 @@ JSON
     *) _fail "WT1 shape v10" "coluna agent_spawns_total ausente em waves"; return 1 ;;
   esac
   _wt1_ver=$(sqlite3 "$_wt1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wt1_ver" = "13" ] || { _fail "WT1 schema_version" "esperado 13, obtido '$_wt1_ver'"; return 1; }
+  [ "$_wt1_ver" = "14" ] || { _fail "WT1 schema_version" "esperado 14, obtido '$_wt1_ver'"; return 1; }
 }
 
 # Cenario WT2 — onda SEM .agent_usage: as 9 colunas ficam NULL, nunca 0
@@ -3371,7 +3371,7 @@ JSON
   _wt3_new=$(sqlite3 "$_wt3_db" "SELECT agent_spawns_total||'|'||agent_duration_ms FROM waves WHERE feature='feat-wt3';")
   [ "$_wt3_new" = "3|4321" ] || { _fail "WT3 linha nova" "esperado '3|4321', obtido '$_wt3_new'"; return 1; }
   _wt3_ver=$(sqlite3 "$_wt3_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wt3_ver" = "13" ] || { _fail "WT3 schema_version" "esperado '13', obtido '$_wt3_ver'"; return 1; }
+  [ "$_wt3_ver" = "14" ] || { _fail "WT3 schema_version" "esperado '14', obtido '$_wt3_ver'"; return 1; }
   # 2a rodada: idempotente (sem erro de coluna duplicada, sem duplicata)
   capture _rc --ingest --state-dir "$TMPDIR_TEST/wt3/sd" --db "$_wt3_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "WT3 ingest#2 exit (idempotencia)" "$_CAPTURED_EXIT"; return 1; }
@@ -3508,7 +3508,7 @@ INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,session,
   capture _rc --ingest --state-dir "$_sd" --db "$_ot_db"
   [ "$_CAPTURED_EXIT" = "0" ] || { _fail "ingest#1" "$_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
   _v=$(sqlite3 "$_ot_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_v" = "13" ] || { _fail "schema_version" "esperado 13, obtido '$_v'"; return 1; }
+  [ "$_v" = "14" ] || { _fail "schema_version" "esperado 14, obtido '$_v'"; return 1; }
 
   # linha v10 intacta: session preservada, coluna nova NULL (nao 0)
   _leg=$(sqlite3 "$_ot_db" "SELECT session||'|'||COALESCE(otel_cost_usd,-999) FROM waves WHERE project='legacyp10';")
@@ -3558,7 +3558,7 @@ scenario_wmu1_fresh_db_colunas_e_tabela() {
   _wmu1_tbl=$(sqlite3 "$_wmu1_db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='wave_model_usage'")
   [ "$_wmu1_tbl" = "1" ] || { _fail "wmu1 tabela" "wave_model_usage ausente em banco novo"; return 1; }
   _wmu1_ver=$(sqlite3 "$_wmu1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wmu1_ver" = "13" ] || { _fail "wmu1 schema_version" "esperado 13, obtido '$_wmu1_ver'"; return 1; }
+  [ "$_wmu1_ver" = "14" ] || { _fail "wmu1 schema_version" "esperado 14, obtido '$_wmu1_ver'"; return 1; }
   return 0
 }
 
@@ -3588,7 +3588,7 @@ INSERT INTO tasks(project,feature,wave,execution_id,source_ts,source_id,title,ou
   sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_wmu2_db" || {
     _fail "wmu2 apply#1" "recall_apply_schema falhou"; return 1; }
   _wmu2_ver=$(sqlite3 "$_wmu2_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_wmu2_ver" = "13" ] || { _fail "wmu2 schema_version" "esperado 13, obtido '$_wmu2_ver'"; return 1; }
+  [ "$_wmu2_ver" = "14" ] || { _fail "wmu2 schema_version" "esperado 14, obtido '$_wmu2_ver'"; return 1; }
 
   # linha v11 intacta: session/otel_cost_usd preservados, colunas novas NULL (nao 0)
   _wmu2_leg=$(sqlite3 "$_wmu2_db" "SELECT session||'|'||otel_cost_usd||'|'||COALESCE(otel_main_input_tokens,-999) FROM waves WHERE project='p11';")
@@ -4235,7 +4235,7 @@ scenario_lu1_fresh_db_tabela_e_versao() {
   _lu1_tbl=$(sqlite3 "$_lu1_db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='loose_usage'")
   [ "$_lu1_tbl" = "1" ] || { _fail "lu1 tabela" "loose_usage ausente em banco novo"; return 1; }
   _lu1_ver=$(sqlite3 "$_lu1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_lu1_ver" = "13" ] || { _fail "lu1 schema_version" "esperado 13, obtido '$_lu1_ver'"; return 1; }
+  [ "$_lu1_ver" = "14" ] || { _fail "lu1 schema_version" "esperado 14, obtido '$_lu1_ver'"; return 1; }
   return 0
 }
 
@@ -4266,7 +4266,7 @@ INSERT INTO tasks(project,feature,wave,execution_id,source_ts,source_id,title,ou
   sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_lu2_db" || {
     _fail "lu2 apply#1" "recall_apply_schema falhou"; return 1; }
   _lu2_ver=$(sqlite3 "$_lu2_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
-  [ "$_lu2_ver" = "13" ] || { _fail "lu2 schema_version" "esperado 13, obtido '$_lu2_ver'"; return 1; }
+  [ "$_lu2_ver" = "14" ] || { _fail "lu2 schema_version" "esperado 14, obtido '$_lu2_ver'"; return 1; }
 
   # linha v12 intacta
   _lu2_leg=$(sqlite3 "$_lu2_db" "SELECT session||'|'||otel_cost_usd FROM waves WHERE project='p12';")
@@ -4360,6 +4360,139 @@ scenario_lu6_prune_db_ausente() {
   _lu6_rc=$?
   [ "$_lu6_rc" = "0" ] || { _fail "lu6 exit" "esperado 0, obtido $_lu6_rc"; return 1; }
   [ "$_lu6_out" = "0" ] || { _fail "lu6 contagem" "esperado 0, obtido '$_lu6_out'"; return 1; }
+  return 0
+}
+
+# =========================================================================
+# Feature plan-usage-capture — v14: tabela plan_usage
+# =========================================================================
+
+# Task 1.1.4/1.1.5 (banco novo) — banco criado do zero ja nasce em v14:
+# sqlite_master confirma a existencia da tabela plan_usage e schema_meta
+# confirma v14. Mesma forma de scenario_lu1 (loose_usage, v13).
+scenario_pu1_fresh_db_tabela_e_versao() {
+  _have_deps || return 0
+  _pu1_db="$TMPDIR_TEST/pu1/k.db"
+  mkdir -p "$TMPDIR_TEST/pu1"
+  sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_pu1_db" || {
+    _fail "pu1 apply" "recall_apply_schema falhou em banco novo"; return 1; }
+  _pu1_tbl=$(sqlite3 "$_pu1_db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='plan_usage'")
+  [ "$_pu1_tbl" = "1" ] || { _fail "pu1 tabela" "plan_usage ausente em banco novo"; return 1; }
+  _pu1_ver=$(sqlite3 "$_pu1_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
+  [ "$_pu1_ver" = "14" ] || { _fail "pu1 schema_version" "esperado 14, obtido '$_pu1_ver'"; return 1; }
+  return 0
+}
+
+# Task 1.1.4 (base v13 populada) — fixture v13 real com linhas em
+# waves/decisions/tasks/loose_usage. Apos recall_apply_schema: schema_version=14,
+# plan_usage existe VAZIA (nenhuma ingestao real ainda — FASE 4), e TODAS as
+# linhas/colunas pre-existentes continuam intactas. 2a rodada confirma
+# idempotencia (sem erro de tabela duplicada, sem duplicar linha) — migracao
+# e puramente aditiva (sem ALTER TABLE, sem DROP; precedente literal de
+# loose_usage na v12->v13). Mesma forma de scenario_lu2.
+scenario_pu2_migracao_v13_v14_real_idempotente() {
+  _have_deps || return 0
+  _pu2_db="$TMPDIR_TEST/pu2/k.db"
+  mkdir -p "$TMPDIR_TEST/pu2"
+  sqlite3 "$_pu2_db" "
+CREATE TABLE waves (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, stages TEXT, started_at TEXT, finished_at TEXT, wallclock_seconds INTEGER, tool_calls INTEGER, termination_reason TEXT, n_stages INTEGER, n_skills INTEGER, session TEXT, otel_cost_usd REAL, otel_cost_main_usd REAL, otel_cost_subagent_usd REAL, otel_total_tokens INTEGER, otel_subagent_tokens INTEGER, agent_spawns_total INTEGER, agent_spawns_with_usage INTEGER, agent_total_tokens INTEGER, agent_input_tokens INTEGER, agent_output_tokens INTEGER, agent_cache_read_tokens INTEGER, agent_cache_creation_tokens INTEGER, agent_tool_use_count INTEGER, agent_duration_ms INTEGER, otel_main_input_tokens INTEGER, otel_main_output_tokens INTEGER, otel_main_cache_read_tokens INTEGER, otel_main_cache_creation_tokens INTEGER, otel_subagent_input_tokens INTEGER, otel_subagent_output_tokens INTEGER, otel_subagent_cache_read_tokens INTEGER, otel_subagent_cache_creation_tokens INTEGER, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE decisions (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, agent TEXT, stage TEXT, choice TEXT, score INTEGER, context TEXT, rationale TEXT, evidence TEXT, options TEXT, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE tasks (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, feature TEXT NOT NULL, wave TEXT NOT NULL, execution_id TEXT NOT NULL, source_ts TEXT NOT NULL, source_id TEXT NOT NULL, title TEXT, outcome TEXT, tests_run INTEGER, tests_passed INTEGER, lint_ok INTEGER, touched_files INTEGER, ingested_at TEXT NOT NULL, UNIQUE(project, feature, wave, source_id));
+CREATE TABLE loose_usage (id INTEGER PRIMARY KEY AUTOINCREMENT, project TEXT NOT NULL, project_path TEXT, process_key TEXT NOT NULL, segment_id TEXT NOT NULL, model TEXT, cost_usd REAL, total_tokens INTEGER, segment_open INTEGER, captured_at TEXT NOT NULL, ingested_at TEXT NOT NULL, UNIQUE(process_key, segment_id, model));
+CREATE TABLE schema_meta (key TEXT PRIMARY KEY, value TEXT);
+INSERT INTO schema_meta VALUES('schema_version','13');
+INSERT INTO waves(project,feature,wave,execution_id,source_ts,source_id,session,otel_cost_usd,ingested_at) VALUES('p13','f13','onda-1','e13','t','onda-1','sess13',0.5,'t');
+INSERT INTO decisions(project,feature,wave,execution_id,source_ts,source_id,choice,ingested_at) VALUES('p13','f13','onda-1','e13','t','dec-1','keep','t');
+INSERT INTO tasks(project,feature,wave,execution_id,source_ts,source_id,title,outcome,ingested_at) VALUES('p13','f13','onda-1','e13','t','1.1','Task 1','pass','t');
+INSERT INTO loose_usage(project,project_path,process_key,segment_id,model,cost_usd,total_tokens,segment_open,captured_at,ingested_at) VALUES('p13','/p','proc-1','seg-001','sonnet',0.3,300,0,'t','t');
+" || { _fail "pu2 fixture v13" "criacao do DB v13 falhou"; return 1; }
+
+  # 1a rodada: migra v13 -> v14
+  sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_pu2_db" || {
+    _fail "pu2 apply#1" "recall_apply_schema falhou"; return 1; }
+  _pu2_ver=$(sqlite3 "$_pu2_db" "SELECT value FROM schema_meta WHERE key='schema_version';")
+  [ "$_pu2_ver" = "14" ] || { _fail "pu2 schema_version" "esperado 14, obtido '$_pu2_ver'"; return 1; }
+
+  # linha v13 intacta (waves e loose_usage, a tabela mais recente antes desta)
+  _pu2_leg=$(sqlite3 "$_pu2_db" "SELECT session||'|'||otel_cost_usd FROM waves WHERE project='p13';")
+  [ "$_pu2_leg" = "sess13|0.5" ] || { _fail "pu2 linha v13 waves" "esperado 'sess13|0.5', obtido '$_pu2_leg'"; return 1; }
+  _pu2_lu=$(sqlite3 "$_pu2_db" "SELECT model||'|'||cost_usd FROM loose_usage WHERE project='p13';")
+  [ "$_pu2_lu" = "sonnet|0.3" ] || { _fail "pu2 linha v13 loose_usage" "esperado 'sonnet|0.3', obtido '$_pu2_lu'"; return 1; }
+
+  # contagens pre-existentes intactas
+  _pu2_nw=$(sqlite3 "$_pu2_db" "SELECT count(*) FROM waves;")
+  [ "$_pu2_nw" = "1" ] || { _fail "pu2 waves count" "esperado 1, obtido $_pu2_nw"; return 1; }
+  _pu2_nd=$(sqlite3 "$_pu2_db" "SELECT count(*) FROM decisions;")
+  [ "$_pu2_nd" = "1" ] || { _fail "pu2 decisions count" "esperado 1, obtido $_pu2_nd"; return 1; }
+  _pu2_nt=$(sqlite3 "$_pu2_db" "SELECT count(*) FROM tasks;")
+  [ "$_pu2_nt" = "1" ] || { _fail "pu2 tasks count" "esperado 1, obtido $_pu2_nt"; return 1; }
+  _pu2_nlu=$(sqlite3 "$_pu2_db" "SELECT count(*) FROM loose_usage;")
+  [ "$_pu2_nlu" = "1" ] || { _fail "pu2 loose_usage count" "esperado 1, obtido $_pu2_nlu"; return 1; }
+
+  # plan_usage existe e esta vazia (nenhuma ingestao real ainda — FASE 4)
+  _pu2_tbl=$(sqlite3 "$_pu2_db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='plan_usage';")
+  [ "$_pu2_tbl" = "1" ] || { _fail "pu2 tabela nova" "plan_usage ausente pos-migracao"; return 1; }
+  _pu2_purows=$(sqlite3 "$_pu2_db" "SELECT count(*) FROM plan_usage;")
+  [ "$_pu2_purows" = "0" ] || { _fail "pu2 tabela vazia" "esperado 0 linhas, obtido $_pu2_purows"; return 1; }
+
+  # 2a rodada: idempotente — sem erro de tabela duplicada, sem duplicar linha
+  assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_pu2_db" || return 1
+  _pu2_nw2=$(sqlite3 "$_pu2_db" "SELECT count(*) FROM waves;")
+  [ "$_pu2_nw2" = "1" ] || { _fail "pu2 idempotencia waves" "linhas mudaram para $_pu2_nw2"; return 1; }
+  return 0
+}
+
+# Task 1.2.5 — payload adversarial de injecao no INSERT de plan_usage
+# (session_id/project_path com aspas simples, ';', '--', fragmento
+# '; DROP TABLE plan_usage; --). Confirma que sql_escape neutraliza o
+# vetor e o valor literal e persistido escapado, nunca interpretado como
+# SQL. Mesma forma dos cenarios 13b/13c (injecao adversarial), agora
+# exercitando recall_plan_usage_insert() diretamente (task 4.3 — CLI
+# `cstk plan-usage ingest --stdin` — ainda nao existe nesta fase).
+scenario_pu3_injecao_no_insert() {
+  _have_deps || return 0
+  _pu3_db="$TMPDIR_TEST/pu3/k.db"
+  mkdir -p "$TMPDIR_TEST/pu3"
+  sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_pu3_db" || {
+    _fail "pu3 apply" "recall_apply_schema falhou"; return 1; }
+  _pu3_sess="sess'; DROP TABLE plan_usage; --"
+  _pu3_proj_path="/home/u/proj'X"
+  assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_plan_usage_insert "$1" "p-adv" "$2" "$3" "five_hour" "7.5" "1786372200" "2026-08-10T13:00:00Z" "2026-08-10T13:00:00Z"' \
+    _ "$_pu3_db" "$_pu3_proj_path" "$_pu3_sess" || return 1
+  # Tabela plan_usage intacta (nao dropada) e com a linha (1 registro).
+  _pu3_n=$(sqlite3 "$_pu3_db" "SELECT count(*) FROM plan_usage" 2>/dev/null)
+  [ "$_pu3_n" = "1" ] || { _fail "pu3 injecao insert" "esperado 1 linha, obtido $_pu3_n (tabela dropada?)"; return 1; }
+  # Valor literal preservado (aspas + fragmento SQL como texto puro).
+  _pu3_val=$(sqlite3 "$_pu3_db" "SELECT session_id FROM plan_usage WHERE project='p-adv';")
+  [ "$_pu3_val" = "$_pu3_sess" ] || { _fail "pu3 valor literal" "esperado '$_pu3_sess', obtido '$_pu3_val'"; return 1; }
+  # sqlite_master confirma que plan_usage sobrevive (schema nao foi alterado).
+  _pu3_tbl=$(sqlite3 "$_pu3_db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='plan_usage';")
+  [ "$_pu3_tbl" = "1" ] || { _fail "pu3 tabela sobrevive" "plan_usage foi dropada pela injecao"; return 1; }
+  return 0
+}
+
+# Task 1.2.6 — used_percentage/resets_at ausentes (string vazia) persistem
+# NULL real na coluna (nunca string "NULL", nunca 0 fabricado — Constitution
+# VI/dec-029). Confirma tambem o caminho com valores presentes (nao-NULL)
+# no mesmo teste, paridade defensiva.
+scenario_pu4_null_vs_valor_presente() {
+  _have_deps || return 0
+  _pu4_db="$TMPDIR_TEST/pu4/k.db"
+  mkdir -p "$TMPDIR_TEST/pu4"
+  sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_apply_schema "$1"' _ "$_pu4_db" || {
+    _fail "pu4 apply" "recall_apply_schema falhou"; return 1; }
+  # used_percentage/resets_at ausentes (string vazia)
+  assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_plan_usage_insert "$1" "p-null" "/p" "sess-null" "seven_day" "" "" "2026-08-10T13:00:00Z" "2026-08-10T13:00:00Z"' \
+    _ "$_pu4_db" || return 1
+  _pu4_row=$(sqlite3 "$_pu4_db" "SELECT (used_percentage IS NULL)||'|'||(resets_at IS NULL) FROM plan_usage WHERE project='p-null';")
+  [ "$_pu4_row" = "1|1" ] || { _fail "pu4 NULL real" "esperado '1|1' (ambos NULL), obtido '$_pu4_row'"; return 1; }
+  # valores presentes: preservados sem arredondar (ruido de float, FR-004)
+  assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_plan_usage_insert "$1" "p-val" "/p" "sess-val" "five_hour" "7.000000000000001" "1786372200" "2026-08-10T13:00:00Z" "2026-08-10T13:00:00Z"' \
+    _ "$_pu4_db" || return 1
+  _pu4_used=$(sqlite3 "$_pu4_db" "SELECT used_percentage FROM plan_usage WHERE project='p-val';")
+  [ "$_pu4_used" = "7.000000000000001" ] || { _fail "pu4 ruido float" "esperado '7.000000000000001', obtido '$_pu4_used'"; return 1; }
+  _pu4_resets=$(sqlite3 "$_pu4_db" "SELECT resets_at FROM plan_usage WHERE project='p-val';")
+  [ "$_pu4_resets" = "1786372200" ] || { _fail "pu4 resets_at" "esperado '1786372200', obtido '$_pu4_resets'"; return 1; }
   return 0
 }
 

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -4489,8 +4489,14 @@ scenario_pu4_null_vs_valor_presente() {
   # valores presentes: preservados sem arredondar (ruido de float, FR-004)
   assert_exit 0 sh -c '. "$CSTK_LIB/common.sh"; . "$CSTK_LIB/recall.sh"; recall_plan_usage_insert "$1" "p-val" "/p" "sess-val" "five_hour" "7.000000000000001" "1786372200" "2026-08-10T13:00:00Z" "2026-08-10T13:00:00Z"' \
     _ "$_pu4_db" || return 1
-  _pu4_used=$(sqlite3 "$_pu4_db" "SELECT used_percentage FROM plan_usage WHERE project='p-val';")
-  [ "$_pu4_used" = "7.000000000000001" ] || { _fail "pu4 ruido float" "esperado '7.000000000000001', obtido '$_pu4_used'"; return 1; }
+  # NB: o CLI sqlite3 formata REAL na saida padrao com %!.15g (exibe "7.0"),
+  # o que e um artefato de EXIBICAO — o valor ARMAZENADO preserva o ruido de
+  # float com precisao total. Afere-se o valor por comparacao numerica
+  # exata (nao por igualdade textual da saida formatada, dec-046).
+  _pu4_eq=$(sqlite3 "$_pu4_db" "SELECT used_percentage = 7.000000000000001 FROM plan_usage WHERE project='p-val';")
+  [ "$_pu4_eq" = "1" ] || { _fail "pu4 ruido float" "esperado used_percentage = 7.000000000000001 (comparacao numerica), obtido eq=$_pu4_eq"; return 1; }
+  _pu4_neq_rounded=$(sqlite3 "$_pu4_db" "SELECT used_percentage = 7.0 FROM plan_usage WHERE project='p-val';")
+  [ "$_pu4_neq_rounded" = "0" ] || { _fail "pu4 nao-arredondado" "esperado used_percentage != 7.0 (prova de nao-arredondamento), obtido eq=$_pu4_neq_rounded"; return 1; }
   _pu4_resets=$(sqlite3 "$_pu4_db" "SELECT resets_at FROM plan_usage WHERE project='p-val';")
   [ "$_pu4_resets" = "1786372200" ] || { _fail "pu4 resets_at" "esperado '1786372200', obtido '$_pu4_resets'"; return 1; }
   return 0

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -1812,20 +1812,28 @@ scenario_ctx_15_auditabilidade_pre_decisao() {
 
   # 4.2.1 — Decisao existe com stage specify, context read-back, K e termos.
   # Leitura EN + fallback pt (state-decisions.sh escreve .decisions/.context/...).
-  _sj="$_osd/state.json"
-  _ndec=$(jq '[((.decisions // .decisoes) // [])[] | select((.context // .contexto) | startswith("read-back PRE-DECISAO"))] | length' "$_sj")
+  #
+  # AGNOSTICO A BACKEND: le via `state-rw.sh read` em vez de `jq` direto no
+  # state.json. Com `state_backend=sqlite` (default desde a v6) o `init`
+  # acima materializa `state.db` e NAO existe state.json — o jq falhava com
+  # "No such file", o cenario reprovava, e a suite ficava vermelha para
+  # qualquer um no backend novo. Nao ha override por env: o backend sai so
+  # do config global, entao forcar JSON aqui nao e opcao.
+  _sj_json=$("$_RWSH" read --state-dir "$_osd" 2>/dev/null) || _sj_json=""
+  [ -n "$_sj_json" ] || { _fail "ctx-audit read" "state-rw.sh read nao devolveu o state (backend $(cat "$HOME/.claude/cstk/config" 2>/dev/null || echo '?'))"; return 1; }
+  _ndec=$(printf '%s' "$_sj_json" | jq '[((.decisions // .decisoes) // [])[] | select((.context // .contexto) | startswith("read-back PRE-DECISAO"))] | length')
   [ "$_ndec" = "1" ] || { _fail "ctx-audit 4.2.1" "esperado 1 Decisao read-back, obtido $_ndec"; return 1; }
-  _etapa=$(jq -r '((.decisions // .decisoes) // [])[] | select((.context // .contexto) | startswith("read-back")) | (.stage // .etapa)' "$_sj")
+  _etapa=$(printf '%s' "$_sj_json" | jq -r '((.decisions // .decisoes) // [])[] | select((.context // .contexto) | startswith("read-back")) | (.stage // .etapa)')
   [ "$_etapa" = "specify" ] || { _fail "ctx-audit stage" "esperado specify, obtido $_etapa"; return 1; }
   # K e termos presentes (K no context, termos na rationale).
-  jq -e '((.decisions // .decisoes) // [])[] | select((.context // .contexto) | startswith("read-back")) | select((.context // .contexto) | contains("K='"$K"'"))' "$_sj" >/dev/null \
+  printf '%s' "$_sj_json" | jq -e '((.decisions // .decisoes) // [])[] | select((.context // .contexto) | startswith("read-back")) | select((.context // .contexto) | contains("K='"$K"'"))' >/dev/null \
     || { _fail "ctx-audit K" "context nao contem K=$K"; return 1; }
-  jq -e '((.decisions // .decisoes) // [])[] | select((.context // .contexto) | startswith("read-back")) | select((.rationale // .justificativa) | contains("'"$TERMS"'"))' "$_sj" >/dev/null \
+  printf '%s' "$_sj_json" | jq -e '((.decisions // .decisoes) // [])[] | select((.context // .contexto) | startswith("read-back")) | select((.rationale // .justificativa) | contains("'"$TERMS"'"))' >/dev/null \
     || { _fail "ctx-audit termos" "rationale nao contem os termos"; return 1; }
 
-  # 4.2.3 — body bruto recuperado NAO foi persistido no state.json (CHK013).
+  # 4.2.3 — body bruto recuperado NAO foi persistido no state (CHK013).
   if [ -n "$_bruto" ]; then
-    case "$(cat "$_sj")" in
+    case "$_sj_json" in
       *"$_bruto"*) _fail "ctx-audit CHK013" "body bruto recuperado vazou para state.json"; return 1 ;;
     esac
   fi
@@ -1850,9 +1858,14 @@ scenario_ctx_15b_k0_sem_decisao() {
       --contexto "read-back PRE-DECISAO: nao deveria acontecer" \
       --opcoes '["a","b"]' --escolha a --justificativa "justificativa longa o suficiente" --score 2 >/dev/null 2>&1
   fi
-  _sj="$_osd/state.json"
-  _ndec=$(jq '[((.decisions // .decisoes) // [])[]? | select((.context // .contexto) | startswith("read-back"))] | length' "$_sj" 2>/dev/null) || _ndec=0
-  [ "${_ndec:-0}" = "0" ] || { _fail "ctx-audit 4.2.2" "K=0 nao deveria gerar Decisao read-back, obtido $_ndec"; return 1; }
+  # AGNOSTICO A BACKEND (mesma razao de ctx_15). Aqui o bug era PIOR que uma
+  # reprovacao: com sqlite o jq falhava no arquivo ausente, o `|| _ndec=0`
+  # engolia o erro e a assercao `= 0` passava TRIVIALMENTE — o cenario ficava
+  # verde sem ter verificado nada. Falha de leitura agora reprova.
+  _sj_json=$("$_RWSH" read --state-dir "$_osd" 2>/dev/null) || _sj_json=""
+  [ -n "$_sj_json" ] || { _fail "ctx-audit 4.2.2 read" "state-rw.sh read nao devolveu o state — assercao seria vacua"; return 1; }
+  _ndec=$(printf '%s' "$_sj_json" | jq '[((.decisions // .decisoes) // [])[]? | select((.context // .contexto) | startswith("read-back"))] | length') || _ndec=""
+  [ "$_ndec" = "0" ] || { _fail "ctx-audit 4.2.2" "K=0 nao deveria gerar Decisao read-back, obtido '$_ndec'"; return 1; }
 }
 
 # Cenario regressao — modos existentes (busca/ingest/reindex) intactos

--- a/tests/cstk/test_setup.sh
+++ b/tests/cstk/test_setup.sh
@@ -215,8 +215,12 @@ scenario_dispatch_setup_wiring() {
     _fail "scenario_dispatch_setup_wiring" "case de help por subcomando: setup) ausente"
     return 1
   }
-  grep -qE '\|setup\)$' "$CSTK" || {
-    _fail "scenario_dispatch_setup_wiring" "case generico do dispatch: |setup) ausente"
+  # `setup` precisa ser UMA das alternativas do case generico — em qualquer
+  # posicao. A ancora `\|setup\)$` anterior exigia que fosse a ULTIMA, o que
+  # nunca foi invariante: bastou a v7.2.0 acrescentar `plan-usage` depois
+  # dela para o cenario reprovar com o wiring intacto.
+  grep -qE '\|setup[|)]' "$CSTK" || {
+    _fail "scenario_dispatch_setup_wiring" "case generico do dispatch: setup ausente das alternativas"
     return 1
   }
   _n_validos=$(grep -c "usage, setup, 00c" "$CSTK") || _n_validos=0

--- a/tests/cstk/test_statusline.sh
+++ b/tests/cstk/test_statusline.sh
@@ -1,0 +1,262 @@
+#!/bin/sh
+# test_statusline.sh — cobre cli/lib/statusline.sh (feature plan-usage-capture,
+# FASE 3 / tasks.md 3.1.1-3.1.6).
+#
+# HOME e SEMPRE controlado via env HOME=<sandbox> (mesmo padrao de
+# test_hooks.sh _hooks_main_run_home) — statusline install/status
+# operam sobre ${HOME}/.claude/settings.json, e o guard global do
+# repositorio proibe mutar o HOME real em teste.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+CSTK_LIB="$REPO_ROOT/cli/lib"
+export CSTK_LIB
+
+_has_jq() {
+  command -v jq >/dev/null 2>&1
+}
+
+# _sl_home_fixture: cria HOME sandbox com o catalogo minimo
+# (${HOME}/.claude/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh)
+# copiado do arquivo real desta feature. Retorna o path do HOME via stdout.
+# TMPDIR_TEST e unico por scenario (run_all_scenarios chama mktemp_test em
+# subshell isolada para cada um), entao "home" simples ja basta.
+_sl_home_fixture() {
+  _slh_home="$TMPDIR_TEST/home"
+  mkdir -p "$_slh_home/.claude/skills/agente-00c-runtime/hooks"
+  cp "$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh" \
+    "$_slh_home/.claude/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh"
+  printf '%s' "$_slh_home"
+}
+
+_sl_script_path_for() {
+  printf '%s/.claude/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh' "$1"
+}
+
+# _sl_run HOME_DIR ARGS...: invoca statusline_main sob HOME controlado.
+_sl_run() {
+  _slr_home=$1
+  shift
+  capture env HOME="$_slr_home" CSTK_LIB="$CSTK_LIB" sh -c \
+    '. "$CSTK_LIB/statusline.sh" && statusline_main "$@"' _ "$@"
+}
+
+# ==== install: settings.json sem statusLine.command previo (task 3.1.5) ====
+
+scenario_install_sem_statusline_previa_cria_chave() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _home=$(_sl_home_fixture)
+  _script=$(_sl_script_path_for "$_home")
+
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+
+  [ -f "$_home/.claude/settings.json" ] || { _fail "settings" "settings.json nao foi criado"; return 1; }
+
+  _cmd=$(jq -r '.statusLine.command' "$_home/.claude/settings.json")
+  [ "$_cmd" = "$_script" ] || { _fail "statusLine.command" "esperado $_script, obtido $_cmd"; return 1; }
+  return 0
+}
+
+# ==== install: settings.json com statusLine.command customizado previo
+#      (task 3.1.6) — valor original preservado em
+#      CSTK_STATUSLINE_INNER_COMMAND, nova chave aponta pro script ====
+
+scenario_install_preserva_customizacao_previa() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _home=$(_sl_home_fixture)
+  _script=$(_sl_script_path_for "$_home")
+  mkdir -p "$_home/.claude"
+  printf '{"statusLine":{"command":"~/my-old-statusline.sh --flag"},"other":{"key":"preserved"}}\n' \
+    > "$_home/.claude/settings.json"
+
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+
+  _cmd=$(jq -r '.statusLine.command' "$_home/.claude/settings.json")
+  case "$_cmd" in
+    *"CSTK_STATUSLINE_INNER_COMMAND="*"~/my-old-statusline.sh --flag"*"$_script")
+      ;;
+    *)
+      _fail "wrapper" "esperava wrapper com CSTK_STATUSLINE_INNER_COMMAND preservando o comando antigo + script novo; obtido: $_cmd"
+      return 1
+      ;;
+  esac
+
+  _other=$(jq -r '.other.key' "$_home/.claude/settings.json")
+  [ "$_other" = "preserved" ] || { _fail "other-keys" "chaves nao relacionadas devem ser preservadas"; return 1; }
+  return 0
+}
+
+# ==== install: aspas duplas dentro do comando previo sobrevivem ao
+#      round-trip de escaping (aspas simples aninhadas) ====
+
+scenario_install_preserva_customizacao_com_aspas() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _home=$(_sl_home_fixture)
+  jq -n '{"statusLine":{"command":"~/old.sh --flag \"quoted arg\" '\''single'\''"}}' \
+    > "$_home/.claude/settings.json"
+
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+
+  # settings.json continua JSON valido apos a escrita (jq -e falha se invalido).
+  jq -e . "$_home/.claude/settings.json" >/dev/null 2>&1 \
+    || { _fail "json-valido" "settings.json corrompido apos escapar aspas"; return 1; }
+
+  _inner=$(jq -r '.statusLine.command' "$_home/.claude/settings.json")
+  case "$_inner" in
+    *'"quoted arg"'*) ;;
+    *) _fail "aspas-preservadas" "aspas duplas do comando original devem sobreviver: $_inner"; return 1 ;;
+  esac
+  return 0
+}
+
+# ==== Idempotencia (task 3.1.3): 2x seguidas produz o mesmo settings.json,
+#      sem aninhar wrapper sobre wrapper ====
+
+scenario_install_idempotente_sem_customizacao() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _home=$(_sl_home_fixture)
+
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "1a-install" "exit $_CAPTURED_EXIT"; return 1; }
+  _before=$(cat "$_home/.claude/settings.json")
+
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "2a-install" "exit $_CAPTURED_EXIT"; return 1; }
+  _after=$(cat "$_home/.claude/settings.json")
+
+  [ "$_before" = "$_after" ] || { _fail "idempotencia" "settings.json mudou entre a 1a e a 2a instalacao"; return 1; }
+  return 0
+}
+
+scenario_install_idempotente_com_customizacao() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _home=$(_sl_home_fixture)
+  printf '{"statusLine":{"command":"~/my-old-statusline.sh"}}\n' > "$_home/.claude/settings.json"
+
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "1a-install" "exit $_CAPTURED_EXIT"; return 1; }
+  _once=$(jq -r '.statusLine.command' "$_home/.claude/settings.json")
+  # nao deve haver wrapper duplo (uma unica ocorrencia da variavel).
+  _n_wraps=$(printf '%s' "$_once" | grep -o 'CSTK_STATUSLINE_INNER_COMMAND=' | wc -l | tr -d ' ')
+  [ "$_n_wraps" = 1 ] || { _fail "1-wrap" "esperado exatamente 1 wrap, obtido $_n_wraps"; return 1; }
+
+  # 2a chamada: idempotente, NAO deve envolver o wrapper de novo.
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "2a-install" "exit $_CAPTURED_EXIT"; return 1; }
+  _twice=$(jq -r '.statusLine.command' "$_home/.claude/settings.json")
+
+  [ "$_once" = "$_twice" ] || { _fail "no-double-wrap" "statusLine.command mudou na 2a chamada: $_once -> $_twice"; return 1; }
+  return 0
+}
+
+# ==== status (task 3.1.4) ====
+
+scenario_status_nao_instalado_settings_ausente() {
+  _home=$(_sl_home_fixture)
+  _sl_run "$_home" status
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1 (nao instalado), obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *"nao instalado"*) ;;
+    *) _fail "mensagem" "stdout deveria reportar 'nao instalado': $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+scenario_status_ativo_apos_install() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _home=$(_sl_home_fixture)
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "install" "exit $_CAPTURED_EXIT"; return 1; }
+
+  _sl_run "$_home" status
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 (ativo), obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *"ativo"*) ;;
+    *) _fail "mensagem" "stdout deveria reportar 'ativo': $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+scenario_status_aponta_para_outro_comando() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _home=$(_sl_home_fixture)
+  printf '{"statusLine":{"command":"~/totally-unrelated.sh"}}\n' > "$_home/.claude/settings.json"
+
+  _sl_run "$_home" status
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1 (nao ativo), obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *"NAO ativa"*) ;;
+    *) _fail "mensagem" "stdout deveria reportar captura nao ativa: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+# ==== jq ausente: degrada graciosamente (Principio II carve-out) ====
+
+scenario_install_sem_jq_orienta_colagem_manual() {
+  _home=$(_sl_home_fixture)
+  _shim="$TMPDIR_TEST/shimbin-$$"
+  mkdir -p "$_shim"
+  for _cmd in sh mktemp awk sed grep find head printf cp mv rm mkdir chmod ls \
+              dirname basename tr cut wc env command sort uniq date cat; do
+    _src=$(command -v "$_cmd" 2>/dev/null) || continue
+    ln -sf "$_src" "$_shim/$_cmd" 2>/dev/null || :
+  done
+  capture env -i PATH="$_shim" HOME="$_home" CSTK_LIB="$CSTK_LIB" sh -c \
+    '. "$CSTK_LIB/statusline.sh" && statusline_main install'
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1 (jq ausente), obtido $_CAPTURED_EXIT"; return 1; }
+  [ ! -f "$_home/.claude/settings.json" ] \
+    || { _fail "no-write" "nao deveria escrever settings.json sem jq"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"jq ausente"*) ;;
+    *) _fail "mensagem" "stderr deveria orientar sobre jq ausente: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  return 0
+}
+
+# ==== --dry-run: nao escreve nada ====
+
+scenario_install_dry_run_nao_escreve() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _home=$(_sl_home_fixture)
+  _sl_run "$_home" install --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ ! -f "$_home/.claude/settings.json" ] \
+    || { _fail "no-write" "--dry-run nao deveria criar settings.json"; return 1; }
+  return 0
+}
+
+# ==== script ausente no catalogo: erro claro ====
+
+scenario_install_script_ausente_no_catalogo() {
+  _home="$TMPDIR_TEST/home-vazio"
+  mkdir -p "$_home/.claude"
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"script nao encontrado"*) ;;
+    *) _fail "mensagem" "stderr deveria reportar script ausente: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  return 0
+}
+
+# ==== --help ====
+
+scenario_help_imprime_uso() {
+  _home=$(_sl_home_fixture)
+  _sl_run "$_home" --help
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"cstk statusline"*) ;;
+    *) _fail "help" "stderr deveria imprimir texto de uso: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  return 0
+}
+
+run_all_scenarios

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -378,6 +378,13 @@ _is_internal_test() {
       # esta fora do escaneio por convencao. Existence-guarded.
       [ -f "$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/hooks/posttooluse-loose-usage.sh" ] && return 0
       return 1 ;;
+    test_statusline-plan-usage.sh)
+      # cobre plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh
+      # (entry-point de statusLine.command que captura o gauge de plano —
+      # feature plan-usage-capture FASE 2) — mesma razao dos 4 casos acima:
+      # hooks/ esta fora do escaneio por convencao. Existence-guarded.
+      [ -f "$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh" ] && return 0
+      return 1 ;;
     *) return 1 ;;
   esac
 }

--- a/tests/test_guard-hooks-status.sh
+++ b/tests/test_guard-hooks-status.sh
@@ -24,12 +24,42 @@
 #   INV-7: tick-mode rebaixa para "manual" no par exato
 #          (copia cega a backend + projeto com state.db). Copia cega sobre
 #          backend JSON SEGUE "hook" — rebaixar ali daria contagem DUPLA.
+#   INV-8: hook provido pelo PLUGIN (v7+) conta como ativo, mesmo sem copia
+#          em <PAP>/.claude/hooks/ nem registro em settings.json — e
+#          tick-mode devolve "hook". Foi o 3o modo de falha de campo: o
+#          `check` mandava rodar `cstk hooks install` (que pula por dedup,
+#          "plugin vence") e o `tick-mode` dizia "manual", fazendo o
+#          orquestrador tickar EM PARALELO ao hook do plugin — `end` soma
+#          ticks manuais + sidecar, entao tool_calls saia em DOBRO.
+#          Degradacao assimetrica: hooks.json ilegivel/ausente => "plugin
+#          nao prove" (comportamento anterior), nunca o inverso.
 
 TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
 . "$TESTS_ROOT/lib/harness.sh"
 
 SCRIPT="$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-status.sh"
+
+# _ghs ARGS... -> invoca o SCRIPT com o ambiente NEUTRO quanto a plugin.
+#
+# Praticamente todos os cenarios deste arquivo simulam um projeto-alvo SEM o
+# plugin cstk: os fixtures materializam (ou omitem) copias classicas em
+# <PAP>/.claude/hooks/ e exigem veredito missing/stale/unregistered. Desde
+# que `guard-hooks-status.sh` passou a enxergar hooks providos pelo plugin,
+# o script consulta o registro NATIVO do Claude Code (~/.claude/plugins +
+# ~/.claude/settings.json) — que e do DESENVOLVEDOR, nao do fixture.
+#
+# Sem esta neutralizacao o teste vira dependente de ambiente do pior jeito
+# possivel: passa no CI (runner limpo, sem plugin) e falha so na maquina de
+# quem tem o cstk instalado como plugin — exatamente o inverso do modo de
+# falha que a memoria do projeto ja registra para helpers resolvidos via
+# ~/.claude. Cenarios que QUEREM testar o caminho do plugin setam as vars
+# explicitamente (ver scenario_check_plugin_*).
+_ghs() {
+  capture env HOME="$TMPDIR_TEST/.home-sem-plugin" CLAUDE_PLUGIN_ROOT='' \
+    CSTK_HOOKS_CATALOG_DIR="${CSTK_HOOKS_CATALOG_DIR:-}" \
+    sh "$SCRIPT" "$@"
+}
 
 _HOOKS='pretooluse-bash-guard.sh
 posttooluse-tool-call-tick.sh
@@ -130,7 +160,7 @@ _fully_provisioned() {
 scenario_check_completo_exit0() {
   _p=$(_mkproj proj-ok)
   _fully_provisioned "$_p"
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
   for _h in $_HOOKS; do
     printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered	current$" \
@@ -143,7 +173,7 @@ scenario_check_completo_exit0() {
 
 scenario_check_nenhum_hook_exit1() {
   _p=$(_mkproj proj-virgem)
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
   _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c 'missing	unregistered')
   [ "$_n" = 3 ] || { _fail "TSV" "esperado 3 linhas missing/unregistered, obtido $_n"; return 1; }
@@ -156,7 +186,7 @@ scenario_check_presente_sem_registro_exit1() {
   _p=$(_mkproj proj-sem-settings)
   for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
   # settings.json deliberadamente ausente
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q 'present	unregistered' \
     || { _fail "TSV" "esperado present+unregistered"; return 1; }
@@ -169,7 +199,7 @@ scenario_check_registrado_sem_arquivo_exit1() {
   _p=$(_mkproj proj-so-settings)
   # shellcheck disable=SC2086
   _register "$_p" $_HOOKS
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q 'missing	registered' \
     || { _fail "TSV" "esperado missing+registered"; return 1; }
@@ -182,7 +212,7 @@ scenario_check_hook_sem_exec_bit_nao_conta() {
   _p=$(_mkproj proj-noexec)
   _fully_provisioned "$_p"
   chmod -x "$_p/.claude/hooks/pretooluse-bash-guard.sh"
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^pretooluse-bash-guard.sh	missing' \
     || { _fail "TSV" "hook sem +x deve contar como missing"; return 1; }
@@ -195,7 +225,7 @@ scenario_check_parcial_exit1_com_alerta_da_guarda() {
   _p=$(_mkproj proj-parcial)
   _put_hook "$_p" "posttooluse-tool-call-tick.sh"
   _register "$_p" "posttooluse-tool-call-tick.sh"
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-tool-call-tick.sh	present	registered	current$' \
     || { _fail "TSV" "tick-hook ativo deveria aparecer como present/registered/current"; return 1; }
@@ -209,7 +239,7 @@ scenario_check_parcial_exit1_com_alerta_da_guarda() {
 
 scenario_check_stderr_cita_scope_project() {
   _p=$(_mkproj proj-remediacao)
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   printf '%s\n' "$_CAPTURED_STDERR" | grep -q -- '--scope project' \
     || { _fail "stderr" "remediacao deve citar 'cstk install --scope project'"; return 1; }
   return 0
@@ -219,7 +249,7 @@ scenario_check_stderr_cita_scope_project() {
 
 scenario_check_quiet_sem_stderr() {
   _p=$(_mkproj proj-quiet)
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --quiet
+  _ghs check --projeto-alvo-path "$_p" --quiet
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
   [ -z "$_CAPTURED_STDERR" ] || { _fail "stderr" "--quiet nao pode emitir stderr"; return 1; }
   [ -n "$_CAPTURED_STDOUT" ] || { _fail "stdout" "--quiet nao pode suprimir o TSV"; return 1; }
@@ -231,8 +261,8 @@ scenario_check_quiet_sem_stderr() {
 scenario_read_only_nao_cria_nada() {
   _p=$(_mkproj proj-readonly)
   _before=$(find "$_p" | sort)
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
-  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
+  _ghs tick-mode --projeto-alvo-path "$_p"
   _after=$(find "$_p" | sort)
   [ "$_before" = "$_after" ] \
     || { _fail "read-only" "arvore do projeto-alvo mudou apos as consultas"; return 1; }
@@ -244,7 +274,7 @@ scenario_read_only_nao_cria_nada() {
 scenario_tick_mode_hook_quando_ativo() {
   _p=$(_mkproj proj-tick-hook)
   _fully_provisioned "$_p"
-  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  _ghs tick-mode --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
   [ "$_CAPTURED_STDOUT" = "hook" ] \
     || { _fail "stdout" "esperado 'hook', obtido '$_CAPTURED_STDOUT'"; return 1; }
@@ -253,7 +283,7 @@ scenario_tick_mode_hook_quando_ativo() {
 
 scenario_tick_mode_manual_quando_ausente() {
   _p=$(_mkproj proj-tick-manual)
-  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  _ghs tick-mode --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
   [ "$_CAPTURED_STDOUT" = "manual" ] \
     || { _fail "stdout" "esperado 'manual', obtido '$_CAPTURED_STDOUT'"; return 1; }
@@ -271,7 +301,7 @@ scenario_tick_mode_exit0_mesmo_sem_hooks() {
 scenario_tick_mode_manual_sem_registro() {
   _p=$(_mkproj proj-tick-noreg)
   _put_hook "$_p" "posttooluse-tool-call-tick.sh"
-  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  _ghs tick-mode --projeto-alvo-path "$_p"
   [ "$_CAPTURED_STDOUT" = "manual" ] \
     || { _fail "stdout" "hook nao-registrado deve dar 'manual'"; return 1; }
   return 0
@@ -287,7 +317,7 @@ scenario_check_stale_exit1() {
   for _h in $_HOOKS; do _put_hook_stale "$_p" "$_h"; done
   # shellcheck disable=SC2086
   _register "$_p" $_HOOKS
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "copia stale deve reprovar (esperado 1, obtido $_CAPTURED_EXIT)"; return 1; }
   _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c '	present	registered	stale$')
   [ "$_n" = 3 ] || { _fail "TSV" "esperado 3 linhas present/registered/stale, obtido $_n"; return 1; }
@@ -302,7 +332,7 @@ scenario_check_stale_da_guarda_tem_alerta_destacado() {
   _p=$(_mkproj proj-stale-guarda)
   _fully_provisioned "$_p"
   _put_hook_stale "$_p" "pretooluse-bash-guard.sh"
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'pretooluse-bash-guard.sh STALE' \
     || { _fail "stderr" "faltou alerta destacado da guarda stale"; return 1; }
@@ -339,7 +369,7 @@ scenario_check_catalogo_ausente_da_unknown_e_nao_reprova() {
 # o que reprova ali e o missing, nao o drift.
 scenario_check_hook_ausente_da_unknown() {
   _p=$(_mkproj proj-unknown-missing)
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c '	missing	unregistered	unknown$')
   [ "$_n" = 3 ] || { _fail "TSV" "hook ausente deve dar freshness unknown, obtido $_n linhas"; return 1; }
   return 0
@@ -354,7 +384,7 @@ scenario_tick_mode_manual_com_copia_cega_e_state_db() {
   _fully_provisioned "$_p"
   mkdir -p "$_p/.claude/feature-00c-state/demo"
   : > "$_p/.claude/feature-00c-state/demo/state.db"
-  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  _ghs tick-mode --projeto-alvo-path "$_p"
   [ "$_CAPTURED_STDOUT" = "manual" ] \
     || { _fail "stdout" "copia cega + state.db deve dar 'manual', obtido '$_CAPTURED_STDOUT'"; return 1; }
   return 0
@@ -366,7 +396,7 @@ scenario_tick_mode_manual_com_copia_cega_e_state_db_agente() {
   _fully_provisioned "$_p"
   mkdir -p "$_p/.claude/agente-00c-state"
   : > "$_p/.claude/agente-00c-state/state.db"
-  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  _ghs tick-mode --projeto-alvo-path "$_p"
   [ "$_CAPTURED_STDOUT" = "manual" ] \
     || { _fail "stdout" "copia cega + state.db (agente) deve dar 'manual', obtido '$_CAPTURED_STDOUT'"; return 1; }
   return 0
@@ -379,7 +409,7 @@ scenario_tick_mode_hook_com_copia_cega_e_backend_json() {
   _fully_provisioned "$_p"
   mkdir -p "$_p/.claude/feature-00c-state/demo"
   printf '{}\n' > "$_p/.claude/feature-00c-state/demo/state.json"
-  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  _ghs tick-mode --projeto-alvo-path "$_p"
   [ "$_CAPTURED_STDOUT" = "hook" ] \
     || { _fail "stdout" "copia cega + backend JSON deve seguir 'hook', obtido '$_CAPTURED_STDOUT'"; return 1; }
   return 0
@@ -396,7 +426,7 @@ scenario_tick_mode_hook_com_copia_atual_e_state_db() {
 exit 0'
   mkdir -p "$_p/.claude/feature-00c-state/demo"
   : > "$_p/.claude/feature-00c-state/demo/state.db"
-  capture sh "$SCRIPT" tick-mode --projeto-alvo-path "$_p"
+  _ghs tick-mode --projeto-alvo-path "$_p"
   [ "$_CAPTURED_STDOUT" = "hook" ] \
     || { _fail "stdout" "copia atual + state.db deve dar 'hook', obtido '$_CAPTURED_STDOUT'"; return 1; }
   return 0
@@ -460,7 +490,7 @@ scenario_funciona_sem_jq() {
 scenario_loose_usage_detection_current_runtime() {
   _p=$(_mkproj proj-loose-current)
   _fully_provisioned "$_p"
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --include-loose-usage
+  _ghs check --projeto-alvo-path "$_p" --include-loose-usage
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 (hook opt-in ausente nao afeta exit), obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-loose-usage.sh	missing	unregistered	' \
     || { _fail "TSV" "esperado 4a linha posttooluse-loose-usage.sh missing/unregistered"; return 1; }
@@ -473,7 +503,7 @@ scenario_loose_usage_detection_current_runtime() {
 scenario_loose_usage_sem_flag_saida_identica() {
   _p=$(_mkproj proj-loose-sem-flag)
   _fully_provisioned "$_p"
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | wc -l | tr -d ' ')
   [ "$_n" = 3 ] || { _fail "TSV" "sem a flag deve continuar 3 linhas, obtido $_n"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q 'loose-usage' \
@@ -523,7 +553,7 @@ scenario_verify_registration_canonical() {
   for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
   # shellcheck disable=SC2086
   _register_canonical "$_p" $_HOOKS
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --verify-registration
+  _ghs check --projeto-alvo-path "$_p" --verify-registration
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "registro canonico deveria manter exit 0, obtido $_CAPTURED_EXIT"; return 1; }
   for _h in $_HOOKS; do
     printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered	current	canonical$" \
@@ -538,7 +568,7 @@ scenario_verify_registration_sem_flag_saida_identica() {
   for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
   # shellcheck disable=SC2086
   _register_canonical "$_p" $_HOOKS
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p"
+  _ghs check --projeto-alvo-path "$_p"
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q 'canonical\|divergent\|indeterminate' \
     && { _fail "TSV" "sem a flag nao pode ter 5a coluna"; return 1; }
@@ -562,7 +592,7 @@ scenario_hook_redirected_reports_divergent() {
     printf '            "command": "\134\042$CLAUDE_PROJECT_DIR\134\042/.claude/hooks/posttooluse-agent-usage.sh"\n'
     printf '          }\n        ]\n      }\n    ]\n  }\n}\n'
   } > "$_p/.claude/settings.json"
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --verify-registration --quiet
+  _ghs check --projeto-alvo-path "$_p" --verify-registration --quiet
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "hook redirecionado deve reprovar com a flag, esperado 1 obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^pretooluse-bash-guard.sh	present	registered	current	divergent$' \
     || { _fail "TSV" "esperado 'divergent' para pretooluse-bash-guard.sh"; return 1; }
@@ -591,7 +621,7 @@ scenario_decoy_line_not_canonical() {
     printf '            "command": "\134\042$CLAUDE_PROJECT_DIR\134\042/.claude/hooks/posttooluse-agent-usage.sh"\n'
     printf '          }\n        ]\n      }\n    ]\n  }\n}\n'
   } > "$_p/.claude/settings.json"
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --verify-registration --quiet
+  _ghs check --projeto-alvo-path "$_p" --verify-registration --quiet
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "decoy + command divergente deve reprovar, esperado 1 obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^pretooluse-bash-guard.sh	present	registered	current	divergent$' \
     || { _fail "TSV" "linha-isca nao pode contar como canonical (SEC-01)"; return 1; }
@@ -608,7 +638,7 @@ scenario_minified_settings_indeterminate() {
   # Colapsa para uma unica linha fisica preservando todo o conteudo textual.
   _minified=$(tr '\n' ' ' < "$_p/.claude/settings.json")
   printf '%s' "$_minified" > "$_p/.claude/settings.json"
-  capture sh "$SCRIPT" check --projeto-alvo-path "$_p" --verify-registration
+  _ghs check --projeto-alvo-path "$_p" --verify-registration
   for _h in $_HOOKS; do
     printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered	current	indeterminate$" \
       || { _fail "TSV" "settings.json minificado deveria dar 'indeterminate' para $_h"; return 1; }
@@ -700,6 +730,132 @@ exit 0'
     || { _fail "exit" "esperado 0 (3 hooks current via plugin), obtido $_CAPTURED_EXIT; stdout=$_CAPTURED_STDOUT stderr=$_CAPTURED_STDERR"; return 1; }
   _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c '	present	registered	current$')
   [ "$_n" = 3 ] || { _fail "TSV" "esperado 3 linhas current (catalogo resolvido via plugin), stdout=$_CAPTURED_STDOUT"; return 1; }
+  return 0
+}
+
+# ==== INV-8: hooks providos pelo PLUGIN (v7+) ====
+#
+# Regressao do 3o modo de falha de campo: com o cstk instalado como plugin
+# nativo, os 3 hooks sao registrados pelo hooks.json do plugin e NAO existe
+# copia em <PAP>/.claude/hooks/ nem registro em <PAP>/.claude/settings.json.
+# Antes deste fix o `check` acusava "3 de 3 NAO estao ativos" e o
+# `tick-mode` devolvia "manual" — este ultimo fazendo o orquestrador tickar
+# em paralelo ao hook, com `state-ondas.sh end` somando as duas fontes
+# (tool_calls em DOBRO em toda onda).
+
+# _fake_plugin_hooks_json HOOK... -> materializa um hooks.json de plugin
+# citando os hooks passados e ecoa o path.
+_fake_plugin_hooks_json() {
+  _fpj_dir="$TMPDIR_TEST/fake-plugin-registry/hooks"
+  mkdir -p "$_fpj_dir"
+  {
+    printf '{"hooks":{"PostToolUse":['
+    _fpj_first=1
+    for _fpj_h in "$@"; do
+      [ "$_fpj_first" = 1 ] || printf ','
+      _fpj_first=0
+      printf '{"hooks":[{"type":"command","command":"sh \\"${CLAUDE_PLUGIN_ROOT}/skills/agente-00c-runtime/hooks/%s\\""}]}' "$_fpj_h"
+    done
+    printf ']}}'
+  } > "$_fpj_dir/hooks.json"
+  printf '%s' "$_fpj_dir/hooks.json"
+}
+
+# _ghs_plugin HOOKS_JSON ARGS... -> invoca o SCRIPT com plugin simulado.
+_ghs_plugin() {
+  _gp_json=$1
+  shift
+  capture env HOME="$TMPDIR_TEST/.home-sem-plugin" CLAUDE_PLUGIN_ROOT='' \
+    CSTK_PLUGIN_HOOKS_JSON="$_gp_json" \
+    CSTK_HOOKS_CATALOG_DIR="${CSTK_HOOKS_CATALOG_DIR:-}" \
+    sh "$SCRIPT" "$@"
+}
+
+scenario_check_plugin_prove_hooks_exit0() {
+  _p=$(_mkproj proj-plugin-only)
+  # ZERO copia classica e ZERO settings.json — exatamente o layout v7+.
+  # shellcheck disable=SC2086
+  _pj=$(_fake_plugin_hooks_json $_HOOKS)
+  _ghs_plugin "$_pj" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "exit" "esperado 0 (hooks providos pelo plugin), obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
+  _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c '	present	registered	current$')
+  [ "$_n" = 3 ] || { _fail "TSV" "esperado 3 linhas present/registered/current, stdout=$_CAPTURED_STDOUT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'providos pelo PLUGIN' \
+    || { _fail "stderr" "esperado aviso de origem plugin, stderr=$_CAPTURED_STDERR"; return 1; }
+  # NAO pode mandar rodar `cstk hooks install` — o comando pula por dedup.
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'cstk hooks install' \
+    && { _fail "stderr" "nao deve sugerir remediacao quando o plugin ja prove"; return 1; }
+  return 0
+}
+
+scenario_tick_mode_plugin_devolve_hook() {
+  _p=$(_mkproj proj-plugin-tick)
+  _pj=$(_fake_plugin_hooks_json posttooluse-tool-call-tick.sh)
+  _ghs_plugin "$_pj" tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_STDOUT" = "hook" ] \
+    || { _fail "tick-mode" "esperado 'hook' (senao o orquestrador ticka em paralelo ao hook => tool_calls em dobro), obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+scenario_tick_mode_sem_plugin_segue_manual() {
+  # Guarda de nao-regressao do default seguro: sem plugin E sem copia
+  # classica, continua "manual" (INV-4 intacto).
+  _p=$(_mkproj proj-sem-nada)
+  _pj="$TMPDIR_TEST/hooks-json-inexistente"
+  _ghs_plugin "$_pj" tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_STDOUT" = "manual" ] \
+    || { _fail "tick-mode" "esperado 'manual', obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+scenario_check_plugin_mais_classico_alerta_duplicidade() {
+  # Plugin PROVE e a copia classica tambem esta registrada => o hook roda
+  # duas vezes e cada tool call e contado em dobro.
+  _p=$(_mkproj proj-dup)
+  _fully_provisioned "$_p"
+  # shellcheck disable=SC2086
+  _pj=$(_fake_plugin_hooks_json $_HOOKS)
+  _ghs_plugin "$_pj" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'contado em dobro' \
+    || { _fail "stderr" "esperado alerta de duplicidade, stderr=$_CAPTURED_STDERR"; return 1; }
+  return 0
+}
+
+scenario_check_plugin_quiet_sem_stderr() {
+  # --quiet cala tambem o aviso de origem plugin (INV: quiet e quiet).
+  _p=$(_mkproj proj-plugin-quiet)
+  # shellcheck disable=SC2086
+  _pj=$(_fake_plugin_hooks_json $_HOOKS)
+  _ghs_plugin "$_pj" check --projeto-alvo-path "$_p" --quiet
+  [ -z "$_CAPTURED_STDERR" ] \
+    || { _fail "stderr" "esperado stderr vazio com --quiet, obtido: $_CAPTURED_STDERR"; return 1; }
+  return 0
+}
+
+scenario_check_plugin_verify_registration_canonical() {
+  # Com --verify-registration, hook provido pelo plugin e canonical por
+  # construcao (o registro e o do proprio hooks.json do plugin).
+  _p=$(_mkproj proj-plugin-vr)
+  # shellcheck disable=SC2086
+  _pj=$(_fake_plugin_hooks_json $_HOOKS)
+  _ghs_plugin "$_pj" check --projeto-alvo-path "$_p" --verify-registration
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c '	canonical$')
+  [ "$_n" = 3 ] || { _fail "TSV" "esperado 3 linhas canonical, stdout=$_CAPTURED_STDOUT"; return 1; }
+  return 0
+}
+
+scenario_plugin_hooks_json_ilegivel_degrada() {
+  # Override apontando para arquivo inexistente => "plugin nao prove",
+  # comportamento anterior preservado byte-a-byte. Na duvida NUNCA se
+  # afirma cobertura de plugin.
+  _p=$(_mkproj proj-plugin-ilegivel)
+  _ghs_plugin "$TMPDIR_TEST/nao-existe/hooks.json" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1 (degrada p/ sem plugin), obtido $_CAPTURED_EXIT"; return 1; }
+  _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | grep -c 'missing	unregistered')
+  [ "$_n" = 3 ] || { _fail "TSV" "esperado 3 missing/unregistered, stdout=$_CAPTURED_STDOUT"; return 1; }
   return 0
 }
 

--- a/tests/test_statusline-plan-usage.sh
+++ b/tests/test_statusline-plan-usage.sh
@@ -1,0 +1,326 @@
+#!/bin/sh
+# test_statusline-plan-usage.sh — cobre
+# plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh
+# (entry-point de statusLine.command, feature plan-usage-capture) e o
+# subcomando interno `cstk plan-usage ingest --stdin` (cli/lib/plan-usage.sh,
+# task 4.3) que ele invoca via subprocesso.
+#
+# Contrato sob teste: docs/specs/plan-usage-capture/contracts/statusline-hook.md
+# Cenarios: docs/specs/plan-usage-capture/quickstart.md
+#
+# Fail-open absoluto: o hook NUNCA sai com exit != 0, NUNCA imprime erro de
+# diagnostico em stdout (so pass-through/fallback), e NUNCA toca sqlite3
+# diretamente (persistencia delegada via subprocesso a `cstk plan-usage
+# ingest --stdin`, research.md Decision 6).
+#
+# Sem sessao `claude` real (GOTCHA: statusline nao dispara em `claude -p`) —
+# todo teste alimenta fixture via stdin (FR-012).
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh"
+
+# _require_jq -> ERROR (skip) se jq indisponivel.
+_require_jq() {
+  command -v jq >/dev/null 2>&1 && return 0
+  _error "no_jq" "jq indisponivel neste ambiente de teste"
+  return 1
+}
+
+# _require_sqlite3 -> ERROR (skip) se sqlite3 indisponivel.
+_require_sqlite3() {
+  command -v sqlite3 >/dev/null 2>&1 && return 0
+  _error "no_sqlite3" "sqlite3 indisponivel neste ambiente de teste"
+  return 1
+}
+
+# _fixture_full -> payload com rate_limits.five_hour + seven_day completos
+# (paridade literal com o schema OBSERVADO na memoria
+# reference_statusline_usage_payload.md).
+_fixture_full() {
+  printf '{"session_id":"sess-1","workspace":{"current_dir":"%s"},"model":{"display_name":"Claude Opus 5"},"rate_limits":{"five_hour":{"used_percentage":7.000000000000001,"resets_at":1786372200},"seven_day":{"used_percentage":19,"resets_at":1786802400}}}' "$1"
+}
+
+# _fixture_no_rl PROJECT_PATH -> payload SEM a chave rate_limits (sessao
+# sem nenhuma resposta de API completa ainda).
+_fixture_no_rl() {
+  printf '{"session_id":"sess-2","workspace":{"current_dir":"%s"},"model":{"display_name":"Claude"}}' "$1"
+}
+
+# _fixture_scope PROJECT_PATH USED RESETS -> payload so com five_hour.
+_fixture_scope() {
+  printf '{"session_id":"s","workspace":{"current_dir":"%s"},"rate_limits":{"five_hour":{"used_percentage":%s,"resets_at":%s}}}' "$1" "$2" "$3"
+}
+
+# _make_shim_with_cstk -> PATH shim contendo POSIX essenciais + jq/sqlite3
+# (se disponiveis no ambiente real) + um wrapper `cstk` que exec's
+# $REPO_ROOT/cli/cstk (layout de dev, CSTK_LIB auto-resolvido relativo a
+# si mesmo — cli/cstk:_resolve_lib_dir).
+_make_shim_with_cstk() {
+  _shim="$TMPDIR_TEST/shimbin"
+  mkdir -p "$_shim"
+  for _cmd in sh mktemp awk sed grep find head printf cp mv rm mkdir \
+              chmod ls dirname basename tr cut wc env command sort \
+              uniq date cat cksum jq sqlite3; do
+    _src=$(command -v "$_cmd" 2>/dev/null) || continue
+    [ -n "$_src" ] || continue
+    ln -sf "$_src" "$_shim/$_cmd" 2>/dev/null || :
+  done
+  cat > "$_shim/cstk" <<EOF
+#!/bin/sh
+exec "$REPO_ROOT/cli/cstk" "\$@"
+EOF
+  chmod +x "$_shim/cstk"
+  printf '%s' "$_shim"
+}
+
+# _run_hook JSON [ENV...] -> invoca o script com JSON via stdin.
+_run_hook() {
+  _rh_json="$1"
+  shift
+  capture env "$@" sh -c 'printf "%s" "$1" | "$2"' _ "$_rh_json" "$SCRIPT"
+}
+
+# ---------------------------------------------------------------------------
+# Task 2.1 — parse do payload e extracao de rate_limits
+# ---------------------------------------------------------------------------
+
+# Task 2.1.5: fixture com rate_limits completo extrai os 4 valores +
+# session_id + project_path corretamente (introspeccao via CSTK_STATUSLINE_DEBUG).
+scenario_extract_4_valores() {
+  _require_jq || return 0
+  mktemp_test
+  _run_hook "$(_fixture_full /tmp/proj-x)" CSTK_STATUSLINE_DEBUG=1
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"session_id=sess-1"*) ;;
+    *) _fail "extract session_id" "obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"project_path=/tmp/proj-x"*) ;;
+    *) _fail "extract project_path" "obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"five_hour.used=7.000000000000001"*) ;;
+    *) _fail "extract five_hour.used" "obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"five_hour.resets=1786372200"*) ;;
+    *) _fail "extract five_hour.resets" "obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"seven_day.used=19"*) ;;
+    *) _fail "extract seven_day.used" "obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  case "$_CAPTURED_STDERR" in
+    *"seven_day.resets=1786802400"*) ;;
+    *) _fail "extract seven_day.resets" "obtido: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+  # Debug NUNCA vaza para stdout (2.4.3 — nao contamina a UI).
+  case "$_CAPTURED_STDOUT" in
+    *session_id=*) _fail "debug vazou p/ stdout" "obtido: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+# Task 2.1.4: payload malformado -> pass-through best-effort, exit 0.
+scenario_payload_malformado() {
+  _require_jq || return 0
+  mktemp_test
+  capture sh -c 'printf "not json{{{" | "$1"' _ "$SCRIPT"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Task 2.2 — semantica de ausencia (dec-029, core da feature)
+# ---------------------------------------------------------------------------
+
+# Task 2.2.4: fixture SEM rate_limits -> zero linhas novas em plan_usage.
+scenario_ausencia_total_zero_linhas() {
+  _require_jq || return 0
+  _require_sqlite3 || return 0
+  mktemp_test
+  _shim=$(_make_shim_with_cstk)
+  _db="$TMPDIR_TEST/k.db"
+  _run_hook "$(_fixture_no_rl /tmp/p)" "PATH=$_shim:$PATH" "CSTK_KNOWLEDGE_DB=$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  if [ -f "$_db" ]; then
+    _n=$(sqlite3 "$_db" "SELECT count(*) FROM plan_usage;" 2>/dev/null) || _n=0
+  else
+    _n=0
+  fi
+  [ "$_n" = "0" ] || { _fail "ausencia total" "esperado 0 linhas, obtido $_n"; return 1; }
+  return 0
+}
+
+# Task 2.2.1/2.2.5: rate_limits presente com os 2 escopos -> 2 linhas
+# novas, valores batem com o fixture (Cenario 1 do quickstart).
+scenario_captura_basica_2_linhas() {
+  _require_jq || return 0
+  _require_sqlite3 || return 0
+  mktemp_test
+  _shim=$(_make_shim_with_cstk)
+  _db="$TMPDIR_TEST/k.db"
+  _run_hook "$(_fixture_full /tmp/proj-y)" "PATH=$_shim:$PATH" "CSTK_KNOWLEDGE_DB=$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  _n=$(sqlite3 "$_db" "SELECT count(*) FROM plan_usage;" 2>/dev/null) || _n=0
+  [ "$_n" = "2" ] || { _fail "captura basica" "esperado 2 linhas, obtido $_n"; return 1; }
+  _fh=$(sqlite3 "$_db" "SELECT used_percentage FROM plan_usage WHERE scope='five_hour';" 2>/dev/null)
+  [ "$_fh" = "7.0" ] || { _fail "five_hour valor" "esperado 7.0 (exibicao CLI), obtido $_fh"; return 1; }
+  _eq=$(sqlite3 "$_db" "SELECT used_percentage = 7.000000000000001 FROM plan_usage WHERE scope='five_hour';" 2>/dev/null)
+  [ "$_eq" = "1" ] || { _fail "five_hour precisao" "used_percentage != 7.000000000000001 (ruido perdido)"; return 1; }
+  return 0
+}
+
+# Task 2.2.2/2.2.3: escopo presente mas campos ausentes dentro dele ->
+# NULL real, NUNCA 0 fabricado (Constitution VI).
+scenario_ausencia_parcial_null_nunca_zero() {
+  _require_jq || return 0
+  _require_sqlite3 || return 0
+  mktemp_test
+  _shim=$(_make_shim_with_cstk)
+  _db="$TMPDIR_TEST/k.db"
+  _payload='{"session_id":"s","workspace":{"current_dir":"/tmp/p"},"rate_limits":{"five_hour":{}}}'
+  _run_hook "$_payload" "PATH=$_shim:$PATH" "CSTK_KNOWLEDGE_DB=$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  _row=$(sqlite3 "$_db" "SELECT (used_percentage IS NULL)||'|'||(resets_at IS NULL) FROM plan_usage WHERE scope='five_hour';" 2>/dev/null)
+  [ "$_row" = "1|1" ] || { _fail "ausencia parcial NULL" "esperado 1|1, obtido $_row"; return 1; }
+  _zero=$(sqlite3 "$_db" "SELECT count(*) FROM plan_usage WHERE used_percentage = 0;" 2>/dev/null)
+  [ "$_zero" = "0" ] || { _fail "0 fabricado" "encontrada linha com used_percentage=0 (Constitution VI violada)"; return 1; }
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Task 2.3 — throttle (FR-010, dec-029/CHK010, dec-050)
+# ---------------------------------------------------------------------------
+
+# Task 2.3.5: 2 capturas identicas -> so 1 linha; 3a com mudanca so na 3a
+# casa decimal -> ainda descartada; 4a com mudanca na 2a casa -> nova linha
+# (paridade literal quickstart.md Cenario 3).
+scenario_throttle_quickstart_cenario3() {
+  _require_jq || return 0
+  _require_sqlite3 || return 0
+  mktemp_test
+  _shim=$(_make_shim_with_cstk)
+  _db="$TMPDIR_TEST/k.db"
+  _run_hook "$(_fixture_scope /tmp/p 7.001 111)" "PATH=$_shim:$PATH" "CSTK_KNOWLEDGE_DB=$_db"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  _run_hook "$(_fixture_scope /tmp/p 7.001 111)" "PATH=$_shim:$PATH" "CSTK_KNOWLEDGE_DB=$_db"
+  _run_hook "$(_fixture_scope /tmp/p 7.009 111)" "PATH=$_shim:$PATH" "CSTK_KNOWLEDGE_DB=$_db"
+  _n1=$(sqlite3 "$_db" "SELECT count(*) FROM plan_usage;" 2>/dev/null)
+  [ "$_n1" = "1" ] || { _fail "throttle passos 1-3" "esperado 1 linha, obtido $_n1"; return 1; }
+  _run_hook "$(_fixture_scope /tmp/p 7.05 111)" "PATH=$_shim:$PATH" "CSTK_KNOWLEDGE_DB=$_db"
+  _n2=$(sqlite3 "$_db" "SELECT count(*) FROM plan_usage;" 2>/dev/null)
+  [ "$_n2" = "2" ] || { _fail "throttle passo 4" "esperado 2 linhas apos mudanca 2a casa, obtido $_n2"; return 1; }
+  return 0
+}
+
+# dec-050 (residual CHK010/tasks.md 2.3.4): ULTIMO registro NULL/NULL e
+# NOVA captura do MESMO escopo TAMBEM NULL/NULL -> conta como identico,
+# descartada pelo throttle.
+scenario_throttle_null_vs_null_dec050() {
+  _require_jq || return 0
+  _require_sqlite3 || return 0
+  mktemp_test
+  _shim=$(_make_shim_with_cstk)
+  _db="$TMPDIR_TEST/k.db"
+  _payload='{"session_id":"s","workspace":{"current_dir":"/tmp/p"},"rate_limits":{"five_hour":{}}}'
+  _run_hook "$_payload" "PATH=$_shim:$PATH" "CSTK_KNOWLEDGE_DB=$_db"
+  _n1=$(sqlite3 "$_db" "SELECT count(*) FROM plan_usage;" 2>/dev/null)
+  _run_hook "$_payload" "PATH=$_shim:$PATH" "CSTK_KNOWLEDGE_DB=$_db"
+  _n2=$(sqlite3 "$_db" "SELECT count(*) FROM plan_usage;" 2>/dev/null)
+  [ "$_n1" = "$_n2" ] || { _fail "NULL-vs-NULL dec-050" "esperado throttle descartar (n1=$_n1 n2=$_n2)"; return 1; }
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Task 2.4 — pass-through obrigatorio do stdout
+# ---------------------------------------------------------------------------
+
+# Task 2.4.1: CSTK_STATUSLINE_INNER_COMMAND definida -> stdout do comando
+# interno repassado verbatim, payload original intacto no stdin dele.
+scenario_pass_through_inner_command() {
+  _require_jq || return 0
+  mktemp_test
+  capture sh -c 'printf "%s" "$1" | CSTK_STATUSLINE_INNER_COMMAND="cat" "$2"' \
+    _ "$(_fixture_full /tmp/p)" "$SCRIPT"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *'"session_id":"sess-1"'*) ;;
+    *) _fail "inner command verbatim" "obtido: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+# Task 2.4.2: sem inner command -> fallback minimo de 1 linha, NUNCA vazio,
+# construido so de model.display_name + five_hour.used_percentage.
+scenario_pass_through_fallback_minimo() {
+  _require_jq || return 0
+  mktemp_test
+  _run_hook "$(_fixture_full /tmp/p)"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -n "$_CAPTURED_STDOUT" ] || { _fail "fallback vazio" "stdout vazio"; return 1; }
+  assert_stdout_contains "Claude Opus 5" || return 1
+  assert_stdout_contains "7.000000000000001" || return 1
+  return 0
+}
+
+# Task 2.4.4: em NENHUM cenario (dep ausente, malformado, throttle,
+# insert ok) o script sai != 0 nem imprime erro de diagnostico em stdout.
+scenario_nunca_erro_em_stdout() {
+  mktemp_test
+  capture sh -c 'printf "not json" | "$1"' _ "$SCRIPT"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    *rror*|*RROR*|*fail*|*FAIL*) _fail "erro vazou p/ stdout" "obtido: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Task 2.5 — sqlite3/knowledge.db/jq indisponivel (Cenario 7 quickstart)
+# ---------------------------------------------------------------------------
+
+# Task 2.5.1/2.5.3: jq ausente -> pass-through normal, captura pulada, exit 0.
+scenario_jq_ausente() {
+  mktemp_test
+  _shim="$TMPDIR_TEST/shim_no_jq"
+  mkdir -p "$_shim"
+  for _cmd in sh mktemp awk sed grep find head printf cp mv rm mkdir \
+              chmod ls dirname basename tr cut wc env command sort \
+              uniq date cat cksum sqlite3; do
+    _src=$(command -v "$_cmd" 2>/dev/null) || continue
+    [ -n "$_src" ] || continue
+    ln -sf "$_src" "$_shim/$_cmd" 2>/dev/null || :
+  done
+  _run_hook "$(_fixture_full /tmp/p)" "PATH=$_shim"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -n "$_CAPTURED_STDOUT" ] || { _fail "sem fallback c/ jq ausente" "stdout vazio"; return 1; }
+  return 0
+}
+
+# Task 2.5.1/2.5.3: cstk ausente do PATH (nao instalado) -> statusline
+# segue funcionando normalmente (persistencia so pulada, pass-through
+# intacto) — o hook NUNCA falha por causa do subprocesso de persistencia.
+scenario_cstk_ausente() {
+  _require_jq || return 0
+  mktemp_test
+  _shim="$TMPDIR_TEST/shim_no_cstk"
+  mkdir -p "$_shim"
+  for _cmd in sh mktemp awk sed grep find head printf cp mv rm mkdir \
+              chmod ls dirname basename tr cut wc env command sort \
+              uniq date cat cksum jq; do
+    _src=$(command -v "$_cmd" 2>/dev/null) || continue
+    [ -n "$_src" ] || continue
+    ln -sf "$_src" "$_shim/$_cmd" 2>/dev/null || :
+  done
+  _run_hook "$(_fixture_full /tmp/p)" "PATH=$_shim"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado exit=0, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "Claude Opus 5" || return 1
+  return 0
+}
+
+run_all_scenarios


### PR DESCRIPTION
Captura o dado do `/usage` (`rate_limits.five_hour`/`seven_day`) sem exigir
credencial OAuth: o harness ja envia esses campos no payload da
`statusLine.command` a cada render — a feature le o que ja estava passando,
persiste localmente e expoe consulta. 100% local (Constitution IV): nenhuma
chamada de rede, nem loopback.

## Added

- **Tabela `plan_usage`** no `knowledge.db` — migracao aditiva pura,
  `RECALL_SCHEMA_VERSION` 13 -> 14, sem `ALTER`/`DROP`.
- **Hook `statusline-plan-usage.sh`** — entry-point de `statusLine.command`,
  pass-through obrigatorio de stdout, nunca toca `sqlite3` direto.
- **`cstk statusline install/status`** — preserva comando pre-existente em
  `CSTK_STATUSLINE_INNER_COMMAND`, idempotente (nao aninha wrapper), `--dry-run`.
- **`cstk plan-usage` / `plan-usage history`** — reusa `--limit` (default 20)
  e `--since` de `cstk usage`, sem convencao nova.

## Fixed

- **`tool_calls` contado em DOBRO** em projeto com o cstk como plugin.
  `guard-hooks-status.sh` so olhava a copia classica em
  `<projeto>/.claude/hooks/` e era cego ao `hooks.json` do plugin. `tick-mode`
  devolvia `manual`, o orquestrador tickava na mao, o hook do plugin tickava
  tambem, e `state-ondas.sh end` soma as duas fontes. Sem correcao retroativa:
  nao ha como separar tick manual de tick de hook depois do fato.
- **`test_recall.sh` reprovava com `state_backend=sqlite`** (`ctx_15`/`ctx_15b`
  liam `state.json`, inexistente nesse backend). O `ctx_15b` era pior: passava
  TRIVIALMENTE, verde sem verificar nada.
- **`test_setup.sh` reprovava por causa desta propria versao** — regex
  `\|setup\)$` exigia que `setup` fosse a ultima alternativa do case; bastou
  `plan-usage` entrar depois dela.
- **`--check-coverage` acusava orfao** — teste de hook novo sem a isencao
  existence-guarded que os outros 4 ja tinham.

## Testado

- Suite completa: `PASS: 2696  FAIL: 0  ERROR: 0  ORPHANS: 0  TIME: 791s`
  (`LC_ALL=C ./tests/run.sh`), zero flaky.
- `./tests/run.sh --check-coverage`: "Cobertura completa: zero orfaos".
- `validate-plugin-manifests.sh --version 7.2.0 --strict`: exit 0 (gate MP-5).
- `cstk doctor`: 34 ok / 0 edited / 0 missing, plugin e catalogo alinhados.
- Fluxo end-to-end verificado a mao (payload -> hook -> banco -> consulta):
  payload com `rate_limits` grava 2 linhas; payload sem, nenhuma; ruido de
  float preservado (`= 7.000000000000001` -> 1, `= 7.0` -> 0); `resets_at`
  lido como epoch em SEGUNDOS; banco vazio reporta `nao medido`, nunca `0%`.

Schema e GOTCHAs derivados de observacao empirica do payload real
(Claude Code 2.1.226, macOS) — zero dado factual inventado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBUDG8zvNGGvHHog6YJYGi