### PR TITLE
fix(agente-00c): ramo de opt-ins exige tool no toolset, nao so token do CLI (8.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "8.3.0",
+      "version": "8.3.1",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "8.3.0",
+      "version": "8.3.1",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,95 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [8.3.1] - 2026-08-18
+
+Bugfix do ramo de captura de opt-ins dos commands `/agente-00c` e
+`/feature-00c` (feature `mcp-elicitation-optins`, 8.1.0). Caso real em
+projeto-alvo com cstk 8.3.0: `/mcp` mostrava `cstk-state · connected · no
+tools` (o launcher `mcp-launch.sh` servia o stub IDLE porque o processo
+`node` real não podia subir), mas o command pai declarava "ramo
+estruturado (MCP ativo)" só porque `cstk mcp start` cunhou um token,
+spawnava o orquestrador — que devolvia o turno sem abrir onda, pois a
+tool `mcp__cstk-state__collect_optins` não existia no harness — e só
+então caía na prosa de opt-in. A premissa do contrato ("o pai só tem o
+token como sinal") era falsa: o pai É a sessão principal e enxerga o
+próprio toolset. Sem breaking; sem skill nova.
+
+### Added
+
+- **`mcp-launch.sh preflight`** (`plugins/cstk/skills/agente-00c-runtime/
+  scripts/mcp-launch.sh`): diagnóstico READ-ONLY que reproduz as mesmas
+  checagens do boot (state-server instalado, Node >= 22,
+  `mcp-build-lazy.sh` presente, `dist/src/index.js` construído) SEM
+  `exec node` e SEM rodar build (nunca invoca `npm` — `npm ci` pode
+  pendurar sem rede). Imprime `ready|<entrypoint>` (exit 0) ou
+  `idle|<motivo>` (exit 3), onde `<motivo>` é o mesmo texto que o boot
+  escreve em stderr ao servir o stub IDLE — permite ao operador descobrir
+  POR QUE o servidor aparece "conectado sem tools". Argumento desconhecido
+  → exit 2; invocação sem argumentos (a registrada no `.mcp.json`) segue
+  idêntica. 7 cenários novos em `tests/test_mcp-launch.sh` (16 no total).
+
+### Fixed
+
+- **Decisão do ramo de opt-ins (2.bis de `agente-00c.md` / bloco
+  equivalente de `feature-00c.md`)**: o token cunhado por `cstk mcp
+  start` passa a promover o ramo apenas a `candidato`; o ramo
+  `estruturado` exige DUAS confirmações adicionais — `mcp-launch.sh
+  preflight` = `ready` E a tool `mcp__cstk-state__collect_optins` visível
+  no toolset do próprio command pai (em dúvida, `ToolSearch` com
+  `select:mcp__cstk-state__collect_optins`). `.mcp.json` presente, `cstk
+  mcp status`/`start` OK e até `preflight=ready` NÃO substituem a checagem
+  do toolset (cobre sessão bootada antes do `.mcp.json` e servidor de
+  projeto não aprovado, invisíveis a qualquer probe de disco). Única
+  exceção ao "nenhum aviso" do ramo legado (FR-005): quando o token FOI
+  cunhado mas o ramo caiu para legado, o pai imprime UMA linha de
+  diagnóstico (`MCP cstk-state: servidor registrado, mas sem tools nesta
+  sessao (<motivo>) — opt-ins seguem por prosa; a onda usa Bash.`) — os
+  prompts em si permanecem byte-a-byte. O bullet de injeção do token
+  cobre o caso novo "token não-vazio com ramo legado": injeta a linha do
+  token (o orquestrador decide MCP-vs-Bash tool a tool), NÃO injeta a
+  linha do ramo estruturado.
+- **Detecção de degradação no pai (4.bis dos dois commands)**: além de
+  `structured:unavailable|failed` (registros que a PRÓPRIA tool escreve),
+  campo aplicável SEM NENHUM registro em `.optin_responses[]` após o
+  primeiro spawn, com `.waves | length == 0`, também é degradação — a
+  tool que nunca chegou a rodar não escreve nada, e o pai ficava cego.
+  Onda aberta prova captura por outro caminho (guard M4/I-2 impede abrir
+  sem registro), então o sinal só conta com zero ondas.
+- **Orquestradores (`agente-00c-orchestrator.md` §1.bis /
+  `agente-00c-feature-orchestrator.md` §3.bis)**: removida a premissa
+  falsa "tool ausente ⇒ o pai decidiu legado por token vazio; siga para o
+  passo 2/4" (com token presente e tool ausente, o guard M4/I-2 travaria a
+  onda-001 e o turno era queimado à toa). O discriminador do ramo passa a
+  ser a PRESENÇA da linha `MCP: ramo estruturado de opt-ins ativo` no
+  prompt de spawn, nunca o token. Três casos: linha ausente → legado,
+  segue; linha presente + tool visível → `collect_optins`; linha presente
+  + tool NÃO visível → tratar como `mechanism: "unavailable"` (não abre
+  onda, devolve o turno em silêncio, sem escrever em `.optin_responses[]`
+  — INV-4). Bloco compartilhado "Orientação MCP-vs-Bash" intocado
+  (byte-idêntico entre os dois orquestradores, FR-011).
+- **Header stale do `mcp-launch.sh`** afirmava "o command pai segue
+  decidindo (via `cstk mcp status`) se a onda usa MCP ou Bash" —
+  exatamente a premissa que causou o bug; corrigido para toolset +
+  preflight (gateado por cenário em `tests/test_mcp-launch.sh`).
+
+### Changed
+
+- **`docs/specs/mcp-elicitation-optins/contracts/optin-capture-order.md`**
+  §2 (tabela de decisão de ramo: token E preflight `ready` E tool visível;
+  linha nova "token presente mas preflight idle ou tool não visível →
+  LEGADO + 1 linha de diagnóstico") e §3.3(b) (sinal estrutural "sem
+  registro + zero ondas"; orquestrador não escreve nada nesse sub-caso).
+- **`plugins/cstk/skills/agente-00c-runtime/SKILL.md`**: parágrafo do
+  `mcp-launch.sh` ainda descrevia o modo Docker pré-cutover (`docker exec
+  -i` attach, exit 3 em bash-fallback); reescrito para o transporte
+  direto (8.0.0), stub IDLE e `preflight`.
+- **`tests/test_command-spawn-optin-elicitation.sh`**: +5 cenários (ordem
+  `candidato` < preflight < toolset < prompt de prosa nos dois commands;
+  o token sozinho nunca mais promove a `estruturado`; 4.bis com "sem
+  registro"; orquestradores sem a premissa stale; bullet do token com
+  ramo legado) — 26 no total.
+
 ## [8.3.0] - 2026-08-18
 
 A oferta de leva paralela pós-roadmap (`8.2.0`) só acontecia automaticamente
@@ -6576,6 +6665,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[8.3.1]: https://github.com/JotJunior/cstk/releases/tag/v8.3.1
 [8.3.0]: https://github.com/JotJunior/cstk/releases/tag/v8.3.0
 [8.2.0]: https://github.com/JotJunior/cstk/releases/tag/v8.2.0
 [8.1.1]: https://github.com/JotJunior/cstk/releases/tag/v8.1.1

--- a/docs/specs/mcp-elicitation-optins/contracts/optin-capture-order.md
+++ b/docs/specs/mcp-elicitation-optins/contracts/optin-capture-order.md
@@ -39,7 +39,19 @@ token vazio / descritor ausente, **nunca** o literal `mode=bash-fallback`
 | Sinal | Ramo | Comportamento observado pelo operador |
 |-------|------|----------------------------------------|
 | descritor ausente / `_mcp_token` vazio | **LEGADO** (§4) | identico a hoje; **nenhum** aviso (FR-005, US3-1, SC-005) |
-| token presente | **ESTRUTURADO** (§3) | formulario, com degradacao conforme §3.3 |
+| token presente **E** `mcp-launch.sh preflight` = `ready` **E** `mcp__cstk-state__collect_optins` visivel no toolset do pai | **ESTRUTURADO** (§3) | formulario, com degradacao conforme §3.3 |
+| token presente, mas preflight `idle` **ou** tool nao visivel | **LEGADO** (§4) + **1 linha** de diagnostico | prosa byte-a-byte; a linha explica o motivo (`idle|<motivo>` do preflight, ou "tool nao visivel — sessao bootada antes do .mcp.json / servidor nao aprovado") |
+
+**Emenda (bugfix 8.3.1, caso real 2026-08-18)**: o token cunhado por `cstk mcp
+start` NAO prova que a tool existe no harness da sessao — `/mcp` mostrava
+`cstk-state · connected · no tools` (launcher em modo IDLE), o pai declarava
+ESTRUTURADO, o orquestrador devolvia o turno sem abrir onda e so entao a
+prosa rodava. A premissa "o pai so tem o token como sinal" era falsa: o pai
+E a sessao principal e enxerga o proprio toolset. Duas confirmacoes passam a
+ser exigidas alem do token (o preflight explica o IDLE ao operador; a
+visibilidade da tool e a unica prova real). A linha de diagnostico e a unica
+excecao ao "nenhum aviso" do ramo LEGADO — so quando o operador registrou o
+`.mcp.json` e o mecanismo esta meio-configurado.
 
 O padrao de leitura do token ja existe e e VERIFICADO:
 `feature-00c.md:741-742` — "`_mcp_token` vazio (bash-fallback / sem descritor)
@@ -96,10 +108,16 @@ nao consegue resposta interativa dentro do proprio turno, a prosa MUST rodar no
 **pai**. Protocolo de retorno:
 
 1. o orquestrador **nao abre onda**, encerra o turno imediatamente;
-2. o pai le o estado — `.optin_responses[]` com `outcome ∈ {unavailable, failed}` —
+2. o pai le o estado — `.optin_responses[]` com `outcome ∈ {unavailable, failed}`,
+   **ou** (bugfix 8.3.1) campo aplicavel **sem nenhum registro** com
+   `.waves | length == 0` (a tool nem chegou a rodar: nao visivel no toolset
+   do subagente, servidor IDLE — ninguem escreve nada nesse caso; onda aberta
+   prova captura por outro caminho, pois M4/I-2 impede abrir sem registro) —
    via `state-rw.sh get`. **Sinal estrutural, nao texto**: o pai nunca
    interpreta o sumario do subagente (mesma disciplina de "fonte de verdade e o
-   state");
+   state"). O orquestrador, no sub-caso "tool nao visivel", devolve o turno
+   sem escrever nada (INV-4) — o discriminador dele e a linha
+   `MCP: ramo estruturado de opt-ins ativo` no prompt de spawn, nunca o token;
 3. o pai executa os blocos de prosa existentes (FR-005, texto inalterado);
 4. o pai persiste via `commit-mode.sh set-enabled` / `roadmap-mode.sh set-enabled`
    / `delivery-tier.sh set [--allow-downgrade]` (**nao** por flags de init — o

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/agents/agente-00c-feature-orchestrator.md
+++ b/plugins/cstk/agents/agente-00c-feature-orchestrator.md
@@ -257,11 +257,26 @@ retomada sempre segue onda fechada" apos o Loop.
    server-side de `executionKind` (`collect_optins.ts:FIELDS_BY_EXECUTION_KIND`)
    — para `feature-00c` isso e SOMENTE `atomic_commit` (`roadmap_mode` e o
    campo de finalidade de entrega sao exclusivos de `agente-00c`; dec-083).
-   Se o token estiver ausente/a tool nao existir no toolset desta sessao
-   (ex.: sessao anterior ao cutover MCP, ou plugin/catalogo desatualizado),
-   NAO trate como erro (SC-003) — o command pai ja decidiu o ramo LEGADO por
-   token vazio e a prosa de opt-in dele ja cobriu a captura; siga
-   normalmente para o passo 4. **Invariante I-2**: nenhuma onda pode abrir
+   O discriminador do ramo e a PRESENCA, no prompt de spawn, da linha
+   `MCP: ramo estruturado de opt-ins ativo` — nunca o token (bugfix 8.3.1:
+   o pai pode injetar token com ramo LEGADO quando o servidor esta
+   registrado mas sem tools nesta sessao). Tres casos:
+   - **Linha ausente** (ramo legado, com ou sem token): NAO trate como
+     erro (SC-003) — a prosa de opt-in do pai ja cobriu a captura e
+     persistiu `.optin_responses[]`; siga normalmente para o passo 4.
+   - **Linha presente E tool visivel**: chame `collect_optins` (acima).
+   - **Linha presente E tool NAO visivel no toolset** (servidor IDLE, nao
+     carregado nesta sessao, plugin/catalogo desatualizado): trate
+     EXATAMENTE como `mechanism: "unavailable"` abaixo — NAO chame
+     `state-ondas.sh start`/`open_wave`, devolva o turno ao pai
+     IMEDIATAMENTE, em silencio (sem relatorio de onda, sem `Schedule
+     intent`, sem escrever em `.optin_responses[]` — INV-4). O pai detecta
+     pelo sinal estrutural "campo aplicavel sem registro + zero ondas"
+     (4.bis dele), roda a prosa e re-spawna. NUNCA "siga para o passo 4"
+     nesse caso: o guard M4/I-2 travaria a onda-001 e o turno seria
+     queimado a toa (caso real 2026-08-18 no `/agente-00c`, `cstk-state ·
+     connected · no tools`).
+   **Invariante I-2**: nenhuma onda pode abrir
    enquanto houver `field` aplicavel a `executionKind` sem registro em
    `.optin_responses[]` — a guarda mecanica completa vive no runtime (FASE
    9.3/M4 de `mcp-elicitation-optins`); aqui a obrigacao e prosa: nao chame

--- a/plugins/cstk/agents/agente-00c-orchestrator.md
+++ b/plugins/cstk/agents/agente-00c-orchestrator.md
@@ -370,12 +370,26 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
    e derivado server-side de `executionKind`
    (`collect_optins.ts:FIELDS_BY_EXECUTION_KIND`) — para `agente-00c` isso
    e `atomic_commit` + `roadmap_mode` + `delivery_tier` (os 3 campos; ver
-   tabela completa no contrato da feature). Se o token estiver
-   ausente/a tool nao existir no toolset desta sessao (sessao anterior ao
-   cutover MCP, ou plugin/catalogo desatualizado), NAO trate como erro
-   (SC-003) — o command pai ja decidiu o ramo LEGADO por token vazio e a
-   prosa de opt-in dele ja cobriu a captura; siga normalmente para o passo
-   2. **Invariante I-2**: nenhuma onda pode abrir enquanto houver `field`
+   tabela completa no contrato da feature). O discriminador do ramo e a
+   PRESENCA, no prompt de spawn, da linha `MCP: ramo estruturado de
+   opt-ins ativo` — nunca o token (bugfix 8.3.1: o pai pode injetar token
+   com ramo LEGADO quando o servidor esta registrado mas sem tools nesta
+   sessao). Tres casos:
+   - **Linha ausente** (ramo legado, com ou sem token): NAO trate como
+     erro (SC-003) — a prosa de opt-in do pai ja cobriu a captura e
+     persistiu `.optin_responses[]`; siga normalmente para o passo 2.
+   - **Linha presente E tool visivel**: chame `collect_optins` (acima).
+   - **Linha presente E tool NAO visivel no toolset** (servidor IDLE, nao
+     carregado nesta sessao, plugin/catalogo desatualizado): trate
+     EXATAMENTE como `mechanism: "unavailable"` abaixo — NAO chame
+     `state-ondas.sh start`, devolva o turno ao pai IMEDIATAMENTE, em
+     silencio (sem relatorio de onda, sem `Schedule intent`, sem
+     escrever em `.optin_responses[]` — INV-4). O pai detecta pelo sinal
+     estrutural "campo aplicavel sem registro + zero ondas" (4.bis dele),
+     roda a prosa e re-spawna. NUNCA "siga para o passo 2" nesse caso: o
+     guard M4/I-2 travaria a onda-001 e o turno seria queimado a toa (caso
+     real 2026-08-18, `cstk-state · connected · no tools`).
+   **Invariante I-2**: nenhuma onda pode abrir enquanto houver `field`
    aplicavel a `executionKind` sem registro em `.optin_responses[]` — a
    guarda mecanica completa vive no runtime (FASE 9.3/M4 de
    `mcp-elicitation-optins`); aqui a obrigacao e prosa: nao chame

--- a/plugins/cstk/commands/agente-00c.md
+++ b/plugins/cstk/commands/agente-00c.md
@@ -328,13 +328,51 @@ if [ -n "$_optin_mcpjson_pre" ] && cstk mcp status --state-dir "<SD>" >/dev/null
 fi
 if [ "$_optin_probe_rc" -eq 0 ]; then
   _optin_token=$(jq -r '.session_id // ""' "<SD>/mcp-server.json" 2>/dev/null) || _optin_token=""
-  [ -n "$_optin_token" ] && _optin_branch="estruturado"
+  [ -n "$_optin_token" ] && _optin_branch="candidato"
+fi
+# Bugfix 8.3.1 — o token cunhado por `cstk mcp start` NAO prova que a tool
+# existe no harness DESTA sessao (caso real: `/mcp` mostrava `cstk-state ·
+# connected · no tools` — launcher em modo IDLE por Node/npm/build — e o
+# pai declarava "estruturado", queimava a onda-001 e so entao caia na
+# prosa). O ramo estruturado exige DUAS confirmacoes alem do token:
+#   (b) preflight do launcher — explica ao operador o motivo do IDLE;
+#   (c) a tool visivel no SEU toolset — unica prova real (cobre tambem
+#       sessao bootada antes do .mcp.json e servidor de projeto nao
+#       aprovado, que nenhum probe de disco enxerga).
+_optin_preflight=""
+if [ "$_optin_branch" = "candidato" ]; then
+  _optin_preflight=$(mcp-launch.sh preflight 2>/dev/null) || :
+  case "$_optin_preflight" in
+    ready\|*) : ;;                       # servidor real serviria as tools
+    *)        _optin_branch="legado" ;;  # `idle|<motivo>` ou helper ausente
+  esac
 fi
 ```
+
+Se `_optin_branch = "candidato"` apos o preflight, aplique a confirmacao (c)
+**voce mesmo, sem script**: `mcp__cstk-state__collect_optins` consta entre
+as tools desta sessao (carregada ou deferred)? Em duvida, `ToolSearch` com
+`select:mcp__cstk-state__collect_optins` — resultado sem a tool = ausente.
+Presente ⇒ `_optin_branch="estruturado"`. Ausente ⇒ `_optin_branch="legado"`.
+`.mcp.json` presente, `cstk mcp status`/`start` OK e ate `preflight=ready`
+NAO substituem esta checagem: o servidor pode nem ter sido carregado nesta
+sessao (o `.mcp.json` e lido no boot; a aprovacao do servidor de projeto e do
+operador). Nunca chame a tool "para testar" — a chamada real e o primeiro
+ato do orquestrador.
 
 - `_optin_branch = "legado"` (subcomando `mcp` ausente, `start` falhou, ou
   token vazio): siga os 3 prompts de prosa abaixo **exatamente como hoje**
   (byte-a-byte, FR-005) — nenhuma mencao ao MCP, nenhum aviso.
+  **Excecao unica (bugfix 8.3.1)**: se o token FOI cunhado (`_optin_token`
+  nao-vazio) e o ramo caiu para legado por (b) ou (c), imprima ANTES dos
+  prompts UMA linha de diagnostico ao operador — ele registrou o
+  `.mcp.json` de proposito e precisa saber por que o formulario nao vem:
+  `MCP cstk-state: servidor registrado, mas sem tools nesta sessao
+  (<motivo>) — opt-ins seguem por prosa; a onda usa Bash.` onde `<motivo>`
+  e o texto apos `idle|` do preflight, ou, com `preflight=ready`, `tool
+  collect_optins nao visivel no toolset — sessao bootada antes do .mcp.json
+  ou servidor de projeto nao aprovado; reinicie a sessao / aprove em /mcp`.
+  Os prompts em si permanecem byte-a-byte.
 - `_optin_branch = "estruturado"`: **pule os 3 prompts de prosa abaixo** —
   a captura acontece via `collect_optins` dentro do turno do orquestrador
   (ver secao "Injecao do token de capacidade", mais abaixo).
@@ -614,6 +652,12 @@ fi
 >   Neste caso `_optin_branch` ja e `"legado"` por construcao (2.bis acima
 >   testa o MESMO `_mcp_token`), entao os opt-ins ja foram capturados por
 >   prosa ANTES do init — nao ha nada pendente para o orquestrador.
+> - `_mcp_token` NAO-vazio **com** `_optin_branch = "legado"` (bugfix 8.3.1:
+>   token cunhado, mas preflight `idle` ou tool ausente no toolset) ⇒ injete
+>   a linha do token normalmente (o orquestrador decide MCP-vs-Bash tool a
+>   tool) e **NAO** injete a linha do ramo estruturado — os opt-ins ja foram
+>   capturados por prosa e persistidos em 3.ter. O discriminador do
+>   orquestrador (1.bis) e a PRESENCA dessa linha, nunca o token.
 > - O token NUNCA e ecoado em stdout/stderr/logs do command — vive apenas
 >   no descritor (`chmod 600`) e no prompt do spawn (SEC-H3: roteamento por
 >   capacidade, nunca por precedencia).
@@ -682,6 +726,13 @@ mid-call do mecanismo estruturado (`contracts/optin-capture-order.md`
 (mesma disciplina de "fonte de verdade e o state"):
 
 ```bash
+# Bugfix 8.3.1: alem de `unavailable`/`failed` (gravados pela PROPRIA
+# tool), campo aplicavel SEM NENHUM registro apos o primeiro spawn tambem e
+# degradacao — a tool nem chegou a rodar (nao visivel no toolset do
+# subagente, servidor IDLE, ...) e ninguem escreve nada nesse caso. So conta
+# quando NENHUMA onda abriu (o guard M4/I-2 impede abrir onda sem registro,
+# entao onda aberta prova que a captura aconteceu por outro caminho).
+_waves_n=$(state-rw.sh get --state-dir "$STATE_DIR" --field '.waves | length' 2>/dev/null) || _waves_n=0
 _optin_degraded=""
 for _f in atomic_commit roadmap_mode delivery_tier; do
   _last=$(state-rw.sh get --state-dir "$STATE_DIR" \
@@ -690,6 +741,7 @@ for _f in atomic_commit roadmap_mode delivery_tier; do
   _last_out=$(printf '%s' "$_last" | jq -r '.outcome // ""')
   case "$_last_ch:$_last_out" in
     structured:unavailable|structured:failed) _optin_degraded="$_optin_degraded $_f" ;;
+    :) [ "${_waves_n:-0}" -eq 0 ] && _optin_degraded="$_optin_degraded $_f" ;;
   esac
 done
 ```

--- a/plugins/cstk/commands/feature-00c.md
+++ b/plugins/cstk/commands/feature-00c.md
@@ -679,10 +679,48 @@ if [ -n "$_optin_mcpjson_pre" ] && cstk mcp status --state-dir "$AGENTE_00C_STAT
 fi
 if [ "$_optin_probe_rc" -eq 0 ]; then
   _optin_token=$(jq -r '.session_id // ""' "$AGENTE_00C_STATE_DIR/mcp-server.json" 2>/dev/null) || _optin_token=""
-  [ -n "$_optin_token" ] && _optin_branch="estruturado"
+  [ -n "$_optin_token" ] && _optin_branch="candidato"
 fi
+# Bugfix 8.3.1 — o token cunhado por `cstk mcp start` NAO prova que a tool
+# existe no harness DESTA sessao (caso real no /agente-00c: `/mcp` mostrava
+# `cstk-state · connected · no tools` — launcher em modo IDLE por Node/npm/
+# build — e o pai declarava "estruturado", queimava a onda-001 e so entao
+# caia na prosa; mesma logica aqui). O ramo estruturado exige DUAS
+# confirmacoes alem do token:
+#   (b) preflight do launcher — explica ao operador o motivo do IDLE;
+#   (c) a tool visivel no SEU toolset — unica prova real (cobre tambem
+#       sessao bootada antes do .mcp.json e servidor de projeto nao
+#       aprovado, que nenhum probe de disco enxerga).
+_optin_preflight=""
+if [ "$_optin_branch" = "candidato" ]; then
+  _optin_preflight=$(mcp-launch.sh preflight 2>/dev/null) || :
+  case "$_optin_preflight" in
+    ready\|*) : ;;                       # servidor real serviria as tools
+    *)        _optin_branch="legado" ;;  # `idle|<motivo>` ou helper ausente
+  esac
+fi
+# Se _optin_branch = "candidato" apos o preflight, aplique a confirmacao (c)
+# VOCE MESMO, sem script: mcp__cstk-state__collect_optins consta entre as
+# tools desta sessao (carregada ou deferred)? Em duvida, ToolSearch com
+# `select:mcp__cstk-state__collect_optins` — resultado sem a tool = ausente.
+# Presente => _optin_branch="estruturado". Ausente => _optin_branch="legado".
+# .mcp.json presente, `cstk mcp status`/`start` OK e ate preflight=ready NAO
+# substituem esta checagem (o .mcp.json e lido no boot da sessao; a
+# aprovacao do servidor de projeto e do operador). Nunca chame a tool "para
+# testar" — a chamada real e o primeiro ato do orquestrador.
+#
 # _optin_branch = "legado": siga o prompt de prosa abaixo exatamente como
 #   hoje (byte-a-byte, FR-005) — nenhuma mencao ao MCP.
+#   Excecao unica (bugfix 8.3.1): se o token FOI cunhado (_optin_token
+#   nao-vazio) e o ramo caiu para legado por (b) ou (c), imprima ANTES do
+#   prompt UMA linha de diagnostico ao operador — ele registrou o .mcp.json
+#   de proposito e precisa saber por que o formulario nao vem:
+#   `MCP cstk-state: servidor registrado, mas sem tools nesta sessao
+#   (<motivo>) — opt-ins seguem por prosa; a onda usa Bash.` onde <motivo> e
+#   o texto apos `idle|` do preflight, ou, com preflight=ready, `tool
+#   collect_optins nao visivel no toolset — sessao bootada antes do
+#   .mcp.json ou servidor de projeto nao aprovado; reinicie a sessao /
+#   aprove em /mcp`. O prompt em si permanece byte-a-byte.
 # _optin_branch = "estruturado": pule o prompt de prosa abaixo por
 #   completo — _atomic permanece NAO-DEFINIDO; a flag --atomic-commit do
 #   init (mais abaixo) e OMITIDA; a captura acontece via collect_optins
