### PR TITLE
fix(00c-runtime): drift.sh backend-agnostico (#101) e fallback de branch default alcancavel (#98)

### DIFF
--- a/plugins/cstk/skills/agente-00c-runtime/scripts/commit-mode.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/commit-mode.sh
@@ -207,8 +207,11 @@ _cm_cmd_guard_branch() {
   # default de `git init` VARIA por ambiente (macOS default "main", muitos
   # Linux/CI default "master"), entao tratamos AMBOS como default — bloquear
   # commit/push tanto em "main" quanto em "master".
-  _default=$(git -C "$_pap" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
-    | sed 's@^refs/remotes/origin/@@') || _default=""
+  # O exit status de um pipe e o do ULTIMO comando (o sed, que sai 0 mesmo
+  # com entrada vazia) — nesta forma o `|| ...` NUNCA dispara (issue #98).
+  # Captura em duas etapas para o fallback ser alcancavel.
+  _sr=$(git -C "$_pap" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) || _sr=""
+  _default=$(printf '%s' "$_sr" | sed 's@^refs/remotes/origin/@@')
 
   printf '%s\n' "$_head"
 
@@ -319,8 +322,11 @@ _cm_cmd_probe_pending_work() {
   fi
 
   # Passo d: default_branch — mesmo padrao de guard-branch/finalize.
-  _dflt=$(git -C "$_pap" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
-    | sed 's@^refs/remotes/origin/@@') || _dflt=""
+  # O exit status de um pipe e o do ULTIMO comando (o sed, que sai 0 mesmo
+  # com entrada vazia) — nesta forma o `|| ...` NUNCA dispara (issue #98).
+  # Captura em duas etapas para o fallback ser alcancavel.
+  _sr=$(git -C "$_pap" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) || _sr=""
+  _dflt=$(printf '%s' "$_sr" | sed 's@^refs/remotes/origin/@@')
   _default_ref=""
   if [ -n "$_dflt" ]; then
     _default_branch="$_dflt"
@@ -871,8 +877,13 @@ _cm_cmd_finalize() {
   fi
 
   # Passo 3: verificar se tem commits novos vs default
-  _default=$(git -C "$_pap" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
-    | sed 's@^refs/remotes/origin/@@') || _default="main"
+  # issue #98: nesta forma o `|| _default="main"` NUNCA disparava (exit do
+  # pipe = exit do sed = 0). _default virava "", o rev-list "..branch"
+  # degenerava para 0 e o finalize concluia "sem commits novos", pulando
+  # push+PR EM SILENCIO. Captura em duas etapas torna o fallback real.
+  _sr=$(git -C "$_pap" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) || _sr=""
+  _default=$(printf '%s' "$_sr" | sed 's@^refs/remotes/origin/@@')
+  [ -n "$_default" ] || _default="main"
   _ahead=$(git -C "$_pap" rev-list "${_default}..$_curr_branch" --count 2>/dev/null) || _ahead="0"
   if [ "$_ahead" = "0" ]; then
     _cm_err "finalize: branch '$_curr_branch' nao tem commits novos vs '$_default' — skip (skipped-no-commits)"

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/drift.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/drift.sh
@@ -72,10 +72,18 @@
 
 set -eu
 
-# Leitura de estado via interface canonica (state-db-runtime-parity FR-001):
-# usada pelos subcomandos LEITORES (check). Subcomandos mutadores (init,
-# mark-touched) seguem no builder direto — fora do escopo do porte 2.1.3.
-. "$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)/_state-read.sh"
+# Leitura de estado via interface canonica (state-db-runtime-parity FR-001).
+# LEITORES (check, debug, aspectos) materializam via state_read_materialize.
+# MUTADORES (init, mark-touched) leem materializado e escrevem via
+# `state-rw.sh set` — a interface canonica, valida nos dois backends.
+# HISTORICO (issue #101): os mutadores ficaram no builder direto sobre
+# state.json ("fora do escopo do porte 2.1.3"). O adiamento virou defeito
+# quando o SQLite passou a ser o backend default: `drift.sh init` abortava
+# com "state.json ausente" em qualquer projeto novo, derrubando a deteccao
+# de drift do agente-00c (invocada em agente-00c-orchestrator.md e
+# agente-00c-resume.md).
+_DR_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+. "$_DR_DIR/_state-read.sh"
 trap state_read_cleanup EXIT INT TERM
 
 _DR_NAME="drift"
@@ -89,26 +97,6 @@ _dr_die()       { printf '%s: %s\n' "$_DR_NAME" "$1" >&2; exit "${2:-1}"; }
 _dr_require_jq() {
   command -v jq >/dev/null 2>&1 \
     || _dr_die "jq nao encontrado no PATH" 1
-}
-
-_dr_state_file() { printf '%s/state.json\n' "$1"; }
-
-_dr_atomic_write() {
-  _dst=$1; _src=$2
-  _tmp=$(mktemp -- "${_dst}.XXXXXX") || _dr_die "mktemp falhou" 1
-  cp -- "$_src" "$_tmp" || { rm -f -- "$_tmp"; _dr_die "I/O cp" 1; }
-  mv -f -- "$_tmp" "$_dst" || { rm -f -- "$_tmp"; _dr_die "mv" 1; }
-}
-
-_dr_update_sha() {
-  _sf=$(_dr_state_file "$1")
-  _shf="$1/state.json.sha256"
-  if command -v sha256sum >/dev/null 2>&1; then
-    _h=$(sha256sum -- "$_sf" | awk '{print $1}')
-  else
-    _h=$(shasum -a 256 -- "$_sf" | awk '{print $1}')
-  fi
-  printf '%s\n' "$_h" > "$_shf"
 }
 
 # _dr_validate_aspectos_array JSON-STR MIN MAX LABEL
@@ -144,8 +132,8 @@ _dr_cmd_init() {
   [ -n "$_asp" ] || _dr_die_usage "init: --aspectos obrigatorio (JSON array de strings)"
   _dr_require_jq
 
-  _sf=$(_dr_state_file "$_sd")
-  [ -f "$_sf" ] || _dr_die "init: state.json ausente em $_sd" 1
+  _sf=$(state_read_materialize "$_sd")
+  [ -f "$_sf" ] || _dr_die "init: estado ausente em $_sd (nem state.json nem state.db)" 1
 
   _dr_validate_aspectos_array "$_asp" 3 7 "--aspectos"
   _dr_validate_aspectos_array "$_tec" 0 7 "--tecnicos"
@@ -158,22 +146,16 @@ _dr_cmd_init() {
     _dr_die "init: initial_key_aspects ja foi gravado ($_existing aspectos). Use --force para sobrescrever (relaxado para retomada de execucoes legadas com aspectos=null)." 1
   fi
 
-  # Writer (schema-en-migration): grava chaves EN. Confia em EN-on-disk
-  # (migrate defensivo do command-pai no inicio da onda).
-  _new_state=$(mktemp) || _dr_die "mktemp falhou" 1
-  jq \
-    --argjson a "$_asp" \
-    --argjson t "$_tec" \
-    --argjson o "$_ope" \
-    '
-    .initial_key_aspects     = $a
-    | .technical_key_aspects   = $t
-    | .operational_key_aspects = $o
-    ' "$_sf" > "$_new_state" \
-    || { rm -f -- "$_new_state"; _dr_die "jq update falhou" 1; }
-  _dr_atomic_write "$_sf" "$_new_state"
-  rm -f -- "$_new_state" 2>/dev/null || :
-  _dr_update_sha "$_sd"
+  # Writer backend-agnostico (issue #101): os 3 campos num UNICO envelope
+  # multi-campo de `state-rw.sh set` — sob SQLite um set por campo abriria
+  # tres transacoes e deixaria janela de estado parcial entre elas.
+  # Grava chaves EN (schema-en-migration); confia em EN-on-disk.
+  "$_DR_DIR/state-rw.sh" set --state-dir "$_sd" \
+    --field '.initial_key_aspects'     --value "$_asp" \
+    --field '.technical_key_aspects'   --value "$_tec" \
+    --field '.operational_key_aspects' --value "$_ope" \
+    >/dev/null \
+    || _dr_die "init: falha ao gravar aspectos via state-rw.sh set" 1
 }
 
 # Programa jq compartilhado pelas funcoes check/debug:
@@ -308,8 +290,8 @@ _dr_cmd_aspectos() {
   done
   [ -n "$_sd" ] || _dr_die_usage "aspectos: --state-dir obrigatorio"
   _dr_require_jq
-  _sf=$(_dr_state_file "$_sd")
-  [ -f "$_sf" ] || _dr_die "aspectos: state.json ausente" 1
+  _sf=$(state_read_materialize "$_sd")
+  [ -f "$_sf" ] || _dr_die "aspectos: estado ausente (nem state.json nem state.db)" 1
 
   # --camada VALUES (iniciais/tecnicos/operacionais) sao valores de flag (nao
   # migrados; follow-up B). Apenas as CHAVES JSON lidas viram EN (+fallback).
@@ -343,25 +325,25 @@ _dr_cmd_mark_touched() {
   [ -n "$_aspecto" ]   || _dr_die_usage "mark-touched: --aspecto obrigatorio"
   _dr_require_jq
 
-  _sf=$(_dr_state_file "$_sd")
-  [ -f "$_sf" ] || _dr_die "mark-touched: state.json ausente" 1
+  _sf=$(state_read_materialize "$_sd")
+  [ -f "$_sf" ] || _dr_die "mark-touched: estado ausente (nem state.json nem state.db)" 1
 
   _has_onda=$(jq -r '((.waves // .ondas) // []) | length' "$_sf")
   if [ "$_has_onda" -eq 0 ]; then
-    _dr_die "mark-touched: nenhuma onda existe em state.json (chame state-ondas.sh start primeiro)" 1
+    _dr_die "mark-touched: nenhuma onda existe no estado (chame state-ondas.sh start primeiro)" 1
   fi
 
-  # Writer (schema-en-migration): grava chave EN (.waves[-1].touched_key_aspects).
-  # Confia em EN-on-disk (migrate defensivo do command-pai).
-  _new_state=$(mktemp) || _dr_die "mktemp falhou" 1
-  jq --arg a "$_aspecto" '
-    .waves[-1].touched_key_aspects =
-      ((.waves[-1].touched_key_aspects // []) + [$a] | unique)
-  ' "$_sf" > "$_new_state" \
-    || { rm -f -- "$_new_state"; _dr_die "jq update falhou" 1; }
-  _dr_atomic_write "$_sf" "$_new_state"
-  rm -f -- "$_new_state" 2>/dev/null || :
-  _dr_update_sha "$_sd"
+  # Writer backend-agnostico (issue #101): calcula o array novo a partir do
+  # estado materializado e grava pela interface canonica. Grava chave EN
+  # (.waves[-1].touched_key_aspects); confia em EN-on-disk.
+  _novo=$(jq -c --arg a "$_aspecto" '
+    ((.waves[-1].touched_key_aspects // []) + [$a] | unique)
+  ' "$_sf") || _dr_die "mark-touched: jq falhou ao calcular o array" 1
+
+  "$_DR_DIR/state-rw.sh" set --state-dir "$_sd" \
+    --field '.waves[-1].touched_key_aspects' --value "$_novo" \
+    >/dev/null \
+    || _dr_die "mark-touched: falha ao gravar via state-rw.sh set" 1
 }
 
 _dr_cmd_debug() {
@@ -376,8 +358,8 @@ _dr_cmd_debug() {
   done
   [ -n "$_sd" ] || _dr_die_usage "debug: --state-dir obrigatorio"
   _dr_require_jq
-  _sf=$(_dr_state_file "$_sd")
-  [ -f "$_sf" ] || _dr_die "debug: state.json ausente" 1
+  _sf=$(state_read_materialize "$_sd")
+  [ -f "$_sf" ] || _dr_die "debug: estado ausente (nem state.json nem state.db)" 1
 
   _lib=$(_dr_jq_lib)
   jq -r --arg only "$_onda" "

--- a/tests/test_commit-mode.sh
+++ b/tests/test_commit-mode.sh
@@ -566,6 +566,32 @@ EOF
 
 # ---- T-51: gh ausente/nao autenticado/falho apos auth ⇒ nunca infere negativo ----
 
+# ===== issue #98: fallback apos pipe nunca disparava =====
+
+# `var=$(cmd | sed ...) || var=FALLBACK` NUNCA cai no fallback: o exit status
+# de um pipe e o do ULTIMO comando, e o sed sai 0 mesmo com entrada vazia.
+# Em commit-mode.sh isso deixava `_default` VAZIO quando o repo nao tem
+# origin/HEAD; o `git rev-list "..branch" --count` seguinte degenerava para 0
+# e o finalize concluia "sem commits novos", pulando push+PR EM SILENCIO.
+# Guard estatico: o idioma nao pode reaparecer em lugar nenhum do script.
+scenario_issue98_idioma_de_fallback_apos_pipe_ausente() {
+  [ -f "$SCRIPT" ] || { _error "script ausente" "$SCRIPT"; return 2; }
+  if grep -nE "\| *sed [^)]*\) *\|\| *_[a-z_]+=" "$SCRIPT" >/dev/null 2>&1; then
+    _fail "idioma de fallback-apos-pipe reapareceu (issue #98)" \
+      "$(grep -nE "\| *sed [^)]*\) *\|\| *_[a-z_]+=" "$SCRIPT" | head -3)"
+    return 1
+  fi
+  return 0
+}
+
+# A captura em duas etapas (exit status do symbolic-ref testavel) tem de
+# estar presente — nao basta o idioma ruim ter sumido.
+scenario_issue98_captura_em_duas_etapas_presente() {
+  [ -f "$SCRIPT" ] || { _error "script ausente" "$SCRIPT"; return 2; }
+  assert_exit 0 grep -Fq 'symbolic-ref refs/remotes/origin/HEAD 2>/dev/null) || _sr=""' "$SCRIPT" || return 1
+  assert_exit 0 grep -Fq '[ -n "$_default" ] || _default="main"' "$SCRIPT" || return 1
+}
+
 # _make_shim_path_no_gh: PATH completo (symlinks) COM git mas SEM gh.
 # Armadilha conhecida do repositorio (memoria de projeto
 # feedback_test_path_stub_cannot_hide_usrbin.md) — PATH deve conter TODOS os

--- a/tests/test_drift.sh
+++ b/tests/test_drift.sh
@@ -24,6 +24,21 @@ _init() {
     --projeto-alvo-path "/tmp/p" --descricao "POC drift tests" >/dev/null 2>&1
 }
 
+# _init_sqlite: HOME sandbox COM `state_backend=sqlite` — o inverso de
+# _init. Trava de regressao da issue #101: os mutadores `init` e
+# `mark-touched` ficaram no builder direto sobre state.json ("fora do escopo
+# do porte 2.1.3") e abortavam com "state.json ausente" em qualquer projeto
+# criado com o backend SQLite, que hoje e o default global. Isso derrubava a
+# deteccao de drift do agente-00c (drift.sh init e invocado por
+# agente-00c-orchestrator.md e agente-00c-resume.md).
+_init_sqlite() {
+  _is_home="$TMPDIR_TEST/home-sqlite"
+  mkdir -p "$_is_home/.claude/cstk"
+  printf 'state_backend=sqlite\n' > "$_is_home/.claude/cstk/config"
+  env HOME="$_is_home" "$RW" init --state-dir "$1" --execucao-id "x" \
+    --projeto-alvo-path "/tmp/p" --descricao "POC drift tests" >/dev/null 2>&1
+}
+
 # Cria 1 onda completa com 1 decisao tendo o contexto especificado
 _run_wave() {
   capture "$ON" start --state-dir "$1"
@@ -451,6 +466,53 @@ scenario_sqlite_check_onda_sem_aspecto_conta_um() {
     _fail "anti-mirror" "check criou state.json dentro do state-dir sqlite"
     return 1
   fi
+}
+
+# ===== Paridade de backend nos MUTADORES (issue #101) =====
+
+scenario_init_funciona_sob_backend_sqlite() {
+  command -v sqlite3 >/dev/null 2>&1 || return 0   # host sem sqlite3: nao exercitavel
+  _sd="$TMPDIR_TEST/state-sqlite-init"
+  _init_sqlite "$_sd"
+  [ -f "$_sd/state.db" ] || { _fail "pre-condicao" "esperado state.db, obtido: $(ls "$_sd" 2>/dev/null | tr '\n' ' ')"; return 1; }
+  # Forma `if`, nao `[ ... ] && { ... }`: um `&&` que avalia falso na ULTIMA
+  # linha faz a funcao retornar 1 sem nenhum assert ter falhado — a mesma
+  # armadilha de exit status que originou a issue #98.
+  if [ -f "$_sd/state.json" ]; then
+    _fail "pre-condicao" "state.json nao deveria existir sob backend sqlite"
+    return 1
+  fi
+
+  capture "$SCRIPT" init --state-dir "$_sd" --aspectos '["auth","cache","lock"]'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "init sob sqlite" "exit $_CAPTURED_EXIT; stderr: $_CAPTURED_STDERR"; return 1; }
+
+  capture "$SCRIPT" aspectos --state-dir "$_sd"
+  assert_stdout_contains "auth" || return 1
+  assert_stdout_contains "cache" || return 1
+  assert_stdout_contains "lock" || return 1
+  return 0
+}
+
+scenario_mark_touched_funciona_sob_backend_sqlite() {
+  command -v sqlite3 >/dev/null 2>&1 || return 0
+  _sd="$TMPDIR_TEST/state-sqlite-mt"
+  _init_sqlite "$_sd"
+  capture "$SCRIPT" init --state-dir "$_sd" --aspectos '["auth","cache","lock"]'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "init sob sqlite" "$_CAPTURED_STDERR"; return 1; }
+  capture "$ON" start --state-dir "$_sd"
+
+  capture "$SCRIPT" mark-touched --state-dir "$_sd" --aspecto cache
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "mark-touched sob sqlite" "exit $_CAPTURED_EXIT; stderr: $_CAPTURED_STDERR"; return 1; }
+
+  # Le de volta pela interface canonica: a escrita tem de ter persistido no
+  # state.db, nao num state.json fantasma.
+  capture "$RW" get --state-dir "$_sd" --field '.waves[-1].touched_key_aspects'
+  assert_stdout_contains "cache" || return 1
+  if [ -f "$_sd/state.json" ]; then
+    _fail "efeito colateral" "mutador criou state.json sob backend sqlite"
+    return 1
+  fi
+  return 0
 }
 
 run_all_scenarios

--- a/tests/test_state-parity-sweep.sh
+++ b/tests/test_state-parity-sweep.sh
@@ -206,10 +206,6 @@ scenario_dinamica_15_leitores_sqlite_sem_degradacao() {
 #   spawn-tracker.sh:codigo-real   — idem (dual-backend desde state-db-foundation)
 #   state-decisions.sh:codigo-real — idem
 #   state-ondas.sh:codigo-real     — idem
-#   drift.sh:codigo-real           — subcomandos mutadores (init/mark-touched)
-#                                    fora do escopo FR-001 por decisao 2.1.3;
-#                                    reader (check/extract) portado e coberto
-#                                    pelo manifest dinamico
 #   report.sh:prosa                — linha de texto markdown gerado (path de
 #                                    exemplo no corpo do relatorio)
 #   wave-usage-report.sh:prosa     — "transcript/state.json" em mensagem de erro
@@ -265,7 +261,6 @@ bloqueios.sh:codigo-real
 spawn-tracker.sh:codigo-real
 state-decisions.sh:codigo-real
 state-ondas.sh:codigo-real
-drift.sh:codigo-real
 report.sh:prosa
 wave-usage-report.sh:prosa
 _hook-active-exec.sh:codigo-real


### PR DESCRIPTION
Corrige as duas issues abertas automaticamente pelo agente-00C que a triagem confirmou como defeitos reais e vivos. Fecha **#98** e **#101**; **#81** será fechada como duplicata da #101.

## Issue #101 — `drift.sh` cravado em `state.json`

O próprio cabeçalho documentava o adiamento (*"mutadores fora do escopo do porte 2.1.3"*), que virou defeito quando o SQLite passou a ser o backend default: `drift.sh init` abortava com `state.json ausente` em qualquer projeto novo, derrubando a detecção de drift do agente-00c.

Reproduzido empiricamente antes do fix: `drift.sh init` num state-dir SQLite → `drift: init: state.json ausente em <dir>`.

- Leitores (`aspectos`, `debug`) portados para `state_read_materialize`, como o `check` já fazia. **O `aspectos` só foi pego pelo teste novo** — o fix inicial cobria só os mutadores; o cenário de regressão acusou.
- `init` grava os 3 campos num **único envelope multi-campo** de `state-rw.sh set` (um set por campo = três transações sob SQLite, com janela de estado parcial).
- `mark-touched` calcula o array novo do estado materializado e grava pela interface canônica.
- Helpers JSON-only sem chamador removidos — e o **próprio parity-sweep acusou a entrada morta** da allowlist depois do porte (o cenário `allowlist_sem_entradas_mortas` funcionando como projetado); a entrada saiu junto.

## Issue #98 — fallback após pipe nunca dispara

```sh
_default=$(git symbolic-ref ... 2>/dev/null | sed 's@...@@') || _default="main"
```

O exit status de um pipe é o do **último** comando, e o `sed` sai 0 com entrada vazia — o `||` nunca dispara. Provado: `v=$(false | sed 's/x/y/') || v="FALLBACK"` deixa `v` vazio.

Consequência no `finalize`: `_default` vazio → `git rev-list "..branch" --count` degenera para `0` → *"sem commits novos"* → **push+PR pulados em silêncio**. Mesma família dos sug-007/sug-008.

As 3 ocorrências reescritas com captura em duas etapas (exit do `symbolic-ref` testável; fallback `"main"` alcançável na do finalize).

## Travas de regressão

- `test_drift.sh`: 2 cenários sob HOME sandbox com `state_backend=sqlite` (skip limpo em host sem `sqlite3`), incluindo assert de que o mutador **não cria `state.json` fantasma** sob SQLite.
- `test_commit-mode.sh`: guard estático contra o idioma de fallback-após-pipe em qualquer ponto do script + assert da captura em duas etapas.

## Validação

- `drift` 32/32 · `commit-mode` 55/55 · `state-parity-sweep` 4/4 · coverage zero órfãos
- Suíte completa: `PASS: 2793  FAIL: 0  ERROR: 0` (891s)
- `shellcheck -s sh` limpo nos dois scripts