### PR TITLE
fix: site sem catalogo, build lazy por stamp, reconcile-wave HOLD (8.1.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "8.1.0",
+      "version": "8.1.1",
       "category": "development"
     }
   ]

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -26,10 +26,10 @@ on:
     branches:
       - main
     paths:
-      - 'global/skills/**'
-      - 'language-related/**'
-      - 'global/agents/**'
-      - 'global/commands/**'
+      - 'plugins/cstk/skills/**'
+      - 'plugins/cstk-language-*/**'
+      - 'plugins/cstk/agents/**'
+      - 'plugins/cstk/commands/**'
       - 'docs-site/**'
       - 'mkdocs.yml'
       - 'requirements-docs.txt'
@@ -39,10 +39,10 @@ on:
       - '.github/workflows/publish-site.yml'
   pull_request:
     paths:
-      - 'global/skills/**'
-      - 'language-related/**'
-      - 'global/agents/**'
-      - 'global/commands/**'
+      - 'plugins/cstk/skills/**'
+      - 'plugins/cstk-language-*/**'
+      - 'plugins/cstk/agents/**'
+      - 'plugins/cstk/commands/**'
       - 'docs-site/**'
       - 'mkdocs.yml'
       - 'requirements-docs.txt'
@@ -91,6 +91,23 @@ jobs:
         env:
           NO_MKDOCS_2_WARNING: "1"
         run: mkdocs build --strict
+
+      - name: Assert catalog pages were generated
+        # Bugfix 8.1.1: apos a v7.0.0 (global/ -> plugins/cstk/) o hook
+        # gen_pages.py apontava para paths inexistentes e o site foi ao ar
+        # com catalogo VAZIO — mkdocs --strict nao reclama de diretorio-fonte
+        # ausente. Este step e a segunda linha de defesa (a primeira e o
+        # RuntimeError dentro do proprio hook): conta paginas geradas por
+        # categoria e falha se alguma zerar. Nunca deve passar com 0.
+        run: |
+          set -eu
+          n_skills=$(find site/skills -mindepth 1 -name 'index.html' -not -path 'site/skills/index.html' | wc -l | tr -d ' ')
+          n_agents=$(find site/agents -mindepth 2 -name 'index.html' | wc -l | tr -d ' ')
+          n_cmds=$(find site/commands -mindepth 2 -name 'index.html' | wc -l | tr -d ' ')
+          echo "catalog pages: skills=$n_skills agents=$n_agents commands=$n_cmds"
+          test "$n_skills" -ge 20 || { echo "::error::site/skills com $n_skills paginas (esperado >=20) — catalogo vazio ou paths-fonte errados"; exit 1; }
+          test "$n_agents" -ge 5  || { echo "::error::site/agents com $n_agents paginas (esperado >=5)"; exit 1; }
+          test "$n_cmds"   -ge 5  || { echo "::error::site/commands com $n_cmds paginas (esperado >=5)"; exit 1; }
 
       - name: Upload Pages artifact
         # So produz artifact em push/dispatch — em PR o build serve como quality gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [8.1.1] - 2026-08-17
+
+Três bugfixes com causa-raiz já diagnosticada e evidência registrada — dois
+deles descobertos ao validar a 8.1.0 de verdade na máquina do operador, o
+terceiro visível a qualquer visitante do site. Cada um vem com teste que
+prova o comportamento novo **e** foi verificado por mutação (o teste fica
+vermelho se o fix for revertido).
+
+### Fixed
+
+- **Site do GitHub Pages sem skills, agents e commands desde a v7.0.0.**
+  `docs-site/hooks/gen_pages.py` apontava para `global/` e
+  `language-related/`, movidos por `git mv` para `plugins/cstk/` e
+  `plugins/cstk-language-<lang>/` na feature `claude-plugin-packaging`. Glob
+  sobre diretório ausente devolve 0 sem erro, então `mkdocs --strict`
+  publicava o site com catálogo vazio há semanas. Os `paths:` do trigger de
+  `publish-site.yml` também eram os antigos — editar uma skill nem
+  redisparava o deploy. Agora: descoberta de linguagens por prefixo
+  `cstk-language-` (extensibilidade FR-016 preservada), `RuntimeError` no
+  hook se qualquer categoria global sair vazia, triggers em `plugins/**`, e
+  um step no workflow que conta páginas geradas por categoria e falha em
+  zero — duas linhas de defesa para o que antes não tinha nenhuma.
+- **`mcp-build-lazy.sh` não recompilava com fonte nova** (dec-106). O
+  fast-path era "entrypoint existe ⇒ no-op"; um `dist/` da 8.0.0 cacheado
+  em `~/.claude/mcp/state-server/` nunca era reconstruído quando o
+  `cstk install` trazia a 8.1.0 — o operador ficava com o catálogo novo e o
+  servidor velho, sem a 8ª tool e sem aviso. Agora o no-op exige que a
+  impressão digital da fonte (`package.json` + `package-lock.json` + `src/`,
+  sha256 portável) bata com o stamp gravado no último build
+  (`dist/.source-stamp`). Fonte nova ⇒ rebuild; `dist/` herdado sem stamp ⇒
+  rebuild uma vez. Idempotência preservada quando nada mudou. **Quem
+  atualizar de 8.0.x/8.1.0 é reconstruído automaticamente na primeira
+  chamada** — a limitação declarada em 8.1.0 deixa de existir.
+- **`state-ondas.sh reconcile-wave` avançava a fase `execute-task` com
+  backlog aberto** (dec-098; 4 ocorrências na mesma linha de trabalho).
+  `pipeline.sh next-stage` avança linearmente sem consultar completude, e a
+  rede de segurança do command pai chegava com dezenas de subtarefas
+  pendentes e promovia para `review-task`. Sem tratamento, `next` vazio
+  cairia no ramo terminal e promoveria a execução a `concluida` — desfecho
+  pior que avançar fase. Agora, em `execute-task` com `--tasks-md`, só
+  avança se não restar nenhum `- [ ]`; senão **HOLD**: fecha a onda sem
+  tocar `current_stage` nem `status`, e a `next_instruction` registra o
+  motivo. `--dry-run` reporta o HOLD sem escrever.
+
 ## [8.1.0] - 2026-08-17
 
 Feature `mcp-elicitation-optins`. Os três opt-ins do início de uma execução
