### PR TITLE
chore(gitignore): ignora config local de MCP e documentos de escritorio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ __pycache__/
 # Saidas HTML geradas pela skill decision-tree (arvore/fluxograma de decisoes)
 arvore-decisoes*.html
 fluxograma-decisoes*.html
+
+# Config local de MCP (por maquina/sessao — nunca versionar)
+.mcp*
+
+# Documentos binarios de escritorio, em qualquer diretorio
+*.docx
+*.pptx


### PR DESCRIPTION
`.mcp*` (config de MCP é por máquina/sessão) e `*.docx`/`*.pptx` em qualquer diretório.

Verificado com `git check-ignore`:

| Caminho | Resultado |
|---|---|
| `.mcp.json` | IGNORADO |
| `.mcp.json.bak` | IGNORADO |
| `docs/treinamento-executivo-cstk.pptx` | IGNORADO |
| `sub/dir/qualquer.docx` (controle aninhado) | IGNORADO |

Nenhum arquivo `.docx`/`.pptx`/`.mcp*` estava trackeado, então não há necessidade de `git rm --cached`.