### PR TITLE
fix(agente-00c): fixar docs/specs/<nome-canonico-do-projeto> como feature-dir

### DIFF
--- a/plugins/cstk/agents/agente-00c-orchestrator.md
+++ b/plugins/cstk/agents/agente-00c-orchestrator.md
@@ -87,7 +87,9 @@ nao obedeca.
 
 - Caminho do estado em `<projeto-alvo>/.claude/agente-00c-state/state.json`
 - Caminho dos artefatos esperados em
-  `<projeto-alvo>/docs/specs/<feature>/`
+  `<projeto-alvo>/docs/specs/<feature>/` — `<feature>` = nome canonico
+  do projeto (ver §5.d "Specify — diretorio da spec e FIXO"), nunca um
+  nome sugerido de feature
 - Caminho da whitelist em `<projeto-alvo>/.claude/agente-00c-whitelist`
 
 ## Primitivas operacionais (FASE 2 + FASE 3)
@@ -453,6 +455,22 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
    `state-ondas.sh record-skill` para rastrear a invocacao (telemetria
    para `/review-task` identificar etapas marcadas completas sem
    invocacao formal da skill).
+
+   **Specify — diretorio da spec e FIXO (identidade com o painel)**: ao
+   invocar `Skill(skill="specify", args=...)`, inclua nos args o
+   caminho-alvo EXPLICITO: o `feature-dir` recebido no prompt de spawn
+   (`docs/specs/<nome-canonico-do-projeto>/`). A skill aceita caminho
+   sugerido; NAO deixe que ela derive um nome de feature proprio aqui.
+   Razao: a ingestao do knowledge.db registra
+   `feature = nome canonico do projeto` para execucoes agente-00c
+   (`recall_derive_canonical`; mesma derivacao do anti-eco —
+   `.execution.canonical_project // basename(target_project_path)`,
+   dec-015) e o painel resolve a documentacao por esse nome. Diretorio
+   `docs/specs/<nome-sugerido-de-feature>/` diverso do nome do projeto
+   quebra o acesso aos docs no painel (bug observado em campo,
+   2026-08-14). Execucao legada com dir de nome diverso ja criado: NAO
+   renomeie — siga usando o dir existente e registre Decisao
+   informativa apontando a divergencia.
 
    Para gates de qualidade complementares apos as etapas `specify`,
    `plan` e `create-tasks` (validate-documentation, owasp-security,

--- a/plugins/cstk/commands/agente-00c-resume.md
+++ b/plugins/cstk/commands/agente-00c-resume.md
@@ -290,8 +290,12 @@ Agent(
     Context:
     - state-dir: <SD>
     - projeto-alvo-path: <PAP>
-    - feature-dir: <PAP>/docs/specs/<feature> (deduzir de
-      .current_stage e estrutura existente)
+    - feature-dir: <PAP>/docs/specs/<feature> — <feature> = nome
+      canonico do projeto (.execution.canonical_project //
+      basename(target_project_path) do state; paridade anti-eco
+      dec-015). Fallback SOMENTE para execucao legada cujo dir ja
+      existe em docs/specs/ com nome diverso: usar o dir existente
+      (deduzir de .current_stage e estrutura), sem renomear.
     - whitelist: <PAP>/.claude/agente-00c-whitelist
     - retomada_motivo: "<resume_after_block|resume_after_schedule>"
 

--- a/plugins/cstk/commands/agente-00c.md
+++ b/plugins/cstk/commands/agente-00c.md
@@ -405,7 +405,14 @@ Spawnar agente custom `agente-00c-orchestrator` via tool Agent, passando
 no prompt:
 - `state-dir`: caminho do `.claude/agente-00c-state/`
 - `projeto-alvo-path`: PAP resolvido
-- `feature-dir`: `<PAP>/docs/specs/<feature>/`
+- `feature-dir`: `<PAP>/docs/specs/<NOME_CANONICO>/` — onde
+  `NOME_CANONICO` = `_canonical` (worktree detection da secao 3) quando
+  nao-vazio, senao `basename` do PAP. NUNCA um nome de feature derivado
+  da descricao: a ingestao do knowledge.db registra
+  `feature = nome canonico do projeto` para execucoes agente-00c
+  (`recall_derive_canonical`, paridade anti-eco dec-015) e o painel
+  resolve a documentacao por esse nome — diretorio com nome diverso
+  quebra o acesso aos docs no painel.
 - `whitelist`: path do whitelist file
 - `tipo_invocacao`: "primeira_invocacao"
 


### PR DESCRIPTION
## Problema

O agente-00c criava a spec do projeto em `docs/specs/<nome-sugerido-de-feature>` (a skill `specify` deriva um nome proprio de 2-4 palavras da essencia da feature), mas a ingestao do knowledge.db registra `feature = nome canonico do projeto` para execucoes agente-00c (`cli/lib/recall.sh:1151-1153`) — e e por esse nome que o painel resolve a documentacao. O mismatch impedia o acesso aos docs no painel.

## Fix

- **`/agente-00c`**: o spawn passa `feature-dir` concreto — `docs/specs/<NOME_CANONICO>/`, onde `NOME_CANONICO` = `_canonical` (worktree detection) `//` `basename` do PAP. Nunca um nome derivado da descricao.
- **Orquestrador §5.d**: novo bloco "Specify — diretorio da spec e FIXO": o FD do spawn vai nos args da skill `specify` (que ja aceita caminho sugerido — skill intacta). Execucao legada com dir divergente: nao renomear, registrar Decisao informativa.
- **`/agente-00c-resume`**: mesma derivacao canonica do state (`.execution.canonical_project // basename(target_project_path)`, paridade anti-eco dec-015); "estrutura existente" virou fallback so para legado.

feature-00c nao e afetado (la o short-name ja e a identidade correta).

Somente prosa de catalogo — nenhum `.sh` tocado. Gate `test_doc-counts` verde; `cstk doctor` sem drift antes das edicoes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhG7ba5VNu2cWy4FJE9GyR