@@ -848,6 +886,12 @@ fi
 >   Neste caso `_optin_branch` ja e `"legado"` por construcao (mesmo
 >   `_mcp_token` testado na decisao de ramo acima) — o opt-in ja foi
 >   capturado por prosa ANTES do init; nada pendente para o orquestrador.
+> - `_mcp_token` NAO-vazio **com** `_optin_branch = "legado"` (bugfix 8.3.1:
+>   token cunhado, mas preflight `idle` ou tool ausente no toolset) ⇒ injete
+>   a linha do token normalmente (o orquestrador decide MCP-vs-Bash tool a
+>   tool) e **NAO** injete a linha do ramo estruturado — o opt-in ja foi
+>   capturado por prosa e persistido em 3.ter. O discriminador do
+>   orquestrador (3.bis) e a PRESENCA dessa linha, nunca o token.
 > - O token NUNCA e ecoado em stdout/stderr/logs do command — vive apenas
 >   no descritor (`chmod 600`) e no prompt do spawn (SEC-H3: roteamento por
 >   capacidade, nunca por precedencia).
@@ -921,9 +965,16 @@ _last=$(state-rw.sh get --state-dir "$AGENTE_00C_STATE_DIR" \
   --field '[.optin_responses[]? | select(.field == "atomic_commit")] | last // {}')
 _last_ch=$(printf '%s' "$_last" | jq -r '.channel // ""')
 _last_out=$(printf '%s' "$_last" | jq -r '.outcome // ""')