@@ -6406,6 +6450,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[8.1.1]: https://github.com/JotJunior/cstk/releases/tag/v8.1.1
 [8.1.0]: https://github.com/JotJunior/cstk/releases/tag/v8.1.0
 [8.0.1]: https://github.com/JotJunior/cstk/releases/tag/v8.0.1
 [8.0.0]: https://github.com/JotJunior/cstk/releases/tag/v8.0.0

--- a/docs-site/hooks/gen_pages.py
+++ b/docs-site/hooks/gen_pages.py
@@ -6,10 +6,10 @@ Zero Duplicacao).
 
 Categorias geradas (paths virtuais sob `docs-site/`):
 
-  - `skills/<slug>.md`          <- global/skills/<slug>/SKILL.md
-  - `skills/<lang>/<slug>.md`   <- language-related/<lang>/skills/<slug>/SKILL.md
-  - `agents/<stem>.md`          <- global/agents/<stem>.md
-  - `commands/<stem>.md`        <- global/commands/<stem>.md
+  - `skills/<slug>.md`          <- plugins/cstk/skills/<slug>/SKILL.md
+  - `skills/<lang>/<slug>.md`   <- plugins/cstk-language-<lang>/skills/<slug>/SKILL.md
+  - `agents/<stem>.md`          <- plugins/cstk/agents/<stem>.md
+  - `commands/<stem>.md`        <- plugins/cstk/commands/<stem>.md
   - `skills/index.md`           <- index agrupado (global / go / dotnet)
   - `agents/index.md`           <- index agents
   - `commands/index.md`         <- index commands
@@ -17,7 +17,7 @@ Categorias geradas (paths virtuais sob `docs-site/`):
 Cada pagina gerada e um shim minimo contendo apenas a diretiva snippets
 `--8<--` referenciando o arquivo fonte (resolvido a partir da raiz do
 repo via `base_path: ['..', 'docs-site']` no `mkdocs.yml`). Isso garante
-que QUALQUER edicao em `global/skills/<X>/SKILL.md` se reflete no site
+que QUALQUER edicao em `plugins/cstk/skills/<X>/SKILL.md` se reflete no site
 sem mudanca aqui.
 
 Pass-through de frontmatter Claude (FR-024):
@@ -35,7 +35,7 @@ Edit links (FR-017):
   do repositorio quando combinado com `edit_uri` do mkdocs.yml.
 
 Extensibilidade (D-I, FR-016):
-  Para adicionar uma linguagem nova (ex: `language-related/python/`),
+  Para adicionar uma linguagem nova (ex: `plugins/cstk-language-python/`),
   basta colocar os SKILL.md no path canonico. Este hook descobre via
   glob — zero edits aqui.
 
@@ -71,10 +71,39 @@ import mkdocs_gen_files
 # parents[0] = hooks/, parents[1] = docs-site/, parents[2] = repo root.
 REPO_ROOT: Path = Path(__file__).resolve().parents[2]
 
-GLOBAL_SKILLS_DIR: Path = REPO_ROOT / "global" / "skills"
-GLOBAL_AGENTS_DIR: Path = REPO_ROOT / "global" / "agents"
-GLOBAL_COMMANDS_DIR: Path = REPO_ROOT / "global" / "commands"
-LANG_RELATED_DIR: Path = REPO_ROOT / "language-related"
+# Layout de plugin nativo (feature claude-plugin-packaging, v7.0.0): o catalogo
+# foi movido por `git mv` de `global/{skills,agents,commands}` para
+# `plugins/cstk/{skills,agents,commands}`, e `language-related/<lang>/` para
+# `plugins/cstk-language-<lang>/`. Este hook apontava para os paths antigos
+# e o site publicava catalogo VAZIO sem falhar o build (diretorio ausente nao
+# e erro para o glob) — bugfix 8.1.1. O guard `_assert_catalog_nonempty`
+# abaixo impede a recorrencia silenciosa.
+PLUGINS_DIR: Path = REPO_ROOT / "plugins"
+GLOBAL_SKILLS_DIR: Path = PLUGINS_DIR / "cstk" / "skills"
+GLOBAL_AGENTS_DIR: Path = PLUGINS_DIR / "cstk" / "agents"
+GLOBAL_COMMANDS_DIR: Path = PLUGINS_DIR / "cstk" / "commands"
+# Prefixo dos plugins de linguagem: `plugins/cstk-language-<lang>/skills/`.
+# A linguagem e o sufixo apos o prefixo (ex.: `cstk-language-go` -> `go`).
+LANG_PLUGIN_PREFIX: str = "cstk-language-"
+
+
+def _iter_lang_plugin_dirs() -> Iterator[tuple[str, Path]]:
+    """Enumera `(lang, plugin_dir)` para cada `plugins/cstk-language-<lang>/`.
+
+    Descoberta dinamica preservada (FR-016, D-I): adicionar
+    `plugins/cstk-language-python/skills/` funciona sem edits aqui.
+    """
+    if not PLUGINS_DIR.is_dir():
+        return
+    for plugin_dir in sorted(PLUGINS_DIR.iterdir()):
+        if not plugin_dir.is_dir():
+            continue
+        name = plugin_dir.name
+        if not name.startswith(LANG_PLUGIN_PREFIX):
+            continue
+        lang = name[len(LANG_PLUGIN_PREFIX):]
+        if lang:
+            yield lang, plugin_dir
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +280,7 @@ def _iter_skill_dirs(base_dir: Path) -> Iterator[Path]:
 def gen_skill_pages_global() -> int:
     """Gera paginas virtuais para skills globais.
 
-    Fonte: `global/skills/<slug>/SKILL.md`
+    Fonte: `plugins/cstk/skills/<slug>/SKILL.md`
     Destino: `skills/<slug>.md` (sob docs-site/)
     """
     count = 0
@@ -266,20 +295,14 @@ def gen_skill_pages_global() -> int:
 def gen_skill_pages_lang() -> dict[str, int]:
     """Gera paginas virtuais para skills por linguagem.
 
-    Fonte: `language-related/<lang>/skills/<slug>/SKILL.md`
+    Fonte: `plugins/cstk-language-<lang>/skills/<slug>/SKILL.md`
     Destino: `skills/<lang>/<slug>.md`
 
-    Descoberto via glob — adicionar `language-related/python/skills/`
+    Descoberto via glob — adicionar `plugins/cstk-language-python/skills/`
     funciona sem edits aqui (FR-016, D-I).
     """
     counts: dict[str, int] = {}
