### PR TITLE
fix(00c): resume/abort aceitam backend SQLite e corrigem semantica do lock

### DIFF
--- a/plugins/cstk/commands/agente-00c-abort.md
+++ b/plugins/cstk/commands/agente-00c-abort.md
@@ -36,7 +36,11 @@ Extrair `--projeto-alvo-path` (default = `cwd`). Defina:
 #### 2.a. Estado existe?
 
 ```bash
-[ -f <SD>/state.json ] || die "Nao ha execucao 00C em <PAP>."
+# Backend-agnostico (state-db-runtime-parity, v6.3): sob backend SQLite o
+# estado e state.db, nao state.json. Checar so state.json tornaria
+# impossivel abortar execucao iniciada apos `cstk state enable-sqlite`.
+[ -f <SD>/state.json ] || [ -f <SD>/state.db ] \
+  || die "Nao ha execucao 00C em <PAP>."
 ```
 
 Se nao existe, retorne mensagem clara e termine (exit 0 — operador pode

--- a/plugins/cstk/commands/feature-00c-abort.md
+++ b/plugins/cstk/commands/feature-00c-abort.md
@@ -37,7 +37,12 @@ _proj=$(realpath "$PROJETO")
 AGENTE_00C_STATE_DIR="$_proj/.claude/feature-00c-state/$SHORT"
 export AGENTE_00C_STATE_DIR
 
-if [ ! -d "$AGENTE_00C_STATE_DIR" ] || [ ! -f "$AGENTE_00C_STATE_DIR/state.json" ]; then
+# Backend-agnostico (state-db-runtime-parity, v6.3): sob backend SQLite o
+# estado e state.db, nao state.json — exigir state.json aqui tornaria
+# impossivel abortar uma execucao iniciada apos `cstk state enable-sqlite`.
+if [ ! -d "$AGENTE_00C_STATE_DIR" ] \
+   || { [ ! -f "$AGENTE_00C_STATE_DIR/state.json" ] \
+        && [ ! -f "$AGENTE_00C_STATE_DIR/state.db" ]; }; then
   stderr "feature-00c-state inexistente para '$SHORT' em $_proj — nada para abortar"
   exit 1
 fi

--- a/plugins/cstk/commands/feature-00c-resume.md
+++ b/plugins/cstk/commands/feature-00c-resume.md
@@ -43,8 +43,13 @@ if [ ! -d "$AGENTE_00C_STATE_DIR" ]; then
   exit 6
 fi
 
-if [ ! -f "$AGENTE_00C_STATE_DIR/state.json" ]; then
-  stderr "state.json ausente em $AGENTE_00C_STATE_DIR"
+# Backend-agnostico (state-db-runtime-parity, v6.3): sob backend SQLite
+# NAO existe state.json — o estado transacional e state.db. Exigir
+# state.json aqui recusaria, com exit 6, toda execucao iniciada apos
+# `cstk state enable-sqlite`. Mesma forma ja usada em feature-00c.md.
+if [ ! -f "$AGENTE_00C_STATE_DIR/state.json" ] \
+   && [ ! -f "$AGENTE_00C_STATE_DIR/state.db" ]; then
+  stderr "estado ausente em $AGENTE_00C_STATE_DIR (nem state.json nem state.db)"
   exit 6
 fi
 ```
@@ -57,18 +62,31 @@ fi
 > `agente-00c-feature-orchestrator.md`.
 
 ```
-1. checar lock — se ocupado (PID vivo), abortar
-   if state-lock.sh check --state-dir "$AGENTE_00C_STATE_DIR"; then
-     stderr "outra sessao ativa para $SHORT"
-     exit 3
-   fi
+1. checar lock — ATENCAO a semantica REAL do script: `check` sai **0
+   quando o lock esta LIVRE** e **3 quando esta DETIDO**, e NAO distingue
+   dono vivo de morto (basta o diretorio `.lock` existir). Escrever
+   `if state-lock.sh check ...; then abortar` INVERTE a condicao: aborta
+   com lock livre e prossegue com lock ocupado.
+   state-lock.sh check --state-dir "$AGENTE_00C_STATE_DIR" || _lock_detido=1
 
-2. adquirir lock
-   state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR" || {
-     stderr "falha ao adquirir lock"; exit 3;
-   }
+2. adquirir lock — lock ORFAO (dono morto) e o caso NORMAL entre ondas: o
+   processo que fez o `acquire` da onda anterior ja saiu. Quem distingue
+   vivo de morto e o `acquire --force`: readquire emitindo
+   `DIAG|warning|lock-force-acquired` quando o dono esta morto, e RECUSA
+   com exit 3 quando o dono esta VIVO.
+   state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR" \
+     || state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR" --force \
+     || { stderr "outra sessao ativa para $SHORT (dono do lock VIVO)"; exit 3; }
+
+   > Preferivel a `--force`: o command pai libera o lock ANTES de agendar a
+   > proxima onda (passo 5, Cleanup). Ai a retomada adquire limpo e o
+   > `--force` nunca precisa disparar.
 
 3. validar hash state.json contra .sha256 (FR-014)
