### PR TITLE
fix(statusline): gravar statusLine.type=command (7.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "7.2.0",
+      "version": "7.2.1",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [7.2.1] - 2026-08-10
+
+`cstk statusline install` da 7.2.0 escrevia um `settings.json` que o Claude
+Code REJEITA — e o harness descarta o arquivo INTEIRO quando encontra uma
+chave invalida, nao so a chave. Quem rodou o comando ficou sem
+`permissions`, `mcpServers` e todo o resto das proprias configuracoes.
+
+### Fixed
+
+- **`statusLine.type` obrigatorio.** O instalador gravava
+  `{"statusLine": {"command": "..."}}`, e o schema do harness exige
+  `{"statusLine": {"type": "command", "command": "..."}}`. Sintoma no
+  proximo `claude`: `Settings Error — statusLine.type: Invalid value.
+  Expected one of: "command"` e o aviso de que "files with errors are
+  skipped entirely". A causa raiz foi inferir o contrato pelo nome do campo
+  em vez de verifica-lo — o mesmo erro que a Constitution VI proibe para
+  dado factual, aplicado a um schema. Corrigido nos TRES pontos de escrita:
+  merge em arquivo existente, criacao de arquivo novo, e a instrucao de
+  colagem manual usada quando `jq` esta ausente.
+- **`install` agora REPARA o estado quebrado.** O check de idempotencia
+  comparava so `statusLine.command`; com o comando ja correto e o `type`
+  ausente, saia por "ja instalado, nada a fazer" e deixava o operador
+  travado sem remediacao pelo proprio comando. Agora `type` correto e
+  pre-condicao do no-op. O reparo seta campo a campo (`.statusLine.type` e
+  `.statusLine.command`) em vez de substituir o objeto, entao subchaves do
+  operador como `padding` sobrevivem, e a customizacao previa em
+  `CSTK_STATUSLINE_INNER_COMMAND` e mantida sem aninhar wrapper.
+- **`status` reporta o estado invalido.** Antes dizia "ativo" para um
+  `settings.json` que o harness estava descartando. Agora imprime
+  `INVALIDO` com a remediacao, e sai 1.
+- **Permissao do `settings.json` preservada.** O `mv` do arquivo temporario
+  carregava o modo do `mktemp` para o destino. Agora o modo original e lido
+  antes (`stat -f %Lp` BSD, `stat -c %a` GNU) e reaplicado; sem nenhum dos
+  dois, cai em `0600` — o mais restritivo, nunca afrouxa por engano.
+
 ## [7.2.0] - 2026-08-10
 
 Captura do gauge de uso do plano (`/usage`) sem credencial OAuth: o
@@ -5508,6 +5543,7 @@ nome — skills continuam respondendo aos mesmos triggers e argumentos.
   (Step 0..7) agora usam terminologia genérica de camadas ("server /
   backend", "client / frontend", "cross-boundary") em vez de listas
   específicas de Go/React. Comandos de build/test/lint apresentados em
+[7.2.1]: https://github.com/JotJunior/cstk/releases/tag/v7.2.1
 [7.2.0]: https://github.com/JotJunior/cstk/releases/tag/v7.2.0
 [7.1.1]: https://github.com/JotJunior/cstk/releases/tag/v7.1.1
 [7.1.0]: https://github.com/JotJunior/cstk/releases/tag/v7.1.0

--- a/cli/lib/statusline.sh
+++ b/cli/lib/statusline.sh
@@ -2,7 +2,7 @@
 # statusline.sh — subcomando `cstk statusline` (feature plan-usage-capture,
 # FASE 3 / tasks.md 3.1.1-3.1.6, dec-042).
 #
-# Provisiona a chave UNICA `statusLine.command` do settings.json do
+# Provisiona a chave `statusLine` (type+command) do settings.json do
 # harness (research.md Decision 2, plan.md linha 17-24) apontando para
 # `statusline-plan-usage.sh` (o entry-point de captura da FASE 2).
 #
@@ -78,8 +78,8 @@ USO:
   cstk statusline status  [--catalog DIR]
 
 install:
-  Escreve/atualiza a chave `statusLine.command` de
-  ${HOME}/.claude/settings.json apontando para
+  Escreve/atualiza a chave `statusLine` (com `type: "command"`, exigido
+  pelo schema do harness) de ${HOME}/.claude/settings.json apontando para
   <catalog>/skills/agente-00c-runtime/hooks/statusline-plan-usage.sh
   (catalog default: ${HOME}/.claude).
 
@@ -87,7 +87,8 @@ install:
   desta feature), o valor original e preservado movendo-o para a
   variavel de ambiente CSTK_STATUSLINE_INNER_COMMAND — NUNCA sobrescrito
   silenciosamente. Idempotente: rodar 2x seguidas nao aninha wrapper
-  sobre wrapper.
+  sobre wrapper. Repara `statusLine` sem `type` (estado escrito pela
+  v7.2.0, que fazia o harness descartar o settings.json inteiro).
 
 status:
   Reporta se a captura esta instalada e ativa em
@@ -130,14 +131,24 @@ statusline_cmd_install() {
   if ! _sl_detect_jq; then
     log_warn "statusline install: jq ausente — nao da para editar settings.json com seguranca."
     log_warn "statusline install: cole manualmente esta chave em $_si_settings:"
-    printf '  "statusLine": { "command": "%s" }\n' "$_si_script" >&2
+    printf '  "statusLine": { "type": "command", "command": "%s" }\n' "$_si_script" >&2
     return 1
   fi
 
   _si_cur=""
+  _si_type=""
   if [ -f "$_si_settings" ]; then
     _si_cur=$(jq -r '.statusLine.command // empty' -- "$_si_settings" 2>/dev/null) || _si_cur=""
+    _si_type=$(jq -r '.statusLine.type // empty' -- "$_si_settings" 2>/dev/null) || _si_type=""
   fi
+
+  # `type` correto e pre-condicao dos ramos de no-op abaixo. Um settings.json
+  # com o `command` JA apontando para o script certo mas SEM `type` esta
+  # QUEBRADO (o harness rejeita o arquivo inteiro) — sair por "nada a fazer"
+  # ali deixaria o operador travado sem remediacao possivel pelo proprio
+  # comando. Nesse estado seguimos para a escrita, que repara o campo.
+  _si_type_ok=0
+  [ "$_si_type" = "command" ] && _si_type_ok=1
 
   case "$_si_cur" in
     "")
@@ -145,12 +156,20 @@ statusline_cmd_install() {
       _si_msg="instalado (sem statusline previa)"
       ;;
     "$_si_script")
-      log_info "statusline install: ja instalado e atualizado em $_si_settings (nada a fazer)"
-      return 0
+      if [ "$_si_type_ok" = 1 ]; then
+        log_info "statusline install: ja instalado e atualizado em $_si_settings (nada a fazer)"
+        return 0
+      fi
+      _si_new="$_si_script"
+      _si_msg="reparado: statusLine.type ausente/invalido (settings.json era rejeitado inteiro pelo harness)"
       ;;
     *"CSTK_STATUSLINE_INNER_COMMAND="*"$_si_script")