+# Bugfix 8.3.1: campo SEM NENHUM registro apos o primeiro spawn tambem e
+# degradacao — a tool nem chegou a rodar (nao visivel no toolset do
+# subagente, servidor IDLE, ...) e ninguem escreve nada nesse caso. So
+# conta quando NENHUMA onda abriu (o guard M4/I-2 impede abrir onda sem
+# registro, entao onda aberta prova captura por outro caminho).
+_waves_n=$(state-rw.sh get --state-dir "$AGENTE_00C_STATE_DIR" --field '.waves | length' 2>/dev/null) || _waves_n=0
 _optin_degraded="false"
 case "$_last_ch:$_last_out" in
   structured:unavailable|structured:failed) _optin_degraded="true" ;;
+  :) [ "${_waves_n:-0}" -eq 0 ] && _optin_degraded="true" ;;
 esac
 ```
 

--- a/plugins/cstk/skills/agente-00c-runtime/SKILL.md
+++ b/plugins/cstk/skills/agente-00c-runtime/SKILL.md
@@ -166,12 +166,17 @@ pelo servidor MCP de estado (`mcp/state-server/src/session/resolve.ts`) e
 pelo `mcp-launch.sh` (abaixo).
 
 `mcp-launch.sh` e o comando registrado em `.mcp.json` (via `cstk mcp