+   NOTA (backend SQLite): `sha256-verify` e no-op e sai 0 — a integridade
+   do state.db vem de `PRAGMA integrity_check`, por desenho
+   (state-db-foundation). Exit 0 aqui NAO significa "hash conferido" sob
+   SQLite; significa "nao ha .sha256 a conferir".
    state-rw.sh sha256-verify --state-dir "$AGENTE_00C_STATE_DIR" || {
      # divergencia = bloqueio humano por tampering (gera relatorio parcial)
      bloqueios.sh register --state-dir "$AGENTE_00C_STATE_DIR" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -219,6 +219,14 @@ _is_internal_test() {
       # Cobre interacao install.sh + manifest.sh + doctor.sh para os kinds
       # commands/agents (nao mapeia 1:1 para um unico script sob a convencao).
       return 0 ;;
+    test_00c-state-backend-contract.sh)
+      # Smoke textual sobre resume/abort dos 2 escopos: aceitacao de
+      # state.db (paridade de backend) + semantica correta do lock no
+      # resume da feature. Assert no .md, nao em um unico script —
+      # existence-guarded ao command portador das duas regras. Se a fonte
+      # sumir, volta a ser orfao real.
+      [ -f "$REPO_ROOT/plugins/cstk/commands/feature-00c-resume.md" ] && return 0
+      return 1 ;;
     test_command-spawn-model-routing.sh)
       # Smoke textual sobre os 4 commands de spawn/resume (model-routing
       # por onda, FASE 3 de model-routing-por-onda). Assert no .md, nao em

--- a/tests/test_00c-state-backend-contract.sh
+++ b/tests/test_00c-state-backend-contract.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# test_00c-state-backend-contract.sh — smoke textual: trava de regressao de
+# dois defeitos no TEXTO dos commands 00c (resume/abort), descobertos ao
+# conduzir a pipeline da feature `feature-reopen` com state_backend=sqlite.
+#
+# Defeito 1 — semantica do lock INVERTIDA (so em feature-00c-resume.md):
+#   o passo 1 mandava `if state-lock.sh check ...; then abortar`, mas o
+#   script sai 0 quando o lock esta LIVRE e 3 quando esta DETIDO. Seguir o
+#   texto abortava toda retomada com lock livre e prosseguia com lock
+#   ocupado. O `check` tambem NAO distingue dono vivo de morto — quem
+#   distingue e `acquire --force` (recusa se o dono estiver VIVO).
+#
+# Defeito 2 — exigencia de state.json (resume + os 2 aborts): sob backend
+#   SQLite nao existe state.json, o estado e state.db. O texto recusava
+#   com exit 6 (resume) / exit 1 (abort) toda execucao iniciada apos
+#   `cstk state enable-sqlite` — checagem obsoleta desde a paridade de
+#   runtime (state-db-runtime-parity, v6.3). O feature-00c.md inicial ja
+#   aceitava os dois backends; resume e abort ficaram para tras.
+#
+# Natureza: assert TEXTUAL no .md (contrato consumido como prompt). NAO
+# mapeia 1:1 a um .sh — interno em tests/run.sh::_is_internal_test
+# (orphan-check), existence-guarded. Se a regra sumir do texto, o bug volta
+# silenciosamente — por isso a presenca e travada aqui.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+CMD_DIR="$REPO_ROOT/plugins/cstk/commands"
+RES_FEAT="$CMD_DIR/feature-00c-resume.md"
+ABORT_FEAT="$CMD_DIR/feature-00c-abort.md"
+ABORT_AGENTE="$CMD_DIR/agente-00c-abort.md"
+
+# ==== Defeito 2: os 3 commands aceitam state.db, nao so state.json ====
+
+_assert_aceita_state_db() {
+  [ -f "$1" ] || { _error "arquivo ausente" "$1"; return 2; }
+  assert_exit 0 grep -Fq 'state.db' "$1" || return 1
+}
+
+scenario_resume_feature_aceita_state_db() { _assert_aceita_state_db "$RES_FEAT"; }
+scenario_abort_feature_aceita_state_db()  { _assert_aceita_state_db "$ABORT_FEAT"; }
+scenario_abort_agente_aceita_state_db()   { _assert_aceita_state_db "$ABORT_AGENTE"; }
+
+# A forma exata importa: a checagem so e correta se a AUSENCIA de state.json
+# for combinada com a ausencia de state.db (E logico), nunca sozinha.
+scenario_resume_feature_checa_ambos_backends() {
+  [ -f "$RES_FEAT" ] || { _error "arquivo ausente" "$RES_FEAT"; return 2; }
+  assert_exit 0 grep -Fq '! -f "$AGENTE_00C_STATE_DIR/state.db"' "$RES_FEAT" || return 1
+}
+
+scenario_abort_feature_checa_ambos_backends() {
+  [ -f "$ABORT_FEAT" ] || { _error "arquivo ausente" "$ABORT_FEAT"; return 2; }
+  assert_exit 0 grep -Fq '! -f "$AGENTE_00C_STATE_DIR/state.db"' "$ABORT_FEAT" || return 1
+}
+
+# ==== Defeito 1: semantica do lock no resume da feature ====
+
+# O idioma invertido `if state-lock.sh check ...; then` NAO pode reaparecer.
+scenario_resume_sem_idioma_de_check_invertido() {
+  [ -f "$RES_FEAT" ] || { _error "arquivo ausente" "$RES_FEAT"; return 2; }
+  if grep -Eq '^[[:space:]]*if[[:space:]]+state-lock\.sh[[:space:]]+check' "$RES_FEAT"; then
+    _fail "idioma invertido de lock reapareceu em feature-00c-resume.md" \
+      "'if state-lock.sh check ...; then abortar' aborta com lock LIVRE (check sai 0 quando livre, 3 quando detido)"
+    return 1
+  fi
+  return 0
+}
+
+# A semantica correta tem de estar escrita, nao apenas o idioma removido.
+scenario_resume_documenta_semantica_do_check() {
+  [ -f "$RES_FEAT" ] || { _error "arquivo ausente" "$RES_FEAT"; return 2; }
+  assert_exit 0 grep -Eq 'LIVRE' "$RES_FEAT" || return 1
+  assert_exit 0 grep -Eq 'DETIDO' "$RES_FEAT" || return 1
+}
+
+# Lock orfao (dono morto) e o caso normal entre ondas: o caminho de saida
+# (`acquire --force`) precisa estar no texto, senao a retomada trava.
+scenario_resume_documenta_force_para_lock_orfao() {
+  [ -f "$RES_FEAT" ] || { _error "arquivo ausente" "$RES_FEAT"; return 2; }
+  assert_exit 0 grep -Fq 'acquire' "$RES_FEAT" || return 1
+  assert_exit 0 grep -Fq -- '--force' "$RES_FEAT" || return 1
+  assert_exit 0 grep -Fq 'lock-force-acquired' "$RES_FEAT" || return 1
+}
+
+# ==== Nota de integridade sob SQLite ====
+
+# sha256-verify e no-op sob SQLite; sem essa nota, exit 0 no passo 3 e lido
+# como "hash conferido" quando nada foi conferido.
+scenario_resume_nota_sha256_noop_sob_sqlite() {
+  [ -f "$RES_FEAT" ] || { _error "arquivo ausente" "$RES_FEAT"; return 2; }
+  assert_exit 0 grep -Fq 'integrity_check' "$RES_FEAT" || return 1
+}
+
+run_all_scenarios "$0"


