### PR TITLE
fix(agente-00c-runtime): infer-aspectos sob state.db + next-id imune a CRLF (7.5.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "7.5.0",
+      "version": "7.5.1",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "7.5.0",
+      "version": "7.5.1",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [7.5.1] - 2026-08-14
+
+Release de correcao dirigida pelas issues #118-#124, abertas
+automaticamente pelo proprio agente-00C em execucoes reais de usuarios:
+dois bugs do runtime `agente-00c-runtime` que quebravam a drift
+detection sob backend SQLite e o registro de BloqueioHumano em
+Windows/Git-Bash.
+
+### Fixed
+
+- **`state-rw.sh infer-aspectos` cego ao backend `state.db` (issues
+  #118/#119/#121/#124).** O subcomando checava `[ -f state.json ]`
+  hardcoded e morria com `state.json ausente` em qualquer execucao
+  migrada para SQLite — cegando o hook pos-deteccao de aspectos tocados
+  (drift detection, FR-027) do Loop principal do orquestrador, sem
+  fallback automatico. Agora materializa o documento uma unica vez de
+  forma backend-aware (`_sr_db_read` sob SQLite; canonicalizacao
+  pt-BR->EN com fallback raw sob JSON, mesmo contrato do `read`) e
+  resolve `execution.target_project_path` do documento materializado.
+  `state-rw.sh migrate` sob SQLite vira no-op exit 0 com aviso explicito
+  (nada a canonicalizar) em vez do erro enganoso. Cenarios novos em
+  `tests/test_state-rw.sh` (incl. assert anti-mirror FR-003) e
+  `infer-aspectos` promovido a 16o leitor do manifest dinamico de
+  `tests/test_state-parity-sweep.sh` — fecha a lacuna da rede de
+  seguranca que deixou o subcomando escapar da feature
+  state-db-runtime-parity.
+- **`bloqueios.sh next-id` quebrava em Windows/Git-Bash com jq CRLF
+  (issues #122/#123).** O padrao `jq | { read -r _max; ... }` em
+  `_bl_next_block_id` preservava o `\r` residual do jq nativo do Windows
+  e corrompia a aritmetica (`invalid arithmetic operator`), bloqueando
+  100% dos registros de BloqueioHumano (Pause-or-Decide) nesse ambiente.
+  Trocado por command substitution com `tr -d '\r'` + guard numerico
+  POSIX — command substitution sozinha, como proposto nas issues, NAO
+  remove o CR (reproduzido empiricamente com stub de jq CRLF). Mesmo
+  hardening preventivo em `state-decisions.sh#_sd_next_dec_id`
+  (vulnerabilidade latente identica). Cenarios de regressao com stub de
+  jq CRLF em `tests/test_bloqueios.sh` e `tests/test_state-decisions.sh`.
+
 ## [7.5.0] - 2026-08-14
 
 Release nascida de feedback direto de usuarios sobre a profundidade e a
@@ -5920,6 +5958,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[7.5.1]: https://github.com/JotJunior/cstk/releases/tag/v7.5.1
 [7.5.0]: https://github.com/JotJunior/cstk/releases/tag/v7.5.0
 [7.4.0]: https://github.com/JotJunior/cstk/releases/tag/v7.4.0
 [7.3.3]: https://github.com/JotJunior/cstk/releases/tag/v7.3.3

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/bloqueios.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/bloqueios.sh
@@ -111,12 +111,18 @@ _bl_backup_current() {
 
 _bl_next_block_id() {
   _sf=$(_bl_state_file "$1")
-  jq -r '
+  # Command substitution + strip de CR (issues #122/#123): o jq nativo do
+  # Windows emite CRLF e o antigo `| { read -r _max; ... }` preservava o \r
+  # residual, corrompendo a aritmetica ('invalid arithmetic operator').
+  # O tr remove o CR independente do jq do host; o case garante fallback 0
+  # para saida vazia/nao-numerica (jq ausente, state corrompido).
+  _max=$(jq -r '
     ((.human_blocks // .bloqueios_humanos) // []) as $hb
     | if ($hb | length) == 0 then 0
     else ([$hb[].id // ""] | map(sub("^block-0*"; "") | tonumber? // 0) | max)
-    end' "$_sf" 2>/dev/null \
-    | { read -r _max; printf 'block-%03d\n' "$((_max + 1))"; }
+    end' "$_sf" 2>/dev/null | tr -d '\r')
+  case "$_max" in '' | *[!0-9]*) _max=0 ;; esac
+  printf 'block-%03d\n' "$((_max + 1))"
 }
 
 # _bl_decisao_exists STATE_DIR DEC_ID -> 0 if exists, 1 otherwise

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/state-decisions.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/state-decisions.sh
@@ -88,11 +88,15 @@ _sd_state_file() { printf '%s/state.json\n' "$1"; }
 _sd_next_dec_id() {
   _sf=$(_sd_state_file "$1")
   [ -f "$_sf" ] || _sd_die "next-id: state.json ausente em $1" 1
+  # Strip de CR + guard numerico (paridade com bloqueios.sh#_bl_next_block_id,
+  # issues #122/#123): jq nativo do Windows emite CRLF e o \r residual
+  # corromperia a aritmetica.
   _max=$(jq -r '
     ((.decisions // .decisoes) // []) as $d
     | if ($d | length) == 0 then 0
       else ([$d[].id // ""] | map(sub("^dec-0*"; "") | tonumber? // 0) | max)
-      end' "$_sf" 2>/dev/null) || _max=0
+      end' "$_sf" 2>/dev/null | tr -d '\r')
+  case "$_max" in '' | *[!0-9]*) _max=0 ;; esac
   _next=$((_max + 1))
   printf 'dec-%03d\n' "$_next"
 }

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/state-rw.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/state-rw.sh
@@ -876,16 +876,40 @@ _sr_cmd_infer_aspectos() {
   command -v jq >/dev/null 2>&1 || _sr_die "infer-aspectos: jq ausente" 1
   command -v git >/dev/null 2>&1 || _sr_die "infer-aspectos: git ausente" 1
 
-  _sf="$_sd/state.json"
-  [ -f "$_sf" ] || _sr_die "infer-aspectos: state.json ausente em $_sd" 1
-
-  # Resolver projeto-alvo: flag explicita > execution.target_project_path
-  # (canonicaliza para ler tanto states EN quanto pt-BR vivos).
-  if [ -z "$_pap" ]; then
-    _pap=$(_sr_canonicalize_file "$_sf" 2>/dev/null | jq -r '.execution.target_project_path // ""')
+  # Materializa o documento de estado UMA vez, backend-aware (issues
+  # #118/#119/#121/#124: a checagem hardcoded de state.json deixava o
+  # subcomando cego ao backend state.db, enquanto get/set ja despacham).
+  # Sob SQLite o read ja devolve o documento canonico EN; sob JSON
+  # canonicaliza (fallback raw se jq/JSON falhar — mesmo contrato do read).
+  _sr_canon_state=$(mktemp) || _sr_die "infer-aspectos: mktemp falhou" 1
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    if ! _sr_db_read "$_sd" > "$_sr_canon_state"; then
+      rm -f -- "$_sr_canon_state" 2>/dev/null || :
+      _sr_die "infer-aspectos: falha lendo state.db em $_sd" 1
+    fi
+  else
+    _sf=$(_sr_state_file "$_sd")
+    if [ ! -f "$_sf" ]; then
+      rm -f -- "$_sr_canon_state" 2>/dev/null || :
+      _sr_die "infer-aspectos: state.json ausente em $_sd" 1
+    fi
+    if ! _sr_canonicalize_file "$_sf" > "$_sr_canon_state" 2>/dev/null; then
+      cp -- "$_sf" "$_sr_canon_state" 2>/dev/null || :
+    fi
   fi
-  [ -n "$_pap" ] || _sr_die "infer-aspectos: nao consegui resolver projeto-alvo-path" 1
-  [ -d "$_pap" ] || _sr_die "infer-aspectos: projeto-alvo nao e diretorio: $_pap" 1
+
+  # Resolver projeto-alvo: flag explicita > execution.target_project_path.
+  if [ -z "$_pap" ]; then
+    _pap=$(jq -r '.execution.target_project_path // ""' "$_sr_canon_state" 2>/dev/null)
+  fi
+  if [ -z "$_pap" ]; then
+    rm -f -- "$_sr_canon_state" 2>/dev/null || :
+    _sr_die "infer-aspectos: nao consegui resolver projeto-alvo-path" 1
+  fi
+  if [ ! -d "$_pap" ]; then
+    rm -f -- "$_sr_canon_state" 2>/dev/null || :
+    _sr_die "infer-aspectos: projeto-alvo nao e diretorio: $_pap" 1
+  fi
 
   # Coletar arquivos modificados nesta onda. Estrategia:
   #   1. Se HEAD~1 existe, usa `git diff --name-only HEAD~1..HEAD`
@@ -903,11 +927,7 @@ _sr_cmd_infer_aspectos() {
 
   # Aplicar matcher fuzzy: aspecto detectado se token-overlap com paths.
   # Reusa logica do drift.sh (matcher bidirecional + tokens >=3 chars).
-  # Le o state canonicalizado (EN) — fallback raw se jq/JSON falhar.
-  _sr_canon_state=$(mktemp) || _sr_die "infer-aspectos: mktemp falhou" 1
-  if ! _sr_canonicalize_file "$_sf" > "$_sr_canon_state" 2>/dev/null; then
-    cp -- "$_sf" "$_sr_canon_state" 2>/dev/null || :
-  fi
+  # Le o documento ja materializado (canonico EN) acima.
   printf '%s\n' "$_diff" | jq -R -s --slurpfile state "$_sr_canon_state" '
     def tokenize($s):
       ($s // "")
@@ -952,6 +972,13 @@ _sr_cmd_migrate() {
     esac
   done
   [ -n "$_sd" ] || _sr_die "migrate: --state-dir obrigatorio" 2
+  # Backend SQLite (issue #124): nao ha state.json pt-BR a canonicalizar —
+  # o schema do state.db ja e EN por construcao. No-op explicito em vez do
+  # erro enganoso "state.json ausente".
+  if [ "$(_sr_backend "$_sd")" = "sqlite" ]; then
+    _sr_log "migrate: backend sqlite (state.db) em $_sd — nada a canonicalizar, no-op"
+    return 0
+  fi
   _sr_require_jq
   _sr_sf=$(_sr_state_file "$_sd")
   [ -f "$_sr_sf" ] || _sr_die "migrate: state.json ausente em $_sd" 1

--- a/tests/test_bloqueios.sh
+++ b/tests/test_bloqueios.sh
@@ -648,4 +648,24 @@ scenario_c2_state_json_coexistente_ignorado_quando_state_db_presente() {
 
 fi # sqlite3 disponivel
 
+# Issues #122/#123: jq nativo do Windows emite CRLF; o antigo padrao
+# `jq | { read -r _max; ... }` preservava o \r residual e quebrava a
+# aritmetica do next-id ('invalid arithmetic operator'). Simula com um stub
+# de jq que reemite a saida do jq real com terminador CRLF.
+scenario_next_id_tolera_jq_com_saida_crlf() {
+  _sd="$TMPDIR_TEST/state-crlf"
+  mkdir -p -- "$_sd"
+  printf '%s\n' '{"execution":{"id":"exec-1"},"human_blocks":[{"id":"block-002","status":"aguardando"}]}' \
+    > "$_sd/state.json"
+  _bin="$TMPDIR_TEST/crlf-bin"
+  mkdir -p -- "$_bin"
+  _realjq=$(command -v jq) || { _error "jq ausente" ""; return 2; }
+  printf '#!/bin/sh\n%s "$@" | while IFS= read -r _l; do printf "%%s\\r\\n" "$_l"; done\n' \
+    "$_realjq" > "$_bin/jq"
+  chmod +x "$_bin/jq"
+  capture env PATH="$_bin:$PATH" "$SCRIPT" next-id --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "next-id com jq CRLF" "exit $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "block-003" || return 1
+}
+
 run_all_scenarios

--- a/tests/test_state-decisions.sh
+++ b/tests/test_state-decisions.sh
@@ -672,4 +672,24 @@ scenario_c2_state_json_coexistente_ignorado_quando_state_db_presente() {
 
 fi # sqlite3 disponivel
 
+# Paridade com o fix das issues #122/#123 (bloqueios.sh): _sd_next_dec_id ja
+# usava command substitution, mas sem strip de \r — jq Windows com CRLF
+# corromperia a aritmetica do mesmo jeito. Cobre o hardening (tr -d '\r' +
+# guard numerico) com um stub de jq que emite CRLF.
+scenario_next_id_tolera_jq_com_saida_crlf() {
+  _sd="$TMPDIR_TEST/state-crlf"
+  mkdir -p -- "$_sd"
+  printf '%s\n' '{"execution":{"id":"exec-1"},"decisions":[{"id":"dec-007"}]}' \
+    > "$_sd/state.json"
+  _bin="$TMPDIR_TEST/crlf-bin"
+  mkdir -p -- "$_bin"
+  _realjq=$(command -v jq) || { _error "jq ausente" ""; return 2; }
+  printf '#!/bin/sh\n%s "$@" | while IFS= read -r _l; do printf "%%s\\r\\n" "$_l"; done\n' \
+    "$_realjq" > "$_bin/jq"
+  chmod +x "$_bin/jq"
+  capture env PATH="$_bin:$PATH" "$SCRIPT" next-id --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "next-id com jq CRLF" "exit $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "dec-008" || return 1
+}
+
 run_all_scenarios

--- a/tests/test_state-parity-sweep.sh
+++ b/tests/test_state-parity-sweep.sh
@@ -9,7 +9,8 @@
 #
 # Duas camadas:
 #
-# (a) DINAMICA — manifest literal dos 15 leitores do FR-001, cada um
+# (a) DINAMICA — manifest literal dos leitores do FR-001 (15 originais +
+#     state-rw.sh infer-aspectos, issues #118/#119/#121/#124), cada um
 #     executado contra um state-dir SQLite POPULADO (fixture minima da
 #     research §CHK032: 9 passos via primitivas, nunca write direto).
 #     Falha se: stdout/stderr contem o marcador de degradacao
@@ -159,10 +160,11 @@ state-decisions-reconcile-check|0|$R/state-decisions-reconcile.sh check --state-
 issue-create-dry-run|0|$R/issue.sh create --state-dir $SWEEP_SD --suggestion-id sug-001 --skill specify --diagnostico diagnostico-de-fixture-com-tamanho-suficiente-para-a-trava-de-cinquenta --proposta proposta-concreta --dry-run
 pipeline-require-blockade-resolved|0|$R/pipeline.sh require-blockade-resolved --state-dir $SWEEP_SD --etapa specify
 state-lock-check-execution-busy|3|$R/state-lock.sh check-execution-busy --state-dir $SWEEP_SD
+state-rw-infer-aspectos|0|$R/state-rw.sh infer-aspectos --state-dir $SWEEP_SD --projeto-alvo-path $SWEEP_SD
 EOF
 }
 
-scenario_dinamica_15_leitores_sqlite_sem_degradacao() {
+scenario_dinamica_16_leitores_sqlite_sem_degradacao() {
   _sqlite3_adequate || { printf '# skip: sqlite3 real >= %s indisponivel\n' "$MIN_SQLITE_VER"; return 0; }
   _mk_populated_sqlite_sd || { _error "fixture" "construcao da fixture CHK032 falhou"; return 2; }
 
@@ -188,7 +190,7 @@ scenario_dinamica_15_leitores_sqlite_sem_degradacao() {
     [ "$_ok" = 0 ] || _fails="$_fails $_label(exit=$_rc,esperado:$_exits)"
   done < "$TMPDIR_TEST/sweep-manifest.txt"
 
-  [ "$_count" = 15 ] || { _fail "manifest" "esperado 15 leitores, obtido $_count"; return 1; }
+  [ "$_count" = 16 ] || { _fail "manifest" "esperado 16 leitores, obtido $_count"; return 1; }
   [ -z "$_fails" ] || { _fail "leitores degradados/divergentes" "$_fails"; return 1; }
 
   # SC-004 anti-mirror: nenhum state.json materializado DENTRO do state-dir

--- a/tests/test_state-rw.sh
+++ b/tests/test_state-rw.sh
@@ -1250,6 +1250,38 @@ scenario_sqlite_set_multi_rejeita_resync_de_array_em_lote() {
   [ "$_v" = "specify" ] || { _fail "nada deveria ter sido escrito" "obtido '$_v'"; return 1; }
 }
 
+# Issues #118/#119/#121/#124: infer-aspectos checava state.json hardcoded e
+# morria com 'state.json ausente' sob backend state.db, enquanto get/set ja
+# despachavam. Deve materializar via read e aplicar o matcher normalmente,
+# resolvendo target_project_path do proprio documento (sem flag explicita).
+scenario_sqlite_infer_aspectos_funciona_sob_state_db() {
+  _sd="$TMPDIR_TEST/sq-infer"
+  _seed_sqlite_backend "$_sd" || return 1
+  _pap="$TMPDIR_TEST/sq-infer-pap"
+  _setup_pap_with_diff "$_pap" "README.md" "src/slack-handler.ts src/threads.ts"
+  sqlite3 "$_sd/state.db" "UPDATE execution SET target_project_path='$_pap', initial_key_aspects='[\"slack\",\"bot\",\"threads\"]' WHERE id='exec-1';" \
+    || { _fail "seed: update execution falhou" ""; return 1; }
+  capture "$SCRIPT" infer-aspectos --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "infer sob sqlite" "exit $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "slack" || return 1
+  assert_stdout_contains "threads" || return 1
+  # Anti-mirror (FR-003 da parity): nada pode ter materializado state.json
+  # dentro do state-dir.
+  [ ! -f "$_sd/state.json" ] || { _fail "infer nao pode criar state.json no state-dir" ""; return 1; }
+}
+
+# Issue #124: migrate (canonicalizacao pt-BR->EN de state.json) sob backend
+# sqlite nao tem o que migrar — deve ser no-op exit 0 com aviso explicito,
+# nao o erro enganoso 'state.json ausente'.
+scenario_sqlite_migrate_e_noop_exit_0() {
+  _sd="$TMPDIR_TEST/sq-migrate"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" migrate --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "migrate sob sqlite deve ser no-op exit 0" "exit $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "no-op" || return 1
+  [ ! -f "$_sd/state.json" ] || { _fail "migrate nao pode criar state.json sob sqlite" ""; return 1; }
+}
+
 fi # sqlite3 disponivel
 
 # ==== set aceita literais JSON falsy (state-db-runtime-parity 2.4.3) ====


### PR DESCRIPTION
## Resumo

Dois bugfixes no runtime `agente-00c-runtime`, dirigidos pelas issues #118–#124 (abertas automaticamente pelo agente-00C em execucoes reais):

- **`state-rw.sh infer-aspectos` cego ao backend `state.db`** (#118/#119/#121/#124): checagem `[ -f state.json ]` hardcoded matava o hook de drift detection (FR-027) sob SQLite. Agora materializa o documento backend-aware (`_sr_db_read` sob SQLite; canonicalizacao com fallback raw sob JSON) e resolve `target_project_path` do documento. `migrate` sob SQLite vira no-op exit 0.
- **`bloqueios.sh next-id` quebrado em Windows/Git-Bash** (#122/#123): `jq | { read -r }` preservava o \r do jq nativo do Windows, corrompendo a aritmetica e bloqueando 100% dos BloqueioHumano. Fix: command substitution + `tr -d '\r'` + guard numerico (substitution sozinha NAO remove o CR — confirmado com stub de jq CRLF). Hardening identico em `state-decisions.sh#_sd_next_dec_id`.

Inclui bump dos manifests de plugin para 7.5.1 (gate MP-5) e changelog.

## Testes

- 4 cenarios de regressao novos (sqlite infer/migrate com assert anti-mirror; next-id com stub jq CRLF em bloqueios e decisions)
- `infer-aspectos` promovido a 16o leitor do manifest dinamico do `test_state-parity-sweep.sh`
- Suite completa local: **2915 PASS / 0 FAIL / 0 ERROR** (LC_ALL=C, 1001s)
- `--check-coverage`: zero orfaos · `cstk doctor`: drift zero · MP-5 validado local (`--version 7.5.1 --strict` exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhG7ba5VNu2cWy4FJE9GyR