### PR TITLE
release 8.4.0: hooks install --local/status (#135) + finalize set -e (#139) + state-rw set sem sucesso falso

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "8.3.1",
+      "version": "8.4.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "8.3.1",
+      "version": "8.4.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,99 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [8.4.0] - 2026-08-19
+
+Release de manutenção com uma feature pequena pedida por quem usa o cstk em
+repositório de terceiro (issue #135) e dois fixes de "sucesso falso" — um
+contrato `sempre exit 0` que vazava exit 1/3 (issue #139, aberta pelo
+próprio agente-00C) e um `state-rw.sh set` que reportava `atualizado` sem
+efeito observável sob SQLite (3 sugestões da knowledge.db reproduzidas).
+Sem breaking; sem skill nova.
+
+### Added
+
+- **`cstk hooks install --local`** (#135): grava o REGISTRO dos hooks 00c em
+  `.claude/settings.local.json` em vez de `.claude/settings.json`. Para
+  repos em que o time versiona `settings.json` de propósito: o Claude Code
+  SOMA hooks entre escopos e o arquivo local costuma estar gitignored, então
+  os hooks disparam só para o operador e o arquivo do time fica byte a byte
+  intacto (nem `settings.json.bak` é criado). Scripts continuam em
+  `.claude/hooks/` (dica no help/README: `.git/info/exclude`). Idempotente
+  como o fluxo padrão; `apply_guard_hooks()` ganha 5º argumento opcional
+  (basename do arquivo de registro, validado — `settings.json` default,
+  comportamento histórico intacto em `install.sh`/`setup.sh`).
+- **Dedup entre os dois arquivos de registro**: registro em `settings.json`
+  E `settings.local.json` = cada tool call contada em dobro. O arquivo
+  recém-escrito vence e o outro é oferecido para remoção com as MESMAS
+  guardas do dedup do plugin (`_hooks_dedup_classic` generalizada: só
+  entradas do cstk, hooks de terceiros e demais chaves preservados, backup
+  `.bak-pre-dedup`, prompt com TTY / `--remove-classic` sem prompt / sem TTY
+  mantém e avisa). O ramo plugin-vence também limpa o arquivo local.
+- **`cstk hooks status [--project-path PATH]`**: diagnóstico READ-ONLY (exit
+  0 sempre; 2 em uso incorreto) que imprime, por hook 00c (3 obrigatórios +
+  `posttooluse-loose-usage.sh` opt-in), se o script está em
+  `.claude/hooks/` e em QUAL arquivo está o registro — `settings.json` |
+  `settings.local.json` | `both` | `plugin` | `none` — com aviso de
+  duplicidade e de ausência. Nasce porque `--local` cria um segundo lugar
+  possível para o registro e o operador precisa enxergar onde ele está sem
+  abrir JSON na mão.
+- Testes: 12 cenários novos em `tests/cstk/test_hooks.sh` (com fixture de
+  catálogo REAL — a sintética registra comandos `x`/`y`/`z` e não serve para
+  verificar registro por basename), 4 em `tests/test_guard-hooks-status.sh`,
+  1 em `tests/cstk/test_doctor.sh`, 2 em `tests/test_commit-mode.sh`, 1 em
+  `tests/cstk/test_session.sh`, 2 em `tests/test_state-rw.sh`. Todos os
+  cenários de regressão falham sem o fix correspondente (mutation check
+  feito antes de commitar).
+
+### Changed
+
+- **`guard-hooks-status.sh` (runtime) lê os dois arquivos de registro**:
+  `_gh_registered`, `--verify-registration` e a detecção de duplicidade com
+  o plugin consideram `settings.json` E `settings.local.json`. Sem isso,
+  registro local faria `check` responder `unregistered`, `tick-mode`
+  responder `manual` e o orquestrador tickar NA MÃO por cima de um hook
+  ativo (contagem dupla de `tool_calls`). `verify-registration`: "divergent"
+  se QUALQUER linha de QUALQUER dos dois arquivos que cite o basename falhar
+  a regra canônica; sem `settings.local.json` a saída é byte a byte a
+  histórica.
+- **`cstk doctor` (`Distribution Paths`)**: o estado `duplicated-hooks`
+  olha também `./.claude/settings.local.json` e cita os arquivos onde o
+  registro clássico foi encontrado; remediação menciona `cstk hooks status`.
+- Help de `cstk hooks --help` / `cstk help hooks` e `README.md` /
+  `README.pt-BR.md` (§hooks do runtime 00c) documentam `--local` e `status`.
+
+### Fixed
+
+- **`commit-mode.sh finalize` honra "sempre exit 0" quando `guard-branch`
+  falha (#139)**. `_branch_out=$(_cm_cmd_guard_branch …)` herda o exit do
+  guard e, sob o `set -eu` do script, abortava o finalize ANTES do
+  `_guard_rc=$?` — os dois ramos seguintes (`skipped-default-branch` para
+  exit 3 e `error` para exit 1) eram código morto e sem teste. Caso real da
+  issue: projeto-alvo recém `git init` (HEAD unborn) na 1ª execução do
+  agente-00c vazava exit 1 com o stderr do guard-branch e sem
+  `.push_pr_result`; HEAD na branch default vazava exit 3 (nunca gravou
+  `skipped-default-branch`). Fix: `|| _guard_rc=$?` (o mesmo padrão já
+  aplicado ao `cstk session pr` mais abaixo no arquivo).
+- **Mesma classe (`var=$(cmd)` seguido de `rc=$?` sob `set -eu`) nos irmãos
+  do binário**: `cli/lib/session.sh` — `gh pr create` falhando abortava
+  `_session_pr` antes do ramo de falha parcial FR-017 (o operador via o
+  exit cru do gh, sem as instruções de retry/desfazer push; agora exit 1 +
+  orientação, cenário `scenario_pr_gh_create_falha_reporta_falha_parcial_exit_1`);
+  `cli/lib/mcp.sh` e `cli/lib/serve-docker.sh` — `docker rm -f` capturado
+  com `|| rc=$?` (defensivo: hoje só chamados em contexto condicional).
+- **`state-rw.sh set` sob SQLite deixa de reportar sucesso sem efeito**:
+  `.execution` / `.accumulated_metrics` inteiros e
+  `.waves[N].{skills_invoked,id,started_at}` caíam no fallback
+  `extra_fields`, eram sombreados pela reconstrução real na leitura (colunas
+  da tabela `execution`; tabela `skill_invocation`) e o comando imprimia
+  `atualizado (backend sqlite)` com exit 0 — `.execution.status` seguia o
+  antigo, `.waves[-1].skills_invoked` seguia `[]` (sugestões
+  wp-intel/mcp-server-host sug-001/sug-003 e cstk/mcp-direct-transport
+  sug-002, reproduzidas). Agora exit 1 com mensagem apontando o caminho
+  certo (campo a campo, `state-ondas.sh record-skill`, `state-rw.sh write`),
+  no set simples e no lote multi-campo (rejeição all-or-nothing, estado
+  intacto). Campos extra genuínos seguem no fallback (round-trip C1).
+
 ## [8.3.1] - 2026-08-18
 
 Bugfix do ramo de captura de opt-ins dos commands `/agente-00c` e
@@ -6665,6 +6758,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[8.4.0]: https://github.com/JotJunior/cstk/releases/tag/v8.4.0
 [8.3.1]: https://github.com/JotJunior/cstk/releases/tag/v8.3.1
 [8.3.0]: https://github.com/JotJunior/cstk/releases/tag/v8.3.0
 [8.2.0]: https://github.com/JotJunior/cstk/releases/tag/v8.2.0

--- a/README.md
+++ b/README.md
@@ -352,7 +352,30 @@ cstk hooks install                    # touches .claude/hooks/ + settings.json o
 cstk hooks install --dry-run          # show the plan without writing
 cstk hooks install --project-path ../other-project
 cstk hooks install --remove-classic   # de-duplicate against the plugin, no prompt
+cstk hooks install --local            # register in settings.local.json (third-party repos)
+cstk hooks status                     # read-only: where is each hook registered?
 ```
+
+**Third-party repos** (`--local`, issue #135): when the client's team
+versions `.claude/settings.json` on purpose, a personal tool has no business
+in it. `--local` writes the *registration* to `.claude/settings.local.json`
+instead — Claude Code **sums** hooks across scopes, and the local file is
+normally gitignored — so the hooks fire only for you and the team's file
+stays byte-for-byte untouched. The scripts still land in `.claude/hooks/`;
+keep them out of the client's `git status` without touching their
+`.gitignore`:
+
+```bash
+printf '.claude/hooks/\n.claude/settings.local.json\n' >> .git/info/exclude
+```
+
+Idempotent like the default flow. If the *other* file already registers
+the 00c hooks (both would fire, double-counting every tool call) the
+command warns and offers the same removal as the plugin dedup
+(`--remove-classic` skips the prompt). `cstk hooks status` and
+`guard-hooks-status.sh check` read both files, so `tick-mode` keeps
+answering `hook` and the orchestrator does not tick by hand on top of an
+active hook.
 
 When the plugin already provides the hooks, `cstk hooks install` skips the
 classic provisioning (plugin wins) and, if the project **still** carries a

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -354,7 +354,29 @@ cstk hooks install                    # toca só .claude/hooks/ + settings.json
 cstk hooks install --dry-run          # mostra o plano sem escrever
 cstk hooks install --project-path ../outro-projeto
 cstk hooks install --remove-classic   # deduplica contra o plugin, sem prompt
+cstk hooks install --local            # registra em settings.local.json (repos de terceiros)
+cstk hooks status                     # read-only: onde cada hook esta registrado?
 ```
+
+**Repos de terceiros** (`--local`, issue #135): quando o time do cliente
+versiona `.claude/settings.json` de propósito, uma ferramenta pessoal não
+tem o que fazer lá dentro. `--local` grava o *registro* em
+`.claude/settings.local.json` — o Claude Code **soma** hooks entre escopos
+e o arquivo local costuma estar gitignored — então os hooks disparam só
+para você e o arquivo do time fica byte a byte intacto. Os scripts
+continuam em `.claude/hooks/`; para não sujar o `git status` do cliente
+sem mexer no `.gitignore` dele:
+
+```bash
+printf '.claude/hooks/\n.claude/settings.local.json\n' >> .git/info/exclude
+```
+
+Idempotente como o fluxo padrão. Se o *outro* arquivo já registrar os
+hooks 00c (os dois disparariam, contando cada tool call em dobro) o comando
+avisa e oferece a mesma remoção do dedup do plugin (`--remove-classic`
+pula o prompt). `cstk hooks status` e `guard-hooks-status.sh check` leem
+os dois arquivos, então o `tick-mode` continua respondendo `hook` e o
+orquestrador não ticka na mão por cima de um hook ativo.
 
 Quando o plugin já fornece os hooks, o `cstk hooks install` pula o
 provisionamento clássico (plugin vence) e, se o projeto **ainda** carrega um

--- a/cli/cstk
+++ b/cli/cstk
@@ -145,8 +145,8 @@ COMANDOS:
   serve         Inicia o painel web cstk; baixa e instala na primeira execucao
   state         Operacoes sobre o estado transacional 00c (state migrate)
   mcp           Servidor MCP de estado das execucoes 00c (mcp status)
-  hooks         Provisiona os hooks do runtime 00c num projeto-alvo
-                (so hooks + settings.json; nao duplica skill/commands/agents)
+  hooks         Provisiona (install) / diagnostica (status) os hooks do runtime 00c
+                (so hooks + settings.json, ou settings.local.json com --local)
   statusline    Instala/inspeciona a captura de uso do plano via
                 statusLine.command (install/status); preserva customizacao
                 previa em CSTK_STATUSLINE_INNER_COMMAND
@@ -176,6 +176,8 @@ HELP
       printf 'cstk help hooks: provisiona os hooks do runtime 00c num projeto-alvo.\n'
       printf 'Toca apenas .claude/hooks/ + .claude/settings.json — nao duplica\n'
       printf 'skill/commands/agents como "cstk install --scope project".\n'
+      printf 'Flag --local registra em .claude/settings.local.json (repos de terceiros);\n'
+      printf '"cstk hooks status" mostra em qual arquivo esta cada registro.\n'
       printf 'Para help inline, rode: cstk hooks --help\n'
       exit "$CSTK_EXIT_OK"
       ;;

--- a/cli/lib/doctor.sh
+++ b/cli/lib/doctor.sh
@@ -513,16 +513,24 @@ _doctor_distribution_paths() {
   fi
 
   # duplicated-hooks tem precedencia — checagem barata (grep -F, sem jq).
-  if [ -f "$_dp_project_settings" ] \
-     && grep -qF "pretooluse-bash-guard.sh" "$_dp_project_settings" 2>/dev/null; then
+  # Olha os DOIS arquivos de registro do projeto (issue #135, `cstk hooks
+  # install --local`): settings.json e settings.local.json somam.
+  _dp_dup_files=""
+  for _dp_f in "$_dp_project_settings" "./.claude/settings.local.json"; do
+    if [ -f "$_dp_f" ] && grep -qF "pretooluse-bash-guard.sh" "$_dp_f" 2>/dev/null; then
+      _dp_dup_files="${_dp_dup_files:+$_dp_dup_files, }$_dp_f"
+    fi
+  done
+  if [ -n "$_dp_dup_files" ]; then
     {
       printf '\n==> Distribution Paths (plugin cstk)\n'
       printf '  [duplicated-hooks] plugin habilitado E registro classico de hooks\n'
-      printf '                     presente em %s\n' "$_dp_project_settings"
+      printf '                     presente em %s\n' "$_dp_dup_files"
       printf '  remediacao: rode `cstk hooks install` no projeto — ele oferece remover\n'
       printf '              o registro classico (ou `--remove-classic` para nao perguntar).\n'
       printf '              Remove apenas as entradas dos hooks 00c, preserva hooks de\n'
-      printf '              terceiros e grava backup em settings.json.bak-pre-dedup.\n'
+      printf '              terceiros e grava backup em <arquivo>.bak-pre-dedup.\n'
+      printf '              `cstk hooks status` mostra em qual arquivo esta cada registro.\n'
     } >&2
     return 1
   fi

--- a/cli/lib/hooks.sh
+++ b/cli/lib/hooks.sh
@@ -31,7 +31,7 @@
 #                                         no array .hooks.PostToolUse[]
 #                                         ja populado pelo merge_settings
 #                                         base (loose-usage-capture task 3.3).
-#   apply_guard_hooks <src_dir> <dest_claude_root> <dry_run> [with_loose_usage]
+#   apply_guard_hooks <src_dir> <dest_claude_root> <dry_run> [with_loose_usage] [settings_basename]
 #                                       — provisiona o hook PreToolUse/Bash
 #                                         de enforced-guards (US1): copia
 #                                         pretooluse-bash-guard.sh para
@@ -324,8 +324,8 @@ print_paste_block() {
 #                      trouxe hooks/ nesta instalacao — nao e erro)
 #   error            — falha de I/O (mkdir/cp/merge)
 apply_guard_hooks() {
-  if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
-    log_error "hooks: apply_guard_hooks espera 3 ou 4 argumentos (src_dir, dest_claude_root, dry_run, [with_loose_usage])"
+  if [ "$#" -lt 3 ] || [ "$#" -gt 5 ]; then
+    log_error "hooks: apply_guard_hooks espera 3 a 5 argumentos (src_dir, dest_claude_root, dry_run, [with_loose_usage], [settings_basename])"
     printf '%s' "error"
     return 2
   fi
@@ -333,6 +333,22 @@ apply_guard_hooks() {
   _agh_dest_root=$2
   _agh_dry_run=$3
   _agh_with_loose=${4:-0}
+  # 5o arg (issue #135): basename do arquivo de REGISTRO dentro de
+  # <dest_claude_root>. Default `settings.json` (comportamento historico);
+  # `settings.local.json` via `cstk hooks install --local` — o Claude Code
+  # SOMA hooks entre escopos e o arquivo local costuma estar gitignored,
+  # entao o registro liga os hooks so para o operador sem tocar o
+  # settings.json versionado do time. Os SCRIPTS continuam em
+  # <dest_claude_root>/hooks/ nos dois casos.
+  _agh_settings_name=${5:-settings.json}
+  case "$_agh_settings_name" in
+    settings.json|settings.local.json) ;;
+    *)
+      log_error "hooks: settings_basename invalido: $_agh_settings_name (use settings.json ou settings.local.json)"
+      printf '%s' "error"
+      return 2
+      ;;
+  esac
 
   if [ ! -d "$_agh_src" ]; then
     log_warn "hooks: guard-hooks source ausente: $_agh_src"
@@ -343,7 +359,7 @@ apply_guard_hooks() {
   _agh_hook_script="$_agh_src/pretooluse-bash-guard.sh"
   _agh_snippet="$_agh_src/settings.snippet.json"
   _agh_hooks_dst="$_agh_dest_root/hooks"
-  _agh_settings_dst="$_agh_dest_root/settings.json"
+  _agh_settings_dst="$_agh_dest_root/$_agh_settings_name"
 
   if [ ! -f "$_agh_hook_script" ]; then
     log_warn "hooks: pretooluse-bash-guard.sh ausente em $_agh_src"
@@ -597,24 +613,32 @@ _hooks_prompt_yn() {
 # AUTO_REMOVE=1 (`--remove-classic`) remove sem perguntar — caminho para
 # script/CI. Sem ele: pergunta SE houver TTY; sem TTY, mantem e avisa
 # (jamais mutar settings.json de alguem sem confirmacao explicita).
+#
+# 4o arg (opcional, issue #135): basename do arquivo a limpar (default
+# `settings.json`). 5o arg (opcional): quem "vence" na mensagem — default
+# "o plugin"; `hooks install --local` passa "o registro em
+# settings.local.json" (e vice-versa) para o dedup entre os DOIS arquivos
+# de registro do projeto, que tambem somam e contariam cada tool call em
+# dobro.
 _hooks_dedup_classic() {
   _hdc_dest=$1
   _hdc_dry=$2
   _hdc_auto=$3
-  _hdc_settings="$_hdc_dest/settings.json"
+  _hdc_settings="$_hdc_dest/${4:-settings.json}"
+  _hdc_winner=${5:-o plugin}
 
   [ -f "$_hdc_settings" ] || return 0
 
   if ! detect_jq; then
     log_warn "hooks install: jq ausente — nao da para editar settings.json com seguranca."
-    log_warn "hooks install: se houver registro classico em $_hdc_settings, remova-o a mao (duplicidade com o plugin)."
+    log_warn "hooks install: se houver registro classico em $_hdc_settings, remova-o a mao (duplicidade com $_hdc_winner)."
     return 0
   fi
 
   _hdc_n=$(_hooks_classic_count "$_hdc_settings")
   case "$_hdc_n" in ''|0|*[!0-9]*) return 0 ;; esac
 
-  log_warn "hooks install: $_hdc_settings ainda registra $_hdc_n hook(s) 00c pelo caminho classico — duplicidade com o plugin."
+  log_warn "hooks install: $_hdc_settings ainda registra $_hdc_n hook(s) 00c pelo caminho classico — duplicidade com $_hdc_winner."
 
   if [ "$_hdc_dry" = 1 ]; then
     log_info "hooks install: [dry-run] removeria $_hdc_n entrada(s) do bloco classico (hooks de terceiros e demais chaves preservados)"
@@ -628,7 +652,7 @@ _hooks_dedup_classic() {
       return 0
     fi
     if ! _hooks_prompt_yn "hooks install: remover o registro classico de $_hdc_settings? (y/N)"; then
-      log_info "hooks install: bloco classico mantido a pedido — 'cstk doctor' seguira reportando duplicated-hooks"
+      log_info "hooks install: bloco classico mantido a pedido — 'cstk doctor'/'cstk hooks status' seguirao reportando duplicidade"
       return 0
     fi
   fi
@@ -662,16 +686,33 @@ _hooks_dedup_classic() {
 
 _hooks_print_help() {
   cat >&2 <<'HELP'
-cstk hooks — provisiona os hooks do runtime 00c num projeto-alvo.
+cstk hooks — provisiona (install) e diagnostica (status) os hooks do runtime 00c.
 
 USO:
   cstk hooks install [--project-path PATH] [--catalog DIR] [--dry-run]
-                      [--with-loose-usage] [--remove-classic]
+                      [--with-loose-usage] [--remove-classic] [--local]
+  cstk hooks status  [--project-path PATH]
 
 Copia pretooluse-bash-guard.sh + posttooluse-tool-call-tick.sh +
 posttooluse-agent-usage.sh para <PATH>/.claude/hooks/ e mescla o bloco de
 registro em <PATH>/.claude/settings.json (via jq; sem jq, imprime o bloco
 para colagem manual).
+
+--local: grava o REGISTRO em <PATH>/.claude/settings.local.json em vez de
+settings.json (os scripts continuam em .claude/hooks/). Para repos de
+terceiros em que settings.json e versionado pelo time: o Claude Code SOMA
+hooks entre escopos, entao o arquivo local (normalmente gitignored) liga
+os hooks so para o operador sem tocar o arquivo compartilhado. Idempotente
+como o fluxo padrao. Se o OUTRO arquivo (settings.json sem --local;
+settings.local.json com --local) ja registrar os hooks 00c, os dois ficam
+ativos e cada tool call e contada em dobro — o comando avisa e oferece a
+remocao (mesmo dedup do plugin; --remove-classic remove sem perguntar).
+Dica para nao sujar o git status do cliente com os scripts:
+  printf '.claude/hooks/\n.claude/settings.local.json\n' >> .git/info/exclude
+
+status: diagnostico READ-ONLY (exit 0 sempre) — para cada hook 00c,
+script presente em .claude/hooks/ e em QUAL arquivo esta o registro
+(settings.json | settings.local.json | both | plugin | none).
 
 --with-loose-usage (opt-in, default DESLIGADA): tambem provisiona
 posttooluse-loose-usage.sh, hook que captura consumo avulso (fora de
@@ -698,6 +739,84 @@ Para conferir o estado atual sem escrever nada:
 HELP
 }
 
+# ============================================================================
+# _hooks_status_main — comando `cstk hooks status` (issue #135)
+# ============================================================================
+# Diagnostico READ-ONLY do provisionamento classico + registro num projeto:
+# para cada hook 00c (3 obrigatorios + loose-usage opt-in), se o script
+# esta em <PATH>/.claude/hooks/ e em QUAL arquivo esta o registro —
+# settings.json, settings.local.json, both (duplicado: cada tool call
+# contada em dobro), plugin (hooks.json do plugin cstk habilitado) ou
+# none. Existe porque `--local` cria um segundo lugar possivel para o
+# registro e o operador precisa enxergar onde ele esta sem abrir JSON na
+# mao. Nunca escreve nada; exit 0 sempre (consulta respondida, nao
+# veredito) — exit 2 so em uso incorreto.
+_hooks_status_main() {
+  _hs_project_path="."
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --project-path)
+        [ "$#" -ge 2 ] || { log_error "hooks status: --project-path exige valor"; return 2; }
+        _hs_project_path=$2; shift 2 ;;
+      --project-path=*) _hs_project_path=${1#--project-path=}; shift ;;
+      -h|--help) _hooks_print_help; return 0 ;;
+      *) log_error "hooks status: flag desconhecida: $1"; return 2 ;;
+    esac
+  done
+  if [ ! -d "$_hs_project_path" ]; then
+    log_error "hooks status: --project-path nao e diretorio: $_hs_project_path"
+    return 1
+  fi
+  _hs_abs=$(CDPATH= cd -- "$_hs_project_path" 2>/dev/null && pwd -P) \
+    || { log_error "hooks status: nao consegui resolver $_hs_project_path"; return 1; }
+  _hs_dest="$_hs_abs/.claude"
+  _hs_settings="$_hs_dest/settings.json"
+  _hs_local="$_hs_dest/settings.local.json"
+
+  _hs_plugin=0
+  if plugin_enabled cstk && plugin_hooks_present cstk; then
+    _hs_plugin=1
+  fi
+
+  printf 'hooks status: %s\n' "$_hs_dest"
+  printf '  plugin cstk (hooks.json): %s\n' "$([ "$_hs_plugin" = 1 ] && printf 'habilitado' || printf 'nao')"
+  printf '  arquivo settings.json:        %s\n' "$([ -f "$_hs_settings" ] && printf 'presente' || printf 'ausente')"
+  printf '  arquivo settings.local.json:  %s\n' "$([ -f "$_hs_local" ] && printf 'presente' || printf 'ausente')"
+
+  _hs_dup=0
+  _hs_none=0
+  for _hs_hook in pretooluse-bash-guard.sh posttooluse-tool-call-tick.sh posttooluse-agent-usage.sh posttooluse-loose-usage.sh; do
+    if [ -f "$_hs_dest/hooks/$_hs_hook" ]; then _hs_script="present"; else _hs_script="missing"; fi
+    _hs_in_p=0; _hs_in_l=0
+    [ -f "$_hs_settings" ] && grep -Fq -- "$_hs_hook" "$_hs_settings" 2>/dev/null && _hs_in_p=1
+    [ -f "$_hs_local" ] && grep -Fq -- "$_hs_hook" "$_hs_local" 2>/dev/null && _hs_in_l=1
+    if [ "$_hs_in_p" = 1 ] && [ "$_hs_in_l" = 1 ]; then
+      _hs_reg="both"; _hs_dup=$((_hs_dup + 1))
+    elif [ "$_hs_in_p" = 1 ]; then _hs_reg="settings.json"
+    elif [ "$_hs_in_l" = 1 ]; then _hs_reg="settings.local.json"
+    elif [ "$_hs_plugin" = 1 ] && [ "$_hs_hook" != "posttooluse-loose-usage.sh" ]; then _hs_reg="plugin"
+    else
+      _hs_reg="none"
+      [ "$_hs_hook" != "posttooluse-loose-usage.sh" ] && _hs_none=$((_hs_none + 1))
+    fi
+    if [ "$_hs_plugin" = 1 ] && [ "$_hs_hook" != "posttooluse-loose-usage.sh" ] \
+       && { [ "$_hs_in_p" = 1 ] || [ "$_hs_in_l" = 1 ]; }; then
+      _hs_reg="$_hs_reg+plugin"; _hs_dup=$((_hs_dup + 1))
+    fi
+    _hs_tag=""
+    [ "$_hs_hook" = "posttooluse-loose-usage.sh" ] && _hs_tag=" (opt-in)"
+    printf '  %-32s script=%-7s registro=%s%s\n' "$_hs_hook" "$_hs_script" "$_hs_reg" "$_hs_tag"
+  done
+
+  if [ "$_hs_dup" -gt 0 ]; then
+    log_warn "hooks status: $_hs_dup hook(s) registrados em MAIS de um lugar — cada tool call e contada em dobro. Rode 'cstk hooks install' (ou --local) no projeto: ele oferece remover o registro redundante."
+  fi
+  if [ "$_hs_none" -gt 0 ]; then
+    log_warn "hooks status: $_hs_none hook(s) obrigatorio(s) sem registro algum — a guarda NAO esta enforced. Rode 'cstk hooks install --project-path $_hs_abs' (ou --local)."
+  fi
+  return 0
+}
+
 hooks_main() {
   _hooks_sub="${1:-}"
   [ "$#" -ge 1 ] && shift || :
@@ -709,8 +828,9 @@ hooks_main() {
       return 0
       ;;
     install) ;;
+    status) _hooks_status_main "$@"; return $? ;;
     *)
-      log_error "hooks: subcomando desconhecido: $_hooks_sub (use: install)"
+      log_error "hooks: subcomando desconhecido: $_hooks_sub (use: install, status)"
       return 2
       ;;
   esac
@@ -720,6 +840,7 @@ hooks_main() {
   _hooks_dry_run=0
   _hooks_with_loose=0
   _hooks_remove_classic=0
+  _hooks_settings_name="settings.json"
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -734,6 +855,7 @@ hooks_main() {
       --dry-run) _hooks_dry_run=1; shift ;;
       --with-loose-usage) _hooks_with_loose=1; shift ;;
       --remove-classic) _hooks_remove_classic=1; shift ;;
+      --local) _hooks_settings_name="settings.local.json"; shift ;;
       -h|--help) _hooks_print_help; return 0 ;;
       *) log_error "hooks install: flag desconhecida: $1"; return 2 ;;
     esac
@@ -777,6 +899,7 @@ hooks_main() {
       # Dedup ATIVO: havendo registro classico pre-existente, oferece a
       # remocao em vez de so mandar o operador editar settings.json a mao.
       _hooks_dedup_classic "$_hooks_dest" "$_hooks_dry_run" "$_hooks_remove_classic"
+      _hooks_dedup_classic "$_hooks_dest" "$_hooks_dry_run" "$_hooks_remove_classic" "settings.local.json"
       return 0
     else
       log_warn "hooks install: plugin 'cstk' habilitado mas hooks/hooks.json NAO encontrado no install path — instalacao do plugin parece incompleta"
@@ -784,19 +907,31 @@ hooks_main() {
     fi
   fi
 
-  _hooks_state=$(apply_guard_hooks "$_hooks_src" "$_hooks_dest" "$_hooks_dry_run" "$_hooks_with_loose")
+  _hooks_state=$(apply_guard_hooks "$_hooks_src" "$_hooks_dest" "$_hooks_dry_run" "$_hooks_with_loose" "$_hooks_settings_name")
 
   case "$_hooks_state" in
     merged)
       if [ "$_hooks_dry_run" = 1 ]; then
-        log_info "hooks install: [dry-run] provisionaria os hooks 00c em $_hooks_dest"
+        log_info "hooks install: [dry-run] provisionaria os hooks 00c em $_hooks_dest (registro em $_hooks_settings_name)"
       else
-        log_info "hooks install: hooks 00c provisionados e registrados em $_hooks_dest"
+        log_info "hooks install: hooks 00c provisionados e registrados em $_hooks_dest/$_hooks_settings_name"
+      fi
+      # Dedup entre os DOIS arquivos de registro do projeto (issue #135):
+      # settings.json e settings.local.json SOMAM no Claude Code — registro
+      # nos dois = cada tool call contada em dobro. O arquivo recem-escrito
+      # vence; o outro e oferecido para remocao (mesma rotina, mesmas
+      # guardas: so entradas do cstk, backup, prompt/--remove-classic).
+      if [ "$_hooks_settings_name" = "settings.local.json" ]; then
+        _hooks_dedup_classic "$_hooks_dest" "$_hooks_dry_run" "$_hooks_remove_classic" \
+          "settings.json" "o registro em settings.local.json (--local)"
+      else
+        _hooks_dedup_classic "$_hooks_dest" "$_hooks_dry_run" "$_hooks_remove_classic" \
+          "settings.local.json" "o registro em settings.json"
       fi
       return 0
       ;;
     paste-instructed)
-      log_warn "hooks install: jq ausente — hooks copiados, mas o REGISTRO em settings.json"
+      log_warn "hooks install: jq ausente — hooks copiados, mas o REGISTRO em $_hooks_settings_name"
       log_warn "hooks install: precisa ser colado manualmente (bloco impresso acima)."
       log_warn "hooks install: sem o registro os hooks NAO rodam."
       return 0

--- a/cli/lib/mcp.sh
+++ b/cli/lib/mcp.sh
@@ -172,8 +172,11 @@ _mcp_docker_list_managed() {
 _mcp_docker_reconcile_container() {
   _mdrc_name="$1"
 
-  _mdrc_out=$(docker rm -f "$_mdrc_name" 2>&1)
-  _mdrc_exit=$?
+  # `|| _mdrc_exit=$?`: sob o `set -eu` do binario, `_x=$(cmd)` herda o exit
+  # de `cmd` — sem isso um "No such container" abortaria a funcao quando
+  # chamada fora de contexto condicional (classe da issue #139).
+  _mdrc_exit=0
+  _mdrc_out=$(docker rm -f "$_mdrc_name" 2>&1) || _mdrc_exit=$?
 
   if [ "$_mdrc_exit" -eq 0 ]; then
     return 0

--- a/cli/lib/serve-docker.sh
+++ b/cli/lib/serve-docker.sh
@@ -519,8 +519,11 @@ _serve_docker_kdb_host_dir() {
 _serve_docker_reconcile_container() {
   _sdrc_name="$1"
 
-  _sdrc_out=$(docker rm -f "$_sdrc_name" 2>&1)
-  _sdrc_exit=$?
+  # `|| _sdrc_exit=$?`: sob o `set -eu` do binario, `_x=$(cmd)` herda o exit
+  # de `cmd` — sem isso um "No such container" abortaria a funcao quando
+  # chamada fora de contexto condicional (classe da issue #139).
+  _sdrc_exit=0
+  _sdrc_out=$(docker rm -f "$_sdrc_name" 2>&1) || _sdrc_exit=$?
 
   if [ "$_sdrc_exit" -eq 0 ]; then
     return 0

--- a/cli/lib/session.sh
+++ b/cli/lib/session.sh
@@ -1008,8 +1008,12 @@ _session_pr() {
   fi
 
   # Capturar URL do gh pr create. gh imprime URL em stdout em caso de sucesso.
-  _create_out=$( cd -- "$_wt_path" && gh pr create "$@" 2>&1 )
-  _create_rc=$?
+  # `|| _create_rc=$?` e OBRIGATORIO: session_main roda sob o `set -eu` do
+  # binario e `_x=$(cmd)` herda o exit de `cmd` — sem isso a falha do gh
+  # abortava aqui e o ramo de falha parcial (FR-017) abaixo era codigo
+  # morto (mesma classe da issue #139 em commit-mode.sh finalize).
+  _create_rc=0
+  _create_out=$( cd -- "$_wt_path" && gh pr create "$@" 2>&1 ) || _create_rc=$?
   if [ "$_create_rc" != 0 ]; then
     # 7. Falha parcial (FR-017): push ja foi feito, mas create falhou
     log_error "session pr: 'gh pr create' falhou (push ja foi feito)"

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "8.3.1",
+  "version": "8.4.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "8.3.1",
+  "version": "8.4.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/_state-rw-db.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/_state-rw-db.sh
@@ -490,6 +490,16 @@ _sr_db_wave_field_resolve() {
     agent_usage)                _sr_wfr_col=agent_usage; _sr_wfr_type=json ;;
     agent_spawns)               _sr_wfr_col=agent_spawns; _sr_wfr_type=json ;;
     otel_usage)                _sr_wfr_col=otel_usage; _sr_wfr_type=json ;;
+    # Campos MODELADOS fora de wave.<coluna> — o fallback extra_fields seria
+    # SOMBREADO pela reconstrucao real na leitura (skills_invoked vem da
+    # tabela skill_invocation; id/started_at sao identidade da linha) e o
+    # `set` reportaria "atualizado" sem efeito observavel (caso real:
+    # sugestoes wp-intel/mcp-server-host sug-001, cstk/mcp-direct-transport
+    # sug-002). Falhar alto, apontando o caminho certo — nunca sucesso falso.
+    skills_invoked)
+      _sr_die "set: '.$_wfr_bare' e derivado da tabela skill_invocation sob backend SQLite (extra_fields seria sombreado na leitura) — use 'state-ondas.sh record-skill' (ou 'state-rw.sh write' com o documento inteiro)" 1 ;;
+    id|started_at)
+      _sr_die "set: '.$_wfr_bare' e identidade da onda sob backend SQLite (imutavel via set) — use 'state-ondas.sh start' / 'state-rw.sh write'" 1 ;;
     *) : ;;
   esac
 }
@@ -771,6 +781,15 @@ _sr_db_set() {
           *.*|*\[*)
             _sr_die "set: campo nao suportado sob backend SQLite (path aninhado nao modelado): '$_sds_field' — so campos de topo simples tem fallback para extra_fields" 1
             ;;
+          execution|accumulated_metrics)
+            # Objeto inteiro de um container MODELADO (colunas da tabela
+            # execution / metricas derivadas): cair em extra_fields.execution
+            # seria sombreado pela reconstrucao real na leitura — o `set`
+            # reportaria sucesso e `.execution.status` continuaria o antigo
+            # (caso real: sugestao wp-intel/mcp-server-host sug-003). Falhar
+            # alto e apontar o caminho por campo.
+            _sr_die "set: '$_sds_field' e um container modelado sob backend SQLite (extra_fields seria sombreado na leitura) — atualize campo a campo ('.execution.status', ...) ou use 'state-rw.sh write' com o documento inteiro" 1
+            ;;
         esac
         _sds_cur_extra=$(_state_db_exec "$_sds_db" "SELECT coalesce(extra_fields,'{}') FROM execution LIMIT 1;")
         _sds_new_extra=$(printf '%s' "$_sds_cur_extra" | jq -c --argjson v "$_sds_value" "$_sds_field = \$v") \
@@ -871,6 +890,11 @@ _sr_db_set_multi() {
           case "$_sm_bare" in
             *.*|*\[*)
               _sr_die "set: campo nao suportado sob backend SQLite (path aninhado nao modelado): '$_sm_f' — so campos de topo simples tem fallback para extra_fields" 1
+              ;;
+            execution|accumulated_metrics)
+              # Mesma regra do set simples (container modelado nunca cai em
+              # extra_fields sombreado) — lote inteiro rejeitado, estado intacto.
+              _sr_die "set: '$_sm_f' e um container modelado sob backend SQLite (extra_fields seria sombreado na leitura) — atualize campo a campo ('.execution.status', ...) ou use 'state-rw.sh write' com o documento inteiro" 1
               ;;
           esac
           [ -n "$_sm_extra" ] || _sm_extra=$(_state_db_exec "$_sm_db" "SELECT coalesce(extra_fields,'{}') FROM execution LIMIT 1;")

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/commit-mode.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/commit-mode.sh
@@ -952,8 +952,15 @@ _cm_cmd_finalize() {
   fi
 
   # Passo 2: guard-branch
-  _branch_out=$(_cm_cmd_guard_branch --state-dir "$_sdir" --projeto-alvo-path "$_pap")
-  _guard_rc=$?
+  # issue #139: `_x=$(cmd)` herda o exit de `cmd`; sob `set -eu` (topo do
+  # script) um exit != 0 aqui ABORTAVA o finalize ANTES do `_guard_rc=$?`,
+  # e os dois ramos abaixo (skipped-default-branch / error) eram codigo
+  # morto — o finalize vazava exit 1 (repo sem commits, HEAD unborn) ou
+  # exit 3 (HEAD na default) em vez do contrato "sempre exit 0 +
+  # .push_pr_result registrado". Mesmo padrao ja aplicado ao `cstk session
+  # pr` mais abaixo (`|| _cstk_rc=$?`).
+  _guard_rc=0
+  _branch_out=$(_cm_cmd_guard_branch --state-dir "$_sdir" --projeto-alvo-path "$_pap") || _guard_rc=$?
   _curr_branch=$(printf '%s' "$_branch_out" | head -1)
 
   if [ "$_guard_rc" = 3 ]; then

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
@@ -52,6 +52,9 @@
 #         --verify-registration):
 #             <arquivo>\t<present|missing>\t<registered|unregistered>\t<current|stale|unknown>[\t<canonical|divergent|indeterminate>]
 #         "registered" = o basename aparece em <PAP>/.claude/settings.json
+#         OU em <PAP>/.claude/settings.local.json (`cstk hooks install
+#         --local`, issue #135 — hooks SOMAM entre escopos no Claude Code,
+#         entao qualquer um dos dois arquivos ativa o hook).
 #         (o hook so roda de fato se estiver copiado E registrado).
 #         "current"/"stale" = comparacao byte-a-byte (cmp) da copia do
 #         projeto com a do catalogo; "unknown" = hook ausente ou catalogo
@@ -160,16 +163,34 @@ _gh_present() {
   [ -f "$1/.claude/hooks/$2" ] && [ -x "$1/.claude/hooks/$2" ]
 }
 
-# _gh_registered PAP HOOK -> 0 se o basename aparece no settings.json.
-# Busca textual (grep -F) em vez de parse: o hook e registrado como
-# fragmento de linha de comando ("$CLAUDE_PROJECT_DIR"/.claude/hooks/X.sh),
-# entao a presenca do basename e condicao necessaria e suficiente na
-# pratica — e mantem o script sem dependencia de jq (que pode faltar
-# justamente no projeto-alvo mal provisionado que estamos diagnosticando).
+# _gh_registered PAP HOOK -> 0 se o basename aparece em settings.json OU em
+# settings.local.json. Busca textual (grep -F) em vez de parse: o hook e
+# registrado como fragmento de linha de comando
+# ("$CLAUDE_PROJECT_DIR"/.claude/hooks/X.sh), entao a presenca do basename
+# e condicao necessaria e suficiente na pratica — e mantem o script sem
+# dependencia de jq (que pode faltar justamente no projeto-alvo mal
+# provisionado que estamos diagnosticando).
 _gh_registered() {
-  _gh_settings="$1/.claude/settings.json"
-  [ -f "$_gh_settings" ] || return 1
-  grep -Fq -- "$2" "$_gh_settings" 2>/dev/null
+  for _gh_settings in "$1/.claude/settings.json" "$1/.claude/settings.local.json"; do
+    [ -f "$_gh_settings" ] || continue
+    grep -Fq -- "$2" "$_gh_settings" 2>/dev/null && return 0
+  done
+  return 1
+}
+
+# _gh_registered_in PAP HOOK -> stdout: "settings.json", "settings.local.json",
+# "both" ou "" (nao registrado). Diagnostico legivel para o operador saber
+# QUAL arquivo carrega o registro (issue #135).
+_gh_registered_in() {
+  _gh_ri_p=0
+  _gh_ri_l=0
+  [ -f "$1/.claude/settings.json" ] && grep -Fq -- "$2" "$1/.claude/settings.json" 2>/dev/null && _gh_ri_p=1
+  [ -f "$1/.claude/settings.local.json" ] && grep -Fq -- "$2" "$1/.claude/settings.local.json" 2>/dev/null && _gh_ri_l=1
+  if [ "$_gh_ri_p" = 1 ] && [ "$_gh_ri_l" = 1 ]; then printf 'both'
+  elif [ "$_gh_ri_p" = 1 ]; then printf 'settings.json'
+  elif [ "$_gh_ri_l" = 1 ]; then printf 'settings.local.json'
+  fi
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -362,31 +383,38 @@ _gh_backend_blind() {
 _gh_verify_registration() {
   _gh_vr_pap="$1"
   _gh_vr_hook="$2"
-  _gh_vr_settings="$_gh_vr_pap/.claude/settings.json"
 
-  [ -f "$_gh_vr_settings" ] || { printf 'indeterminate'; return 0; }
-
-  # Layout minificado (uma unica linha fisica) impede atribuicao por linha.
-  _gh_vr_nr=$(awk 'END{print NR}' "$_gh_vr_settings" 2>/dev/null || printf '0')
-  case "$_gh_vr_nr" in '' | 0 | 1) printf 'indeterminate'; return 0 ;; esac
-
+  # Percorre settings.json E settings.local.json (issue #135): o veredito e
+  # "divergent" se QUALQUER linha de QUALQUER arquivo que cite o basename
+  # falhar a regra; "indeterminate" se nenhum arquivo existe, nenhum cita o
+  # hook, ou o unico que cita esta minificado numa linha.
   _gh_vr_canonical="\\\"\$CLAUDE_PROJECT_DIR\\\"/.claude/hooks/$_gh_vr_hook"
   _gh_vr_matched=0
   _gh_vr_all_ok=1
-  while IFS= read -r _gh_vr_line; do
-    [ -n "$_gh_vr_line" ] || continue
-    _gh_vr_matched=1
-    _gh_vr_has_cmd=0
-    _gh_vr_has_canon=0
-    case "$_gh_vr_line" in *'"command"'*) _gh_vr_has_cmd=1 ;; esac
-    case "$_gh_vr_line" in *"$_gh_vr_canonical"*) _gh_vr_has_canon=1 ;; esac
-    if [ "$_gh_vr_has_cmd" = 0 ] || [ "$_gh_vr_has_canon" = 0 ]; then
-      _gh_vr_all_ok=0
-    fi
-  done <<GHVR
+  _gh_vr_any_file=0
+  for _gh_vr_settings in "$_gh_vr_pap/.claude/settings.json" "$_gh_vr_pap/.claude/settings.local.json"; do
+    [ -f "$_gh_vr_settings" ] || continue
+    _gh_vr_any_file=1
+    grep -Fq -- "$_gh_vr_hook" "$_gh_vr_settings" 2>/dev/null || continue
+    # Layout minificado (uma unica linha fisica) impede atribuicao por linha.
+    _gh_vr_nr=$(awk 'END{print NR}' "$_gh_vr_settings" 2>/dev/null || printf '0')
+    case "$_gh_vr_nr" in '' | 0 | 1) continue ;; esac
+    while IFS= read -r _gh_vr_line; do
+      [ -n "$_gh_vr_line" ] || continue
+      _gh_vr_matched=1
+      _gh_vr_has_cmd=0
+      _gh_vr_has_canon=0
+      case "$_gh_vr_line" in *'"command"'*) _gh_vr_has_cmd=1 ;; esac
+      case "$_gh_vr_line" in *"$_gh_vr_canonical"*) _gh_vr_has_canon=1 ;; esac
+      if [ "$_gh_vr_has_cmd" = 0 ] || [ "$_gh_vr_has_canon" = 0 ]; then
+        _gh_vr_all_ok=0
+      fi
+    done <<GHVR
 $(grep -F -- "$_gh_vr_hook" "$_gh_vr_settings" 2>/dev/null)
 GHVR
+  done
 
+  [ "$_gh_vr_any_file" -eq 1 ] || { printf 'indeterminate'; return 0; }
   if [ "$_gh_vr_matched" -eq 0 ]; then
     printf 'indeterminate'
     return 0
@@ -516,8 +544,8 @@ _gh_cmd_check() {
     _gh_err "$_plugin_hooks de 3 hooks 00c sao providos pelo PLUGIN cstk (hooks.json), nao pela copia classica em $_pap/.claude/hooks/ — ativos, nada a provisionar."
   fi
   if [ "$_quiet" = 0 ] && [ "$_dup_hooks" -gt 0 ]; then
-    _gh_err "ATENCAO: $_dup_hooks hook(s) registrados DUAS vezes (plugin + copia classica em $_pap/.claude/settings.json) — cada tool call e contado em dobro."
-    _gh_err "  Remediacao: remova o bloco classico de $_pap/.claude/settings.json (o plugin vence)."
+    _gh_err "ATENCAO: $_dup_hooks hook(s) registrados DUAS vezes (plugin + copia classica em $_pap/.claude/settings.json ou settings.local.json) — cada tool call e contado em dobro."
+    _gh_err "  Remediacao: remova o bloco classico (o plugin vence) — 'cstk hooks install --project-path $_pap' oferece a remocao."
   fi
 
   [ "$_missing" -eq 0 ] && [ "$_stale" -eq 0 ] && [ "$_divergent" -eq 0 ] && return 0
@@ -530,7 +558,7 @@ _gh_cmd_check() {
       _gh_err "$_stale de 3 hooks 00c estao STALE em $_pap/.claude/hooks/ (copia diverge do catalogo)"
     fi
     if [ "$_divergent" -gt 0 ]; then
-      _gh_err "$_divergent de 3 hooks 00c estao com registro DIVERGENTE (settings.json aponta para outro comando)"
+      _gh_err "$_divergent de 3 hooks 00c estao com registro DIVERGENTE (settings.json/settings.local.json aponta para outro comando)"
     fi
     if [ "$_guard_missing" = 1 ]; then
       _gh_err "ATENCAO: pretooluse-bash-guard.sh inativo — a guarda fail-closed de Bash NAO esta enforced nesta execucao."

--- a/tests/cstk/test_doctor.sh
+++ b/tests/cstk/test_doctor.sh
@@ -503,6 +503,27 @@ scenario_doctor_distribution_paths_duplicated_hooks() {
   assert_stderr_contains "[duplicated-hooks]" || return 1
 }
 
+# issue #135: registro classico em settings.local.json (`cstk hooks install
+# --local`) tambem duplica com o plugin — doctor precisa enxergar os DOIS
+# arquivos, senao reporta "aligned" com hook rodando em dobro.
+scenario_doctor_distribution_paths_duplicated_hooks_via_settings_local() {
+  if ! command -v jq >/dev/null 2>&1; then _error "no_jq" "jq indisponivel"; return 2; fi
+  _h="$TMPDIR_TEST/dp-h-duplicated-local"
+  _ip=$(_dp_plugin_home "$_h")
+  _dp_fill_skills "$_ip" "same"
+  _dp_fill_skills "$_h/.claude" "same"
+  _proj="$TMPDIR_TEST/dp-proj-duplicated-local"
+  mkdir -p "$_proj/.claude"
+  # settings.json do time SEM hooks do cstk; registro so no arquivo local.
+  printf '{"permissions":{"allow":["Bash(ls:*)"]}}\n' > "$_proj/.claude/settings.json"
+  printf '{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"pretooluse-bash-guard.sh"}]}]}}\n' \
+    > "$_proj/.claude/settings.local.json"
+  _run_doctor_in "$_h" "$_proj"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "duplicated-hooks (local) exit" "esperado 1, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "[duplicated-hooks]" || return 1
+  assert_stderr_contains "settings.local.json" || return 1
+}
+
 scenario_doctor_distribution_paths_undetermined_installed_json_corrompido() {
   # Scenario 7 do quickstart: settings.json diz habilitado, mas
   # installed_plugins.json esta corrompido -> secao MOSTRADA (gate e o

--- a/tests/cstk/test_hooks.sh
+++ b/tests/cstk/test_hooks.sh
@@ -902,4 +902,213 @@ scenario_dedup_nao_remove_quando_plugin_incompleto() {
   return 0
 }
 
+# ==== `--local` + `hooks status` (issue #135) ====
+
+# _hooks_catalog_fixture_real: catalogo com os hooks + snippets REAIS do repo
+# (a fixture sintetica acima registra comandos "x"/"y"/"z", que nao casam o
+# basename do hook — inutil para verificar EM QUAL arquivo o registro esta).
+_hooks_catalog_fixture_real() {
+  _hcfr_cat="$TMPDIR_TEST/catalog-real"
+  _hcfr_hooks="$_hcfr_cat/skills/agente-00c-runtime/hooks"
+  mkdir -p "$_hcfr_hooks"
+  cp "$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/hooks"/*.sh "$_hcfr_hooks/" 2>/dev/null || :
+  cp "$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/hooks"/settings*.json "$_hcfr_hooks/" 2>/dev/null || :
+  chmod +x "$_hcfr_hooks"/*.sh 2>/dev/null || :
+  printf '%s' "$_hcfr_cat"
+}
+#
+# Repos de terceiros versionam .claude/settings.json de proposito; o registro
+# dos hooks do cstk (ferramenta pessoal) nao pode pousar la. `--local` grava
+# o registro em settings.local.json (hooks SOMAM entre escopos no Claude
+# Code) e o settings.json do time fica byte-a-byte intacto. Os scripts
+# continuam em .claude/hooks/.
+
+scenario_local_registra_em_settings_local_e_preserva_settings_json() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_real)
+  _proj="$TMPDIR_TEST/proj-local"
+  mkdir -p "$_proj/.claude"
+  printf '{\n  "permissions": {"allow": ["Bash(ls:*)"]}\n}\n' > "$_proj/.claude/settings.json"
+  cp "$_proj/.claude/settings.json" "$TMPDIR_TEST/settings.json.team-orig"
+
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --local --with-loose-usage
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  # settings.json do time: byte-a-byte intacto (o ponto inteiro da flag).
+  cmp -s "$_proj/.claude/settings.json" "$TMPDIR_TEST/settings.json.team-orig" \
+    || { _fail "settings.json do time foi tocado" "$(cat "$_proj/.claude/settings.json")"; return 1; }
+  [ -f "$_proj/.claude/settings.json.bak" ] \
+    && { _fail "settings.json.bak criado" "--local nao pode sujar o git status do cliente"; return 1; }
+  # Registro (3 obrigatorios + opt-in) no arquivo local.
+  [ -f "$_proj/.claude/settings.local.json" ] || { _fail "settings.local.json ausente" ""; return 1; }
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.local.json")" = "4" ] \
+    || { _fail "registro local" "esperado 4 entradas 00c, obtido $(_n_hooks_cstk "$_proj/.claude/settings.local.json")"; return 1; }
+  # Scripts continuam em .claude/hooks/ (o registro local aponta para la).
+  for _h in pretooluse-bash-guard.sh posttooluse-tool-call-tick.sh posttooluse-agent-usage.sh posttooluse-loose-usage.sh; do
+    [ -x "$_proj/.claude/hooks/$_h" ] || { _fail "hook ausente" "$_h"; return 1; }
+  done
+  # (path via pwd -P pode diferir de $_proj em symlinks de TMPDIR — casa so o sufixo)
+  assert_stderr_contains "provisionados e registrados em " || return 1
+  assert_stderr_contains "/.claude/settings.local.json" || return 1
+  return 0
+}
+
+scenario_local_idempotente() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_real)
+  _proj="$TMPDIR_TEST/proj-local-idem"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --local
+  _n1=$(_n_hooks_cstk "$_proj/.claude/settings.local.json")
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --local
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "2a run exit" "$_CAPTURED_EXIT"; return 1; }
+  _n2=$(_n_hooks_cstk "$_proj/.claude/settings.local.json")
+  [ "$_n1" = "3" ] && [ "$_n1" = "$_n2" ] \
+    || { _fail "idempotencia" "entradas 00c: $_n1 -> $_n2 (esperado 3 -> 3)"; return 1; }
+  [ -e "$_proj/.claude/settings.json" ] \
+    && { _fail "settings.json criado" "--local nunca deve criar settings.json"; return 1; }
+  return 0
+}
+
+scenario_local_dry_run_nao_escreve_e_cita_arquivo_local() {
+  _cat=$(_hooks_catalog_fixture_real)
+  _proj="$TMPDIR_TEST/proj-local-dry"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --local --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -e "$_proj/.claude" ] && { _fail "dry-run escreveu" ".claude nao deveria existir"; return 1; }
+  assert_stderr_contains "settings.local.json" || return 1
+  return 0
+}
+
+# Registro nos DOIS arquivos = cada tool call contada em dobro. Sem TTY e
+# sem --remove-classic o outro arquivo e MANTIDO com aviso (settings.json e
+# do operador/time; nada e removido sem confirmacao explicita).
+scenario_local_dedup_sem_tty_avisa_e_mantem_settings_json() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_real)
+  _proj="$TMPDIR_TEST/proj-local-dedup-keep"
+  _settings_com_classico "$_proj/.claude/settings.json"
+  _n_before=$(_n_hooks_cstk "$_proj/.claude/settings.json")
+
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --local </dev/null
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "duplicidade com o registro em settings.local.json" || return 1
+  assert_stderr_contains "MANTIDO" || return 1
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.json")" = "$_n_before" ] \
+    || { _fail "settings.json alterado sem confirmacao" ""; return 1; }
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.local.json")" = "3" ] \
+    || { _fail "registro local" "esperado 3, obtido $(_n_hooks_cstk "$_proj/.claude/settings.local.json")"; return 1; }
+  return 0
+}
+
+scenario_local_dedup_remove_classic_limpa_settings_json_preservando_terceiros() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_real)
+  _proj="$TMPDIR_TEST/proj-local-dedup-rm"
+  _settings_com_classico "$_proj/.claude/settings.json"
+
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --local --remove-classic
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.json")" = "0" ] \
+    || { _fail "remocao" "entradas 00c deveriam ter sumido de settings.json"; return 1; }
+  jq -e '.permissions.allow[0] == "Bash(ls:*)"
+         and ([.hooks.PreToolUse[].hooks[].command] | index("/opt/hook-do-time.sh") != null)
+         and ([.hooks.PostToolUse[].hooks[].command] | index("/usr/local/bin/telemetria.sh") != null)' \
+    "$_proj/.claude/settings.json" >/dev/null \
+    || { _fail "hooks de terceiros/chaves perdidos" "$(cat "$_proj/.claude/settings.json")"; return 1; }
+  [ -f "$_proj/.claude/settings.json.bak-pre-dedup" ] || { _fail "backup" "backup nao gravado"; return 1; }
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.local.json")" = "3" ] \
+    || { _fail "registro local" "esperado 3"; return 1; }
+  return 0
+}
+
+# Direcao inversa: instalar CLASSICO num projeto que ja tem registro local
+# tambem e duplicidade — mesmo aviso, mesma guarda.
+scenario_classico_sobre_local_avisa_duplicidade() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_real)
+  _proj="$TMPDIR_TEST/proj-classic-over-local"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --local
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" </dev/null
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "settings.local.json ainda registra 3 hook(s) 00c" || return 1
+  assert_stderr_contains "duplicidade com o registro em settings.json" || return 1
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.local.json")" = "3" ] \
+    || { _fail "settings.local.json alterado sem confirmacao" ""; return 1; }
+  return 0
+}
+
+# Sem --local o comportamento e byte-a-byte o historico: settings.json.
+scenario_sem_local_comportamento_identico() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_real)
+  _proj="$TMPDIR_TEST/proj-no-local"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT"; return 1; }
+  [ "$(_n_hooks_cstk "$_proj/.claude/settings.json")" = "3" ] || { _fail "settings.json" "esperado 3"; return 1; }
+  [ -e "$_proj/.claude/settings.local.json" ] && { _fail "settings.local.json criado sem --local" ""; return 1; }
+  return 0
+}
+
+scenario_apply_guard_hooks_settings_basename_invalido_exit2() {
+  _src=$(_guard_src_fixture)
+  capture sh -c '. "$CSTK_LIB/hooks.sh" && apply_guard_hooks "$1" "$2" 0 0 "settings.evil.json"' _ "$_src" "$TMPDIR_TEST/dest-evil"
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "error" || return 1
+  [ -e "$TMPDIR_TEST/dest-evil" ] && { _fail "escreveu" "basename invalido nao pode provisionar"; return 1; }
+  return 0
+}
+
+# --- cstk hooks status ---
+
+scenario_status_reporta_registro_local() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_real)
+  _proj="$TMPDIR_TEST/proj-status-local"
+  mkdir -p "$_proj"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --local --with-loose-usage
+  _hooks_main_run status --project-path "$_proj"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT / $_CAPTURED_STDERR"; return 1; }
+  for _h in pretooluse-bash-guard.sh posttooluse-tool-call-tick.sh posttooluse-agent-usage.sh posttooluse-loose-usage.sh; do
+    printf '%s\n' "$_CAPTURED_STDOUT" | grep -E "^  $_h +script=present +registro=settings.local.json" >/dev/null \
+      || { _fail "linha de $_h" "$_CAPTURED_STDOUT"; return 1; }
+  done
+  case "$_CAPTURED_STDERR" in *"MAIS de um lugar"*|*"sem registro algum"*) _fail "aviso indevido" "$_CAPTURED_STDERR"; return 1 ;; esac
+  return 0
+}
+
+scenario_status_reporta_both_e_avisa_dobro() {
+  if ! _has_jq; then _error "no_jq" "skip"; return 2; fi
+  _cat=$(_hooks_catalog_fixture_real)
+  _proj="$TMPDIR_TEST/proj-status-both"
+  _settings_com_classico "$_proj/.claude/settings.json"
+  _hooks_main_run install --project-path "$_proj" --catalog "$_cat" --local </dev/null
+  _hooks_main_run status --project-path "$_proj"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 (diagnostico), obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -E "^  pretooluse-bash-guard.sh +script=present +registro=both" >/dev/null \
+    || { _fail "esperado registro=both" "$_CAPTURED_STDOUT"; return 1; }
+  assert_stderr_contains "3 hook(s) registrados em MAIS de um lugar" || return 1
+  return 0
+}
+
+scenario_status_sem_nada_reporta_none_e_orienta() {
+  _proj="$TMPDIR_TEST/proj-status-none"
+  mkdir -p "$_proj"
+  _hooks_main_run status --project-path "$_proj"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -E "^  pretooluse-bash-guard.sh +script=missing +registro=none" >/dev/null \
+    || { _fail "esperado script=missing registro=none" "$_CAPTURED_STDOUT"; return 1; }
+  assert_stderr_contains "sem registro algum" || return 1
+  [ -e "$_proj/.claude" ] && { _fail "status escreveu" ".claude nao deveria existir (read-only)"; return 1; }
+  return 0
+}
+
+scenario_status_flag_desconhecida_exit2() {
+  _hooks_main_run status --xyz
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "flag desconhecida" || return 1
+}
+
 run_all_scenarios

--- a/tests/cstk/test_session.sh
+++ b/tests/cstk/test_session.sh
@@ -880,6 +880,45 @@ STUBGH
   assert_stderr_contains "gh auth login" || return 1
 }
 
+# ==== FR-017 (falha parcial): gh pr create falha => exit 1 + orientacao ====
+# Regressao (classe da issue #139): `_create_out=$(gh pr create ...)` herda o
+# exit do gh e, sob o `set -eu` do binario, abortava _session_pr ANTES do
+# `_create_rc=$?` — o ramo de falha parcial (push feito, PR nao) era codigo
+# morto e o operador so via o exit cru do gh, sem retry/desfazer.
+scenario_pr_gh_create_falha_reporta_falha_parcial_exit_1() {
+  _src="$TMPDIR_TEST/repo-pr-cfail"
+  _make_repo "$_src"
+  _phys=$( cd "$TMPDIR_TEST" && pwd -P )
+  # origin local (bare) para o `git push -u origin` do passo 5 ter sucesso.
+  _bare="$TMPDIR_TEST/repo-pr-cfail-origin.git"
+  git init -q --bare "$_bare"
+  ( cd "$_src" && git remote add origin "$_bare" && git push -q -u origin main 2>/dev/null )
+  ( cd "$_src" && CSTK_LIB="$CSTK_LIB" sh "$CSTK_BIN" session start cfail-x >/dev/null )
+  _wt="$_phys/repo-pr-cfail-cfail-x"
+  ( cd "$_wt" && git commit -q --allow-empty -m "test commit" )
+  # Stub gh: auth ok, pr view "nao existe", pr create FALHA.
+  _stub_dir="$TMPDIR_TEST/stub-gh-cfail"
+  mkdir -p "$_stub_dir"
+  cat > "$_stub_dir/gh" <<'STUBGH'
+#!/bin/sh
+case "$1 $2" in
+  "auth status") exit 0 ;;
+  "pr view") exit 1 ;;
+  "pr create") printf 'GraphQL: stub falhou de proposito\n'; exit 1 ;;
+  *) exit 0 ;;
+esac
+STUBGH
+  chmod +x "$_stub_dir/gh"
+  capture sh -c "cd '$_src' && PATH='$_stub_dir:/usr/bin:/bin' CSTK_LIB='$CSTK_LIB' sh '$CSTK_BIN' session pr cfail-x"
+  if [ "$_CAPTURED_EXIT" != 1 ]; then
+    _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"
+    return 1
+  fi
+  assert_stderr_contains "'gh pr create' falhou (push ja foi feito)" || return 1
+  assert_stderr_contains "para desfazer push" || return 1
+  assert_stderr_contains "stub falhou de proposito" || return 1
+}
+
 scenario_pr_unknown_flag_exit_2() {
   _src="$TMPDIR_TEST/repo-pr-flag"
   _make_repo "$_src"

--- a/tests/test_commit-mode.sh
+++ b/tests/test_commit-mode.sh
@@ -1417,4 +1417,45 @@ GHEOF
     || { _fail "status esperado pr-opened" "stdout: $_fin_out"; return 1; }
 }
 
+# ==== issue #139: guard-branch != 0 dentro do finalize NAO pode vazar ====
+# `_branch_out=$(_cm_cmd_guard_branch ...)` herda o exit do guard; sob
+# `set -eu` o finalize abortava ANTES de `_guard_rc=$?` e os ramos
+# skipped-default-branch (exit 3) / error (exit 1) eram codigo morto.
+# Caso real: projeto-alvo recem `git init` (HEAD unborn) na 1a execucao do
+# agente-00c — finalize vazava exit 1 com stderr do guard-branch.
+
+scenario_issue139_finalize_repo_sem_commits_exit0_status_error() {
+  _gdir="$TMPDIR_TEST/repo-unborn-139"
+  _sd="$TMPDIR_TEST/fin-unborn-139"
+  _init_state "$_sd" true
+  mkdir -p "$_gdir"
+  git -C "$_gdir" init -q 2>/dev/null
+  # ZERO commits: HEAD unborn — `rev-parse --abbrev-ref HEAD` falha.
+
+  capture "$SCRIPT" finalize --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0 (contrato finalize)" "obtido $_CAPTURED_EXIT; stderr: $_CAPTURED_STDERR"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | grep -q '"status":"error"' \
+    || { _fail "status esperado error" "stdout: $_CAPTURED_STDOUT"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | grep -q '"reason":"guard-branch exit 1"' \
+    || { _fail "reason esperado 'guard-branch exit 1'" "stdout: $_CAPTURED_STDOUT"; return 1; }
+  _status=$(jq -r '.push_pr_result.status // "absent"' "$_sd/state.json" 2>/dev/null)
+  [ "$_status" = "error" ] || { _fail "push_pr_result.status no state" "obtido '$_status'"; return 1; }
+}
+
+scenario_issue139_finalize_head_na_default_exit0_skipped_default_branch() {
+  _gdir="$TMPDIR_TEST/repo-default-139"
+  _sd="$TMPDIR_TEST/fin-default-139"
+  _init_state "$_sd" true
+  _init_git_repo "$_gdir" "main"
+
+  capture "$SCRIPT" finalize --state-dir "$_sd" --projeto-alvo-path "$_gdir"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0 (contrato finalize)" "obtido $_CAPTURED_EXIT; stderr: $_CAPTURED_STDERR"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | grep -q '"status":"skipped-default-branch"' \
+    || { _fail "status esperado skipped-default-branch" "stdout: $_CAPTURED_STDOUT"; return 1; }
+  printf '%s' "$_CAPTURED_STDOUT" | grep -q '"branch":"main"' \
+    || { _fail "branch esperado main" "stdout: $_CAPTURED_STDOUT"; return 1; }
+  _status=$(jq -r '.push_pr_result.status // "absent"' "$_sd/state.json" 2>/dev/null)
+  [ "$_status" = "skipped-default-branch" ] || { _fail "push_pr_result.status no state" "obtido '$_status'"; return 1; }
+}
+
 run_all_scenarios

--- a/tests/test_guard-hooks-status.sh
+++ b/tests/test_guard-hooks-status.sh
@@ -859,5 +859,71 @@ scenario_plugin_hooks_json_ilegivel_degrada() {
   return 0
 }
 
+# ==== issue #135: registro em settings.local.json (`cstk hooks install --local`) ====
+#
+# Hooks SOMAM entre escopos no Claude Code — registro em
+# <PAP>/.claude/settings.local.json ativa o hook exatamente como o
+# settings.json. Se estes leitores ignorassem o arquivo local, `check`
+# diria "unregistered" (falso), `tick-mode` diria "manual" e o orquestrador
+# tickaria NA MAO por cima do hook ativo => contagem DUPLA de tool calls.
+
+scenario_local_check_registrado_via_settings_local_exit0() {
+  _p=$(_mkproj proj-local-ok)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  # shellcheck disable=SC2086
+  _register "$_p" $_HOOKS
+  mv "$_p/.claude/settings.json" "$_p/.claude/settings.local.json"
+  _ghs check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 (registro local vale), obtido $_CAPTURED_EXIT"; return 1; }
+  for _h in $_HOOKS; do
+    printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered	current$" \
+      || { _fail "TSV" "esperado '$_h present registered current' via settings.local.json"; return 1; }
+  done
+  return 0
+}
+
+scenario_local_tick_mode_hook_via_settings_local() {
+  _p=$(_mkproj proj-local-tick)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  # shellcheck disable=SC2086
+  _register "$_p" $_HOOKS
+  mv "$_p/.claude/settings.json" "$_p/.claude/settings.local.json"
+  _ghs tick-mode --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_STDOUT" = "hook" ] \
+    || { _fail "stdout" "esperado 'hook' (registro local ativa o tick), obtido '$_CAPTURED_STDOUT'"; return 1; }
+  return 0
+}
+
+scenario_local_verify_registration_canonical_via_settings_local() {
+  _p=$(_mkproj proj-local-verify)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  # shellcheck disable=SC2086
+  _register_canonical "$_p" $_HOOKS
+  mv "$_p/.claude/settings.json" "$_p/.claude/settings.local.json"
+  _ghs check --projeto-alvo-path "$_p" --verify-registration
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  for _h in $_HOOKS; do
+    printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered	current	canonical$" \
+      || { _fail "TSV" "esperado 'canonical' via settings.local.json para $_h"; return 1; }
+  done
+  return 0
+}
+
+# Registro divergente no arquivo LOCAL tambem reprova (a regra vale para os
+# dois arquivos — um local desviando o command e a mesma linha-isca).
+scenario_local_verify_registration_divergent_no_local_reprova() {
+  _p=$(_mkproj proj-local-divergent)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  # shellcheck disable=SC2086
+  _register_canonical "$_p" $_HOOKS
+  printf '{\n  "hooks": {\n    "PreToolUse": [\n      {\n        "hooks": [\n          {\n            "type": "command",\n            "command": "/tmp/evil/pretooluse-bash-guard.sh"\n          }\n        ]\n      }\n    ]\n  }\n}\n' \
+    > "$_p/.claude/settings.local.json"
+  _ghs check --projeto-alvo-path "$_p" --verify-registration
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1 (divergent no local), obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^pretooluse-bash-guard.sh	present	registered	current	divergent$" \
+    || { _fail "TSV" "esperado divergent para o guard: $_CAPTURED_STDOUT"; return 1; }
+  return 0
+}
+
 run_all_scenarios
 exit $?

--- a/tests/test_state-rw.sh
+++ b/tests/test_state-rw.sh
@@ -935,6 +935,46 @@ scenario_sqlite_set_campo_aninhado_nao_modelado_falha_alto() {
   [ "$_CAPTURED_EXIT" != 0 ] || { _fail "set aninhado nao modelado deveria falhar" "obtido exit 0"; return 1; }
 }
 
+# Anti-sucesso-falso (Principio VI): container/derivado MODELADO nao pode
+# cair em extra_fields e ser sombreado na leitura com "atualizado" no
+# stderr. Casos reais (knowledge.db): `.execution` inteiro (sug-003
+# wp-intel/mcp-server-host) e `.waves[-1].skills_invoked` (sug-001 idem;
+# sug-002 cstk/mcp-direct-transport) — exit 0, valor antigo na releitura.
+scenario_sqlite_set_execution_inteiro_falha_alto_e_nao_sombreia() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.execution' --value '{"status":"concluida"}'
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "set .execution inteiro deveria falhar" "obtido exit 0"; return 1; }
+  assert_stderr_contains "container modelado" || return 1
+  _ef=$(sqlite3 "$_sd/state.db" "SELECT coalesce(extra_fields,'{}') FROM execution;")
+  case "$_ef" in *'"execution"'*) _fail "extra_fields.execution gravado" "$_ef"; return 1 ;; esac
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.execution.status'
+  [ "$_CAPTURED_STDOUT" != "concluida" ] || { _fail "status nao deveria mudar" ""; return 1; }
+  # Lote multi-campo com o container no meio: rejeitado inteiro, estado intacto.
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.current_stage' --value '"plan"' \
+    --field '.execution' --value '{"status":"concluida"}'
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "lote com .execution deveria falhar" "obtido exit 0"; return 1; }
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.current_stage'
+  [ "$_CAPTURED_STDOUT" = "specify" ] || { _fail "lote parcial aplicado" "current_stage='$_CAPTURED_STDOUT'"; return 1; }
+}
+
+scenario_sqlite_set_waves_skills_invoked_falha_alto_e_nao_sombreia() {
+  _sd="$TMPDIR_TEST/migrated"
+  _seed_sqlite_backend "$_sd" || return 1
+  sqlite3 "$_sd/state.db" "INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z');" \
+    || { _fail "seed wave falhou" ""; return 1; }
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.waves[-1].skills_invoked' \
+    --value '[{"skill":"briefing","decision_id":"dec-001","timestamp":"2026-07-30T00:00:01Z"}]'
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "set .waves[-1].skills_invoked deveria falhar" "obtido exit 0"; return 1; }
+  assert_stderr_contains "record-skill" || return 1
+  _ef=$(sqlite3 "$_sd/state.db" "SELECT coalesce(extra_fields,'{}') FROM wave WHERE id='onda-001';")
+  case "$_ef" in *skills_invoked*) _fail "wave.extra_fields.skills_invoked gravado" "$_ef"; return 1 ;; esac
+  capture "$SCRIPT" get --state-dir "$_sd" --field '.waves[-1].skills_invoked | length'
+  [ "$_CAPTURED_STDOUT" = "0" ] || { _fail "skills_invoked deveria seguir vazio" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+  capture "$SCRIPT" set --state-dir "$_sd" --field '.waves[-1].id' --value '"onda-999"'
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "set .waves[-1].id deveria falhar" "obtido exit 0"; return 1; }
+}
+
 scenario_sqlite_set_events_substitui_array_completo() {
   _sd="$TMPDIR_TEST/migrated"
   _seed_sqlite_backend "$_sd" || return 1


### PR DESCRIPTION
## Resumo

- **#135** `cstk hooks install --local` (registro em `.claude/settings.local.json`, `settings.json` do time intacto) + `cstk hooks status` (read-only) + dedup cruzado entre os dois arquivos + `guard-hooks-status.sh`/`cstk doctor` lendo os dois (senão `tick-mode=manual` ⇒ tick em dobro).
- **#139** `commit-mode.sh finalize` honra "sempre exit 0": `_branch_out=$(guard-branch)` sob `set -eu` abortava antes de `_guard_rc=$?` — os ramos `error` (HEAD unborn) e `skipped-default-branch` eram código morto. Mesma classe fechada em `session.sh` (`gh pr create` falhando matava o ramo FR-017), `mcp.sh`, `serve-docker.sh`.
- `state-rw.sh set` sob SQLite: `.execution` inteiro e `.waves[N].skills_invoked` reportavam `atualizado` sem efeito (extra_fields sombreado na leitura) — agora exit 1 com caminho certo (3 sugestões da knowledge.db reproduzidas).
- CHANGELOG 8.4.0 + manifestos de plugin em lockstep (`validate-plugin-manifests.sh --version 8.4.0 --strict` OK).

## Testado

- Suite completa (`LC_ALL=C ./tests/run.sh`) na integração das 3 branches: **PASS 3228 / FAIL 0** (940s).
- 22 cenários novos; cada regressão falha sem o fix correspondente (mutation check).
- `--check-coverage` zero órfãos; `cstk doctor` drift zero.

Closes #135
Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiHRXC83ja2JERyfeZNJqs