### PR DESCRIPTION
Dois defeitos no **texto** dos commands 00c, expostos ao conduzir a pipeline da feature `feature-reopen` com `state_backend=sqlite`. São bugs de contrato (markdown consumido como prompt), não de script.

## 1. Semântica do lock invertida — `feature-00c-resume.md`

O passo 1 mandava:

```sh
if state-lock.sh check --state-dir "$SD"; then
  stderr "outra sessao ativa"; exit 3
fi
```

Mas `state-lock.sh check` sai **0 quando o lock está LIVRE** e **3 quando está DETIDO**. Seguir o texto **aborta toda retomada com lock livre** e **prossegue com lock ocupado** — exatamente o inverso.

O `check` também não distingue dono vivo de morto (basta o diretório `.lock` existir). Quem distingue é `acquire --force`: readquire emitindo `DIAG|warning|lock-force-acquired` se o dono está morto, e recusa com exit 3 se está vivo. **Lock órfão é o caso normal entre ondas**, porque o processo que fez o `acquire` anterior já saiu.

## 2. Exigência de `state.json` — resume + os 2 aborts

`feature-00c-resume.md`, `feature-00c-abort.md` e `agente-00c-abort.md` exigiam `state.json`, recusando com exit 6 / exit 1. Sob backend SQLite não existe `state.json` — o estado transacional é `state.db`. Toda execução iniciada após `cstk state enable-sqlite` era recusada.

Checagem obsoleta desde `state-db-runtime-parity` (v6.3). O `feature-00c.md` inicial já aceitava os dois backends (linhas 171, 296, 418); resume e abort ficaram para trás.

Inclui também a nota de que `sha256-verify` é **no-op sob SQLite** (integridade via `PRAGMA integrity_check`), para que exit 0 no passo 3 não seja lido como "hash conferido".

## Trava de regressão

`tests/test_00c-state-backend-contract.sh` — 9 cenários, registrado como interno em `run.sh::_is_internal_test` (assert textual em `.md`, não mapeia 1:1 a um script; existence-guarded).

Verificado que **reprova as versões pré-fix**: rodado num sandbox contra os arquivos da `main`, falha inclusive no cenário que detecta o idioma invertido, com o diagnóstico exato.

## Validação

- Suíte completa: `PASS: 2711  FAIL: 0  ERROR: 0`
- `--check-coverage`: zero órfãos
- `doc-counts`, `doc-subcommands`, `state-parity-sweep`: verdes

Sem conflito com a PR #105 (`feature-reopen`) — nenhum arquivo em comum.