-install`) que o Claude Code invoca ao conectar ao servidor MCP `cstk-state`:
-resolve a sessao ativa do projeto-alvo (delegando a `mcp-session.sh
-resolve`) e, se `mode=docker`, faz `docker exec -i` attach ao container
-ja rodando (subido por `cstk mcp start`); nunca sobe um container novo.
-Sessao `bash-fallback`, token ausente/invalido, ou Docker indisponivel ⇒
-exit 3 sem tentar `docker exec` (mesmo padrao fail-closed do resolve).
+install`) que o Claude Code invoca ao conectar ao servidor MCP `cstk-state`.
+Desde o cutover `mcp-direct-transport` (v8.0.0) ele faz `exec node
+dist/src/index.js` direto (build lazy via `mcp-build-lazy.sh`; a sessao e
+resolvida por chamada pelo token). Quando o processo real NAO pode subir
+(Node < 22/ausente, build lazy falhou), serve um stub IDLE com 0 tools —
+no `/mcp` aparece `connected · no tools`. `mcp-launch.sh preflight`
+(bugfix 8.3.1) reproduz as mesmas checagens sem servir nem buildar e
+imprime `ready|<entrypoint>` (exit 0) ou `idle|<motivo>` (exit 3); os
+commands `/agente-00c` e `/feature-00c` o usam para decidir o ramo de
+opt-ins e explicar o IDLE ao operador — a prova final de que a tool existe
+segue sendo o toolset do proprio command pai.
 
 Ambos POSIX puros + `jq`, seguem a mesma convencao `--state-dir` do resto
 do runtime. Detalhes completos: `docs/specs/state-mcp-server/`

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/mcp-launch.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/mcp-launch.sh
@@ -50,8 +50,10 @@
 # exit != 0 faria o harness reportar "Failed to reconnect to cstk-state:
 # -32000" em toda sessao normal — em vez disso, servimos o stub idle com
 # motivo explicito em stderr; o `/mcp` mostra o servidor conectado, sem
