### PR TITLE
docs: 7.3.2 — sync da documentacao (plugin no pt-BR, plan-usage, --reopen)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "7.3.1",
+      "version": "7.3.2",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "7.3.1",
+      "version": "7.3.2",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [7.3.2] - 2026-08-12
+
+Sincroniza a documentacao de entrada com o estado real do toolkit: o
+README.pt-BR estava varias versoes atras do ingles (nem mencionava a
+distribuicao via plugin nativo, v7.0.0), e as features 7.2.0 (plan-usage)
+e 7.3.0 (`--reopen`) nao apareciam em documentacao nenhuma fora do
+changelog. Release 100% docs — zero mudanca de codigo, skill ou contrato.
+
+### Changed
+
+- **README.pt-BR.md em paridade com o ingles.** §Estrutura atualizada para o
+  layout `plugins/` + `marketplace.json` (relocacao da v7.0.0, antes ainda
+  mostrava `global/`/`language-related/`); secao nova "Via plugin do Claude
+  Code (nativo, sem binario)" com a tabela comparativa classico × plugin;
+  secao de hooks com `--remove-classic`, dedup "plugin vence" e o paragrafo
+  de copia stale; nota do wrapper de telemetria opt-in do `cstk install`
+  (v6.9.0).
+- **Novidades 7.2.0/7.3.0 documentadas nos dois idiomas.** READMEs ganham a
+  subsecao do gauge de uso do plano (`cstk statusline` + `cstk plan-usage`)
+  e o paragrafo do modo `--reopen` na trilha avancada; `docs/cstk-usage*.md`
+  ganha a secao completa do plan-usage (flags conferidas contra
+  `cli/lib/plan-usage.sh`, semantica NULL-nunca-zero, throttle FR-010);
+  `docs/agente-00c*.md` ganha a subsecao "Reabrindo uma feature concluida
+  (`--reopen`)" + linha nova na tabela de comandos do feature-00c, com links
+  para `docs/specs/feature-reopen/` e seus contratos.
+- **CONTRIBUTING.md (2 idiomas).** Diagrama de distribuicao ganha o segundo
+  caminho oficial (marketplace → plugin nativo → Claude Code); referencias
+  stale a `language-related/` atualizadas para `plugins/cstk-language-go/`.
+- **PRIVACY.md.** Linha nova na tabela de dados para o gauge de plano
+  (tabela `plan_usage` no `knowledge.db`, opt-in via `cstk statusline
+  install`, default desligado); effective date 2026-08-12.
+
+### Fixed
+
+- **Contagem "29 skills" no comentario do `--profile all`** corrigida para
+  28 (21 globais + 7 Go) nos dois READMEs — a tabela de perfis ja dizia 28 e
+  o comentario divergia. Badge SemVer `5.x` → `7.x` tambem nos dois.
+- **Link quebrado da spec enforced-guards** em `docs/agente-00c*.md`:
+  apontava `specs/enforced-guards/`, que nao existe desde o archive —
+  corrigido para `specs/_archived/2026-07-28-enforced-guards/`.
+
 ## [7.3.1] - 2026-08-12
 
 Fecha duas issues abertas automaticamente pelo agente-00C durante execucoes