-    if not LANG_RELATED_DIR.is_dir():
-        return counts
-
-    for lang_dir in sorted(LANG_RELATED_DIR.iterdir()):
-        if not lang_dir.is_dir():
-            continue
-        lang = lang_dir.name
+    for lang, lang_dir in _iter_lang_plugin_dirs():
         skills_base = lang_dir / "skills"
         if not skills_base.is_dir():
             continue
@@ -298,7 +321,7 @@ def gen_skill_pages_lang() -> dict[str, int]:
 def gen_agent_pages() -> int:
     """Gera paginas virtuais para agents.
 
-    Fonte: `global/agents/<stem>.md`
+    Fonte: `plugins/cstk/agents/<stem>.md`
     Destino: `agents/<stem>.md`
     """
     if not GLOBAL_AGENTS_DIR.is_dir():
@@ -318,7 +341,7 @@ def gen_agent_pages() -> int:
 def gen_command_pages() -> int:
     """Gera paginas virtuais para slash commands.
 
-    Fonte: `global/commands/<stem>.md`
+    Fonte: `plugins/cstk/commands/<stem>.md`
     Destino: `commands/<stem>.md`
     """
     if not GLOBAL_COMMANDS_DIR.is_dir():
@@ -379,23 +402,20 @@ def gen_skill_index() -> int:
         sections.append(("Skills Globais", global_items))
 
     # Skills por linguagem (descoberta dinamica)