-      log_info "statusline install: ja instalado (customizacao preservada) em $_si_settings (nada a fazer)"
-      return 0
+      if [ "$_si_type_ok" = 1 ]; then
+        log_info "statusline install: ja instalado (customizacao preservada) em $_si_settings (nada a fazer)"
+        return 0
+      fi
+      _si_new="$_si_cur"
+      _si_msg="reparado: statusLine.type ausente/invalido (customizacao previa mantida intacta)"
       ;;
     *)
       _si_escaped=$(_sl_escape_single_quotes "$_si_cur")
@@ -177,21 +196,44 @@ statusline_cmd_install() {
       log_error "statusline install: mktemp em $_si_settings_dir falhou"
       return 1
     }
-    if ! jq --arg cmd "$_si_new" '.statusLine.command = $cmd' -- "$_si_settings" > "$_si_tmp" 2>/dev/null; then
+    # `type` e OBRIGATORIO no schema de settings.json do Claude Code —
+    # `{"statusLine": {"command": ...}}` sem ele e recusado com
+    # `statusLine.type: Invalid value. Expected one of: "command"`, e o
+    # harness DESCARTA O ARQUIVO INTEIRO (nao so a chave invalida), deixando
+    # o operador sem permissions/mcpServers/tudo. Setar campo a campo, nao
+    # substituir o objeto, para preservar subchaves que o operador tenha
+    # (ex.: `padding`). Idempotente e auto-reparador: um settings.json que
+    # ja tenha `statusLine` SEM `type` (escrito por versao anterior a este
+    # fix) e consertado no proximo install.
+    if ! jq --arg cmd "$_si_new" '.statusLine.type = "command" | .statusLine.command = $cmd' -- "$_si_settings" > "$_si_tmp" 2>/dev/null; then
       log_error "statusline install: jq falhou ao mesclar $_si_settings (JSON invalido?)"
       rm -f -- "$_si_tmp"
       return 1
     fi
