### PR TITLE
fix(serve): preflight de Node, update sem destruição e detecção de ABI mismatch (issue #113)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "7.3.2",
+      "version": "7.3.3",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "7.3.2",
+      "version": "7.3.3",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [7.3.3] - 2026-08-13
+
+Defesa em profundidade do `cstk serve` para a issue
+[#113](https://github.com/JotJunior/cstk/issues/113) (painel nao
+instalava em Node 24): o fix de fato e o bump do `better-sqlite3` para
+`^12.4.1` no cstk-panel 0.28.0 (prebuilds para Node 20/22/23/24); aqui
+entram as guardas do lado do cstk para que a combinacao errada de Node
+falhe cedo e nunca destrua uma instalacao funcional.
+
+### Fixed
+
+- **`--update`/`--reinstall` sem janela de destruicao** (`cli/lib/serve.sh`):
+  o `--update` fazia `rm -rf` do painel instalado ANTES de instalar a versao
+  nova — se o `npm install` da nova falhasse (caso real da #113: Node 24 x
+  `better-sqlite3` 9.6.0), o usuario ficava sem painel nenhum. Agora a nova
+  e instalada em staging irmao e so entra no lugar apos sucesso; falha
+  mantem a instalada (aviso em stderr) e o painel ainda sobe. No
+  `--reinstall`, o preflight de Node roda ANTES do `rm -rf`.
+
+### Added
+
+- **Preflight de Node no install** (issue #113): antes de qualquer download,
+  `cstk serve` valida que o major do Node corrente esta na faixa suportada
+  pelo painel (20/22/23/24 — espelho dos engines do cstk-panel >= 0.28.0 /
+  prebuilds do better-sqlite3 12.x) e falha cedo com mensagem acionavel
+  (`use uma versao suportada (ex.: nvm use 22)`) em vez de vazar centenas de
+  linhas de node-gyp. Node indetectavel nao bloqueia (aviso + prossegue).
+- **Deteccao de mismatch de ABI** (sugestao da #113): o install grava o
+  major do Node usado em `.panel-node-major` (ao lado do `.panel-version`);
+  starts subsequentes sob major diferente falham cedo orientando `nvm use
+  <major>` ou `cstk serve --reinstall`, em vez de estourar erro cru de
+  dlopen do modulo nativo. Instalacoes antigas (sem o arquivo) seguem sem
+  checagem — o valor nunca e inferido.
+
 ## [7.3.2] - 2026-08-12
 
 Sincroniza a documentacao de entrada com o estado real do toolkit: o
@@ -5760,6 +5794,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[7.3.3]: https://github.com/JotJunior/cstk/releases/tag/v7.3.3
 [7.3.2]: https://github.com/JotJunior/cstk/releases/tag/v7.3.2
 [7.3.1]: https://github.com/JotJunior/cstk/releases/tag/v7.3.1
 [7.3.0]: https://github.com/JotJunior/cstk/releases/tag/v7.3.0

--- a/cli/lib/serve.sh
+++ b/cli/lib/serve.sh
@@ -6,8 +6,10 @@
 #   serve_main [--port P] [--host H] [--reinstall] [--update]
 #              [--allow-unverified] [--help]
 #     exit 0  sucesso (painel rodando ou --help)
-#     exit 1  erro geral (prereq ausente, download falhou, instalacao
-#             corrompida, integridade nao confirmada sem bypass explicito)
+#     exit 1  erro geral (prereq ausente, Node major fora da faixa suportada
+#             para instalar, mismatch de ABI com o Node do install, download
+#             falhou, instalacao corrompida, integridade nao confirmada sem
+#             bypass explicito)
 #     exit 2  uso incorreto (porta invalida, flag desconhecida)
 #
 # Dependencias internas (sourced via $CSTK_LIB):
@@ -113,6 +115,63 @@ _serve_check_npm_interop() {
 _serve_is_installed() {
   _sii_dir="$1"
   [ -f "$_sii_dir/package.json" ]
+}
+
+# Majors de Node suportados pela instalacao do painel (issue #113).
+# Fonte: engines do cstk-panel >= 0.28.0 ("20.x || 22.x || 23.x || 24.x"),
+# que espelha o suporte declarado pelo better-sqlite3@12.x (prebuilds ABI
+# v115/v127/v131/v137 verificados nos assets das releases v12.4.1+ de
+# WiseLibs/better-sqlite3). Atualizar em sincronia quando o painel mudar a
+# faixa. Constante fixa, NAO overridable via env (mesmo racional de
+# CSTK_TRUSTED_RELEASE_HOSTS: muda so em release nova do cstk).
+_SERVE_SUPPORTED_NODE_MAJORS="20 22 23 24"
+
+# _serve_node_major
+# Ecoa o major da versao do node encontrado no PATH (ex.: "24" para
+# v24.19.0). exit 1 (sem eco) se node ausente ou saida fora do formato
+# vN.N.N — o caller decide o que fazer com "indetectavel".
+_serve_node_major() {
+  command -v node >/dev/null 2>&1 || return 1
+  _snm_v=$(node -v 2>/dev/null | head -1 | tr -d ' \r\n')
+  case "$_snm_v" in
+    v[0-9]*) ;;
+    *) return 1 ;;
+  esac
+  _snm_major="${_snm_v#v}"
+  _snm_major="${_snm_major%%.*}"
+  case "$_snm_major" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s\n' "$_snm_major"
+}
+
+# _serve_node_preflight
+# Gate de INSTALACAO (issue #113): valida que o major do Node corrente esta
+# na faixa suportada pelo painel ANTES de qualquer download/npm install —
+# falha cedo com mensagem acionavel em vez de vazar centenas de linhas de
+# node-gyp (better-sqlite3 sem prebuild para o ABI corrente cai em
+# compilacao nativa; na linha 9.6.0 do painel < 0.28.0, Node 24 nem
+# compilava — APIs de V8 removidas).
+# Node indetectavel NAO bloqueia (aviso + prossegue): este e um guard de UX
+# de instalacao, nao de seguranca — o npm install continua sendo o
+# verificador final. So roda nos caminhos que INSTALAM; servir um painel ja
+# instalado e coberto pelo check de mismatch de ABI (.panel-node-major).
+# exit 0 = prossegue; exit 1 = major fora da faixa (mensagem em stderr).
+_serve_node_preflight() {
+  _snp_major=$(_serve_node_major) || {
+    printf 'cstk serve: aviso: nao foi possivel detectar a versao do Node; prosseguindo com a instalacao\n' >&2
+    return 0
+  }
+  for _snp_ok in $_SERVE_SUPPORTED_NODE_MAJORS; do
+    if [ "$_snp_major" = "$_snp_ok" ]; then
+      return 0
+    fi
+  done
+  _snp_list=$(printf '%s' "$_SERVE_SUPPORTED_NODE_MAJORS" | tr ' ' '/')
+  printf 'cstk serve: erro: o painel requer Node %s (detectado: Node %s)\n' \
+    "$_snp_list" "$_snp_major" >&2
+  printf 'cstk serve: use uma versao suportada (ex.: nvm use 22) e tente novamente\n' >&2
+  return 1
 }
 
 # _serve_latest_tag
@@ -482,6 +541,15 @@ _serve_install() {
     return 1
   fi
 
+  # Registrar o major do Node que rodou o npm install: modulos nativos
+  # (better-sqlite3) ficam presos ao ABI desse Node. Consumido no start para
+  # detectar mismatch e sugerir --reinstall em vez de estourar erro cru de
+  # dlopen (issue #113). Best-effort: node indetectavel -> arquivo ausente
+  # -> check no start e pulado (nunca fabricar o valor — Constitution VI).
+  if _si_node_major=$(_serve_node_major); then
+    printf '%s\n' "$_si_node_major" > "$_si_extract/.panel-node-major"
+  fi
+
   # Move atomico para panel_dir (apos extrair + npm install)
   mkdir -p "$(dirname -- "$_si_panel_dir")"
   if ! mv -- "$_si_extract" "$_si_panel_dir"; then
@@ -549,7 +617,13 @@ Usage: cstk serve [--port PORT] [--host HOST] [--update] [--reinstall]
 
 Start the cstk panel web interface. On first run, downloads the latest
 release from GitHub and installs it locally. Subsequent runs reuse the
-cached installation. When the release publishes a <name>.tar.gz asset
+cached installation. Installing requires a supported Node major
+(20/22/23/24 — checked before any download; the panel's native modules
+must match better-sqlite3's prebuilt targets). The Node major used at
+install time is recorded (.panel-node-major) and checked on later runs:
+running under a different major would break the native modules' ABI, so
+cstk serve fails early and suggests --reinstall instead of crashing at
+startup. When the release publishes a <name>.tar.gz asset
 with a matching <name>.tar.gz.sha256, that verifiable asset is preferred
 and its SHA-256 is enforced; otherwise the API auto-tarball is used,
 whose integrity cannot be confirmed (see --allow-unverified).
@@ -569,7 +643,10 @@ Options:
                         reinstall only if one exists (otherwise reuse the
                         cached version). Best-effort: if it fails
                         (offline/API error), the installed version is kept
-                        and the panel still starts.
+                        and the panel still starts. The new version is
+                        staged in a sibling directory and only swapped in
+                        after its npm install succeeds — a failed update
+                        never destroys the working installation.
                         With --docker, rebuilds the local image instead of
                         the install directory (same "only if newer"
                         semantics).
@@ -612,7 +689,9 @@ Options:
 
 Exit codes:
   0   Panel started (or --help shown).
-  1   General error (prereq missing, download failed, install corrupt,
+  1   General error (prereq missing, unsupported Node major for install,
+      Node major differs from the one recorded at install time (native
+      ABI mismatch — use --reinstall), download failed, install corrupt,
       integrity unverified/mismatched without --allow-unverified; with
       --docker also: Docker not installed/daemon unreachable, image build
       failed, or a stale container could not be reconciled).
@@ -740,6 +819,17 @@ HELP
   # Resolver diretorio do painel (FR-007)
   _serve_panel_dir="${CSTK_PANEL_DIR:-${HOME}/.local/share/cstk/panel}"
 
+  # Preflight de Node ANTES de qualquer caminho que va instalar (issue #113):
+  # cobre a primeira instalacao e o --reinstall (checar DEPOIS do rm abaixo
+  # destruiria a instalacao antes de descobrir que o Node corrente nao
+  # consegue instalar a nova). O caminho --update faz o proprio preflight
+  # adiante, so quando existe versao nova de fato.
+  if [ "$_serve_reinstall" = "1" ] || ! _serve_is_installed "$_serve_panel_dir"; then
+    if ! _serve_node_preflight; then
+      return 1
+    fi
+  fi
+
   # --reinstall: remover instalacao existente antes de qualquer check
   if [ "$_serve_reinstall" = "1" ]; then
     rm -rf -- "$_serve_panel_dir"
@@ -749,6 +839,14 @@ HELP
   # se houver versao nova (comparando com .panel-version). Best-effort: se a
   # checagem falhar (offline/API), mantem a versao instalada. Sem efeito quando
   # combinado com --reinstall (o dir ja foi removido acima -> instala a latest).
+  #
+  # A versao instalada NUNCA e destruida antes de a nova estar completa
+  # (issue #113): a nova e instalada num diretorio staging IRMAO e so entra
+  # no lugar apos npm install bem-sucedido. Falha na instalacao da nova =>
+  # aviso + segue servindo a instalada (mesma semantica best-effort da
+  # checagem). O rm -rf antecipado anterior deixava o usuario sem painel
+  # nenhum quando o npm install da nova falhava (ex.: Node 24 x painel com
+  # better-sqlite3 9.6.0).
   if [ "$_serve_update" = "1" ] && _serve_is_installed "$_serve_panel_dir"; then
     printf 'cstk serve: verificando atualizacoes do painel...\n'
     _serve_latest=$(_serve_latest_tag)
@@ -757,7 +855,35 @@ HELP
       if [ "$_serve_latest" != "$_serve_current" ]; then
         printf 'cstk serve: atualizando painel: %s -> %s\n' \
           "${_serve_current:-desconhecida}" "$_serve_latest"
-        rm -rf -- "$_serve_panel_dir"
+        # Preflight de Node ANTES de baixar/instalar (issue #113): update
+        # explicito com Node fora da faixa e erro acionavel, nao um npm
+        # install fadado a falhar depois do download.
+        if ! _serve_node_preflight; then
+          return 1
+        fi
+        _serve_stage="${_serve_panel_dir}.stage.$$"
+        rm -rf -- "$_serve_stage"
+        if _serve_install "$_serve_stage" "$_serve_allow_unverified" "$_serve_bypass_method"; then
+          _serve_old="${_serve_panel_dir}.old.$$"
+          rm -rf -- "$_serve_old"
+          if mv -- "$_serve_panel_dir" "$_serve_old" \
+            && mv -- "$_serve_stage" "$_serve_panel_dir"; then
+            rm -rf -- "$_serve_old"
+          else
+            # Swap parou no meio: devolver a versao antiga ao lugar se ela
+            # saiu e a nova nao entrou.
+            if [ ! -d "$_serve_panel_dir" ] && [ -d "$_serve_old" ]; then
+              mv -- "$_serve_old" "$_serve_panel_dir" || :
+            fi
+            rm -rf -- "$_serve_stage"
+            printf 'cstk serve: aviso: falha ao trocar para a versao nova; mantendo a versao instalada (%s)\n' \
+              "${_serve_current:-desconhecida}" >&2
+          fi
+        else
+          rm -rf -- "$_serve_stage"
+          printf 'cstk serve: aviso: instalacao da versao nova falhou; mantendo a versao instalada (%s)\n' \
+            "${_serve_current:-desconhecida}" >&2
+        fi
       else
         printf 'cstk serve: painel ja esta na versao mais recente (%s)\n' "$_serve_current"
       fi
@@ -774,7 +900,9 @@ HELP
     return 1
   fi
 
-  # Lazy-install: so instalar se nao instalado
+  # Lazy-install: so instalar se nao instalado (o preflight de Node deste
+  # caminho ja rodou acima, antes do --reinstall poder destruir qualquer
+  # coisa).
   if ! _serve_is_installed "$_serve_panel_dir"; then
     if ! _serve_install "$_serve_panel_dir" "$_serve_allow_unverified" "$_serve_bypass_method"; then
       return 1
@@ -786,6 +914,26 @@ HELP
     _serve_version=$(cat "$_serve_panel_dir/.panel-version" 2>/dev/null)
     if [ -n "$_serve_version" ]; then
       printf 'cstk serve: usando painel ja instalado (%s)\n' "$_serve_version"
+    fi
+  fi
+
+  # Mismatch de ABI entre o Node do install e o Node corrente (issue #113):
+  # modulos nativos (better-sqlite3) ficam presos ao ABI do Node que rodou o
+  # npm install — cada major de Node tem NODE_MODULE_VERSION distinto, entao
+  # major divergente = dlopen falhando com erro criptico no start. Detectar
+  # aqui e orientar. So checa quando o install registrou .panel-node-major
+  # (instalacoes anteriores a este check nao tem o arquivo -> sem checagem,
+  # nunca inferir) e quando o Node corrente e detectavel.
+  if [ -f "$_serve_panel_dir/.panel-node-major" ]; then
+    _serve_inst_major=$(tr -d ' \n' < "$_serve_panel_dir/.panel-node-major" 2>/dev/null)
+    _serve_cur_major=$(_serve_node_major) || _serve_cur_major=""
+    if [ -n "$_serve_inst_major" ] && [ -n "$_serve_cur_major" ] \
+      && [ "$_serve_inst_major" != "$_serve_cur_major" ]; then
+      printf 'cstk serve: erro: o painel instalado foi compilado com Node %s, mas o Node corrente e o %s (modulos nativos sao incompativeis entre majors)\n' \
+        "$_serve_inst_major" "$_serve_cur_major" >&2
+      printf 'cstk serve: use o Node do install (ex.: nvm use %s) ou reinstale com o Node corrente: cstk serve --reinstall\n' \
+        "$_serve_inst_major" >&2
+      return 1
     fi
   fi
 

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "7.3.2",
+  "version": "7.3.3",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "7.3.2",
+  "version": "7.3.3",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/tests/cstk/test_serve.sh
+++ b/tests/cstk/test_serve.sh
@@ -1879,4 +1879,242 @@ scenario_wsl_fluxo_completo_com_npm_da_distro_instala() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# Issue #113 — preflight de Node no install, swap sem destruicao no --update,
+# e deteccao de mismatch de ABI via .panel-node-major.
+# ---------------------------------------------------------------------------
+
+# _stub_node_version BIN_DIR VERSION: stub de node que responde `node -v`
+# com VERSION (ex.: v18.20.0) e sai 0 para qualquer outro uso. Sombreia o
+# node real do PATH (o _STUB_BIN e prependado), permitindo simular majors
+# arbitrarios sem depender da versao instalada na maquina/CI.
+_stub_node_version() {
+  _snv_bin="$1"
+  _snv_version="$2"
+  cat > "$_snv_bin/node" <<STUB
+#!/bin/sh
+if [ "\$1" = "-v" ] || [ "\$1" = "--version" ]; then
+  printf '%s\n' "$_snv_version"
+  exit 0
+fi
+exit 0
+STUB
+  chmod +x "$_snv_bin/node"
+}
+
+scenario_node_preflight_major_nao_suportado_exit1() {
+  _setup_serve_env
+  _make_bin_dir
+  _stub_curl_ok "$_STUB_BIN"
+  _stub_npm_ok "$_STUB_BIN"
+  _stub_node_version "$_STUB_BIN" "v18.20.0"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "preflight_18_exit" "esperado exit 1 (Node 18 fora da faixa), obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  if ! printf '%s' "$_CAPTURED_STDERR" | grep -qi 'requer Node'; then
+    _fail "preflight_18_msg" "stderr nao traz mensagem acionavel de faixa de Node: $_CAPTURED_STDERR"
+    return 1
+  fi
+  # Falhou ANTES de qualquer download/instalacao: nada foi criado.
+  if [ -d "$CSTK_PANEL_DIR" ]; then
+    _fail "preflight_18_sem_efeito" "preflight deveria falhar antes de criar o panel dir"
+    return 1
+  fi
+}
+
+scenario_reinstall_node_nao_suportado_preserva_instalacao() {
+  _setup_serve_env
+  _make_bin_dir
+  # --reinstall com Node fora da faixa: o preflight roda ANTES do rm -rf —
+  # a instalacao existente e preservada (sem janela de destruicao).
+  mkdir -p "$CSTK_PANEL_DIR"
+  printf '{"name":"cstk-panel","version":"0.0.1"}\n' > "$CSTK_PANEL_DIR/package.json"
+  : > "$CSTK_PANEL_DIR/SENTINELA"
+  _stub_curl_ok "$_STUB_BIN"
+  _stub_npm_ok "$_STUB_BIN"
+  _stub_node_version "$_STUB_BIN" "v18.20.0"
+  _run_serve --reinstall
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "reinstall_preflight_exit" "esperado exit 1, obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  if [ ! -f "$CSTK_PANEL_DIR/SENTINELA" ]; then
+    _fail "reinstall_preflight_preserva" "--reinstall destruiu a instalacao antes do preflight de Node falhar"
+    return 1
+  fi
+}
+
+scenario_node_preflight_major_suportado_instala() {
+  _setup_serve_env
+  _make_bin_dir
+  _stub_curl_ok "$_STUB_BIN"
+  _stub_npm_ok "$_STUB_BIN"
+  _stub_node_version "$_STUB_BIN" "v22.5.1"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "preflight_22_exit" "esperado exit 0 (Node 22 suportado), obtido $_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if [ ! -f "$CSTK_PANEL_DIR/package.json" ]; then
+    _fail "preflight_22_instalou" "painel nao foi instalado com Node suportado"
+    return 1
+  fi
+}
+
+scenario_node_preflight_indetectavel_prossegue() {
+  _setup_serve_env
+  _make_bin_dir
+  _stub_curl_ok "$_STUB_BIN"
+  _stub_npm_ok "$_STUB_BIN"
+  # node com saida fora do formato vN.N.N: preflight avisa e prossegue
+  # (guard de UX, nao de seguranca — o npm install e o verificador final).
+  _stub_node_version "$_STUB_BIN" "saida-improvavel"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "preflight_indetectavel_exit" "esperado exit 0 (node indetectavel nao bloqueia), obtido $_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if ! printf '%s' "$_CAPTURED_STDERR" | grep -qi 'nao foi possivel detectar'; then
+    _fail "preflight_indetectavel_aviso" "stderr nao avisa que a versao do Node nao foi detectada: $_CAPTURED_STDERR"
+    return 1
+  fi
+}
+
+scenario_install_grava_panel_node_major() {
+  _setup_serve_env
+  _make_bin_dir
+  _stub_curl_ok "$_STUB_BIN"
+  _stub_npm_ok "$_STUB_BIN"
+  _stub_node_version "$_STUB_BIN" "v22.5.1"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "grava_major_exit" "esperado exit 0, obtido $_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if [ "$(cat "$CSTK_PANEL_DIR/.panel-node-major" 2>/dev/null | tr -d ' \n')" != "22" ]; then
+    _fail "grava_major_valor" ".panel-node-major deveria registrar 22 (obtido: '$(cat "$CSTK_PANEL_DIR/.panel-node-major" 2>/dev/null)')"
+    return 1
+  fi
+}
+
+scenario_node_major_mismatch_exit1() {
+  _setup_serve_env
+  _make_bin_dir
+  # Painel ja instalado, compilado com Node 20; Node corrente e 24.
+  mkdir -p "$CSTK_PANEL_DIR"
+  printf '{"name":"cstk-panel","version":"0.0.1"}\n' > "$CSTK_PANEL_DIR/package.json"
+  printf 'v0.0.1\n' > "$CSTK_PANEL_DIR/.panel-version"
+  printf '20\n' > "$CSTK_PANEL_DIR/.panel-node-major"
+  _stub_npm_ok "$_STUB_BIN"
+  _stub_node_version "$_STUB_BIN" "v24.19.0"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "1" ]; then
+    _fail "mismatch_exit" "esperado exit 1 (ABI mismatch 20 vs 24), obtido $_CAPTURED_EXIT"
+    return 1
+  fi
+  if ! printf '%s' "$_CAPTURED_STDERR" | grep -q -- '--reinstall'; then
+    _fail "mismatch_orientacao" "stderr nao sugere --reinstall: $_CAPTURED_STDERR"
+    return 1
+  fi
+}
+
+scenario_node_major_match_prossegue() {
+  _setup_serve_env
+  _make_bin_dir
+  mkdir -p "$CSTK_PANEL_DIR"
+  printf '{"name":"cstk-panel","version":"0.0.1"}\n' > "$CSTK_PANEL_DIR/package.json"
+  printf 'v0.0.1\n' > "$CSTK_PANEL_DIR/.panel-version"
+  printf '22\n' > "$CSTK_PANEL_DIR/.panel-node-major"
+  _stub_npm_ok "$_STUB_BIN"
+  _stub_node_version "$_STUB_BIN" "v22.9.0"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "match_exit" "esperado exit 0 (majors iguais), obtido $_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+}
+
+scenario_node_major_ausente_prossegue() {
+  _setup_serve_env
+  _make_bin_dir
+  # Instalacao anterior a este check: sem .panel-node-major -> sem checagem
+  # (nunca inferir o Node do install — Constitution VI).
+  mkdir -p "$CSTK_PANEL_DIR"
+  printf '{"name":"cstk-panel","version":"0.0.1"}\n' > "$CSTK_PANEL_DIR/package.json"
+  printf 'v0.0.1\n' > "$CSTK_PANEL_DIR/.panel-version"
+  _stub_npm_ok "$_STUB_BIN"
+  _stub_node_version "$_STUB_BIN" "v24.19.0"
+  _run_serve
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "sem_arquivo_exit" "esperado exit 0 (sem .panel-node-major nao ha checagem), obtido $_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+}
+
+scenario_update_npm_install_falha_mantem_instalado() {
+  _setup_serve_env
+  _make_bin_dir
+  # Instalado v0.0.0 + sentinela; ha versao nova (v0.0.1), mas o npm install
+  # da nova falha -> a instalada NUNCA e destruida (issue #113: o rm -rf
+  # antecipado deixava o usuario sem painel nenhum).
+  mkdir -p "$CSTK_PANEL_DIR"
+  printf '{"name":"cstk-panel","version":"0.0.0"}\n' > "$CSTK_PANEL_DIR/package.json"
+  printf 'v0.0.0\n' > "$CSTK_PANEL_DIR/.panel-version"
+  : > "$CSTK_PANEL_DIR/SENTINELA"
+  _stub_curl_ok "$_STUB_BIN"
+  cat > "$_STUB_BIN/npm" <<'STUB'
+#!/bin/sh
+case "$1" in
+  install) exit 1 ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$_STUB_BIN/npm"
+  _run_serve --update
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "update_install_falha_exit" "esperado exit 0 (mantem instalada e sobe), obtido $_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if [ ! -f "$CSTK_PANEL_DIR/SENTINELA" ]; then
+    _fail "update_install_falha_preserva" "instalacao existente foi destruida apesar da falha do npm install da versao nova"
+    return 1
+  fi
+  if [ "$(cat "$CSTK_PANEL_DIR/.panel-version" 2>/dev/null | tr -d ' \n')" != "v0.0.0" ]; then
+    _fail "update_install_falha_versao" ".panel-version deveria permanecer v0.0.0"
+    return 1
+  fi
+  if ! printf '%s' "$_CAPTURED_STDERR" | grep -qi 'mantendo a versao instalada'; then
+    _fail "update_install_falha_aviso" "stderr nao avisa que manteve a versao instalada: $_CAPTURED_STDERR"
+    return 1
+  fi
+}
+
+scenario_update_sucesso_sem_residuo_stage_old() {
+  _setup_serve_env
+  _make_bin_dir
+  mkdir -p "$CSTK_PANEL_DIR"
+  printf '{"name":"cstk-panel","version":"0.0.0"}\n' > "$CSTK_PANEL_DIR/package.json"
+  printf 'v0.0.0\n' > "$CSTK_PANEL_DIR/.panel-version"
+  _stub_curl_ok "$_STUB_BIN"
+  _stub_npm_ok "$_STUB_BIN"
+  _run_serve --update
+  if [ "$_CAPTURED_EXIT" != "0" ]; then
+    _fail "update_residuo_exit" "esperado exit 0, obtido $_CAPTURED_EXIT stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if [ "$(cat "$CSTK_PANEL_DIR/.panel-version" 2>/dev/null | tr -d ' \n')" != "v0.0.1" ]; then
+    _fail "update_residuo_versao" ".panel-version nao foi atualizada para v0.0.1"
+    return 1
+  fi
+  # Sem residuo de staging/backup ao lado do panel dir.
+  for _urso_d in "$CSTK_PANEL_DIR".stage.* "$CSTK_PANEL_DIR".old.*; do
+    if [ -e "$_urso_d" ]; then
+      _fail "update_residuo_dir" "residuo de swap deixado para tras: $_urso_d"
+      return 1
+    fi
+  done
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Resumo

Defesa em profundidade do `cstk serve` para a issue #113 (painel não instalava em Node 24). O fix de fato é o **cstk-panel v0.28.0** (better-sqlite3 `^9.6.0` → `^12.4.1`, já released com prebuilds para Node 20/22/23/24 — PR JotJunior/cstk-panel#28); aqui entram as guardas do lado do cstk:

1. **Preflight de Node no install**: major fora da faixa suportada (20/22/23/24) falha cedo com mensagem acionável, antes de qualquer download. Node indetectável avisa e prossegue.
2. **`--update`/`--reinstall` sem janela de destruição**: a versão nova é instalada em staging irmão e só entra no lugar após `npm install` bem-sucedido; falha mantém a instalada (era o `rm -rf` antecipado que deixou o reporter da #113 sem painel nenhum). No `--reinstall`, o preflight roda antes do `rm -rf`.
3. **Detecção de mismatch de ABI** (sugestão da issue): o install grava `.panel-node-major`; starts sob major divergente falham cedo sugerindo `nvm use <major>` ou `--reinstall` em vez de erro cru de dlopen. Instalações antigas (sem o arquivo) seguem sem checagem — valor nunca inferido.

Release 7.3.3 (changelog + bump MP-5 dos manifests inclusos).

## Validação

- Suite completa local: **PASS 2803 / FAIL 0** (1369s, `LC_ALL=C`)
- 10 cenários novos em `tests/cstk/test_serve.sh` (preflight suportado/não-suportado/indetectável, preservação no `--reinstall` e no `--update` com install falho, swap sem resíduo, gravação/match/mismatch/ausência do `.panel-node-major`)
- `--check-coverage` zero órfãos; shellcheck limpo; `validate-plugin-manifests.sh --version 7.3.3 --strict` OK; `cstk doctor` drift zero

Closes #113 (junto com cstk-panel v0.28.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhG7ba5VNu2cWy4FJE9GyR