@@ -5719,6 +5760,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[7.3.2]: https://github.com/JotJunior/cstk/releases/tag/v7.3.2
 [7.3.1]: https://github.com/JotJunior/cstk/releases/tag/v7.3.1
 [7.3.0]: https://github.com/JotJunior/cstk/releases/tag/v7.3.0
 [7.2.1]: https://github.com/JotJunior/cstk/releases/tag/v7.2.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,14 +35,21 @@ flowchart TD
         S[plugins/cstk/skills/*]
         C[plugins/cstk/commands/*]
         A[plugins/cstk/agents/*]
-        L[language-related/*]
+        L[plugins/cstk-language-go/*]
     end
     BR[scripts/build-release.sh] -->|tarball + SHA-256| REL[(GitHub Release)]
     Source --> BR
     REL -->|"curl | sh / cstk update"| INST["~/.claude/skills, commands, agents"]
+    Source -->|".claude-plugin/marketplace.json<br/>/plugin install cstk@cstk"| PLG["Claude Code plugin (installPath)"]
     INST -->|consumed by| CC[Claude Code]
+    PLG -->|consumed by| CC
     CC -.->|cstk doctor detects drift| INST
 ```
+
+Since v6.9.0 the same catalog is also installable as a **native Claude Code
+plugin** (`/plugin marketplace add JotJunior/cstk`) — a second official
+delivery path alongside the classic tarball; the `cstk` binary itself is not
+part of the plugin. See [README §Installation](./README.md#installation).
 
 ### 1.1 The SDD pipeline
 
@@ -114,7 +121,7 @@ cstk install --from "file://$PWD/dist/cstk-X.Y.Z.tar.gz"
 2. **`description` as a trigger condition**, not a summary: "Use when X, Y or Z.
    Do NOT use when W."
 3. Document **gotchas** — the most valuable content.
-4. **Generalize**: skills in `plugins/cstk/skills/` or `language-related/` **must not
+4. **Generalize**: skills in `plugins/cstk/skills/` or `plugins/cstk-language-go/` **must not
    name specific clients/companies/projects** (see the warning in
    [README §Contributing](./README.md#contributing); historical case: removal of
    `create-report` in v3.12.0). If it can't be generalized, the skill belongs in

--- a/CONTRIBUTING.pt-BR.md
+++ b/CONTRIBUTING.pt-BR.md
@@ -34,14 +34,21 @@ flowchart TD
         S[plugins/cstk/skills/*]
         C[plugins/cstk/commands/*]
         A[plugins/cstk/agents/*]
-        L[language-related/*]
+        L[plugins/cstk-language-go/*]
     end
     BR[scripts/build-release.sh] -->|tarball + SHA-256| REL[(GitHub Release)]
     Fonte --> BR
     REL -->|"curl | sh / cstk update"| INST["~/.claude/skills, commands, agents"]
+    Fonte -->|".claude-plugin/marketplace.json<br/>/plugin install cstk@cstk"| PLG["Plugin do Claude Code (installPath)"]
     INST -->|consumido por| CC[Claude Code]
+    PLG -->|consumido por| CC
     CC -.->|cstk doctor detecta drift| INST
 ```
+
+Desde a v6.9.0 o mesmo catálogo também é instalável como **plugin nativo do
+Claude Code** (`/plugin marketplace add JotJunior/cstk`) — um segundo caminho
+oficial de entrega ao lado do tarball clássico; o binário `cstk` em si não
+faz parte do plugin. Ver [README §Instalação](./README.pt-BR.md#instalação).
 
 ### 1.1 O pipeline SDD
 
@@ -112,7 +119,7 @@ cstk install --from "file://$PWD/dist/cstk-X.Y.Z.tar.gz"
 2. **`description` como trigger condition**, não resumo: "Use quando X, Y ou Z.
    NÃO use quando W."
 3. Documente **gotchas** — o conteúdo mais valioso.
-4. **Generalize**: skills em `plugins/cstk/skills/` ou `language-related/` **não podem
+4. **Generalize**: skills em `plugins/cstk/skills/` ou `plugins/cstk-language-go/` **não podem
    nomear clientes/empresas/projetos específicos** (ver o aviso em
    [README §Contribuindo](./README.pt-BR.md#contribuindo); caso histórico: remoção de
    `create-report` na v3.12.0). Se não generalizar, a skill pertence a

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy — cstk
 
-**Effective date:** 2026-08-08 · **Applies to:** the `cstk` and `cstk-language-go`
+**Effective date:** 2026-08-12 · **Applies to:** the `cstk` and `cstk-language-go`
 Claude Code plugins, and the `cstk` command-line tool.
 
 ## Summary
@@ -20,6 +20,7 @@ All of it is local to your machine. Nothing is transmitted.
 | Knowledge index (decisions, blocks, retrospectives, skills used, memories) | `~/.claude/cstk/knowledge.db` (SQLite) | Lets past runs inform new work (`cstk recall`) |
 | Guard decisions (allowed/blocked commands) | `<project>/.claude/enforcement-log.jsonl` | Audit trail for the enforced Bash guard |
 | Loose usage counters (tokens/cost of interactive sessions) | `~/.claude/cstk/loose-usage/` | **Opt-in only** (`cstk hooks install --with-loose-usage`); off by default |
+| Plan usage gauge (rate-limit percentages Claude Code already sends in the statusline payload) | `~/.claude/cstk/knowledge.db` (`plan_usage` table) | **Opt-in only** (`cstk statusline install`); off by default |
 | Documentation artifacts (specs, plans, checklists, task backlogs) | `<project>/docs/` | The deliverables you asked the toolkit to produce |
 
 Everything above lives in ordinary files you own. Delete the directories and the

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Latest Release](https://img.shields.io/github/v/release/JotJunior/cstk?label=latest%20release&color=blue)](https://github.com/JotJunior/cstk/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
-[![SemVer](https://img.shields.io/badge/SemVer-5.x-orange.svg)](./CHANGELOG.md)
+[![SemVer](https://img.shields.io/badge/SemVer-7.x-orange.svg)](./CHANGELOG.md)
 [![Docs Site](https://img.shields.io/badge/docs-jotjunior.github.io/cstk-blue?logo=readthedocs)](https://jotjunior.github.io/cstk/)
 [![Publish Site](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml/badge.svg?branch=main)](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml)
 
@@ -190,6 +190,13 @@ existing project. Subsystems: per-wave model routing, atomic-commit mode
 parallel sessions in worktrees, and cross-feature knowledge memory consulted
 before deciding.
 
+Since v7.3.0 a finished feature is no longer a dead end:
+`/feature-00c "<increment>" --reopen=<short-name>` preserves the previous
+execution as an immutable round, records the increment as
+`## Delta Requirements` in the existing spec, and appends a new task phase
+instead of regenerating the backlog — with an advisory opinion (reopen vs new
+feature) and a human block before anything touches disk.
+
 | Topic | Document |
 |--------|-----------|
 | `/agente-00c` + `/feature-00c` orchestrators, model-routing, atomic-commit, guards | [docs/agente-00c.md](./docs/agente-00c.md) |
@@ -225,7 +232,7 @@ After that, typical commands:
 ```bash
 cstk --version                       # confirms installation
 cstk install                         # installs the 'sdd' profile into ~/.claude/skills/
-cstk install --profile all           # installs ALL 29 skills (includes language-go)
+cstk install --profile all           # installs ALL 28 skills (includes language-go)
 cstk install advisor bugfix          # cherry-pick by name
 cstk update                          # applies new releases preserving local edits
 cstk update --force                  # overwrites locally edited skills
@@ -451,6 +458,28 @@ cstk install --interactive   # lists numbered profiles + skills; selection via t
 cstk install --dry-run --profile all
 cstk update --dry-run
 ```
+
+### Plan usage gauge (`cstk statusline` + `cstk plan-usage`)
+
+Since v7.2.0 the toolkit can also capture the plan usage gauge you see in
+`/usage` — no OAuth credential, no API key: Claude Code already sends
+`rate_limits.five_hour`/`seven_day` in the statusline payload on every
+render, so the capture hook just reads what is already passing by and
+persists it locally in the `plan_usage` table of
+`~/.claude/cstk/knowledge.db`.
+
+```bash
+cstk statusline install    # wires the capture hook into ~/.claude/settings.json
+cstk statusline status     # is the capture active (and settings.json still valid)?
+cstk plan-usage            # latest capture per scope (five_hour / seven_day)
+cstk plan-usage history    # time series; reuses --scope/--limit/--since from cstk usage
+```
+
+Opt-in by construction — nothing is captured until you run `statusline
+install` — and 100% local. An existing custom statusline command is preserved
+and chained as a mandatory stdout pass-through, never silently overwritten. A
+scope without measurement prints `nao medido` (`null` with `--json`) — never
+a fabricated zero.
 
 ### Manual installation (deprecated, still supported)
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -4,7 +4,7 @@
 
 [![Latest Release](https://img.shields.io/github/v/release/JotJunior/cstk?label=latest%20release&color=blue)](https://github.com/JotJunior/cstk/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
-[![SemVer](https://img.shields.io/badge/SemVer-5.x-orange.svg)](./CHANGELOG.md)
+[![SemVer](https://img.shields.io/badge/SemVer-7.x-orange.svg)](./CHANGELOG.md)
 [![Docs Site](https://img.shields.io/badge/docs-jotjunior.github.io/cstk-blue?logo=readthedocs)](https://jotjunior.github.io/cstk/)
 [![Publish Site](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml/badge.svg?branch=main)](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml)
 
@@ -82,34 +82,46 @@ descartados antes de tocar o disco.
 ## Estrutura
 
 ```
-├── global/                     # Skills globais (independentes de linguagem)
-│   └── skills/                 # 21 skills globais (cada skill é uma pasta)
-│       ├── advisor/
-│       ├── agente-00c-runtime/ # runtime POSIX interno (não user-invocável)
-│       ├── analyze/
-│       ├── apply-insights/
-│       ├── briefing/
-│       ├── bugfix/
-│       ├── checklist/
-│       ├── clarify/
-│       ├── constitution/
-│       ├── converge/           # reconcilia spec/plan/tasks vs código real
-│       ├── create-tasks/
-│       ├── e2e-integration-flow/ # testes E2E de integração full-stack (Playwright)
-│       ├── execute-task/
-│       ├── model-selector/     # heurística de roteamento de modelo (sugestor)
-│       ├── owasp-security/
-│       ├── plan/
-│       ├── review-features/
-│       ├── review-task/
-│       ├── specify/
-│       ├── validate-docs-rendered/
-│       └── validate-documentation/
-├── language-related/           # Skills e hooks específicos por linguagem
-│   └── go/                     # Go — ver docs/go-toolkit.md
-├── cli/                        # Binário cstk + libs POSIX
-└── docs/                       # Documentação por tópicos (ver índice abaixo)
+├── plugins/                     # Catálogo, empacotado como plugins instaláveis do Claude Code
+│   ├── cstk/                    # Plugin default (entrada "cstk" no marketplace)
+│   │   ├── commands/            # Os 6 slash commands /agente-00c*, /feature-00c*
+│   │   ├── agents/              # Orquestradores, clarify asker/answerer, data-veracity
+│   │   ├── hooks/hooks.json     # 3 guard hooks enforced (bash-guard, tool-call-tick, agent-usage)
+│   │   └── skills/               # 21 skills globais (cada skill é uma pasta)
+│   │       ├── advisor/
+│   │       ├── agente-00c-runtime/ # runtime POSIX interno (não user-invocável)
+│   │       ├── analyze/
+│   │       ├── apply-insights/
+│   │       ├── briefing/
+│   │       ├── bugfix/
+│   │       ├── checklist/
+│   │       ├── clarify/
+│   │       ├── constitution/
+│   │       ├── converge/           # reconcilia spec/plan/tasks vs código real
+│   │       ├── create-tasks/
+│   │       ├── e2e-integration-flow/ # testes E2E de integração full-stack (Playwright)
+│   │       ├── execute-task/
+│   │       ├── model-selector/     # heurística de roteamento de modelo (sugestor)
+│   │       ├── owasp-security/
+│   │       ├── plan/
+│   │       ├── review-features/
+│   │       ├── review-task/
+│   │       ├── specify/
+│   │       ├── validate-docs-rendered/
+│   │       └── validate-documentation/
+│   └── cstk-language-go/        # Plugin do perfil Go (entrada "cstk-language-go")
+│       ├── hooks/                # Hooks específicos de Go
+│       └── skills/               # Go — ver docs/go-toolkit.md
+├── .claude-plugin/marketplace.json  # Manifest do marketplace (2 entradas: cstk, cstk-language-go)
+├── cli/                          # Binário cstk + libs POSIX (não empacotado no plugin — FR-006)
+└── docs/                         # Documentação por tópicos (ver índice abaixo)
 ```
+
+> Instalado via CLI clássico `cstk`, esse mesmo conteúdo pousa em
+> `~/.claude/skills/`, `~/.claude/commands/` e `~/.claude/agents/`
+> (achatado, sem o prefixo `plugins/cstk/`). Instalado via plugin nativo do
+> Claude Code, materializa sob o `installPath` do próprio harness
+> (ver [Instalação](#instalação) para os dois caminhos).
 
 ### Anatomia de uma skill
 
@@ -178,6 +190,13 @@ atomic-commit (commits automáticos + push/PR no finalize), guardas enforced
 (hook fail-closed), sessões paralelas em worktrees e memória de conhecimento
 cross-feature consultada antes de decidir.
 
+Desde a v7.3.0 uma feature concluída deixou de ser beco sem saída:
+`/feature-00c "<incremento>" --reopen=<short-name>` preserva a execução
+anterior como round imutável, grava o incremento como `## Delta Requirements`
+na spec existente e apenda uma fase nova de tasks em vez de regenerar o
+backlog — com parecer advisory (reabrir vs criar feature nova) e bloqueio
+humano antes de tocar disco.
+
 | Tópico | Documento |
 |--------|-----------|
 | Orquestradores `/agente-00c` + `/feature-00c`, model-routing, atomic-commit, guardas | [docs/agente-00c.md](./docs/agente-00c.pt-BR.md) |
@@ -212,7 +231,7 @@ Depois disso, comandos típicos:
 ```bash
 cstk --version                       # confirma instalação
 cstk install                         # instala perfil 'sdd' em ~/.claude/skills/
-cstk install --profile all           # instala TODAS as 29 skills (inclui language-go)
+cstk install --profile all           # instala TODAS as 28 skills (inclui language-go)
 cstk install advisor bugfix          # cherry-pick por nome
 cstk update                          # aplica novas releases preservando edits locais
 cstk update --force                  # sobrescreve skills com edição local
@@ -250,6 +269,52 @@ cstk install --scope project advisor owasp-security
 # (em --scope global, hooks são omitidos com aviso no summary — FR-009c)
 ```
 
+### Via plugin do Claude Code (nativo, sem binário)
+
+Desde a v6.9.0 o catálogo também é distribuível como [plugin nativo do
+Claude Code](https://docs.claude.com/en/docs/claude-code/plugins) — sem
+binário `cstk`, sem clone, sem bootstrap via `curl`:
+
+```text
+/plugin marketplace add JotJunior/cstk
+/plugin install cstk@cstk
+# opcional, apenas projetos Go:
+/plugin install cstk-language-go@cstk
+```
+
+Habilite o plugin e abra uma sessão nova em qualquer projeto — as skills, os
+6 commands `/agente-00c*`/`/feature-00c*` e os guard hooks enforced
+(`pretooluse-bash-guard`, `posttooluse-tool-call-tick`,
+`posttooluse-agent-usage`) ativam automaticamente, **sem** o passo
+`cstk hooks install` (confirmado empiricamente — ver
+[`docs/specs/_archived/2026-08-08-claude-plugin-packaging/spec.md`](docs/specs/_archived/2026-08-08-claude-plugin-packaging/spec.md)
+§Clarifications, assumption A1). O `posttooluse-loose-usage.sh` (captura
+opt-in de consumo) deliberadamente **não** faz parte do `hooks.json` do
+plugin — segue sendo opt-in explícito via `cstk hooks install
+--with-loose-usage`.
+
+**Escolhendo entre os dois caminhos:**
+
+| | Clássico (CLI `cstk`) | Plugin (nativo) |
+|---|---|---|
+| Passo de instalação | one-liner de bootstrap + `cstk install` | `/plugin marketplace add` + `/plugin install` |
+| Fornece o binário `cstk` (`recall`, `usage`, `mcp`, `session`, `serve`, `self-update`) | Sim | **Não** — o formato de plugin não instala binário persistente no `PATH` (FR-006); use o bootstrap clássico para esses |
+| Ativação dos guard hooks | Exige `cstk hooks install` por projeto | Automática ao abrir a sessão, zero passo por projeto |
+| Verificação de integridade | SHA-256 do tarball, fail-closed (`serve-integrity`), allowlist fixa de hosts confiáveis | Pin de commit (`gitCommitSha`) registrado pelo harness + diálogo de confiança "Will install" do próprio harness |
+| Propagação de update | `cstk update` (explícito, por invocação) | **Não é automática**: `claude plugin marketplace update` e depois `claude plugin update cstk --scope <escopo>`, mais reinício de sessão — o próprio CLI de plugin imprime `Restart to apply changes.` |
+
+Os dois caminhos são igualmente oficiais (não há um terceiro mecanismo de
+distribuição sem governança — ver `FR-017` em
+[`docs/specs/current/guards-defense-in-depth.md`](docs/specs/current/guards-defense-in-depth.md))
+e entregam o mesmo conteúdo auditável com **proteção comparável, não
+mecanismos idênticos** — escolha o plugin para o onboarding mais rápido, sem
+binário, de skills + guard hooks; o CLI clássico quando precisar de
+`recall`/`usage`/`mcp`/`session`/`serve`; ou **os dois juntos**: `cstk
+doctor`/`cstk hooks install` detectam o plugin e automaticamente evitam
+registrar os guard hooks em dobro (o plugin vence; `cstk doctor` reporta
+`aligned`/`diverged`/`duplicated-hooks` com correção acionável para cada
+caso).
+
 ### Hooks do runtime 00c (`cstk hooks`)
 
 Os três hooks do runtime 00c — `pretooluse-bash-guard.sh` (guarda
@@ -267,7 +332,19 @@ cd ~/projects/meu-projeto-alvo
 cstk hooks install                    # toca só .claude/hooks/ + settings.json
 cstk hooks install --dry-run          # mostra o plano sem escrever
 cstk hooks install --project-path ../outro-projeto
+cstk hooks install --remove-classic   # deduplica contra o plugin, sem prompt
 ```
+
+Quando o plugin já fornece os hooks, o `cstk hooks install` pula o
+provisionamento clássico (plugin vence) e, se o projeto **ainda** carrega um
+registro clássico no `settings.json`, as duas camadas dispararam juntas.
+Nesse caso ele pergunta se pode remover o bloco clássico, apagando apenas as
+entradas dos hooks 00c — hooks de terceiros e todas as demais chaves do
+arquivo são preservados — e gravando backup em
+`settings.json.bak-pre-dedup`. Use `--remove-classic` para pular o prompt
+(scripts/CI). Sem TTY e sem a flag o bloco é **mantido**, com aviso: o
+`settings.json` é do operador e nunca é reescrito sem consentimento
+explícito.
 
 Sem esse passo a guarda de Bash fica inerte e `tool_calls`/`agent_usage`
 ficam zerados em todas as ondas. Para conferir o estado atual sem escrever
@@ -275,7 +352,19 @@ nada:
 
 ```bash
 guard-hooks-status.sh check --projeto-alvo-path .
+# <hook>  present|missing  registered|unregistered  current|stale|unknown
 ```
+
+Rode `cstk hooks install` de novo após todo upgrade do cstk que toque os
+hooks: as cópias em `.claude/hooks/` são snapshots e nada as reconcilia com o
+catálogo. Cópia **stale** é tão danosa quanto ausente — roda um conjunto de
+regras antigo. Isso é regressão real, não hipótese: depois do cutover
+`state.json` → `state.db`, projetos ficaram com um tick hook que só sabia ler
+`state.json`, então `tool_calls` saía 0 em toda onda enquanto o check ainda
+reportava "3/3 hooks ativos". A quarta coluna existe para tornar isso
+visível, e o `tick-mode` cai para `manual` exatamente nesse pareamento (cópia
+cega ao backend + `state.db`), para a métrica sobreviver até você
+reprovisionar.
 
 ### Custo real por onda (`otel-usage.sh`)
 
@@ -320,7 +409,14 @@ inteira de 16 ondas não mediu nada.
 A correção é uma função-launcher no seu `~/.zshrc` que pede ao OS uma porta
 livre a cada lançamento (bind na porta `0` deixa o kernel escolher) e aponta o
 scraper do cstk para ela via `CSTK_OTEL_ENDPOINT` — hooks e scripts do runtime
-rodam dentro do processo do Claude, então herdam as duas variáveis:
+rodam dentro do processo do Claude, então herdam as duas variáveis.
+
+> Desde a v6.9.0 raramente é preciso fazer isso à mão: o `cstk install`
+> oferece esse wrapper como **opt-in** na primeira instalação (escreve no rc
+> do seu shell entre marcadores `# >>> cstk telemetry >>>`, só com
+> consentimento explícito — nunca em ambiente não-interativo), e
+> `cstk help telemetry` imprime o bloco canônico pronto para colar se você
+> recusou ou quiser configurar depois.
 
 ```zsh
 # Um exporter OTel por processo do claude: OS sorteia porta livre a cada lancamento.
@@ -367,6 +463,27 @@ cstk install --interactive   # lista perfis + skills numerados; seleção via to
 cstk install --dry-run --profile all
 cstk update --dry-run
 ```
+
+### Gauge de uso do plano (`cstk statusline` + `cstk plan-usage`)
+
+Desde a v7.2.0 o toolkit também captura o gauge de uso do plano que você vê
+no `/usage` — sem credencial OAuth, sem API key: o Claude Code já envia
+`rate_limits.five_hour`/`seven_day` no payload da statusline a cada render, e
+o hook de captura só lê o que já está passando, persistindo localmente na
+tabela `plan_usage` do `~/.claude/cstk/knowledge.db`.
+
+```bash
+cstk statusline install    # registra o hook de captura em ~/.claude/settings.json
+cstk statusline status     # a captura está ativa (e o settings.json válido)?
+cstk plan-usage            # captura mais recente por escopo (five_hour / seven_day)
+cstk plan-usage history    # série temporal; reusa --scope/--limit/--since do cstk usage
+```
+
+Opt-in por construção — nada é capturado até você rodar `statusline
+install` — e 100% local. Um comando de statusline customizado já existente é
+preservado e encadeado como pass-through obrigatório do stdout, nunca
+sobrescrito em silêncio. Escopo sem medição imprime `nao medido` (`null` com
+`--json`) — nunca zero fabricado.
 
 ### Instalação manual (deprecated, ainda suportada)
 

--- a/docs/agente-00c.md
+++ b/docs/agente-00c.md
@@ -95,6 +95,7 @@ prerequisites validated in FR-PRE-001..004).
 | Command | When to use |
 |---------|-------------|
 | `/feature-00c "<descricao>" [<short-name>]` | Add a new feature to an existing project |
+| `/feature-00c "<incremento>" --reopen=<short-name>` | Reopen a completed feature to receive an increment (v7.3.0 — see below) |
 | `/feature-00c-resume <short-name> [--resposta-bloqueio "..."]` | Resume after a pause or schedule |
 | `/feature-00c-abort <short-name> [--purge-backups]` | Manual abort (SIGTERM + 60s grace period) |
 
@@ -104,6 +105,45 @@ in the same project are allowed; concurrency with an active agente-00c is
 blocked (FR-026). Full reuse of the shared POSIX runtime
 (`agente-00c-runtime`). Details in
 [`specs/_archived/feature-00c/`](./specs/_archived/feature-00c/).
+
+### Reopening a completed feature (`--reopen`)
+
+Until v7.3.0 a completed feature was a dead end: re-invoking `/feature-00c`
+with the same short-name died at init because the state already existed, and
+the only way out was editing state by hand or opening a parallel feature —
+fragmenting the spec and losing the identity of what is, conceptually, the
+same capability. `/feature-00c "<incremento>" --reopen=<short-name>` fixes
+that:
+
+- **The previous execution is preserved as an immutable round** and the new
+  execution starts pointing at it. Rotation primitive: `state-rounds.sh`
+  (`next-label`, `rotate`, `recover`, `list`); the rotation commit is a
+  single directory `mv` (POSIX's only atomic primitive) with journal +
+  staging, and `recover` resolves an interruption by command — no manual
+  file editing. Rounds are zero-padded (`r01`, `r02`) for correct
+  lexicographic ordering.
+- **The increment lands in the existing spec, not in a parallel one**: the
+  archived spec is restored and `specify` records the increment as
+  `## Delta Requirements`; `create-tasks` detects the reopening and
+  **appends** a new phase to `tasks.md`, preserving completed tasks
+  (phase number computed by `next-task-id.sh --phase`).
+- **Advisory opinion + human block before touching disk**: the command
+  issues a reopen-vs-new-feature opinion and pauses for the human decision
+  before any write.
+- **Pending-work probe fail-closed**: `commit-mode.sh probe-pending-work`
+  checks for non-integrated work (branch not merged into the default, open
+  PR). A field only receives a concrete value from a successful, parsed
+  read; any other outcome keeps `unknown` + `probe_status=skipped-*` — it
+  never infers `merged=no` from a failure.
+- **Round provenance in the knowledge index**: `cstk recall --reindex`
+  namespaces provenance per round, so preserved rounds are never counted as
+  active executions nor double-counted (including rounds on the SQLite
+  backend).
+
+Spec: [`specs/feature-reopen/`](./specs/feature-reopen/)
+([`contracts/reopen-flow.md`](./specs/feature-reopen/contracts/reopen-flow.md),
+[`contracts/state-rounds.md`](./specs/feature-reopen/contracts/state-rounds.md),
+[`contracts/pending-work-probe.md`](./specs/feature-reopen/contracts/pending-work-probe.md)).
 
 ## Per-wave model routing (model-routing)
 
@@ -185,7 +225,7 @@ depend on the orchestrator remembering):
 | Automatic provisioning | `apply_guard_hooks()` in `cli/lib/hooks.sh` (`project` scope) |
 | Shared host allowlist | `cli/lib/trusted-hosts.sh` |
 | Auditable log | `.claude/enforcement-log.jsonl` (per target project) |
-| Spec | [`specs/enforced-guards/`](./specs/enforced-guards/) |
+| Spec | [`specs/_archived/2026-07-28-enforced-guards/`](./specs/_archived/2026-07-28-enforced-guards/) |
 
 Runtime complements: `PostToolUse` tool-call metric hook (append-only sidecar,
 v5.21.0) and the `DIAG|severity|code|message|fix` diagnostic envelope in the

--- a/docs/agente-00c.pt-BR.md
+++ b/docs/agente-00c.pt-BR.md
@@ -95,6 +95,7 @@ pré-requisitos validados em FR-PRE-001..004).
 | Comando | Quando usar |
 |---------|-------------|
 | `/feature-00c "<descricao>" [<short-name>]` | Adicionar feature nova em projeto existente |
+| `/feature-00c "<incremento>" --reopen=<short-name>` | Reabrir feature concluída para receber um incremento (v7.3.0 — ver abaixo) |
 | `/feature-00c-resume <short-name> [--resposta-bloqueio "..."]` | Retomar após pausa ou schedule |
 | `/feature-00c-abort <short-name> [--purge-backups]` | Aborto manual (SIGTERM + grace period 60s) |
 
@@ -104,6 +105,45 @@ paralelas no mesmo projeto são permitidas; concorrência com agente-00c
 ativo é bloqueada (FR-026). Reuso integral do runtime POSIX
 compartilhado (`agente-00c-runtime`). Detalhamento em
 [`specs/_archived/feature-00c/`](./specs/_archived/feature-00c/).
+
+### Reabrindo uma feature concluída (`--reopen`)
+
+Até a v7.3.0 uma feature concluída era um beco sem saída: reinvocar
+`/feature-00c` com o mesmo short-name morria no init porque o estado já
+existia, e a única saída era editar estado à mão ou abrir uma feature
+paralela — fragmentando a spec e perdendo a identidade do que é,
+conceitualmente, a mesma capacidade. O
+`/feature-00c "<incremento>" --reopen=<short-name>` resolve isso:
+
+- **A execução anterior é preservada como round imutável** e a execução
+  nova inicia apontando para ela. Primitiva de rotação: `state-rounds.sh`
+  (`next-label`, `rotate`, `recover`, `list`); o commit da rotação é um
+  único `mv` de diretório (o único primitivo atômico do POSIX) com
+  journal + staging, e `recover` resolve interrupção por comando — sem
+  edição manual de arquivo. Rounds com zero-padding (`r01`, `r02`) para
+  ordenação lexicográfica correta.
+- **O incremento pousa na spec existente, não numa paralela**: a spec
+  arquivada é restaurada e o `specify` grava o incremento como
+  `## Delta Requirements`; o `create-tasks` detecta a reabertura e
+  **apenda** uma fase nova ao `tasks.md`, preservando as tarefas já
+  concluídas (número da fase calculado por `next-task-id.sh --phase`).
+- **Parecer advisory + bloqueio humano antes de tocar disco**: o command
+  emite parecer reabrir-vs-criar-feature-nova e pausa para a decisão
+  humana antes de qualquer escrita.
+- **Sonda de trabalho pendente fail-closed**: `commit-mode.sh
+  probe-pending-work` verifica trabalho não integrado (branch não mesclada
+  na default, PR aberto). Um campo só recebe valor concreto de leitura
+  bem-sucedida e parseada; qualquer outro desfecho mantém `unknown` +
+  `probe_status=skipped-*` — nunca infere `merged=no` a partir de falha.
+- **Proveniência por round no índice de conhecimento**: o `cstk recall
+  --reindex` dá namespace de proveniência por round, então rounds
+  preservados nunca são contados como execução ativa nem duplicam contagem
+  (incluindo rounds no backend SQLite).
+
+Spec: [`specs/feature-reopen/`](./specs/feature-reopen/)
+([`contracts/reopen-flow.md`](./specs/feature-reopen/contracts/reopen-flow.md),
+[`contracts/state-rounds.md`](./specs/feature-reopen/contracts/state-rounds.md),
+[`contracts/pending-work-probe.md`](./specs/feature-reopen/contracts/pending-work-probe.md)).
 
 ## Roteamento de modelos por onda (model-routing)
 
@@ -185,7 +225,7 @@ esquema de URL) eram **advisory**. Três frentes passaram a ser **enforced**
 | Provisionamento automático | `apply_guard_hooks()` em `cli/lib/hooks.sh` (escopo `project`) |
 | Allowlist de hosts compartilhada | `cli/lib/trusted-hosts.sh` |
 | Log auditável | `.claude/enforcement-log.jsonl` (por projeto-alvo) |
-| Spec | [`specs/enforced-guards/`](./specs/enforced-guards/) |
+| Spec | [`specs/_archived/2026-07-28-enforced-guards/`](./specs/_archived/2026-07-28-enforced-guards/) |
 
 Complementos do runtime: hook `PostToolUse` de métrica de tool calls
 (sidecar append-only, v5.21.0) e envelope diagnóstico

--- a/docs/cstk-usage.md
+++ b/docs/cstk-usage.md
@@ -58,6 +58,56 @@ Only cost/token/model metadata — `project`, `project_path`, `process_key`,
 the schema. Sidecar directory/files use restrictive permissions (`chmod 700`
 on directories, `chmod 600` on files), same posture as `knowledge.db`.
 
+## Plan usage gauge (`cstk statusline` + `cstk plan-usage`)
+
+Since v7.2.0 the same `knowledge.db` also stores the **plan usage gauge** you
+see in `/usage` — no OAuth credential, no API key: Claude Code already sends
+`rate_limits.five_hour`/`seven_day` in the `statusLine.command` payload on
+every render, so the capture hook (`statusline-plan-usage.sh`) just reads
+what is already passing by and persists it in the `plan_usage` table
+(additive schema migration 13→14).
+
+```bash
+# Enable the capture (opt-in, default OFF)
+cstk statusline install
+
+# Is the capture active (and settings.json still valid)?
+cstk statusline status
+
+# Latest capture per scope (five_hour / seven_day)
+cstk plan-usage [--json] [--db PATH]
+
+# Time series per scope
+cstk plan-usage history [--scope five_hour|seven_day] [--limit N] [--since ISO] [--json] [--db PATH]
+```
+
+- `statusline install` — writes/updates `statusLine.command` in
+  `~/.claude/settings.json` pointing at the capture hook. An existing custom
+  statusline command is preserved in `CSTK_STATUSLINE_INNER_COMMAND` and
+  chained as a mandatory stdout pass-through — never silently overwritten.
+  Idempotent (running it twice does not nest wrapper over wrapper); since
+  v7.2.1 it also **repairs** a broken state (missing `statusLine.type`, which
+  makes the harness discard the whole file) and preserves the file's
+  original permissions.
+- `statusline status` — reports the current state; prints `INVALIDO` with
+  the remediation (exit 1) when `settings.json` is in a state the harness
+  would reject.
+- `plan-usage` / `plan-usage history` — latest capture per scope / time
+  series; `history` literally reuses `--limit`/`--since` from `cstk usage`
+  (no new pagination convention). A scope with no measurement prints
+  `nao medido` (text) / `null` (`--json`) — never a fabricated `0`.
+
+Capture semantics (Principle VI): total absence of `rate_limits` in the
+payload never generates a row; partial absence of a field within a present
+scope writes an explicit `NULL`, never `0`. A throttle compares against the
+**last persisted record** of that scope with 2-decimal tolerance on
+`used_percentage`, so harness float noise does not create new rows.
+
+Spec: [`specs/plan-usage-capture/`](./specs/plan-usage-capture/)
+([`contracts/cli-plan-usage.md`](./specs/plan-usage-capture/contracts/cli-plan-usage.md),
+[`contracts/statusline-hook.md`](./specs/plan-usage-capture/contracts/statusline-hook.md),
+[`data-model.md`](./specs/plan-usage-capture/data-model.md)).
+
 ## Full documentation
 
 - [`specs/_archived/2026-08-08-loose-usage-capture/spec.md`](./specs/_archived/2026-08-08-loose-usage-capture/spec.md) — user stories, FRs, success criteria

--- a/docs/cstk-usage.pt-BR.md
+++ b/docs/cstk-usage.pt-BR.md
@@ -59,6 +59,57 @@ de prompt/conversa no schema. Diretório/arquivos do sidecar usam permissão
 restritiva (`chmod 700` em diretórios, `chmod 600` em arquivos), mesma
 postura do `knowledge.db`.
 
+## Gauge de uso do plano (`cstk statusline` + `cstk plan-usage`)
+
+Desde a v7.2.0 o mesmo `knowledge.db` também guarda o **gauge de uso do
+plano** que você vê no `/usage` — sem credencial OAuth, sem API key: o
+Claude Code já envia `rate_limits.five_hour`/`seven_day` no payload da
+`statusLine.command` a cada render, então o hook de captura
+(`statusline-plan-usage.sh`) só lê o que já está passando e persiste na
+tabela `plan_usage` (migração aditiva de schema 13→14).
+
+```bash
+# Habilitar a captura (opt-in, default DESLIGADO)
+cstk statusline install
+
+# A captura está ativa (e o settings.json válido)?
+cstk statusline status
+
+# Captura mais recente por escopo (five_hour / seven_day)
+cstk plan-usage [--json] [--db PATH]
+
+# Série temporal por escopo
+cstk plan-usage history [--scope five_hour|seven_day] [--limit N] [--since ISO] [--json] [--db PATH]
+```
+
+- `statusline install` — escreve/atualiza `statusLine.command` em
+  `~/.claude/settings.json` apontando para o hook de captura. Um comando de
+  statusline customizado já existente é preservado em
+  `CSTK_STATUSLINE_INNER_COMMAND` e encadeado como pass-through obrigatório
+  do stdout — nunca sobrescrito em silêncio. Idempotente (rodar 2x não
+  aninha wrapper sobre wrapper); desde a v7.2.1 também **repara** estado
+  quebrado (`statusLine.type` ausente, que faz o harness descartar o arquivo
+  inteiro) e preserva a permissão original do arquivo.
+- `statusline status` — reporta o estado atual; imprime `INVALIDO` com a
+  remediação (exit 1) quando o `settings.json` está num estado que o
+  harness rejeitaria.
+- `plan-usage` / `plan-usage history` — captura mais recente por escopo /
+  série temporal; `history` reusa literalmente `--limit`/`--since` do
+  `cstk usage` (sem convenção nova de paginação). Escopo sem medição
+  imprime `nao medido` (texto) / `null` (`--json`) — nunca `0` fabricado.
+
+Semântica da captura (Princípio VI): ausência TOTAL de `rate_limits` no
+payload nunca gera linha; ausência PARCIAL de um campo dentro de um escopo
+presente grava `NULL` explícito, nunca `0`. O throttle compara sempre contra
+o **último registro persistido** daquele escopo, com tolerância de 2 casas
+decimais em `used_percentage` — ruído de ponto flutuante do harness não gera
+linha nova.
+
+Spec: [`specs/plan-usage-capture/`](./specs/plan-usage-capture/)
+([`contracts/cli-plan-usage.md`](./specs/plan-usage-capture/contracts/cli-plan-usage.md),
+[`contracts/statusline-hook.md`](./specs/plan-usage-capture/contracts/statusline-hook.md),
+[`data-model.md`](./specs/plan-usage-capture/data-model.md)).
+
 ## Documentação completa
 
 - [`specs/_archived/2026-08-08-loose-usage-capture/spec.md`](./specs/_archived/2026-08-08-loose-usage-capture/spec.md) — user stories, FRs, success criteria

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"


### PR DESCRIPTION
## Resumo

Release 100% documentação — sincroniza a doc de entrada com o estado real do toolkit:

- **README.pt-BR.md em paridade com o inglês**: layout `plugins/` (v7.0.0), seção nova do plugin nativo com tabela clássico × plugin, hooks com `--remove-classic`/dedup/cópia stale, nota do wrapper de telemetria (v6.9.0).
- **Novidades 7.2.0/7.3.0 documentadas nos dois idiomas**: gauge de plano (`cstk statusline` + `cstk plan-usage`) nos READMEs e em `docs/cstk-usage*`; modo `--reopen` nos READMEs e em `docs/agente-00c*` (subseção + linha na tabela de comandos).
- **CONTRIBUTING (2 idiomas)**: caminho de distribuição via plugin no diagrama; `language-related/` → `plugins/cstk-language-go/`.
- **PRIVACY.md**: linha da tabela `plan_usage` (opt-in via `cstk statusline install`); effective date 2026-08-12.
- **Fixes**: contagem 29→28 no comentário do `--profile all`, badge SemVer 5.x→7.x, link quebrado da spec enforced-guards.
- **Gate MP-5**: manifests de plugin bumpados para 7.3.2 (`validate-plugin-manifests.sh --strict` exit 0).

## Testado

- Suite completa `LC_ALL=C ./tests/run.sh`: **PASS 2793, FAIL 0, ERROR 0** (919s)
- `./tests/run.sh --check-coverage`: zero órfãos
- `cstk doctor`: drift zero
- Checagem de refs do CHANGELOG (headers × bloco de refs): vazia
- Varredura de links relativos nos docs editados: zero quebrados

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhG7ba5VNu2cWy4FJE9GyR