+    # `mv` carrega a permissao do TEMP para o destino — sem preservar o modo
+    # original, um settings.json 0644 vira o modo do mktemp (ou o inverso,
+    # conforme umask). `chmod --reference` e GNU-only; `stat` diverge entre
+    # BSD (-f %Lp) e GNU (-c %a), entao tenta os dois e cai em 0600 (o mais
+    # restritivo) se nenhum responder — nunca AFROUXA permissao por engano.
+    _si_mode=$(stat -f '%Lp' -- "$_si_settings" 2>/dev/null) || _si_mode=""
+    if [ -z "$_si_mode" ]; then
+      _si_mode=$(stat -c '%a' -- "$_si_settings" 2>/dev/null) || _si_mode=""
+    fi
+    case "$_si_mode" in
+      ''|*[!0-7]*) _si_mode=600 ;;
+    esac
+    chmod "$_si_mode" -- "$_si_tmp" 2>/dev/null || :
     if ! mv -f -- "$_si_tmp" "$_si_settings"; then
       log_error "statusline install: mv atomico falhou para $_si_settings"
       rm -f -- "$_si_tmp"
       return 1
     fi
   else
-    if ! jq -n --arg cmd "$_si_new" '{"statusLine": {"command": $cmd}}' > "$_si_settings" 2>/dev/null; then
+    if ! jq -n --arg cmd "$_si_new" '{"statusLine": {"type": "command", "command": $cmd}}' > "$_si_settings" 2>/dev/null; then
       log_error "statusline install: falha ao criar $_si_settings"
       return 1
     fi
+    chmod 600 -- "$_si_settings" 2>/dev/null || :
   fi
 
   log_info "statusline install: $_si_msg ($_si_settings)"