-# erro, e o command pai segue decidindo (via `cstk mcp status`) se a onda
-# usa o caminho MCP ou o Bash.
+# erro (`connected · no tools`), e o command pai decide se a onda usa o
+# caminho MCP ou o Bash olhando o PROPRIO toolset (tool visivel?) — nunca
+# so por `cstk mcp status`/token, que nao enxergam o modo IDLE (bugfix
+# 8.3.1; `mcp-launch.sh preflight` explica o motivo ao operador).
 #
 # `exec node <entrypoint>` substitui o PROCESSO deste script (nao um
 # subshell/fork em background) — o processo do servidor MORRE junto com
@@ -63,12 +65,37 @@
 # POSIX sh puro. Deps: node (>=22), npm (so no caminho de build), o
 # proprio mcp-build-lazy.sh (script irmao).
 #
+# Uso:
+#   mcp-launch.sh              # entrypoint stdio (registrado no .mcp.json)
+#   mcp-launch.sh preflight    # diagnostico READ-ONLY (bugfix 8.3.1)
+#
+# `preflight` (bugfix 8.3.1 — caso real: `/mcp` mostrava `cstk-state ·
+# connected · no tools` e o command pai, decidindo o ramo de opt-ins so pelo
+# token cunhado por `cstk mcp start`, declarava "estruturado" e queimava a
+# onda-001 antes de cair na prosa): reproduz EXATAMENTE as mesmas checagens
+# 1-3 do boot, sem `exec node`, sem rodar o build (nunca dispara `npm`), e
+# reporta numa linha em stdout se ESTE launcher serviria o servidor real ou
+# o stub IDLE (0 tools) nesta maquina:
+#   `ready|<entrypoint>`   exit 0  — o boot serviria as tools reais
+#   `idle|<motivo>`        exit 3  — o boot serviria o stub IDLE (0 tools);
+#                                    <motivo> e o MESMO texto que o boot
+#                                    escreve em stderr, para o operador
+#                                    corrigir a causa
+# NAO prova que o harness desta sessao carregou o servidor (o `.mcp.json`
+# e lido no boot da sessao; aprovacao do servidor de projeto e do
+# operador) — quem decide "a tool esta visivel?" e o proprio command pai,
+# olhando o proprio toolset. O preflight so explica o caso "conectado sem
+# tools".
+#
 # Exit codes:
 #   0  modo IDLE encerrado por EOF do harness (sessao fechou), ou node
 #      encerrado normalmente (nao deveria acontecer via exec, mas o