-    if LANG_RELATED_DIR.is_dir():
-        for lang_dir in sorted(LANG_RELATED_DIR.iterdir()):
-            if not lang_dir.is_dir():
-                continue
-            skills_base = lang_dir / "skills"
-            if not skills_base.is_dir():
-                continue
-            lang_items: list[tuple[str, str, str]] = []
-            for skill_md in _iter_skill_dirs(skills_base):
-                slug = skill_md.parent.name
-                link = f"./{lang_dir.name}/{slug}.md"
-                desc = _extract_description(skill_md)
-                lang_items.append((slug, link, desc))
-            if lang_items:
-                # Titulo capitalizado: "Skills Go", "Skills Dotnet"
-                title = f"Skills {lang_dir.name.capitalize()}"
-                sections.append((title, lang_items))
+    for lang, lang_dir in _iter_lang_plugin_dirs():
+        skills_base = lang_dir / "skills"
+        if not skills_base.is_dir():
+            continue
+        lang_items: list[tuple[str, str, str]] = []
+        for skill_md in _iter_skill_dirs(skills_base):
+            slug = skill_md.parent.name
+            link = f"./{lang}/{slug}.md"
+            desc = _extract_description(skill_md)
+            lang_items.append((slug, link, desc))
+        if lang_items:
+            # Titulo capitalizado: "Skills Go", "Skills Dotnet"
+            title = f"Skills {lang.capitalize()}"
+            sections.append((title, lang_items))
 
     # Renderizar markdown
     lines: list[str] = [
@@ -433,7 +453,7 @@ def gen_skill_index() -> int:
 def gen_agent_index() -> int:
     """Gera `agents/index.md` virtual com listagem alfabetica.
 
-    Lista todos os arquivos `global/agents/*.md`, com descricao curta
+    Lista todos os arquivos `plugins/cstk/agents/*.md`, com descricao curta
     extraida do frontmatter `description:`.
 
     Retorna numero de itens listados.
@@ -479,7 +499,7 @@ def gen_agent_index() -> int:
 def gen_command_index() -> int:
     """Gera `commands/index.md` virtual com listagem alfabetica.
 
-    Lista todos os arquivos `global/commands/*.md`, com descricao curta
+    Lista todos os arquivos `plugins/cstk/commands/*.md`, com descricao curta
     extraida do frontmatter `description:`.
 
     Retorna numero de itens listados.
@@ -527,6 +547,30 @@ def gen_command_index() -> int:
 # ---------------------------------------------------------------------------
 
 
+def _assert_catalog_nonempty(n_skills: int, n_agents: int, n_commands: int) -> None:
+    """Falha o build se alguma categoria GLOBAL do catalogo saiu vazia.
+
+    Um catalogo vazio nunca e estado legitimo do toolkit (ha >20 skills,
+    7 agents e 6 commands versionados). Zero paginas significa que
+    GLOBAL_*_DIR aponta para um path que nao existe mais — exatamente o
+    que aconteceu quando `global/` virou `plugins/cstk/` (v7.0.0) e o site
+    ficou sem catalogo sem ninguem perceber. Skills por linguagem NAO
+    entram no guard: sao opcionais por desenho (FR-016).
+    """
+    empty = [
+        name
+        for name, n in (("skills", n_skills), ("agents", n_agents), ("commands", n_commands))
+        if n == 0
+    ]
+    if empty:
+        raise RuntimeError(
+            "[gen_pages] catalogo VAZIO em: "
+            + ", ".join(empty)
+            + f" — verifique os paths-fonte (GLOBAL_*_DIR sob {PLUGINS_DIR}). "
+            "Um catalogo vazio e bug de path, nao estado valido do site."
+        )
+
+
 def main() -> None:
     """Orquestra a geracao de todas as categorias.
 
@@ -543,6 +587,13 @@ def main() -> None:
 
     total_lang = sum(n_lang.values())
     detail_total = n_global + total_lang + n_agents + n_commands
+
+    # Guard anti-regressao (bugfix 8.1.1): o site publicou catalogo VAZIO por
+    # semanas apos a v7.0.0 porque os paths-fonte mudaram e o glob sobre
+    # diretorio ausente devolve 0 sem erro. Catalogo vazio em qualquer
+    # categoria global e SEMPRE bug de path, nunca estado legitimo — falhar
+    # o build (strict) e a unica forma de tornar isso visivel em CI.
+    _assert_catalog_nonempty(n_global, n_agents, n_commands)
 
     # FASE 3 — paginas-index (catalogos)
     n_skill_idx = gen_skill_index()

--- a/docs/specs/mcp-elicitation-optins/tasks.md
+++ b/docs/specs/mcp-elicitation-optins/tasks.md
@@ -790,13 +790,14 @@ Ref: `quickstart.md` Scenarios 1, 1b, 2, 3, 4, 5, 6, 7, 8, 9
       COM flag) e `:331-364` (elevacao/no-op SEM flag), usando o fixture
       `fake-collect-optins-delivery-tier-captures-argv.sh`. Confirmado
       nesta onda: `npm test` em `mcp/state-server` => 157/157 pass.
-- [!] 11.1.3 Scenario 2 (escopo `/feature-00c`, 1 campo `atomic_commit`,
+- [x] 11.1.3 Scenario 2 (escopo `/feature-00c`, 1 campo `atomic_commit`,
       sem tier). Logica de restricao de escopo unit-testada
       (`collect_optins.test.ts:142`, `feature-00c` restrito a
       `atomic_commit`) — mas a execucao E2E ao vivo com `/feature-00c` real
       (formulario com 1 campo observado por um operador) NAO foi rodada
       nesta linha; so `/agente-00c` foi validado ao vivo (11.1.1/dec-108).
       Requer sessao interativa; nao rodada — nao invento o resultado.
+  <!-- VALIDADO 2026-08-17 pelo OPERADOR em sessao interativa nova, catalogo 8.1.0 oficial: Scenario 2 — /feature-00c em projeto novo com .mcp.json: formulario com UM campo (atomic-commit), sem tier e sem roadmap. Relato literal: "mostrou somente o modo atomic-commit". Escopo por executionKind confirmado (dec-083). -->
 - [x] 11.1.4 Scenario 3 (3a recusa explicita / 3b ausencia headless,
       `declined` x `absent` distinguiveis, SC-004). Unit-testado:
       `collect_optins.test.ts:174` (`action=decline` => `declined` em
@@ -818,6 +819,7 @@ Ref: `quickstart.md` Scenarios 1, 1b, 2, 3, 4, 5, 6, 7, 8, 9
       estao intactos. A observacao COMPORTAMENTAL ao vivo (rodar
       `/agente-00c` sem `cstk mcp start`, confirmar zero linhas em stderr)
       nao foi executada nesta linha. Requer sessao interativa; nao rodada.
+  <!-- PARCIALMENTE VALIDADO 2026-08-17 pelo OPERADOR (sessao interativa nova, catalogo 8.1.0 oficial), projeto SEM .mcp.json: o ramo LEGADO entrou — opt-in de atomic-commit em PROSA nativa, sem TUI, sem mencao a MCP (relato literal: "abriu a opcao do atomic-commit nativo (sem TUI)"). PORÉM o command pai verificou o projeto depois: NENHUM state-dir, NENHUM .mcp.json provisionado — a execucao nao chegou ao init (o operador encerrou apos o 1o prompt; roadmap e tier vem em sequencia e nao foram alcancados). Provado: ramo legado entra silenciosamente (SC-003). NAO provado: os 3 opt-ins em prosa + init com as flags + persistencia channel:prose (FASE 12/3.ter). Repetir ate o init concluir. -->
 - [!] 11.1.7 Scenario 6 (mecanismo falha no meio, 1 aviso, re-spawn,
       operador nao perguntado 2x, SC-005). Parcial: o desfecho `failed`
       no NIVEL da tool MCP (excecao generica => `outcome failed`,
@@ -828,7 +830,8 @@ Ref: `quickstart.md` Scenarios 1, 1b, 2, 3, 4, 5, 6, 7, 8, 9
       re-spawnar sem perguntar 2x) nao tem automatizacao equivalente e
       nao foi observado ao vivo nesta linha. Requer sessao interativa com
       falha induzida a meio da chamada; nao rodada.
-- [!] 11.1.8 Scenario 7 (idempotencia em retomada via
+  <!-- PARCIALMENTE VALIDADO 2026-08-17 pelo command pai (metade SERVIDOR, automatizada, servidor do repo dist 0.6.0): cliente respondeu erro JSON-RPC -32603 a elicitation/create => envelope {mechanism:failed, fields[*].outcome:failed, applied_value=defaults seguros false/false/cloud-public}, persistido em .optin_responses[] com outcome failed. Zero linhas em stderr do SERVIDOR — CORRETO: o aviso de 1 linha e do ORQUESTRADOR (agente-00c-orchestrator.md:402-403, log_err), que le mechanism:failed. A metade orquestrador (aviso, nao abrir onda, re-spawn pelo pai) segue [!]: exige execucao real; a prosa e coberta por test_command-spawn-optin-degradation.sh (16). -->
+- [x] 11.1.8 Scenario 7 (idempotencia em retomada via
       `/agente-00c-resume`, `reused`, zero requisicoes novas, repetivel).
       O mecanismo de reuso (cap M6) esta unit-testado —
       `collect_optins.test.ts:266`: todos os campos aplicaveis ja
@@ -836,7 +839,8 @@ Ref: `quickstart.md` Scenarios 1, 1b, 2, 3, 4, 5, 6, 7, 8, 9
       completo (interromper apos Scenario 1, `/agente-00c-resume` real,
       confirmar zero formularios e repetir 2x) nao foi executado nesta
       linha. Requer sessao interativa; nao rodada.
-- [!] 11.1.9 Scenario 8 (roundtrip envelope real x contrato — nomes de
+  <!-- VALIDADO 2026-08-17 pelo OPERADOR em sessao interativa nova, catalogo 8.1.0 oficial: Scenario 7 — /agente-00c-resume no projeto E2E que ja tinha as 3 respostas do Scenario 1, rodado DUAS vezes: nenhum formulario apareceu, execucao retomou normalmente nas duas. Relato literal: "carregado duas vezes, nas duas nao abriu TUI e continuou normal". Idempotencia confirmada (nao apenas uma-vez-a-menos). -->
+- [x] 11.1.9 Scenario 8 (roundtrip envelope real x contrato — nomes de
       campo, tokens de enum, `applied_value` batendo com os helpers). O
       proprio cenario exige explicitamente "sem mock, sem fixture" —
       subir o servidor de fato e comparar o envelope retornado contra
@@ -846,6 +850,7 @@ Ref: `quickstart.md` Scenarios 1, 1b, 2, 3, 4, 5, 6, 7, 8, 9
       comparacao campo-a-campo do envelope contra o contrato — nao posso
       afirmar "zero divergencia" sem essa evidencia. Nao rodada nesta
       linha; nao invento o resultado.
+  <!-- VALIDADO 2026-08-17 pelo command pai, servidor do repo (dist 0.6.0), execucao descartavel: envelope real {mechanism:structured, fields[{field,outcome,applied_value}], reused[]} — campos batem com o contrato (snake_case, sem coercao); outcome=absent e um dos tokens do data-model; applied_value false/false/cloud-public == commit-mode is-enabled / roadmap-mode is-enabled / delivery-tier get. Zero divergencia. -->
 - [x] 11.1.10 Scenario 9 (guard de composicao — ja coberto por FASE 7.2).
       `./tests/run.sh test_orchestrator-allowlist-guard` executado nesta
       onda: `PASS: 17 FAIL: 0 ERROR: 0 ORPHANS: 0` — inclui

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/mcp-build-lazy.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/mcp-build-lazy.sh
@@ -12,8 +12,9 @@
 #
 # PAPEL: garante que <dir>/dist/src/index.js exista, instalando as
 # dependencias declaradas em <dir>/package.json e compilando o
-# TypeScript quando necessario. Idempotente — se o entrypoint ja existe,
-# e um no-op imediato (nem instala nem builda de novo).
+# TypeScript quando necessario. Idempotente — se o entrypoint ja existe E a
+# fonte nao mudou desde o ultimo build (stamp em dist/.source-stamp), e um
+# no-op imediato; fonte nova (release via `cstk install`) => reconstroi.
 #
 # MITIGACAO DE SUPPLY CHAIN (R8): o Dockerfile removido nesta feature
 # (cli/lib/mcp-docker.sh, FASE 3) tinha a UNICA ocorrencia real, ate
@@ -73,8 +74,10 @@ uso: $_MBL_NAME.sh ensure --dir <path>
 
 Garante que <path>/dist/src/index.js exista: instala as dependencias de
 <path> (fixadas por package-lock.json, sem scripts de ciclo de vida) e
-roda o build (npm run build) quando o entrypoint ainda nao existe.
-Idempotente — no-op se o entrypoint ja existe.
+roda o build (npm run build) quando o entrypoint ainda nao existe OU quando
+a fonte (package.json, package-lock.json, src/) mudou desde o ultimo build.
+Idempotente — no-op se entrypoint existe e o stamp em dist/.source-stamp
+bate com a fonte atual.
 EOF
 }
 
@@ -101,10 +104,55 @@ done
 [ -d "$_mbl_dir" ] || _mbl_die "diretorio nao encontrado: $_mbl_dir" 2
 
 _mbl_entrypoint="$_mbl_dir/dist/src/index.js"
+_mbl_stamp="$_mbl_dir/dist/.source-stamp"
 
-# Fast path idempotente: build ja pronto (cache de sessoes anteriores em
-# ~/.claude/mcp/state-server/) — nem instala, nem builda de novo.
-if [ -f "$_mbl_entrypoint" ]; then
+# _mbl_source_fingerprint DIR -> imprime uma impressao digital da FONTE que
+# alimenta o build: package.json + package-lock.json + todo src/ (paths
+# relativos, ordenados, com o conteudo). Muda sempre que a release nova do
+# servidor chega via `cstk install` — que copia a fonte mas NAO o dist/.
+#
+# Bugfix 8.1.1 (dec-106 da feature mcp-elicitation-optins): o fast-path
+# antigo era "entrypoint existe => no-op", entao um dist/ da 8.0.0 cacheado
+# em ~/.claude/mcp/state-server/ NUNCA era recompilado quando a 8.1.0
+# trouxe a 8a tool — o operador ficava com o catalogo novo e o servidor
+# velho, sem aviso. Agora o no-op exige que a fonte nao tenha mudado desde
+# o ultimo build (stamp gravado em dist/.source-stamp).
+_mbl_source_fingerprint() {
+  _mbl_sf_dir=$1
+  # `find | sort` garante ordem estavel entre execucoes; sha256 do
+  # conteudo concatenado (path + bytes) — o proprio hash da lista de
+  # arquivos ja captura rename/adicao/remocao.
+  (
+    cd "$_mbl_sf_dir" || exit 1
+    {
+      for _f in package.json package-lock.json; do
+        [ -f "$_f" ] && { printf '%s\n' "$_f"; cat "$_f"; }
+      done
+      if [ -d src ]; then
+        find src -type f | LC_ALL=C sort | while IFS= read -r _f; do
+          printf '%s\n' "$_f"; cat "$_f"
+        done
+      fi
+    } | _mbl_sha256
+  )
+}
+
+# sha256 portavel: sha256sum (Linux/coreutils) ou shasum -a 256 (macOS/BSD).
+_mbl_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+_mbl_current_fp=$(_mbl_source_fingerprint "$_mbl_dir") || _mbl_current_fp=""
+
+# Fast path idempotente: build ja pronto E a fonte nao mudou desde ele.
+# Sem stamp (dist/ de versao anterior a este fix) => trata como fonte
+# desconhecida e reconstroi UMA vez, gravando o stamp.
+if [ -f "$_mbl_entrypoint" ] && [ -n "$_mbl_current_fp" ] \
+   && [ -f "$_mbl_stamp" ] && [ "$(cat "$_mbl_stamp" 2>/dev/null)" = "$_mbl_current_fp" ]; then
   printf '%s\n' "$_mbl_entrypoint"
   exit 0
 fi
@@ -133,5 +181,10 @@ fi
 
 [ -f "$_mbl_entrypoint" ] \
   || _mbl_die "build concluido mas entrypoint ainda ausente: $_mbl_entrypoint"
+
+# Grava o stamp da fonte que ACABOU de ser compilada — e o que permite o
+# fast-path da proxima chamada ser um no-op honesto. Best-effort: falha ao
+# gravar so significa que a proxima chamada reconstroi de novo (seguro).
+[ -n "$_mbl_current_fp" ] && printf '%s\n' "$_mbl_current_fp" > "$_mbl_stamp" 2>/dev/null || :
 
 printf '%s\n' "$_mbl_entrypoint"

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/state-ondas.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/state-ondas.sh
@@ -1662,7 +1662,31 @@ _so_cmd_reconcile_wave() {
     _rcw_next=""
   fi
 
+  # Bugfix 8.1.1 (dec-098 de mcp-elicitation-optins; tambem dec-053 de
+  # orchestrator-mcp-allowlist e dec-068 de mcp-direct-transport — 4
+  # ocorrencias na mesma linha de trabalho): pipeline.sh next-stage avanca
+  # LINEARMENTE, sem saber se o backlog da fase execute-task acabou. A rede
+  # de seguranca do pai chegava aqui com 26/92 subtarefas pendentes e
+  # promovia current_stage para review-task, declarando revisavel uma
+  # feature cujo cutover nem tinha acontecido. Regra: em execute-task, so
+  # avanca se NENHUM checkbox `- [ ]` restar no tasks.md fornecido. Sem
+  # --tasks-md nao ha como saber — mantem o comportamento antigo (o pai e
+  # instruido a sempre passar --tasks-md nessa fase).
+  if [ "$_rcw_phase" = "execute-task" ] && [ -n "$_rcw_md" ] && [ -f "$_rcw_md" ] \
+     && [ -n "$_rcw_next" ]; then
+    _rcw_pending=$(grep -cE '^[[:space:]]*- \[ \]' "$_rcw_md" 2>/dev/null) || _rcw_pending=0
+    case "$_rcw_pending" in ''|*[!0-9]*) _rcw_pending=0 ;; esac
+    if [ "$_rcw_pending" -gt 0 ]; then
+      _rcw_next=""
+      _rcw_hold_reason="backlog incompleto: $_rcw_pending subtarefa(s) pendente(s) em $_rcw_md"
+    fi
+  fi
+
   if [ "$_rcw_dry" = "yes" ]; then
+    if [ -n "${_rcw_hold_reason:-}" ]; then
+      printf 'would reconcile: phase=%s (HOLD, %s) -> fecha onda sem avancar\n' "$_rcw_phase" "$_rcw_hold_reason"
+      return 0
+    fi
     if [ -n "$_rcw_next" ]; then
       printf 'would reconcile: phase=%s -> next=%s motivo=etapa_concluida_avancando\n' "$_rcw_phase" "$_rcw_next"
     else
@@ -1687,6 +1711,20 @@ _so_cmd_reconcile_wave() {
   # idempotencia acima tornaria invisivel). O texto proprio da rede de
   # seguranca entra via --next-instruction (FR-004: sobrescreve so o
   # texto; o avanco de fase ocorre igual).
+  if [ -n "${_rcw_hold_reason:-}" ]; then
+    # HOLD (bugfix 8.1.1, dec-098): backlog de execute-task ainda tem
+    # subtarefas pendentes. Fecha a onda SEM avancar a fase e SEM promover
+    # a terminal — o proximo resume continua em execute-task. E o unico
+    # ramo que nao toca current_stage; a next_instruction registra o
+    # motivo para o pai/operador nao confundirem com onda perdida.
+    _rcw_motivo="etapa_concluida_avancando"
+    _rcw_instr=$(printf 'Continuar etapa execute-task — %s (rede de seguranca do command pai NAO avancou a fase).' "$_rcw_hold_reason")
+    _so_cmd_end --state-dir "$_rcw_sdir" --motivo-termino "$_rcw_motivo" \
+      --next-instruction "$_rcw_instr" >/dev/null
+    printf 'reconciled (phase=%s motivo=%s HOLD: %s)\n' "$_rcw_phase" "$_rcw_motivo" "$_rcw_hold_reason"
+    return 0
+  fi
+
   if [ -n "$_rcw_next" ]; then
     _rcw_motivo="etapa_concluida_avancando"
     _rcw_instr=$(printf 'Iniciar etapa %s — retomada pela rede de seguranca do command pai (onda anterior fechada sem Schedule intent).' "$_rcw_next")

--- a/tests/test_mcp-build-lazy.sh
+++ b/tests/test_mcp-build-lazy.sh
@@ -92,18 +92,75 @@ _run_ensure() {
   fi
 }
 
-scenario_entrypoint_ja_existe_e_noop_nao_chama_npm() {
-  _dir="$TMPDIR_TEST/proj-cached"
+# Bugfix 8.1.1 (dec-106): o fast-path deixou de ser "entrypoint existe =>
+# no-op" e passou a exigir que a FONTE nao tenha mudado desde o ultimo build
+# (stamp em dist/.source-stamp). Os 3 cenarios abaixo substituem o antigo
+# `entrypoint_ja_existe_e_noop_nao_chama_npm`, que fixava justamente o bug.
+# Deteccao de chamada ao npm: stub que LOGA em npm-calls.log (o cenario
+# antigo prefixava um bin vazio ao PATH — o npm real seguia acessivel).
+
+# 1) build inicial grava o stamp; 2a chamada com fonte IGUAL e no-op.
+scenario_stamp_gravado_no_build_e_fonte_igual_e_noop() {
+  _dir="$TMPDIR_TEST/proj-stamp"
+  _make_pkg_dir "$_dir"
+  _bin="$TMPDIR_TEST/stubs-stamp"
+  mkdir -p "$_bin"
+  _stub_npm_builds_entrypoint "$_bin" "$_dir"
+  rm -f "$TMPDIR_TEST/npm-calls.log"
+  _run_ensure "$_dir" "$_bin"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "build inicial" "exit $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  [ -f "$_dir/dist/.source-stamp" ] || { _fail "stamp ausente" "build nao gravou dist/.source-stamp"; return 1; }
+  _n1=$(grep -c 'run build' "$TMPDIR_TEST/npm-calls.log" 2>/dev/null || echo 0)
+  # 2a chamada, fonte identica: nao pode chamar npm de novo
+  _run_ensure "$_dir" "$_bin"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "noop exit" "exit $_CAPTURED_EXIT"; return 1; }
+  _n2=$(grep -c 'run build' "$TMPDIR_TEST/npm-calls.log" 2>/dev/null || echo 0)
+  [ "$_n1" = "$_n2" ] || { _fail "noop chamou npm" "builds antes=$_n1 depois=$_n2 (fonte igual devia ser no-op)"; return 1; }
+  assert_stdout_contains "$_dir/dist/src/index.js" || return 1
+}
+
+# Fonte MUDOU (release nova via cstk install) com entrypoint presente:
+# DEVE reconstruir — e o cenario exato do dec-106 (dist/ da 8.0.0 + fonte da 8.1.0).
+scenario_fonte_mudou_com_entrypoint_presente_reconstroi() {
+  _dir="$TMPDIR_TEST/proj-stale"
+  _make_pkg_dir "$_dir"
+  _bin="$TMPDIR_TEST/stubs-stale"
+  mkdir -p "$_bin"
+  _stub_npm_builds_entrypoint "$_bin" "$_dir"
+  rm -f "$TMPDIR_TEST/npm-calls.log"
+  _run_ensure "$_dir" "$_bin"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "build inicial" "exit $_CAPTURED_EXIT"; return 1; }
+  _n1=$(grep -c 'run build' "$TMPDIR_TEST/npm-calls.log" 2>/dev/null || echo 0)
+  # simula a release nova: fonte muda, dist/ velho continua no lugar
+  mkdir -p "$_dir/src/tools"
+  printf 'export const collect_optins = 1;
+' > "$_dir/src/tools/collect_optins.ts"
+  _run_ensure "$_dir" "$_bin"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "rebuild exit" "exit $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  _n2=$(grep -c 'run build' "$TMPDIR_TEST/npm-calls.log" 2>/dev/null || echo 0)
+  [ "$_n2" -gt "$_n1" ] || { _fail "nao reconstruiu" "fonte mudou mas builds antes=$_n1 depois=$_n2 — e o bug dec-106"; return 1; }
+}
+
+# dist/ herdado de versao ANTERIOR ao fix (entrypoint existe, SEM stamp):
+# reconstroi UMA vez e grava o stamp — migracao transparente.
+scenario_dist_legado_sem_stamp_reconstroi_uma_vez() {
+  _dir="$TMPDIR_TEST/proj-legacy"
   _make_pkg_dir "$_dir"
   mkdir -p "$_dir/dist/src"
-  printf 'module.exports={};\n' > "$_dir/dist/src/index.js"
-  _bin="$TMPDIR_TEST/stubs-noop"
+  printf 'module.exports={};\n' > "$_dir/dist/src/index.js"   # dist velho, sem stamp
+  _bin="$TMPDIR_TEST/stubs-legacy"
   mkdir -p "$_bin"
-  # npm ausente do PATH restrito de proposito: se o script chamar npm
-  # aqui, falharia por "nao encontrado" e o teste pegaria a regressao.
+  _stub_npm_builds_entrypoint "$_bin" "$_dir"
+  rm -f "$TMPDIR_TEST/npm-calls.log"
   _run_ensure "$_dir" "$_bin"
-  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "noop exit" "esperado 0, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
-  assert_stdout_contains "$_dir/dist/src/index.js" || return 1
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "rebuild legado" "exit $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  grep -q 'run build' "$TMPDIR_TEST/npm-calls.log" 2>/dev/null || { _fail "nao reconstruiu" "dist sem stamp devia reconstruir uma vez"; return 1; }
+  [ -f "$_dir/dist/.source-stamp" ] || { _fail "stamp" "apos reconstruir devia gravar o stamp"; return 1; }
+  # e agora e no-op
+  _n1=$(grep -c 'run build' "$TMPDIR_TEST/npm-calls.log")
+  _run_ensure "$_dir" "$_bin"
+  _n2=$(grep -c 'run build' "$TMPDIR_TEST/npm-calls.log")
+  [ "$_n1" = "$_n2" ] || { _fail "2a chamada" "devia ser no-op apos gravar stamp"; return 1; }
 }
 
 scenario_lockfile_ausente_falha_fail_closed() {

--- a/tests/test_mcp-launch.sh
+++ b/tests/test_mcp-launch.sh
@@ -51,6 +51,20 @@ _make_state_server_dir_with_dist() {
   _make_state_server_dir "$_mssdwd_dir"
   mkdir -p "$_mssdwd_dir/dist/src"
   printf 'module.exports = {};\n' > "$_mssdwd_dir/dist/src/index.js"
+  # Bugfix 8.1.1 (dec-106): "dist pronto" passou a significar "dist cujo
+  # stamp bate com a fonte" — o build lazy reconstroi qualquer dist/ sem
+  # stamp (era assim que um dist/ da 8.0.0 ficava para tras). Esta fixture
+  # representa um dist LEGITIMO de sessao anterior, entao grava o stamp
+  # com o MESMO fingerprint que mcp-build-lazy.sh calcula (reusa a funcao
+  # do proprio script, extraida por `sed`; se o algoritmo mudar la, muda
+  # aqui junto — nunca duplicar a formula).
+  _mssdwd_bl="$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/scripts/mcp-build-lazy.sh"
+  _mssdwd_fp=$(
+    # shellcheck disable=SC1090
+    eval "$(sed -n '/^_mbl_source_fingerprint()/,/^}/p;/^_mbl_sha256()/,/^}/p' "$_mssdwd_bl")"
+    _mbl_source_fingerprint "$_mssdwd_dir"
+  )
+  printf '%s\n' "$_mssdwd_fp" > "$_mssdwd_dir/dist/.source-stamp"
 }
 
 # _stub_node BIN_DIR [MAJOR] -> stub `node` que responde `-v` com o major

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -986,6 +986,64 @@ scenario_reconcile_wave_idempotente_nao_double_conta() {
   assert_stdout_contains "clarify" || return 1
 }
 
+# Bugfix 8.1.1 (dec-098 de mcp-elicitation-optins; dec-053/dec-068 antes):
+# em execute-task, reconcile-wave so pode avancar a fase se o tasks.md nao
+# tiver NENHUM `- [ ]`. Sem isso o pai chegava com 26/92 pendentes e
+# promovia para review-task (4 ocorrencias na mesma linha de trabalho).
+scenario_reconcile_wave_execute_task_backlog_aberto_nao_avanca() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$RW" set --state-dir "$_sd" --field '.current_stage' --value '"execute-task"'
+  _md="$TMPDIR_TEST/tasks-aberto.md"
+  printf '## FASE 1\n### 1.1 Tarefa `[A]`\n- [x] 1.1.1 feita\n- [ ] 1.1.2 pendente\n- [ ] 1.1.3 pendente\n' > "$_md"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" reconcile-wave --state-dir "$_sd" --terminal-phase review-task --tasks-md "$_md"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "reconcile hold" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "HOLD" || return 1
+  # fase NAO avancou
+  capture "$RW" get --state-dir "$_sd" --field '.current_stage'
+  assert_stdout_contains "execute-task" || { _fail "fase avancou" "esperado execute-task, obtido: $_CAPTURED_STDOUT"; return 1; }
+  # e NAO promoveu a terminal (o pior desfecho: _rcw_next vazio caindo no ramo terminal)
+  capture "$RW" get --state-dir "$_sd" --field '.execution.status'
+  assert_stdout_contains "em_andamento" || { _fail "promoveu terminal" "status: $_CAPTURED_STDOUT"; return 1; }
+  # onda foi fechada mesmo assim (nao fica aberta)
+  capture "$RW" get --state-dir "$_sd" --field '.waves[-1].finished_at'
+  case "$_CAPTURED_STDOUT" in null|"") _fail "onda aberta" "hold devia fechar a onda"; return 1;; esac
+  # next_instruction registra o motivo
+  capture "$RW" get --state-dir "$_sd" --field '.next_instruction'
+  assert_stdout_contains "pendente" || return 1
+}
+
+# Negativo do hold: backlog SEM `- [ ]` (tudo [x] e [!]) => avanca normalmente.
+scenario_reconcile_wave_execute_task_backlog_completo_avanca() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$RW" set --state-dir "$_sd" --field '.current_stage' --value '"execute-task"'
+  _md="$TMPDIR_TEST/tasks-completo.md"
+  printf '## FASE 1\n### 1.1 Tarefa `[A]`\n- [x] 1.1.1 feita\n- [!] 1.1.2 bloqueada com motivo\n' > "$_md"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" reconcile-wave --state-dir "$_sd" --terminal-phase review-task --tasks-md "$_md"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "reconcile avanca" "$_CAPTURED_STDERR"; return 1; }
+  case "$_CAPTURED_STDOUT" in *HOLD*) _fail "hold indevido" "backlog completo nao pode dar HOLD: $_CAPTURED_STDOUT"; return 1;; esac
+  capture "$RW" get --state-dir "$_sd" --field '.current_stage'
+  assert_stdout_contains "review-task" || { _fail "nao avancou" "esperado review-task, obtido: $_CAPTURED_STDOUT"; return 1; }
+}
+
+# --dry-run reporta o HOLD sem escrever nada.
+scenario_reconcile_wave_dry_run_reporta_hold() {
+  _sd="$TMPDIR_TEST/state"
+  _init_state "$_sd"
+  capture "$RW" set --state-dir "$_sd" --field '.current_stage' --value '"execute-task"'
+  _md="$TMPDIR_TEST/tasks-dry.md"
+  printf -- '- [ ] 1.1.1 pendente\n' > "$_md"
+  capture "$SCRIPT" start --state-dir "$_sd"
+  capture "$SCRIPT" reconcile-wave --state-dir "$_sd" --terminal-phase review-task --tasks-md "$_md" --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "dry-run" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "HOLD" || return 1
+  capture "$RW" get --state-dir "$_sd" --field '.waves[-1].finished_at'
+  case "$_CAPTURED_STDOUT" in null|"") : ;; *) _fail "dry-run escreveu" "onda foi fechada em dry-run"; return 1;; esac
+}
+
 scenario_reconcile_wave_terminal_promove_status_feature00c() {
   # feature-00c: review-task e terminal. --terminal-phase review-task evita
   # que pipeline.sh avance erroneamente para review-features. Deve promover


### PR DESCRIPTION
Tres bugfixes com causa-raiz ja diagnosticada e evidencia registrada. Cada um vem com teste que prova o comportamento novo **e** foi verificado por mutacao (revertendo o fix, o teste fica vermelho).

## Fixed

- **Site do GitHub Pages sem skills, agents e commands desde a v7.0.0.** `docs-site/hooks/gen_pages.py` apontava para `global/` e `language-related/`, movidos para `plugins/cstk/` e `plugins/cstk-language-<lang>/`. Glob sobre diretorio ausente devolve 0 sem erro — o site foi ao ar vazio por semanas. Os `paths:` do trigger de `publish-site.yml` tambem eram os antigos (editar skill nem redisparava deploy). Agora: descoberta de linguagens por prefixo, `RuntimeError` no hook se categoria global sair vazia, triggers em `plugins/**`, step no workflow que conta paginas geradas e falha em zero.
- **`mcp-build-lazy.sh` nao recompilava com fonte nova** (dec-106). Fast-path era "entrypoint existe => no-op"; `dist/` da 8.0.0 nunca era reconstruido quando a 8.1.0 chegava. Agora exige stamp da fonte (`dist/.source-stamp`, sha256 de package.json+lockfile+src/) igual ao atual. Quem atualizar e reconstruido na primeira chamada — a limitacao declarada em 8.1.0 deixa de existir.
- **`reconcile-wave` avancava `execute-task` com backlog aberto** (dec-098; 4 ocorrencias). Sem tratamento, `next` vazio caia no ramo terminal e promovia a `concluida`. Agora HOLD: so avanca se nao restar `- [ ]`; senao fecha a onda sem tocar fase/status.

## Testado

- Suite completa: `PASS: 3060  FAIL: 0  ERROR: 0  ORPHANS: 0` (883s)
- `--check-coverage`: zero orfaos
- `validate-plugin-manifests.sh --version 8.1.1 --strict`: OK
- gen_pages.py com stub: 21 skills + 7 go + 7 agents + 6 commands; mutacao (paths antigos) => RuntimeError
- test_mcp-build-lazy 12/12; mutacao => 2 FAIL
- test_state-ondas 150/150; mutacao => 2 FAIL
- test_mcp-launch 9/9 (fixture de dist pronto passa a gravar o stamp)

Inclui atualizacao do tasks.md da mcp-elicitation-optins: Scenarios 2/7/8 validados (operador + automatizado), 5 e 6 parciais com evidencia honesta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015d4YE2oA44PiQFDJvaqBot