### PR TITLE
fix(plan-usage): formatacao de data portavel (BSD + GNU)

### DIFF
--- a/cli/lib/plan-usage.sh
+++ b/cli/lib/plan-usage.sh
@@ -195,14 +195,27 @@ USAGE
 # ==========================================================================
 
 # _pu_local_time EPOCH -> horario local formatado (apresentacao apenas — a
-# persistencia continua epoch INTEGER, FR-003/Cenario 5). `date -r` e
-# BSD/macOS-first (ambiente-alvo desta feature); sem fallback GNU (`date -d
-# @EPOCH`) porque o CLI so precisa rodar no ambiente do operador (macOS/zsh,
-# Constitution). Se a conversao falhar (comando indisponivel/erro), imprime
-# o epoch cru — nunca fabrica um formato (Principio VI).
+# persistencia continua epoch INTEGER, FR-003/Cenario 5).
+#
+# PORTABILIDADE: `date -r EPOCH` e BSD/macOS. No GNU coreutils `-r` significa
+# "mtime deste ARQUIVO", entao `date -r 1786372200` falha com "No such file"
+# e a forma correta e `date -d @EPOCH`. A versao anterior so tinha o ramo BSD,
+# justificando que "o CLI so precisa rodar no ambiente do operador" — premissa
+# que nao se sustenta: o CI roda Ubuntu e o toolkit e distribuido via tarball.
+# Sintoma no Linux: `cstk plan-usage` imprimia o epoch cru (`reset: 1786372200`)
+# em vez da data. Tenta BSD, depois GNU; falhando as duas, imprime o epoch cru
+# — nunca fabrica um formato (Principio VI).
 _pu_local_time() {
   [ -n "$1" ] || { printf ''; return 0; }
-  date -r "$1" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || printf '%s' "$1"
+  if _pu_lt=$(date -r "$1" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null) && [ -n "$_pu_lt" ]; then
+    printf '%s' "$_pu_lt"
+    return 0
+  fi
+  if _pu_lt=$(date -d "@$1" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null) && [ -n "$_pu_lt" ]; then
+    printf '%s' "$_pu_lt"
+    return 0
+  fi
+  printf '%s' "$1"
 }
 
 # _pu_row_field ROW INDEX -> campo INDEX (1-based) de uma linha


### PR DESCRIPTION
O `release.yml` da v7.2.0 reprovou com `PASS: 2695  FAIL: 1` —
`test_plan-usage.sh::scenario_01_flags_e_texto_com_dados`. Nao e flaky:

```
esperado: reset: [0-9]{4}-[0-9]{2}-[0-9]{2}
obtido:   five_hour: 7.5% usado (reset: 1786372200)
```

`_pu_local_time` so tinha o ramo BSD (`date -r EPOCH`), com um comentario
justificando que o CLI "so precisa rodar no ambiente do operador
(macOS/zsh)". A premissa nao se sustenta: o CI roda Ubuntu e o toolkit e
distribuido via tarball. No GNU coreutils `-r` significa "mtime deste
ARQUIVO", entao `date -r 1786372200` falha com "No such file" e a saida caia
no fallback de epoch cru.

Sintoma no Linux: `cstk plan-usage` imprimia `reset: 1786372200` em vez da
data — degradacao silenciosa da feature fora do macOS.

Agora tenta BSD, depois GNU (`date -d @EPOCH`); falhando as duas, imprime o
epoch cru, nunca fabrica formato (Principio VI).

## Testado

- `tests/cstk/test_plan-usage.sh`: 14/14 no macOS.
- Fallback GNU validado com stub emulando coreutils (`-r` falha, `-d @N`
  converte): retorna `2026-08-10 11:30:00 -03` em vez do epoch cru.
- `sh -n`, `dash -n` e `shellcheck -s sh` limpos.
- Varredura: nenhuma outra ocorrencia BSD-only de `date` no codigo novo
  desta versao.

A tag `v7.2.0` sera movida para o commit de merge deste PR — nenhuma release
chegou a ser publicada (o workflow morreu na suite, antes do build), entao a
tag nao foi consumida por ninguem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBUDG8zvNGGvHHog6YJYGi