### PR TITLE
fix(tests): sandbox de PATH do probe nao suprimia o gh no CI

### DIFF
--- a/tests/test_commit-mode.sh
+++ b/tests/test_commit-mode.sh
@@ -566,16 +566,43 @@ EOF
 
 # ---- T-51: gh ausente/nao autenticado/falho apos auth ⇒ nunca infere negativo ----
 
+# _make_shim_path_no_gh: PATH completo (symlinks) COM git mas SEM gh.
+# Armadilha conhecida do repositorio (memoria de projeto
+# feedback_test_path_stub_cannot_hide_usrbin.md) — PATH deve conter TODOS os
+# binarios via symlink, exceto o suprimido, nunca um PATH minimo/stub.
+# Historico: `PATH="$stub:/usr/bin:/bin"` NAO esconde o gh no CI Ubuntu (o gh
+# mora em /usr/bin), so na maquina local (gh em /opt/homebrew/bin) — passava
+# local e queimou a 1a tag v7.3.0 no gate de release.
+# Espelha tests/test_posttooluse-tool-call-tick.sh::_make_shim_path_no_sqlite.
+_make_shim_path_no_gh() {
+  _shim="$TMPDIR_TEST/shimbin-no-gh"
+  mkdir -p "$_shim"
+  for _cmd in sh git jq mktemp awk sed grep find head printf cp mv rm mkdir \
+              chmod ls dirname basename tr cut wc env command sort \
+              uniq date cat; do
+    _src=$(command -v "$_cmd" 2>/dev/null) || continue
+    [ -n "$_src" ] || continue
+    ln -sf "$_src" "$_shim/$_cmd" 2>/dev/null || :
+  done
+  printf '%s' "$_shim"
+}
+
 scenario_t51a_probe_gh_ausente_nunca_infere_negativo() {
   _gdir="$TMPDIR_TEST/repo-probe-t51a"
   _sd="$TMPDIR_TEST/probe-t51a"
   _init_git_repo_probe "$_gdir" "feat/probe-t51a"
 
   _orig_path="$PATH"
-  _stub_dir="$TMPDIR_TEST/stub-t51a-nogh"
-  mkdir -p "$_stub_dir"
-  PATH="$_stub_dir:/usr/bin:/bin"
+  PATH="$(_make_shim_path_no_gh)"
   export PATH
+
+  # Auto-verificacao do sandbox: se o gh continuar visivel, o cenario nao esta
+  # testando o que promete. Falha explicita em vez de falso-positivo silencioso.
+  if command -v gh >/dev/null 2>&1; then
+    PATH="$_orig_path"; export PATH
+    _fail "sandbox de PATH nao suprimiu o gh" "command -v gh ainda resolve sob o shim"
+    return 1
+  fi
 
   capture "$SCRIPT" probe-pending-work --state-dir "$_sd" --projeto-alvo-path "$_gdir" -- feat/probe-t51a
 


### PR DESCRIPTION
Corrige a falha que queimou a 1ª tag `v7.3.0` no gate de release.

## Sintoma

```
not ok 48 - test_commit-mode.sh :: scenario_t51a_probe_gh_ausente_nunca_infere_negativo
# PASS: 2788  FAIL: 1  ERROR: 0  TIME: 446s
```

Suíte local (macOS): 2789 PASS / 0 FAIL. CI (Ubuntu): 1 FAIL.

## Causa

O cenário montava `PATH="$stub:/usr/bin:/bin"` para simular `gh` ausente:

- **macOS**: `gh` está em `/opt/homebrew/bin`, fora da lista → realmente ausente → passa.
- **Ubuntu CI**: `gh` está em `/usr/bin`, que está **embutido na própria lista** → continua visível → o cenário exercitava "gh presente", não o que promete.

É a armadilha já documentada no repositório (`feedback_test_path_stub_cannot_hide_usrbin`): stub de PATH não esconde binário de `/usr/bin`.

## Correção

Adota o padrão canônico já usado em `test_posttooluse-tool-call-tick.sh::_make_shim_path_no_sqlite` e `test_pretooluse-bash-guard.sh`: PATH com **todos** os binários necessários via symlink num diretório próprio, **exceto** o suprimido — nunca um PATH mínimo com `/usr/bin` embutido.

Acrescenta auto-verificação: se `command -v gh` ainda resolver sob o shim, o cenário falha explicitamente, em vez de virar falso-positivo silencioso.

## Honestidade sobre a validação

**Não foi possível reproduzir a falha localmente**: o macOS não tem `/usr/bin/gh`, e o cenário antigo sobrescreve o `PATH` inteiro (prefixar algo não tem efeito). A correção é estrutural — o novo PATH não contém `/usr/bin`, então não há de onde vazar — e a validação efetiva é o próprio gate de release.

Local: `./tests/run.sh commit-mode` → `PASS: 53  FAIL: 0`.