@@ -230,6 +272,19 @@ statusline_cmd_status() {
   _ss_cur=$(jq -r '.statusLine.command // empty' -- "$_ss_settings" 2>/dev/null) || _ss_cur=""
   if [ -z "$_ss_cur" ]; then
     printf 'statusline: nao instalado (statusLine.command ausente em %s)\n' "$_ss_settings"
+    return 1
+  fi
+
+  # `type` ausente = settings.json REJEITADO INTEIRO pelo harness
+  # ("statusLine.type: Invalid value"), nao so a chave. Reportar como
+  # INVALIDO, nao como ativo: com o arquivo descartado a captura nao roda,
+  # e o operador perde tambem permissions/mcpServers/o resto. Detecta o
+  # estado deixado por versoes anteriores a este fix.
+  _ss_type=$(jq -r '.statusLine.type // empty' -- "$_ss_settings" 2>/dev/null) || _ss_type=""
+  if [ "$_ss_type" != "command" ]; then
+    printf 'statusline: INVALIDO — statusLine.type ausente ou diferente de "command" em %s\n' "$_ss_settings"
+    printf '  o harness REJEITA o settings.json inteiro nesse estado (nao so a chave)\n'
+    printf '  remediacao: rode `cstk statusline install` (idempotente, conserta o campo)\n'
     return 1
   fi
 

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/tests/cstk/test_statusline.sh
+++ b/tests/cstk/test_statusline.sh
@@ -186,7 +186,11 @@ scenario_status_ativo_apos_install() {
 scenario_status_aponta_para_outro_comando() {
   if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
   _home=$(_sl_home_fixture)
-  printf '{"statusLine":{"command":"~/totally-unrelated.sh"}}\n' > "$_home/.claude/settings.json"
+  # `type` incluso de proposito: uma statusline de terceiro que de fato
+  # FUNCIONA tem o campo (sem ele o harness rejeita o settings.json inteiro).
+  # Omiti-lo aqui testaria o estado invalido, nao o "aponta para outro
+  # comando" que este cenario existe para cobrir.
+  printf '{"statusLine":{"type":"command","command":"~/totally-unrelated.sh"}}\n' > "$_home/.claude/settings.json"
 
   _sl_run "$_home" status
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1 (nao ativo), obtido $_CAPTURED_EXIT"; return 1; }
@@ -256,6 +260,94 @@ scenario_help_imprime_uso() {
     *"cstk statusline"*) ;;
     *) _fail "help" "stderr deveria imprimir texto de uso: $_CAPTURED_STDERR"; return 1 ;;
   esac
+  return 0
+}
+
+# ==== `type` obrigatorio no schema do harness (regressao da v7.2.0) ====
+#
+# `{"statusLine": {"command": ...}}` sem `type` e recusado pelo Claude Code
+# com `statusLine.type: Invalid value. Expected one of: "command"`, e o
+# harness DESCARTA O ARQUIVO INTEIRO — o operador perde permissions,
+# mcpServers e tudo mais, nao so a statusline. A v7.2.0 saiu escrevendo
+# exatamente esse JSON invalido.
+
+scenario_install_grava_type_command() {
+  _home=$(_sl_home_fixture)
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _t=$(jq -r '.statusLine.type // empty' "$_home/.claude/settings.json" 2>/dev/null)
+  [ "$_t" = "command" ] \
+    || { _fail "type" "esperado statusLine.type=command (senao o harness rejeita o settings.json inteiro), obtido '$_t'"; return 1; }
+  return 0
+}
+
+scenario_install_repara_type_ausente() {
+  # Estado deixado pela v7.2.0: `command` correto, `type` ausente. O install
+  # NAO pode sair por "ja instalado, nada a fazer" — sem reparo o operador
+  # fica travado sem remediacao pelo proprio comando.
+  _home=$(_sl_home_fixture)
+  _scr=$(_sl_script_path_for "$_home")
+  jq -n --arg c "$_scr" '{"permissions":{"allow":["Bash"]},"statusLine":{"command":$c}}' \
+    > "$_home/.claude/settings.json"
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _t=$(jq -r '.statusLine.type // empty' "$_home/.claude/settings.json" 2>/dev/null)
+  [ "$_t" = "command" ] || { _fail "reparo" "type nao foi reparado, obtido '$_t'"; return 1; }
+  _c=$(jq -r '.statusLine.command // empty' "$_home/.claude/settings.json" 2>/dev/null)
+  [ "$_c" = "$_scr" ] || { _fail "command" "command alterado no reparo: $_c"; return 1; }
+  jq -e '.permissions.allow[0] == "Bash"' "$_home/.claude/settings.json" >/dev/null \
+    || { _fail "outras chaves" "reparo destruiu chaves nao relacionadas"; return 1; }
+  return 0
+}
+
+scenario_install_repara_type_preservando_customizacao() {
+  _home=$(_sl_home_fixture)
+  _scr=$(_sl_script_path_for "$_home")
+  _wrapped="CSTK_STATUSLINE_INNER_COMMAND='meu-tema' $_scr"
+  jq -n --arg c "$_wrapped" '{"statusLine":{"command":$c}}' > "$_home/.claude/settings.json"
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _t=$(jq -r '.statusLine.type // empty' "$_home/.claude/settings.json" 2>/dev/null)
+  [ "$_t" = "command" ] || { _fail "reparo" "type nao reparado, obtido '$_t'"; return 1; }
+  _c=$(jq -r '.statusLine.command // empty' "$_home/.claude/settings.json" 2>/dev/null)
+  [ "$_c" = "$_wrapped" ] \
+    || { _fail "customizacao" "reparo nao pode aninhar nem perder o wrapper; obtido: $_c"; return 1; }
+  return 0
+}
+
+scenario_install_preserva_subchaves_do_statusline() {
+  # `padding` (e afins) sao do operador — o reparo seta campo a campo em vez
+  # de substituir o objeto.
+  _home=$(_sl_home_fixture)
+  _scr=$(_sl_script_path_for "$_home")
+  jq -n --arg c "$_scr" '{"statusLine":{"command":$c,"padding":1}}' > "$_home/.claude/settings.json"
+  _sl_run "$_home" install
+  jq -e '.statusLine.padding == 1 and .statusLine.type == "command"' "$_home/.claude/settings.json" >/dev/null \
+    || { _fail "subchaves" "padding perdido no reparo: $(jq -c '.statusLine' "$_home/.claude/settings.json")"; return 1; }
+  return 0
+}
+
+scenario_install_idempotente_apos_reparo() {
+  _home=$(_sl_home_fixture)
+  _scr=$(_sl_script_path_for "$_home")
+  jq -n --arg c "$_scr" '{"statusLine":{"command":$c}}' > "$_home/.claude/settings.json"
+  _sl_run "$_home" install
+  _sl_run "$_home" install
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'nada a fazer' \
+    || { _fail "idempotencia" "2a rodada apos reparo deveria ser no-op; stderr=$_CAPTURED_STDERR"; return 1; }
+  return 0
+}
+
+scenario_status_reporta_type_ausente_como_invalido() {
+  _home=$(_sl_home_fixture)
+  _scr=$(_sl_script_path_for "$_home")
+  jq -n --arg c "$_scr" '{"statusLine":{"command":$c}}' > "$_home/.claude/settings.json"
+  _sl_run "$_home" status
+  [ "$_CAPTURED_EXIT" = 1 ] \
+    || { _fail "exit" "esperado 1 (estado invalido nao e 'ativo'), obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q 'INVALIDO' \
+    || { _fail "stdout" "status deveria reportar INVALIDO; obtido: $_CAPTURED_STDOUT"; return 1; }
   return 0
 }
 


### PR DESCRIPTION
`cstk statusline install` da v7.2.0 gravava um `settings.json` que o Claude
Code REJEITA — e o harness descarta o arquivo INTEIRO quando acha uma chave
invalida, nao so a chave:

```
Settings Error
/Users/<user>/.claude/settings.json
└ statusLine.type: Invalid value. Expected one of: "command"
Files with errors are skipped entirely, not just the invalid settings.
```

Quem rodou o comando perdeu `permissions`, `mcpServers` e todo o resto das
proprias configuracoes ate consertar a mao.

**Causa raiz**: o contrato do `statusLine` foi inferido pelo nome do campo
(`statusLine.command`) em vez de verificado. E o mesmo erro que a
Constitution VI proibe para dado factual, aplicado a um schema.

## Fixed

- `type: "command"` nos **3** pontos de escrita: merge em arquivo
  existente, criacao de arquivo novo, e a instrucao de colagem manual
  usada quando `jq` esta ausente.
- **`install` REPARA o estado quebrado.** O check de idempotencia so olhava
  `.statusLine.command`; com o comando ja correto e o `type` ausente saia
  por "ja instalado, nada a fazer" — o operador ficava travado sem
  remediacao pelo proprio comando. Agora `type` correto e pre-condicao do
  no-op.
- Reparo seta **campo a campo** em vez de substituir o objeto: subchaves do
  operador (`padding`) sobrevivem, e a customizacao previa em
  `CSTK_STATUSLINE_INNER_COMMAND` e mantida sem aninhar wrapper.
- **`status` reporta `INVALIDO`** (exit 1) em vez de "ativo" para um
  arquivo que o harness esta descartando.
- **Modo do `settings.json` preservado** no `mv` atomico (`stat -f %Lp` BSD
  / `-c %a` GNU, fallback `0600` — nunca afrouxa permissao por engano).

## Testado

- Suite completa: `PASS: 2702  FAIL: 0  ERROR: 0  ORPHANS: 0  TIME: 812s`.
- `tests/cstk/test_statusline.sh`: 18/18 (+6 cenarios: grava type, repara
  type ausente, repara preservando customizacao, preserva subchaves,
  idempotente apos reparo, status reporta invalido).
- Fixture de `scenario_status_aponta_para_outro_comando` ganhou o `type`
  que uma statusline de terceiro FUNCIONAL teria — sem isso o cenario
  passava a exercitar o estado invalido em vez do que existe para cobrir.
- `validate-plugin-manifests.sh --version 7.2.1 --strict`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBUDG8zvNGGvHHog6YJYGi