### PR TITLE
fix(recall): ingestao SQL->SQL espelha .suggestions de execution.extra_fields (8.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [8.0.1] - 2026-08-17
+
+Bugfix de paridade da ingestão do `knowledge.db` com o backend SQLite: as
+sugestões para skills globais (`suggestions.sh register`, FR-020) eram
+gravadas corretamente no `state.db` (em `execution.extra_fields.suggestions`,
+sem tabela própria) mas nunca chegavam ao índice — o caminho SQL→SQL
+(`recall_ingest_state_db`, `state-db-foundation`) só copiava as 7 entidades
+com tabela dedicada. Desde o cutover para `state.db` (v6.x), nenhuma sugestão
+nova aparecia no painel nem em `cstk recall --type suggestion` (última
+ingerida em 2026-08-04; caso real: `sug-001` da feature `mcp-scaffold-padrao`
+do projeto `wp-intel`, presente no `.md` e no `state.db`, ausente no índice).
+
+### Fixed
+
+- **`cli/lib/recall.sh` — ingestão SQL→SQL passa a espelhar `.suggestions[]`.**
+  Nova função `recall_suggestions_sql` (UPSERT em `suggestions` + corpo na
+  `knowledge_fts` com `type='suggestion'`, scrub de `diagnosis`/`proposal`/
+  `references` via `secrets-filter.sh`) compartilhada pelos DOIS caminhos:
+  o JSON (que já a fazia inline) e o SQL→SQL, que agora lê o array de
+  `execution.extra_fields` (JSON1, `mode=ro`) no PASS 2. `--ingest` e
+  `--reindex` cobertos pelo mesmo código; contador `N suggestions` do sumário
+  passa a refletir o backend SQLite.
+- **`executions.skill_suggestions_total`/`toolkit_issues_opened` sob SQLite.**
+  Deixam de ser `NULL` no PASS 1 e passam a derivar de
+  `extra_fields.suggestions` (`json_array_length` / contagem de
+  `issue_opened IS NOT NULL`) — a MESMA derivação que `_state-rw-db.sh read`
+  já materializa para o documento lido pelo runtime, portanto paridade e não
+  valor fabricado (Princípio VI).
+
+### Tests
+
+- `tests/cstk/test_recall.sh`: fixture de equivalência JSON↔SQL
+  (`_seed_sql_equiv_state`) passa a semear 2 sugestões (1 com issue aberta,
+  1 com segredo plantado) e a comparação linha-a-linha inclui a tabela
+  `suggestions` + os 2 contadores; cenários novos
+  `scenario_sqldb_suggestions_ingeridas_do_extra_fields` (state-dir SÓ com
+  `state.db`: linhas, FTS, contadores, scrub, busca `--type suggestion`,
+  idempotência) e `scenario_sqldb_suggestions_ausentes_zero`. Ambos falham
+  contra o `recall.sh` anterior (mutation-check executado).
+
 ## [8.0.0] - 2026-08-16
 
 **BREAKING** — duas features encadeadas que, juntas, fazem o caminho MCP
@@ -6266,6 +6306,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[8.0.1]: https://github.com/JotJunior/cstk/releases/tag/v8.0.1
 [8.0.0]: https://github.com/JotJunior/cstk/releases/tag/v8.0.0
 [7.6.2]: https://github.com/JotJunior/cstk/releases/tag/v7.6.2
 [7.6.1]: https://github.com/JotJunior/cstk/releases/tag/v7.6.1

--- a/cli/lib/recall.sh
+++ b/cli/lib/recall.sh
@@ -1102,6 +1102,73 @@ recall_round_label() {
   return 0
 }
 
+# recall_suggestions_sql ARRAY_JSON PROJECT FEATURE EXEC_ID NOW
+#   -> RECALL_SUGG_SQL (statements SQL, cada um precedido de newline; vazio
+#      quando nao ha sugestao) + RECALL_SUGG_N (sugestoes processadas).
+#
+# Gera o SQL de espelho de `.suggestions[]` (tabela suggestions + corpo na
+# knowledge_fts, type='suggestion') a partir do ARRAY JSON — a MESMA rotina
+# para os dois backends de estado: no JSON o array e `.suggestions` do
+# state.json; no SQLite e `execution.extra_fields.suggestions` (catch-all,
+# ver _state-rw-db.sh), que nao tem tabela propria no state.db e portanto
+# ficava FORA do PASS 1 (INSERT...SELECT) da ingestao SQL->SQL. Sem esta
+# partilha, nenhuma sugestao registrada apos o cutover para state.db chegava
+# ao knowledge.db (painel/`recall --type suggestion` cegos).
+#
+# Grao = sugestao por execucao; wave='-' (top-level, como executions);
+# source_id=<id da sugestao> (chave natural estavel, ex. sug-001);
+# source_ts=created_at. diagnosis+proposal sao texto livre -> filtro de
+# segredo (FR-006) e formam o body da FTS. affected_skill/severity/
+# issue_opened sao estruturados (sem filtro). references (array de paths)
+# -> join "," + scrub (paths podem embutir segredo). Aceita chaves EN e
+# legado pt-BR. Sem `id` -> pula (nao ha como deduplicar).
+recall_suggestions_sql() {
+  _rss_arr="$1"; _rss_project="$2"; _rss_feature="$3"
+  _rss_exec_id="$4"; _rss_now="$5"
+  RECALL_SUGG_SQL=""
+  RECALL_SUGG_N=0
+  _rss_lines=$(printf '%s' "$_rss_arr" | jq -r '
+    (. // [] | .[]? // empty)
+    | [(.id // ""),
+       ((.affected_skill // .skill_afetada) // ""),
+       ((.severity // .severidade) // ""),
+       ((.diagnosis // .diagnostico) // ""),
+       ((.proposal // .proposta) // ""),
+       (((.references // .referencias) // []) | join(",")),
+       (((.issue_opened // .issue_aberta) // "") | tostring),
+       ((.created_at // .criada_em) // "")]
+    | @base64' 2>/dev/null) || _rss_lines=""
+  [ -n "$_rss_lines" ] || return 0
+  _rss_OLDIFS="$IFS"; IFS='
+'
+  for _rss_row in $_rss_lines; do
+    _rss_decoded=$(printf '%s' "$_rss_row" | base64 -d 2>/dev/null) || continue
+    _rss_id=$(printf '%s' "$_rss_decoded" | jq -r '.[0]' 2>/dev/null | strip_nul)
+    _rss_sk=$(printf '%s' "$_rss_decoded" | jq -r '.[1]' 2>/dev/null | strip_nul)
+    _rss_sv=$(printf '%s' "$_rss_decoded" | jq -r '.[2]' 2>/dev/null | strip_nul)
+    _rss_dg=$(printf '%s' "$_rss_decoded" | jq -r '.[3]' 2>/dev/null | strip_nul)
+    _rss_pr=$(printf '%s' "$_rss_decoded" | jq -r '.[4]' 2>/dev/null | strip_nul)
+    _rss_rf=$(printf '%s' "$_rss_decoded" | jq -r '.[5]' 2>/dev/null | strip_nul)
+    _rss_ia=$(printf '%s' "$_rss_decoded" | jq -r '.[6]' 2>/dev/null | strip_nul)
+    _rss_ts=$(printf '%s' "$_rss_decoded" | jq -r '.[7]' 2>/dev/null | strip_nul)
+    [ -n "$_rss_id" ] || continue
+    _rss_dg=$(recall_scrub "$_rss_dg")
+    _rss_pr=$(recall_scrub "$_rss_pr")
+    _rss_rf=$(recall_scrub "$_rss_rf")
+    _rss_body=$(printf '%s %s' "$_rss_dg" "$_rss_pr")
+    RECALL_SUGG_SQL="$RECALL_SUGG_SQL
+INSERT INTO suggestions(project,feature,wave,execution_id,source_ts,source_id,affected_skill,severity,diagnosis,proposal,\"references\",issue_opened,ingested_at)
+VALUES('$(sql_escape "$_rss_project")','$(sql_escape "$_rss_feature")','-','$(sql_escape "$_rss_exec_id")','$(sql_escape "$_rss_ts")','$(sql_escape "$_rss_id")','$(sql_escape "$_rss_sk")','$(sql_escape "$_rss_sv")','$(sql_escape "$_rss_dg")','$(sql_escape "$_rss_pr")','$(sql_escape "$_rss_rf")','$(sql_escape "$_rss_ia")','$(sql_escape "$_rss_now")')
+ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,affected_skill=excluded.affected_skill,severity=excluded.severity,diagnosis=excluded.diagnosis,proposal=excluded.proposal,\"references\"=excluded.\"references\",issue_opened=excluded.issue_opened,ingested_at=excluded.ingested_at;
+DELETE FROM knowledge_fts WHERE type='suggestion' AND project='$(sql_escape "$_rss_project")' AND feature='$(sql_escape "$_rss_feature")' AND wave='-' AND source_id='$(sql_escape "$_rss_id")';
+INSERT INTO knowledge_fts(body,type,project,feature,wave,source_id,source_ts)
+VALUES('$(sql_escape "$_rss_body")','suggestion','$(sql_escape "$_rss_project")','$(sql_escape "$_rss_feature")','-','$(sql_escape "$_rss_id")','$(sql_escape "$_rss_ts")');"
+    RECALL_SUGG_N=$((RECALL_SUGG_N + 1))
+  done
+  IFS="$_rss_OLDIFS"
+  return 0
+}
+
 # recall_ingest_state_json STATE_JSON DB -> ingere um unico state.json no DB.
 # Best-effort: qualquer falha de extracao degrada gracioso (aviso + exit 0).
 # Reusado por --ingest (1 arquivo) e --reindex (N arquivos).
@@ -2004,50 +2071,16 @@ ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.sou
   # o body da FTS (type='suggestion'). affected_skill/severity/issue_opened sao
   # estruturados (sem filtro). references (array de paths) -> join "," + scrub
   # (paths podem embutir segredo). Retro-compat: .sugestoes[]? // empty -> 0.
-  _isj_n_suggestion=0
-  _isj_sug_lines=$(jq -r '
-    ((.suggestions // .sugestoes) // [] | .[]? // empty)
-    | [(.id // ""),
-       ((.affected_skill // .skill_afetada) // ""),
-       ((.severity // .severidade) // ""),
-       ((.diagnosis // .diagnostico) // ""),
-       ((.proposal // .proposta) // ""),
-       (((.references // .referencias) // []) | join(",")),
-       (((.issue_opened // .issue_aberta) // "") | tostring),
-       ((.created_at // .criada_em) // "")]
-    | @base64' "$_isj_state" 2>/dev/null) || _isj_sug_lines=""
-  if [ -n "$_isj_sug_lines" ]; then
-    _isj_OLDIFS="$IFS"; IFS='
-'
-    for _isj_row in $_isj_sug_lines; do
-      _isj_decoded=$(printf '%s' "$_isj_row" | base64 -d 2>/dev/null) || continue
-      _f_sgid=$(printf '%s' "$_isj_decoded" | jq -r '.[0]' 2>/dev/null | strip_nul)
-      _f_sgsk=$(printf '%s' "$_isj_decoded" | jq -r '.[1]' 2>/dev/null | strip_nul)
-      _f_sgsv=$(printf '%s' "$_isj_decoded" | jq -r '.[2]' 2>/dev/null | strip_nul)
-      _f_sgdg=$(printf '%s' "$_isj_decoded" | jq -r '.[3]' 2>/dev/null | strip_nul)
-      _f_sgpr=$(printf '%s' "$_isj_decoded" | jq -r '.[4]' 2>/dev/null | strip_nul)
-      _f_sgrf=$(printf '%s' "$_isj_decoded" | jq -r '.[5]' 2>/dev/null | strip_nul)
-      _f_sgia=$(printf '%s' "$_isj_decoded" | jq -r '.[6]' 2>/dev/null | strip_nul)
-      _f_sgts=$(printf '%s' "$_isj_decoded" | jq -r '.[7]' 2>/dev/null | strip_nul)
-      # id e a chave natural; sem ele -> pula (nao ha como deduplicar).
-      [ -n "$_f_sgid" ] || continue
-      # Texto livre -> filtro de segredo; estruturados (sk/sv/issue) sem filtro.
-      _f_sgdg=$(recall_scrub "$_f_sgdg")
-      _f_sgpr=$(recall_scrub "$_f_sgpr")
-      _f_sgrf=$(recall_scrub "$_f_sgrf")
-      # Body da FTS: diagnostico + proposta (ja scrubbed).
-      _f_sgbody=$(printf '%s %s' "$_f_sgdg" "$_f_sgpr")
-      _isj_sql="$_isj_sql
-INSERT INTO suggestions(project,feature,wave,execution_id,source_ts,source_id,affected_skill,severity,diagnosis,proposal,\"references\",issue_opened,ingested_at)
-VALUES('$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','-','$(sql_escape "$_isj_exec_id")','$(sql_escape "$_f_sgts")','$(sql_escape "$_f_sgid")','$(sql_escape "$_f_sgsk")','$(sql_escape "$_f_sgsv")','$(sql_escape "$_f_sgdg")','$(sql_escape "$_f_sgpr")','$(sql_escape "$_f_sgrf")','$(sql_escape "$_f_sgia")','$(sql_escape "$_isj_now")')
-ON CONFLICT(project,feature,wave,source_id) DO UPDATE SET source_ts=excluded.source_ts,affected_skill=excluded.affected_skill,severity=excluded.severity,diagnosis=excluded.diagnosis,proposal=excluded.proposal,\"references\"=excluded.\"references\",issue_opened=excluded.issue_opened,ingested_at=excluded.ingested_at;
-DELETE FROM knowledge_fts WHERE type='suggestion' AND project='$(sql_escape "$_isj_project")' AND feature='$(sql_escape "$_isj_feature")' AND wave='-' AND source_id='$(sql_escape "$_f_sgid")';
-INSERT INTO knowledge_fts(body,type,project,feature,wave,source_id,source_ts)
-VALUES('$(sql_escape "$_f_sgbody")','suggestion','$(sql_escape "$_isj_project")','$(sql_escape "$_isj_feature")','-','$(sql_escape "$_f_sgid")','$(sql_escape "$_f_sgts")');"
-      _isj_n_suggestion=$((_isj_n_suggestion + 1))
-    done
-    IFS="$_isj_OLDIFS"
-  fi
+  # Geracao do SQL compartilhada com o caminho SQL->SQL (state.db guarda o
+  # MESMO array em execution.extra_fields.suggestions) — ver
+  # recall_suggestions_sql. Sem essa partilha o caminho sqlite ficou cego
+  # para sugestoes desde o cutover para state.db (bug corrigido em
+  # fix-recall-sqlite-suggestions-ingest).
+  _isj_sug_arr=$(jq -c '((.suggestions // .sugestoes) // [])' "$_isj_state" 2>/dev/null) \
+    || _isj_sug_arr='[]'
+  recall_suggestions_sql "$_isj_sug_arr" "$_isj_project" "$_isj_feature" "$_isj_exec_id" "$_isj_now"
+  _isj_n_suggestion=$RECALL_SUGG_N
+  [ -z "$RECALL_SUGG_SQL" ] || _isj_sql="$_isj_sql$RECALL_SUGG_SQL"
 
   _isj_sql="$_isj_sql
 COMMIT;"
@@ -2103,7 +2136,10 @@ COMMIT;"
 #     context_for_answer/answer; tasks.title; events.description) sao lidos
 #     de volta (JSON via json_group_array, mesmo idioma de
 #     recall_ingest_state_json), filtrados via recall_scrub e regravados via
-#     UPDATE ... WHERE id=<pk interno>. Encerra reconstruindo knowledge_fts
+#     UPDATE ... WHERE id=<pk interno>. Tambem ingere `.suggestions[]`
+#     (que vive em execution.extra_fields, sem tabela propria no state.db —
+#     logo fora do PASS 1) via recall_suggestions_sql, a mesma rotina do
+#     caminho JSON. Encerra reconstruindo knowledge_fts
 #     (decisions/blocks) so com o corpo ja filtrado, escopado por
 #     execution_id (nunca apaga FTS de outras execucoes da mesma feature).
 #
@@ -2230,7 +2266,8 @@ SELECT $_isd_project_sql,$_isd_feature_sql,$_isd_wave_exec_sql,e.id,e.started_at
   NULL, e.subagent_depth,
   (SELECT count(*) FROM src.decision WHERE execution_id=e.id),
   (SELECT count(*) FROM src.human_block WHERE execution_id=e.id),
-  NULL, NULL,
+  json_array_length(coalesce(json_extract(e.extra_fields,'\$.suggestions'),'[]')),
+  (SELECT count(*) FROM json_each(coalesce(json_extract(e.extra_fields,'\$.suggestions'),'[]')) AS je WHERE json_extract(je.value,'\$.issue_opened') IS NOT NULL),
   $_isd_session_sql,$_isd_path_sql,$_isd_now_sql
 FROM src.execution e
 WHERE 1=1 -- disambigua parser INSERT...SELECT...ON CONFLICT apos FROM sem JOIN (empirico)
@@ -2432,6 +2469,22 @@ UPDATE events SET description='$(sql_escape "$_isd_desc")' WHERE id=$_isd_rid;"
     IFS="$_isd_OLDIFS"
   fi
 
+  # ---- suggestions: `.suggestions[]` vive no catch-all
+  # execution.extra_fields (sem tabela propria no state.db), logo nao entra
+  # no INSERT...SELECT do PASS 1. Le o array (JSON1, mode=ro) e reusa a MESMA
+  # rotina do caminho JSON (recall_suggestions_sql: scrub + UPSERT + FTS
+  # type='suggestion'). Sem isto, toda sugestao registrada sob backend
+  # SQLite ficava invisivel no knowledge.db (painel/`recall --type
+  # suggestion`). ----
+  _isd_n_suggestion=0
+  _isd_sug_arr=$(recall_query_sql_ro "$_isd_state_db" \
+    "SELECT coalesce(json_extract(extra_fields,'\$.suggestions'),'[]') FROM execution WHERE id=$_isd_exec_id_sql LIMIT 1;") \
+    || _isd_sug_arr='[]'
+  [ -n "$_isd_sug_arr" ] || _isd_sug_arr='[]'
+  recall_suggestions_sql "$_isd_sug_arr" "$_isd_project" "$_isd_feature" "$_isd_exec_id" "$_isd_now"
+  _isd_n_suggestion=$RECALL_SUGG_N
+  [ -z "$RECALL_SUGG_SQL" ] || _isd_fix="$_isd_fix$RECALL_SUGG_SQL"
+
   # Reconstrucao de knowledge_fts (decisions/blocks) com o corpo ja
   # filtrado — escopada por execution_id (nunca apaga FTS de outras
   # execucoes da mesma feature/projeto). Ordem do corpo espelha
@@ -2461,6 +2514,7 @@ COMMIT;"
   RECALL_TOTAL_TASK=$((${RECALL_TOTAL_TASK:-0} + _isd_n_task))
   RECALL_TOTAL_EVENT=$((${RECALL_TOTAL_EVENT:-0} + _isd_n_event))
   RECALL_TOTAL_SKILL=$((${RECALL_TOTAL_SKILL:-0} + _isd_n_skill))
+  RECALL_TOTAL_SUGGESTION=$((${RECALL_TOTAL_SUGGESTION:-0} + _isd_n_suggestion))
   return "$RECALL_EXIT_OK"
 }
 

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/tests/cstk/test_recall.sh
+++ b/tests/cstk/test_recall.sh
@@ -4102,9 +4102,25 @@ _seed_sql_equiv_state() {
     _ses_i=$((_ses_i + 1))
   done
 
+  # Sugestoes (FR-020): 2 quando ha decisoes (1 com issue aberta, 1 com
+  # segredo plantado no diagnostico para checar scrub nos DOIS caminhos);
+  # 0 no cenario vazio (exercita array ausente/vazio -> 0 linhas, sem erro).
+  # No state.db o array vive em execution.extra_fields.suggestions (catch-all,
+  # sem tabela propria) — a ingestao SQL->SQL precisa le-lo de la
+  # (fix-recall-sqlite-suggestions-ingest).
+  if [ "$_ses_ndec" -gt 0 ]; then
+    _ses_suggs='[{"id":"sug-001","affected_skill":"agente-00c-runtime","severity":"aviso","diagnosis":"commit-mode.sh stage-derived exclui untracked capturado no baseline sem aviso visivel","proposal":"documentar ordem start-antes-de-editar ou oferecer --refresh-baseline","references":["scripts/commit-mode.sh"],"issue_opened":"https://github.com/JotJunior/cstk/issues/999","created_at":"2026-01-01T00:00:50Z"},{"id":"sug-002","affected_skill":"create-tasks","severity":"informativa","diagnosis":"vazamento com token=ghp_abcdefghijklmnopqrstuvwxyz0123456789 no diagnostico de equivalencia","proposal":"scrub obrigatorio antes da FTS","references":[],"issue_opened":null,"created_at":"2026-01-01T00:00:55Z"}]'
+    _ses_nsug=2; _ses_nissue=1
+  else
+    _ses_suggs='[]'
+    _ses_nsug=0; _ses_nissue=0
+  fi
+
   jq -n \
     --argjson waves "$_ses_waves" --argjson decisions "$_ses_decs" \
     --argjson blocks "$_ses_blocks" --argjson tasks "$_ses_tasks" \
+    --argjson suggestions "$_ses_suggs" \
+    --argjson nsug "$_ses_nsug" --argjson nissue "$_ses_nissue" \
     --argjson ndec "$_ses_ndec" --argjson nwave "$_ses_nwave" '
     {
       schema_version: "1.0.0", short_name: "equiv-feat",
@@ -4130,9 +4146,10 @@ _seed_sql_equiv_state() {
         waves_total:$nwave, tool_calls_total:(5*$nwave), wallclock_total_seconds:(30*$nwave),
         max_depth_reached:1, subagents_spawned:0, decisions_total:$ndec,
         human_blocks_total:(if $ndec>0 then 1 else 0 end),
-        global_skill_suggestions_total:0, toolkit_issues_opened:0
+        global_skill_suggestions_total:$nsug, toolkit_issues_opened:$nissue
       },
       waves:$waves, decisions:$decisions, human_blocks:$blocks, tasks:$tasks,
+      suggestions:$suggestions,
       events: [
         {event_type:"schedule_wait", timestamp:"2026-01-01T00:00:15Z", description:"aguardando wakeup do equivalence test"},
         {event_type:"recall_consulted", timestamp:"2026-01-01T00:00:16Z"}
@@ -4143,11 +4160,14 @@ _seed_sql_equiv_state() {
 
 # _assert_sql_json_equivalent DIR LABEL -> ingere DIR (state.json presente,
 # state.db ausente) via caminho JSON em k-json.db, migra DIR para state.db,
-# ingere de novo (agora via SQL->SQL) em k-sql.db, e compara as 7 tabelas de
+# ingere de novo (agora via SQL->SQL) em k-sql.db, e compara as 8 tabelas de
 # entidade linha-a-linha (ORDER BY source_id), ignorando as colunas
-# `ingested_at` (wall-clock, nunca igual) e as 3 colunas de executions sem
-# fonte em state.db (subagents_spawned/skill_suggestions_total/
-# toolkit_issues_opened — NULL no SQL->SQL vs 0 fabricado no export JSON).
+# `ingested_at` (wall-clock, nunca igual) e a coluna executions.
+# subagents_spawned, sem fonte em state.db (NULL no SQL->SQL vs 0 fabricado
+# no export JSON). skill_suggestions_total/toolkit_issues_opened SAO
+# comparados: sob SQLite derivam de execution.extra_fields.suggestions
+# (mesma derivacao de _state-rw-db.sh read), sob JSON do contador de
+# accumulated_metrics — o seed mantem os dois coerentes.
 _assert_sql_json_equivalent() {
   _aje_dir="$1"; _aje_label="$2"
   _aje_kjson="$TMPDIR_TEST/${_aje_label}-json.db"
@@ -4161,15 +4181,16 @@ _assert_sql_json_equivalent() {
 
   assert_exit 0 _rc --ingest --state-dir "$_aje_dir" --db "$_aje_ksql" || return 1
 
-  for _aje_t in executions waves decisions blocks tasks events skills; do
+  for _aje_t in executions waves decisions blocks tasks events skills suggestions; do
     case "$_aje_t" in
-      executions) _aje_cols="project,feature,wave,execution_id,source_id,status,termination_reason,current_stage,started_at,finished_at,duration_seconds,suggested_stack,waves_total,tool_calls_total,wallclock_total_seconds,decisions_total,human_blocks_total,session,target_project_path" ;;
+      executions) _aje_cols="project,feature,wave,execution_id,source_id,status,termination_reason,current_stage,started_at,finished_at,duration_seconds,suggested_stack,waves_total,tool_calls_total,wallclock_total_seconds,decisions_total,human_blocks_total,skill_suggestions_total,toolkit_issues_opened,session,target_project_path" ;;
       waves) _aje_cols="project,feature,wave,execution_id,source_id,stages,started_at,finished_at,wallclock_seconds,tool_calls,termination_reason,n_stages,n_skills,session" ;;
       decisions) _aje_cols="project,feature,wave,execution_id,source_id,agent,stage,choice,options,score,context,rationale,evidence" ;;
       blocks) _aje_cols="project,feature,wave,execution_id,source_id,status,question,context_for_answer,answer,decision_id,triggered_at,answered_at,latency_seconds" ;;
       tasks) _aje_cols="project,feature,wave,execution_id,source_id,title,outcome,tests_run,tests_passed,lint_ok,touched_files" ;;
       events) _aje_cols="project,feature,wave,execution_id,source_id,event_type,timestamp,description" ;;
       skills) _aje_cols="project,feature,wave,execution_id,source_id,skill_name,decision_id" ;;
+      suggestions) _aje_cols="project,feature,wave,execution_id,source_ts,source_id,affected_skill,severity,diagnosis,proposal,\"references\",issue_opened" ;;
     esac
     _aje_a=$(sqlite3 "$_aje_kjson" "SELECT $_aje_cols FROM $_aje_t ORDER BY source_id;")
     _aje_b=$(sqlite3 "$_aje_ksql" "SELECT $_aje_cols FROM $_aje_t ORDER BY source_id;")
@@ -4226,6 +4247,73 @@ scenario_sqldb_json_path_preservado_sem_migracao() {
   assert_exit 0 _rc --ingest --state-dir "$_d" --db "$TMPDIR_TEST/no-migrate.db" || return 1
   assert_stdout_contains "3 decisions" || return 1
   [ ! -f "$_d/state.db" ] || { _fail "no-migrate: state.db nao deveria existir" ""; return 1; }
+  return 0
+}
+
+# Cenario sqldb-suggestions (bugfix fix-recall-sqlite-suggestions-ingest):
+# `.suggestions[]` vive em execution.extra_fields no state.db (sem tabela
+# propria) e ficava FORA da ingestao SQL->SQL — nenhuma sugestao registrada
+# apos o cutover para state.db chegava ao knowledge.db (painel/`recall
+# --type suggestion` cegos). Ingere um state-dir SO com state.db (state.json
+# removido apos migrar, para garantir que o caminho exercitado e o sqlite) e
+# verifica: linhas em suggestions, FTS type='suggestion', contadores de
+# executions derivados do array, scrub aplicado, busca por --type
+# suggestion encontra, e re-ingestao e idempotente.
+scenario_sqldb_suggestions_ingeridas_do_extra_fields() {
+  _have_deps || return 0
+  _d="$TMPDIR_TEST/sqldb-sugg"
+  _seed_sql_equiv_state "$_d" 2 1
+  capture "$MIGRATE_00C" migrate --state-dir "$_d"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqldb-sugg: migrate" "$_CAPTURED_STDERR"; return 1; }
+  rm -f "$_d/state.json"
+  _db="$TMPDIR_TEST/sqldb-sugg.db"
+  assert_exit 0 _rc --ingest --state-dir "$_d" --db "$_db" || return 1
+  assert_stdout_contains "2 suggestions" || return 1
+  _n=$(sqlite3 "$_db" "SELECT count(*) FROM suggestions WHERE project='equiv-proj' AND feature='equiv-feat' AND wave='-'" 2>/dev/null)
+  [ "$_n" = "2" ] || { _fail "sqldb-sugg: linhas em suggestions" "esperado 2, obtido '$_n'"; return 1; }
+  _row=$(sqlite3 "$_db" "SELECT source_id||'|'||affected_skill||'|'||severity||'|'||coalesce(issue_opened,'NULL')||'|'||\"references\"||'|'||source_ts FROM suggestions WHERE source_id='sug-001'" 2>/dev/null)
+  [ "$_row" = "sug-001|agente-00c-runtime|aviso|https://github.com/JotJunior/cstk/issues/999|scripts/commit-mode.sh|2026-01-01T00:00:50Z" ] \
+    || { _fail "sqldb-sugg: colunas estruturadas de sug-001" "obtido '$_row'"; return 1; }
+  _fts=$(sqlite3 "$_db" "SELECT count(*) FROM knowledge_fts WHERE type='suggestion' AND project='equiv-proj' AND feature='equiv-feat'" 2>/dev/null)
+  [ "$_fts" = "2" ] || { _fail "sqldb-sugg: FTS type=suggestion" "esperado 2, obtido '$_fts'"; return 1; }
+  _cnt=$(sqlite3 "$_db" "SELECT skill_suggestions_total||'|'||toolkit_issues_opened FROM executions WHERE execution_id='exec-equiv-001'" 2>/dev/null)
+  [ "$_cnt" = "2|1" ] || { _fail "sqldb-sugg: contadores derivados em executions" "esperado '2|1', obtido '$_cnt'"; return 1; }
+  # Scrub: segredo plantado em sug-002 nao pode sobreviver nem na tabela nem na FTS.
+  _leak=$(sqlite3 "$_db" "SELECT count(*) FROM suggestions WHERE diagnosis LIKE '%ghp_abcdefghij%'" 2>/dev/null)
+  [ "$_leak" = "0" ] || { _fail "sqldb-sugg: scrub em suggestions.diagnosis" "segredo sobreviveu"; return 1; }
+  _leak=$(sqlite3 "$_db" "SELECT count(*) FROM knowledge_fts WHERE type='suggestion' AND body LIKE '%ghp_abcdefghij%'" 2>/dev/null)
+  [ "$_leak" = "0" ] || { _fail "sqldb-sugg: scrub na FTS" "segredo sobreviveu"; return 1; }
+  # Busca por tipo encontra a sugestao (proveniencia + id).
+  assert_exit 0 _rc "stage-derived" --type suggestion --db "$_db" || return 1
+  assert_stdout_contains "sug-001" || return 1
+  assert_stdout_contains "equiv-feat" || return 1
+  # Idempotencia: re-ingestao do MESMO state.db nao duplica.
+  assert_exit 0 _rc --ingest --state-dir "$_d" --db "$_db" || return 1
+  _n2=$(sqlite3 "$_db" "SELECT count(*) FROM suggestions" 2>/dev/null)
+  _f2=$(sqlite3 "$_db" "SELECT count(*) FROM knowledge_fts WHERE type='suggestion'" 2>/dev/null)
+  [ "$_n2" = "2" ] && [ "$_f2" = "2" ] \
+    || { _fail "sqldb-sugg: idempotencia" "suggestions=$_n2 fts=$_f2 (esperado 2/2)"; return 1; }
+  return 0
+}
+
+# Cenario sqldb-suggestions-ausente: state.db cujo execution.extra_fields
+# nao tem `.suggestions` (ou e NULL) -> 0 sugestoes, contadores 0 (mesma
+# semantica de _state-rw-db.sh read: json_array_length(coalesce(...,'[]'))),
+# ingestao segue sem erro.
+scenario_sqldb_suggestions_ausentes_zero() {
+  _have_deps || return 0
+  _d="$TMPDIR_TEST/sqldb-nosugg"
+  _seed_sql_equiv_state "$_d" 0 1
+  capture "$MIGRATE_00C" migrate --state-dir "$_d"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "sqldb-nosugg: migrate" "$_CAPTURED_STDERR"; return 1; }
+  rm -f "$_d/state.json"
+  _db="$TMPDIR_TEST/sqldb-nosugg.db"
+  assert_exit 0 _rc --ingest --state-dir "$_d" --db "$_db" || return 1
+  assert_stdout_contains "0 suggestions" || return 1
+  _n=$(sqlite3 "$_db" "SELECT count(*) FROM suggestions" 2>/dev/null)
+  [ "$_n" = "0" ] || { _fail "sqldb-nosugg: suggestions" "esperado 0, obtido '$_n'"; return 1; }
+  _cnt=$(sqlite3 "$_db" "SELECT coalesce(skill_suggestions_total,'NULL')||'|'||coalesce(toolkit_issues_opened,'NULL') FROM executions WHERE execution_id='exec-equiv-001'" 2>/dev/null)
+  [ "$_cnt" = "0|0" ] || { _fail "sqldb-nosugg: contadores" "esperado '0|0', obtido '$_cnt'"; return 1; }
   return 0
 }
 


### PR DESCRIPTION
## Resumo

Bugfix de paridade da ingestão do `knowledge.db` com o backend SQLite: `recall_ingest_state_db` só copiava as 7 entidades com tabela própria no `state.db`; `.suggestions[]` vive em `execution.extra_fields` (catch-all) e nunca chegava ao índice. Desde o cutover para `state.db` nenhuma sugestão nova aparecia no painel nem em `cstk recall --type suggestion` (última ingerida 2026-08-04; caso real: `sug-001` de `wp-intel/mcp-scaffold-padrao`, presente no `.md` e no `state.db`, ausente no índice).

- nova `recall_suggestions_sql` compartilhada pelos caminhos JSON e SQL→SQL (UPSERT + FTS `type='suggestion'` + scrub)
- PASS 2 do SQL→SQL lê o array via `json_extract` (`mode=ro`)
- `executions.skill_suggestions_total`/`toolkit_issues_opened` derivados de `extra_fields.suggestions` (mesma derivação de `_state-rw-db.sh read`)
- CHANGELOG 8.0.1 + bump dos manifests de plugin (gate MP-5 validado local)

## Testes

- `tests/cstk/test_recall.sh`: fixture de equivalência JSON↔SQL passa a semear sugestões (comparação inclui tabela `suggestions` + 2 contadores); cenários novos `scenario_sqldb_suggestions_ingeridas_do_extra_fields` e `scenario_sqldb_suggestions_ausentes_zero`. Mutation-check: ambos falham contra o `recall.sh` da main.
- Suite completa local (`LC_ALL=C ./tests/run.sh`): 3006 PASS / 1 FAIL — o FAIL é o flaky documentado `test_00c-bootstrap::sigint_propaga_exit_130` (passa isolado, 19/19).
- `./tests/run.sh --check-coverage`: zero órfãos.
- Ingestão empírica do `state.db` real do wp-intel num `knowledge.db` de rascunho: `1 suggestions`, FTS ok, `recall "baseline untracked" --type suggestion` encontra `sug-001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRz4tEtvr3S9fXpPXE2Si8