-#      codigo de saida do exec e propagado se acontecer)
+#      codigo de saida do exec e propagado se acontecer); ou `preflight`
+#      concluiu `ready`
 #   1  falha de MECANISMO barulhenta (mcp-build-lazy.sh/jq ausentes no
 #      idle, `node` desaparece do PATH entre o preflight e o exec)
+#   2  uso incorreto (argumento desconhecido)
+#   3  `preflight` concluiu `idle|<motivo>`
 
 set -eu
 
@@ -77,6 +104,31 @@ _ML_NAME="mcp-launch"
 _ml_die() {
   printf '%s: %s\n' "$_ML_NAME" "$1" >&2
   exit "${2:-1}"
+}
+
+# Modo de operacao: "serve" (default, entrypoint stdio do harness) ou
+# "preflight" (diagnostico read-only). Qualquer outro argumento e uso
+# incorreto — o harness invoca SEM argumentos, entao nada quebra no boot.
+_ml_mode="serve"
+case "${1:-}" in
+  "") ;;
+  preflight) _ml_mode="preflight" ;;
+  -h|--help)
+    printf 'uso: %s.sh [preflight]\n' "$_ML_NAME"
+    exit 0
+    ;;
+  *) _ml_die "argumento desconhecido: $1 (aceito: preflight)" 2 ;;
+esac
+
+# _ml_unavailable MOTIVO — sink unico das causas de "servidor real nao pode
+# subir". Em modo serve vira o stub IDLE (abaixo); em modo preflight vira a
+# linha `idle|<motivo>` em stdout + exit 3, SEM servir nada.
+_ml_unavailable() {
+  if [ "$_ml_mode" = "preflight" ]; then
+    printf 'idle|%s\n' "$1"
+    exit 3
+  fi
+  _ml_idle_serve "$1"
 }
 
 # Stub MCP idle: JSON-RPC newline-delimited (framing VERIFICADO em
@@ -139,7 +191,7 @@ _ml_project_path="${CSTK_MCP_PROJECT_PATH:-$(pwd)}"
 _ml_state_server_dir="${CSTK_MCP_STATE_SERVER_DIR:-${HOME:-}/.claude/mcp/state-server}"
 
 if [ ! -d "$_ml_state_server_dir" ] || [ ! -f "$_ml_state_server_dir/package.json" ]; then
-  _ml_idle_serve "mcp/state-server nao instalado em $_ml_state_server_dir (rode: cstk install)"
+  _ml_unavailable "mcp/state-server nao instalado em $_ml_state_server_dir (rode: cstk install)"
 fi
 
 # Preflight de Node (L-6, mesmo padrao de cli/lib/serve.sh
@@ -166,10 +218,10 @@ _ml_node_major() {
 }
 
 if ! _ml_major=$(_ml_node_major); then
-  _ml_idle_serve "node nao encontrado no PATH (servidor MCP requer Node >= $_ML_MIN_NODE_MAJOR)"
+  _ml_unavailable "node nao encontrado no PATH (servidor MCP requer Node >= $_ML_MIN_NODE_MAJOR)"
 fi
 if [ "$_ml_major" -lt "$_ML_MIN_NODE_MAJOR" ]; then
-  _ml_idle_serve "Node $_ml_major detectado; servidor MCP requer Node >= $_ML_MIN_NODE_MAJOR"
+  _ml_unavailable "Node $_ml_major detectado; servidor MCP requer Node >= $_ML_MIN_NODE_MAJOR"
 fi
 
 # Build lazy (L-4): idempotente — no-op imediato se dist/src/index.js ja
@@ -179,7 +231,30 @@ fi
 # sessao do harness.
 _ml_build_lazy_sh="$_ml_script_dir/mcp-build-lazy.sh"
 if [ ! -x "$_ml_build_lazy_sh" ]; then
-  _ml_idle_serve "mcp-build-lazy.sh nao encontrado/sem permissao de execucao em $_ml_script_dir"
+  _ml_unavailable "mcp-build-lazy.sh nao encontrado/sem permissao de execucao em $_ml_script_dir"
+fi
+
+# preflight NUNCA dispara o build (npm ci/npm run build podem demorar ou
+# pendurar sem rede): o boot do harness ja rodou o `ensure` real ao subir a
+# sessao — se o entrypoint NAO existe agora, o build falhou (ou nunca rodou
+# nesta maquina), e e isso que o motivo reporta. Diagnostico refinado
+# read-only para as causas mais comuns (mesmos pre-requisitos que
+# mcp-build-lazy.sh exige, sem executa-los).
+if [ "$_ml_mode" = "preflight" ]; then
+  _ml_pf_entry="$_ml_state_server_dir/dist/src/index.js"
+  if [ ! -f "$_ml_pf_entry" ]; then
+    _ml_pf_why="dist/src/index.js ausente em $_ml_state_server_dir — build lazy nao concluiu nesta maquina"
+    if [ ! -f "$_ml_state_server_dir/package-lock.json" ]; then
+      _ml_pf_why="$_ml_pf_why (package-lock.json ausente; rode: cstk install)"
+    elif ! command -v npm >/dev/null 2>&1; then
+      _ml_pf_why="$_ml_pf_why (npm nao encontrado no PATH)"
+    else
+      _ml_pf_why="$_ml_pf_why (npm ci/npm run build falharam ou nunca rodaram — ver stderr do launcher; causa tipica: sem acesso ao registry npm)"
+    fi
+    _ml_unavailable "$_ml_pf_why"
+  fi
+  printf 'ready|%s\n' "$_ml_pf_entry"
+  exit 0
 fi
 
 if _ml_entrypoint=$("$_ml_build_lazy_sh" ensure --dir "$_ml_state_server_dir"); then
@@ -189,7 +264,7 @@ else
 fi
 
 if [ "$_ml_build_rc" -ne 0 ] || [ -z "$_ml_entrypoint" ] || [ ! -f "$_ml_entrypoint" ]; then
-  _ml_idle_serve "build lazy do servidor MCP falhou (exit ${_ml_build_rc}) — ver mensagem acima em stderr"
+  _ml_unavailable "build lazy do servidor MCP falhou (exit ${_ml_build_rc}) — ver mensagem acima em stderr"
 fi
 
 # exec: substitui este processo pelo processo node real — o stdio do

--- a/tests/test_command-spawn-optin-elicitation.sh
+++ b/tests/test_command-spawn-optin-elicitation.sh
@@ -328,4 +328,79 @@ scenario_persistencia_legado_optin_responses_feature() {
   return 0
 }
 
+# ---------- bugfix 8.3.1: token cunhado != tool visivel no harness ----------
+#
+# Caso real 2026-08-18 (/agente-00c em projeto-alvo, cstk 8.3.0): `/mcp`
+# mostrava `cstk-state · connected · no tools` (launcher em modo IDLE), mas
+# o pai decidia "estruturado" so pelo token de `cstk mcp start`, spawnava o
+# orquestrador (que devolvia o turno sem abrir onda, pois a tool nao
+# existia) e so entao caia na prosa. Tres camadas corrigidas:
+#   (1) 2.bis do pai: token vira "candidato"; estruturado exige preflight
+#       `ready` do launcher + tool visivel no toolset do pai;
+#   (2) 4.bis do pai: campo aplicavel SEM registro + zero ondas = degradado
+#       (a tool que nunca rodou nao escreve `unavailable`);
+#   (3) 1.bis/3.bis dos orquestradores: discriminador e a LINHA do ramo
+#       estruturado no spawn, nunca o token; linha presente + tool ausente
+#       => devolve o turno em vez de "seguir para o passo 2/4".
+
+_scenario_gate_toolset_cmd() {
+  # $1=arquivo $2=regex do prompt de prosa (ancora de ordem)
+  _l_cand=$(_first_line_of "$1" '_optin_branch="candidato"')
+  _l_pf=$(_first_line_of "$1" 'mcp-launch\.sh preflight 2>/dev/null')
+  _l_ts=$(_first_line_of "$1" 'select:mcp__cstk-state__collect_optins')
+  _l_prompt=$(_first_line_of "$1" "$2")
+  [ -n "$_l_cand" ] && [ -n "$_l_pf" ] && [ -n "$_l_ts" ] && [ -n "$_l_prompt" ] \
+    || { _fail "ancora ausente" "candidato=$_l_cand preflight=$_l_pf toolset=$_l_ts prompt=$_l_prompt"; return 1; }
+  [ "$_l_cand" -lt "$_l_pf" ] && [ "$_l_pf" -lt "$_l_ts" ] && [ "$_l_ts" -lt "$_l_prompt" ] \
+    || { _fail "ordem" "esperado candidato($_l_cand) < preflight($_l_pf) < toolset($_l_ts) < prompt de prosa($_l_prompt)"; return 1; }
+  # o token sozinho NUNCA mais promove a estruturado
+  if grep -Fq '[ -n "$_optin_token" ] && _optin_branch="estruturado"' "$1"; then
+    _fail "token promove estruturado" "$1 ainda promove _optin_branch=estruturado so pelo token"; return 1
+  fi
+  # ready gate literal + linha unica de diagnostico ao operador
+  assert_exit 0 grep -Fq 'ready\|*) : ;;' "$1" || return 1
+  assert_exit 0 grep -Fq 'MCP cstk-state: servidor registrado, mas sem tools nesta sessao' "$1" || return 1
+  return 0
+}
+
+scenario_gate_toolset_agente() {
+  _scenario_gate_toolset_cmd "$CMD_AGENTE" '^#### Prompt opt-in de commit atomico'
+}
+
+scenario_gate_toolset_feature() {
+  _scenario_gate_toolset_cmd "$CMD_FEATURE" '^# Prompt opt-in de commit atomico'
+}
+
+scenario_4bis_sem_registro_e_zero_ondas_degradado() {
+  for _f in "$CMD_AGENTE" "$CMD_FEATURE"; do
+    assert_exit 0 grep -Fq ":) [ \"\${_waves_n:-0}\" -eq 0 ] && _optin_degraded=" "$_f" || return 1
+    assert_exit 0 grep -Fq -e "--field '.waves | length'" "$_f" || return 1
+    # o caso original (unavailable/failed) permanece
+    assert_exit 0 grep -Fq 'structured:unavailable|structured:failed) _optin_degraded=' "$_f" || return 1
+  done
+  return 0
+}
+
+scenario_orquestradores_discriminador_e_linha_nao_token() {
+  for _a in "$AGENT_AGENTE" "$AGENT_FEATURE"; do
+    # premissa falsa removida: "tool ausente => pai decidiu legado por token vazio"
+    if grep -Fq 'ja decidiu o ramo LEGADO por token vazio' "$_a"; then
+      _fail "premissa stale" "$_a ainda infere ramo legado a partir do token"; return 1
+    fi
+    assert_exit 0 grep -Fq 'Linha presente E tool NAO visivel no toolset' "$_a" || return 1
+    assert_exit 0 grep -Fq 'devolva o turno ao pai' "$_a" || return 1
+    # sem escrever em .optin_responses[] (INV-4) — a deteccao e do pai
+    assert_exit 0 grep -Fq 'escrever em `.optin_responses[]` — INV-4' "$_a" || return 1
+  done
+  return 0
+}
+
+scenario_injecao_token_com_ramo_legado_documentada() {
+  for _f in "$CMD_AGENTE" "$CMD_FEATURE"; do
+    assert_exit 0 grep -Fq 'NAO-vazio **com** `_optin_branch = "legado"`' "$_f" || return 1
+    assert_exit 0 grep -Fq '**NAO** injete a linha do ramo estruturado' "$_f" || return 1
+  done
+  return 0
+}
+
 run_all_scenarios "$@"

--- a/tests/test_mcp-launch.sh
+++ b/tests/test_mcp-launch.sh
@@ -251,4 +251,102 @@ scenario_exec_sem_fork_mesmo_pid_do_launcher() {
   [ "$_node_pid" = "$_launcher_pid" ] || { _fail "exec-mesmo-pid" "esperado node PID == launcher PID ($_launcher_pid), obtido $_node_pid — indica fork em vez de exec (viola L-7/FR-012)"; return 1; }
 }
 
+# ---------- bugfix 8.3.1: `mcp-launch.sh preflight` (diagnostico read-only) ----------
+# Caso real 2026-08-18: `/mcp` mostrava `cstk-state · connected · no tools`
+# (stub IDLE) e o command pai, decidindo o ramo de opt-ins so pelo token
+# de `cstk mcp start`, declarava "estruturado" e queimava a onda-001. O
+# preflight reproduz as MESMAS checagens do boot sem `exec node` e sem
+# rodar build (nunca invoca npm), reportando `ready|<entrypoint>` (exit 0)
+# ou `idle|<motivo>` (exit 3) — o motivo e o mesmo texto que o boot
+# escreve em stderr, para o operador corrigir a causa.
+
+# _run_preflight STATE_SERVER_DIR [NODE_MAJOR] -> roda `preflight` com o
+# stub de node no PATH (mesmo padrao de _run_launch).
+_run_preflight() {
+  _rp_ssd="$1"
+  _rp_major="${2:-24}"
+  _rp_bin="$TMPDIR_TEST/stubs-pf"
+  mkdir -p "$_rp_bin"
+  _stub_node "$_rp_bin" "$_rp_major"
+  capture env PATH="$_rp_bin:$PATH" CSTK_MCP_STATE_SERVER_DIR="$_rp_ssd" "$SCRIPT" preflight < /dev/null
+}
+
+scenario_preflight_ready_quando_dist_presente() {
+  _ssd="$TMPDIR_TEST/ssd-pf-ready"
+  _make_state_server_dir_with_dist "$_ssd"
+  _run_preflight "$_ssd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "preflight ready exit" "esperado 0, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "ready|$_ssd/dist/src/index.js" || return 1
+  # nunca exec'a node nem serve nada: stdout e UMA linha, node so respondeu -v
+  [ "$(printf '%s\n' "$_CAPTURED_STDOUT" | wc -l | tr -d ' ')" = 1 ] \
+    || { _fail "preflight stdout" "esperado 1 linha, obtido: $_CAPTURED_STDOUT"; return 1; }
+  case "$(_node_calls)" in
+    *pid=*) _fail "preflight nao deveria exec'ar node" "$(_node_calls)"; return 1 ;;
+  esac
+}
+
+scenario_preflight_idle_state_server_ausente_exit_3() {
+  _run_preflight "$TMPDIR_TEST/nao-existe-pf"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "preflight idle exit" "esperado 3, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "idle|mcp/state-server nao instalado" || return 1
+  # em preflight NAO serve o stub: sem "modo IDLE" em stderr
+  case "$_CAPTURED_STDERR" in
+    *"modo IDLE"*) _fail "preflight nao deveria servir o stub idle" "$_CAPTURED_STDERR"; return 1 ;;
+  esac
+}
+
+scenario_preflight_idle_node_major_insuficiente_exit_3() {
+  _ssd="$TMPDIR_TEST/ssd-pf-node18"
+  _make_state_server_dir_with_dist "$_ssd"
+  _run_preflight "$_ssd" 18
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "preflight node18 exit" "esperado 3, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "idle|Node 18 detectado" || return 1
+}
+
+scenario_preflight_idle_dist_ausente_nunca_roda_build() {
+  _ssd="$TMPDIR_TEST/ssd-pf-sem-dist"
+  _make_state_server_dir "$_ssd"
+  printf '{}\n' > "$_ssd/package-lock.json"
+  # stub de npm que registra qualquer invocacao — preflight NUNCA pode
+  # dispara-lo (npm ci/npm run build podem pendurar sem rede)
+  _bin="$TMPDIR_TEST/stubs-pf-npm"
+  mkdir -p "$_bin"
+  _stub_node "$_bin" 24
+  printf '#!/bin/sh\necho "npm $*" >> "$TMPDIR_TEST/npm-pf.log"\nexit 0\n' > "$_bin/npm"
+  chmod +x "$_bin/npm"
+  capture env PATH="$_bin:$PATH" CSTK_MCP_STATE_SERVER_DIR="$_ssd" "$SCRIPT" preflight < /dev/null
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "preflight sem dist exit" "esperado 3, obtido $_CAPTURED_EXIT: $_CAPTURED_STDOUT"; return 1; }
+  assert_stdout_contains "idle|dist/src/index.js ausente" || return 1
+  assert_stdout_contains "build lazy nao concluiu" || return 1
+  [ ! -f "$TMPDIR_TEST/npm-pf.log" ] || { _fail "preflight invocou npm" "$(cat "$TMPDIR_TEST/npm-pf.log")"; return 1; }
+}
+
+scenario_preflight_idle_dist_ausente_sem_lockfile_cita_cstk_install() {
+  _ssd="$TMPDIR_TEST/ssd-pf-sem-lock"
+  _make_state_server_dir "$_ssd"
+  _run_preflight "$_ssd"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "exit" "esperado 3, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "package-lock.json ausente; rode: cstk install" || return 1
+}
+
+scenario_argumento_desconhecido_exit_2_sem_servir() {
+  _ssd="$TMPDIR_TEST/ssd-pf-arg"
+  _make_state_server_dir_with_dist "$_ssd"
+  capture env CSTK_MCP_STATE_SERVER_DIR="$_ssd" "$SCRIPT" bogus < /dev/null
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "arg desconhecido exit" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "argumento desconhecido: bogus" || return 1
+}
+
+# ---------- fonte: mensagem stale do header corrigida (8.3.1) ----------
+
+scenario_header_nao_afirma_que_pai_decide_via_cstk_mcp_status() {
+  # A frase antiga "o command pai segue decidindo (via `cstk mcp status`)"
+  # documentava exatamente a premissa que causou o bug (token/status nao
+  # enxergam o modo IDLE). O header agora aponta para o toolset + preflight.
+  if grep -Fq 'segue decidindo (via `cstk mcp status`)' "$SCRIPT"; then
+    _fail "header stale" "mcp-launch.sh ainda afirma que o pai decide via cstk mcp status"; return 1
+  fi
+  assert_exit 0 grep -Fq 'mcp-launch.sh preflight' "$SCRIPT" || return 1
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Resumo

Bugfix 8.3.1. Caso real em projeto-alvo (cstk 8.3.0): `/mcp` mostrava `cstk-state · connected · no tools` (launcher em stub IDLE), mas `/agente-00c` declarava "ramo estruturado (MCP ativo)" só porque `cstk mcp start` cunhou token; spawnava o orquestrador — que devolvia o turno sem abrir onda porque `mcp__cstk-state__collect_optins` não existia no harness — e só então caía na prosa de opt-in.

- **`mcp-launch.sh preflight`**: diagnóstico read-only (sem `exec node`, sem `npm`) → `ready|<entrypoint>` (0) / `idle|<motivo>` (3), mesmo motivo que o boot escreve em stderr ao servir IDLE.
- **2.bis dos 2 commands**: token → `candidato`; `estruturado` exige preflight `ready` E tool visível no toolset do pai (`ToolSearch select:`); legado-com-token imprime 1 linha de diagnóstico; bullet do token cobre "token + legado".
- **4.bis dos 2 commands**: campo sem registro + `.waves|length==0` = degradado (a tool que nunca rodou não escreve `unavailable`).
- **Orquestradores 1.bis/3.bis**: discriminador é a linha do ramo estruturado no spawn, nunca o token; linha + tool ausente ⇒ devolve o turno (INV-4).
- Contrato `optin-capture-order.md` §2/§3.3(b), `SKILL.md` do runtime, header stale do launcher.
- Manifestos de plugin em 8.3.1 (gate MP-5, `validate-plugin-manifests.sh --strict` OK).

## Testado

- Suite completa local `LC_ALL=C ./tests/run.sh`: **3206 PASS / 0 FAIL** (922s); `--check-coverage` zero órfãos.
- `tests/test_mcp-launch.sh` 16/16 (+7), `tests/test_command-spawn-optin-elicitation.sh` 26/26 (+5).
- `cstk doctor`: drift zero antes de editar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiHRXC83ja2JERyfeZNJqs