### PR TITLE
fix(runtime): Decisao com opcoes estruturadas {rotulo,descricao} nao trunca mais o relatorio (#141) — 8.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "8.4.0",
+      "version": "8.4.1",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [8.4.1] - 2026-08-19
+
+Bugfix da issue #141 (aberta pelo próprio agente-00C): uma Decisão com
+`options_considered` em forma estruturada truncava o relatório de auditoria
+no meio, e o pipe da prosa escondia a falha. A causa raiz é nossa: o
+`clarify-asker` emite `opcoes_recomendadas` como objetos `{rotulo,
+descricao}` e o orquestrador passa isso verbatim em `--opcoes` — ou seja,
+TODA Decisão do clarify autônomo quebrava o `report.sh generate`. Mesmo
+defeito da #115, que foi corrigido só para os bloqueios. Sem breaking.
+
+### Fixed
+
+- **`report.sh` renderiza `options_considered` com string OU objeto**
+  (`(rotulo) descricao`, mesmo tratamento já dado a `recommended_options`
+  dos bloqueios). Antes: `jq: string and object cannot be added`, `generate`
+  exit 5, `.md` só com as seções 1-3 e `validate` exit 1 (seções 4/5/6
+  ausentes).
+- **`state-decisions.sh register` valida a FORMA de cada item de
+  `--opcoes`**: string não-vazia OU objeto com `rotulo`/`label` string
+  não-vazia (o formato do clarify-asker). Número, `null`, array, string
+  vazia ou objeto sem rótulo → exit 1 com mensagem clara, nada gravado.
+  Deliberadamente NÃO rejeita objetos (item 1 da issue) — isso quebraria o
+  clarify autônomo. `--referencias`: string não-vazia ou objeto não-vazio
+  (o `report.sh` já renderiza os dois) → senão exit 2.
+- **MCP `record_decision` em paridade** (`mcp/state-server/src/tools/
+  record_decision.ts`): `options_considered` aceita `string |
+  {rotulo|label, descricao?}`; objetos não participam da detecção de
+  `CONSTITUTION_CONFLICT_SCORE` (as 3 opções canônicas são strings por
+  protocolo). Contrato `contracts/mcp-tools.md` atualizado. 3 testes node
+  novos (160/160).
+- **Prosa do orquestrador (passo 12 de `agente-00c-orchestrator.md`)**:
+  o relatório passa a ser gerado por `report.sh emit --flavor agente-00c`
+  (secrets-filter interno e obrigatório; PROPAGA o exit do render; grava em
+  `<SD>/../agente-00c-report.md`) em vez de `generate | secrets-filter.sh
+  scrub > arquivo` — num pipe o exit é o do `scrub`, e foi assim que o
+  `.md` truncado saiu com exit 0 até o `validate` reclamar. Verificado:
+  `emit` com o `report.sh` antigo sai 5, não mascara.
+- Testes: 2 cenários em `tests/test_report.sh` (`generate` e `emit` com
+  opções-objeto → 6 seções + `validate` 0), 3 em
+  `tests/test_state-decisions.sh` (objeto com rótulo aceito e preservado no
+  state; formas inválidas rejeitadas sem gravar; referências). Todos falham
+  sem o fix (mutation check).
+
+Desdobramentos abertos como issues separadas: #143 (`issue.sh` publica
+descrição do projeto-alvo/Decisões/paths sem consentimento — redação por
+default + opt-in) e #144 (amend auditável de Decisão; hoje só SQL cru).
+
 ## [8.4.0] - 2026-08-19
 
 Release de manutenção com uma feature pequena pedida por quem usa o cstk em
@@ -6758,6 +6805,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[8.4.1]: https://github.com/JotJunior/cstk/releases/tag/v8.4.1
 [8.4.0]: https://github.com/JotJunior/cstk/releases/tag/v8.4.0
 [8.3.1]: https://github.com/JotJunior/cstk/releases/tag/v8.3.1
 [8.3.0]: https://github.com/JotJunior/cstk/releases/tag/v8.3.0

--- a/docs/specs/_archived/2026-08-03-state-mcp-server/contracts/mcp-tools.md
+++ b/docs/specs/_archived/2026-08-03-state-mcp-server/contracts/mcp-tools.md
@@ -195,7 +195,7 @@ Registra Decisao auditavel. **Delega para** [VERIFICADO]:
 | `agent` | string | yes | min 1 |
 | `stage` | string | yes | Etapa SDD corrente |
 | `context` | string | yes | **min 20 chars** [VERIFICADO: `state-decisions.sh:185-189`] |
-| `options_considered` | string[] | yes | min 1 item |
+| `options_considered` | (string \| {rotulo\|label: string, descricao?: string})[] | yes | min 1 item; cada item string nao-vazia OU objeto com rotulo/label nao-vazio (issue #141 — paridade com `state-decisions.sh register`; formato do clarify-asker) |
 | `choice` | string | yes | min 1 |
 | `rationale` | string | yes | **min 20 chars** [VERIFICADO: mesma linha] |
 | `justification_score` | integer \| null | no | `null \| 0 \| 1 \| 2 \| 3` [VERIFICADO: `state-decisions.sh:198-201`] |

--- a/mcp/state-server/src/tools/record_decision.ts
+++ b/mcp/state-server/src/tools/record_decision.ts
@@ -47,8 +47,32 @@ const CONSTITUTION_CONFLICT_OPTIONS = [
   "abortar-feature-sem-principios-proprios",
 ] as const;
 
-function isConstitutionConflictOptionSet(options: readonly string[]): boolean {
-  return CONSTITUTION_CONFLICT_OPTIONS.every((opt) => options.includes(opt));
+// Issue #141: o clarify autonomo emite opcoes estruturadas {rotulo, descricao}
+// (clarify-asker) e a prosa do orquestrador as passa verbatim — o helper
+// shell aceita string nao-vazia OU objeto com rotulo/label nao-vazio
+// [VERIFICADO: state-decisions.sh register, validacao de forma de --opcoes].
+// Paridade aqui; `label`/`description` sao os aliases EN aceitos pelo report.
+const decisionOptionSchema = z.union([
+  z.string().min(1, "opcao (string) nao pode ser vazia"),
+  z
+    .object({
+      rotulo: z.string().min(1).optional(),
+      label: z.string().min(1).optional(),
+      descricao: z.string().optional(),
+      description: z.string().optional(),
+    })
+    .passthrough()
+    .refine((o) => Boolean(o.rotulo || o.label), {
+      message: "opcao estruturada exige rotulo (ou label) nao-vazio",
+    }),
+]);
+type DecisionOption = z.infer<typeof decisionOptionSchema>;
+
+function isConstitutionConflictOptionSet(options: readonly DecisionOption[]): boolean {
+  // So strings participam da deteccao — as 3 opcoes canonicas sao strings por
+  // protocolo (orchestrator.md secao 5.b); um objeto nunca casa.
+  const asStrings = options.filter((o): o is string => typeof o === "string");
+  return CONSTITUTION_CONFLICT_OPTIONS.every((opt) => asStrings.includes(opt));
 }
 
 export const recordDecisionInputShape = {
@@ -58,7 +82,7 @@ export const recordDecisionInputShape = {
   // min 20 chars [VERIFICADO: state-decisions.sh:184-186].
   context: z.string().min(20, "context deve ter >= 20 chars (Principio I)"),
   options_considered: z
-    .array(z.string())
+    .array(decisionOptionSchema)
     .min(1, "options_considered precisa de >= 1 item"),
   choice: z.string().min(1, "choice obrigatorio"),
   // min 20 chars [VERIFICADO: state-decisions.sh:187-189].

--- a/mcp/state-server/test/record_decision.test.ts
+++ b/mcp/state-server/test/record_decision.test.ts
@@ -57,6 +57,37 @@ test("inputSchema (FR-002): rejeita options_considered vazio", () => {
   assert.equal(parsed.success, false);
 });
 
+// Issue #141: paridade com state-decisions.sh — opcoes estruturadas
+// {rotulo, descricao} (formato do clarify-asker) sao aceitas; forma invalida
+// (objeto sem rotulo, string vazia, numero) e rejeitada no schema.
+test("inputSchema (#141): aceita opcoes estruturadas {rotulo, descricao} misturadas com strings", () => {
+  const parsed = inputSchema.safeParse({
+    ...VALID_PAYLOAD,
+    options_considered: [{ rotulo: "A", descricao: "opcao A" }, "B", { label: "C" }],
+  });
+  assert.equal(parsed.success, true);
+});
+
+test("inputSchema (#141): rejeita objeto sem rotulo/label, string vazia e numero", () => {
+  for (const bad of [[{ descricao: "sem rotulo" }], [""], [1], [null]]) {
+    const parsed = inputSchema.safeParse({ ...VALID_PAYLOAD, options_considered: bad });
+    assert.equal(parsed.success, false, `deveria rejeitar ${JSON.stringify(bad)}`);
+  }
+});
+
+test("inputSchema (#141): objeto com rotulo igual a opcao canonica NAO dispara CONSTITUTION_CONFLICT_SCORE", () => {
+  const parsed = inputSchema.safeParse({
+    ...VALID_PAYLOAD,
+    options_considered: [
+      { rotulo: "atualizar-global-via-bump-SemVer" },
+      { rotulo: "criar-feature-delta-com-sync-impact-report" },
+      { rotulo: "abortar-feature-sem-principios-proprios" },
+    ],
+    justification_score: 2,
+  });
+  assert.equal(parsed.success, true);
+});
+
 test("inputSchema (EVIDENCE_REQUIRED): score 3 sem evidence e rejeitado", () => {
   const parsed = inputSchema.safeParse({ ...VALID_PAYLOAD, justification_score: 3 });
   assert.equal(parsed.success, false);

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/agents/agente-00c-orchestrator.md
+++ b/plugins/cstk/agents/agente-00c-orchestrator.md
@@ -123,7 +123,7 @@ infraestrutura interna deste agente.
 | `secrets-filter.sh` | scrub/check | FR-030 (filtro de secrets antes de gravar report/suggestions/issue) |
 | `sanitize.sh` | limit-length/check-length/escape-{commit-msg,issue-body,path} | FR-025 (sanitizacao de descricao_curta) |
 | `whitelist-validate.sh` | check/list | FR-031 (rejeita patterns overly broad como `**`, `*://*`, `https://*`) |
-| `report.sh` | generate/validate | FR-011 + SC-001 (relatorio com 6 secoes; validate por regex de headings) |
+| `report.sh` | emit --flavor agente-00c/validate | FR-011 + SC-001 (relatorio com 6 secoes; validate por regex de headings) |
 | `suggestions.sh` | register/list/count/next-id/mark-issue/render-md | FR-020 (sugestoes para skills globais — 3 severidades) |
 | `issue.sh` | create/check-duplicate/hash | FR-021 (abertura automatica de issue no toolkit, com dedup + secrets-filter 2x) |
 
@@ -2227,20 +2227,27 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
     (< 5s tipico); se o pai falhar em agendar, ele atualiza o estado para
     null e emite aviso.
 
-12. **Relatorio parcial** (FR-011, SC-001): gerar via `report.sh
-    generate` aplicando filtro de secrets em pipe; validar via
-    `report.sh validate` apos gravar.
+12. **Relatorio parcial** (FR-011, SC-001): gerar via `report.sh emit
+    --flavor agente-00c` (secrets-filter INTERNO e obrigatorio; grava em
+    `<SD>/../agente-00c-report.md` = `<PAP>/.claude/agente-00c-report.md`);
+    validar via `report.sh validate` apos gravar.
 
     ```bash
-    report.sh generate --state-dir <SD> \
+    report.sh emit --flavor agente-00c --state-dir <SD> \
         [--final --licoes-aprendidas "<texto>"] \
         --paragrafo-resumo "<resumo de 3-5 linhas escrito por voce>" \
-      | secrets-filter.sh scrub --env-file <PAP>/.env \
-      > <PAP>/.claude/agente-00c-report.md
+        --env-file <PAP>/.env \
+      || registrar Decisao (exit + stderr literal) — NAO prosseguir com .md truncado
 
     report.sh validate --report-file <PAP>/.claude/agente-00c-report.md \
       || retentar 1x; falha persistente = registrar Decisao + bloqueio
     ```
+
+    NAO use a forma antiga `report.sh generate ... | secrets-filter.sh scrub
+    ... > arquivo`: num pipe o exit e o do `scrub`, e uma falha do `generate`
+    (ex.: exit 5 por jq) vira `.md` truncado com exit 0 — foi assim que a
+    issue #141 passou despercebida ate o `validate`. O `emit` propaga o exit
+    do render e nunca grava relatorio nao-filtrado ou incompleto.
 
     `--final` apenas no termino da execucao (status `concluida` ou
     `abortada`); em ondas intermediarias, gera relatorio parcial com

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/report.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/report.sh
@@ -252,7 +252,12 @@ _rp_render_secao_3() {
             "",
             "**Contexto**: \(.context // .contexto)",
             "",
-            "**Opcoes consideradas**: \(((.options_considered // .opcoes_consideradas) // []) | join(" / "))",
+            # Issue #141: o clarify autonomo emite opcoes estruturadas
+            # {rotulo, descricao} (clarify-asker) e a prosa do orquestrador as
+            # passa verbatim em --opcoes — `join` sobre objeto quebrava o
+            # generate inteiro (exit 5, .md truncado sem secoes 4/5/6). Mesmo
+            # tratamento ja dado a recommended_options dos bloqueios (#115).
+            "**Opcoes consideradas**: \(((.options_considered // .opcoes_consideradas) // []) | map(if type == "object" then "(\((.rotulo // .label) // "?")) \((.descricao // .description) // "")" else tostring end) | join(" / "))",
             "",
             "**Escolha**: \(.choice // .escolha)",
             "",

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/state-decisions.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/state-decisions.sh
@@ -195,8 +195,26 @@ _sd_cmd_register() {
   if ! printf '%s' "$_ops" | jq -e 'type == "array" and length >= 1' >/dev/null 2>&1; then
     _sd_die "register: violacao Principio I — opcoes_consideradas precisa ser JSON array com >=1 item" 1
   fi
+  # Issue #141: forma de cada elemento. Aceita string nao-vazia OU objeto
+  # estruturado {rotulo|label: string nao-vazia, descricao?} — o formato que
+  # o clarify-asker emite em opcoes_recomendadas e que a prosa do
+  # orquestrador passa verbatim em --opcoes. Qualquer outra coisa (numero,
+  # null, array, objeto sem rotulo) e rejeitada aqui, com mensagem clara, em
+  # vez de ser gravada e quebrar o report.sh generate depois.
+  if ! printf '%s' "$_ops" | jq -e '
+        all(.[];
+          (type == "string" and length > 0)
+          or (type == "object" and (((.rotulo // .label) | type) == "string") and (((.rotulo // .label) | length) > 0)))
+      ' >/dev/null 2>&1; then
+    _sd_die "register: violacao Principio I — cada item de --opcoes precisa ser string nao-vazia ou objeto {rotulo|label: string nao-vazia, descricao?}" 1
+  fi
   if ! printf '%s' "$_refs" | jq -e 'type == "array"' >/dev/null 2>&1; then
     _sd_die "register: --referencias precisa ser JSON array" 2
+  fi
+  # Mesma regra de forma para --referencias (report.sh ja renderiza string
+  # ou objeto chave=valor; numero/null/array quebrariam o to_entries).
+  if ! printf '%s' "$_refs" | jq -e 'all(.[]; (type == "string" and length > 0) or (type == "object" and length > 0))' >/dev/null 2>&1; then
+    _sd_die "register: cada item de --referencias precisa ser string nao-vazia ou objeto nao-vazio" 2
   fi
   # score aceita "null" ou numero 0..3
   case "$_score" in

--- a/tests/test_report.sh
+++ b/tests/test_report.sh
@@ -815,4 +815,54 @@ EOF
   assert_stdout_contains "substituida por auth-basica" || return 1
 }
 
+# ==== issue #141: Decisao com opcoes estruturadas {rotulo, descricao} ====
+# O clarify autonomo emite opcoes_recomendadas como objetos e a prosa do
+# orquestrador as passa verbatim em --opcoes; `join` sobre objeto quebrava o
+# generate inteiro (exit 5, .md truncado sem secoes 4/5/6, validate exit 1).
+scenario_issue141_generate_com_opcoes_objeto_rende_6_secoes() {
+  _sd="$TMPDIR_TEST/state-141"
+  _init "$_sd"
+  capture "$ON" start --state-dir "$_sd"
+  capture "$DEC" register --state-dir "$_sd" \
+    --agente "clarify-answerer" --etapa "clarify" \
+    --contexto "Pergunta de clarify com opcoes estruturadas do asker" \
+    --opcoes '[{"rotulo":"A","descricao":"Comando slash no canal","default_sugerido":true},{"rotulo":"B","descricao":"Mention na thread"},"C-string-solta"]' \
+    --escolha "A" \
+    --justificativa "Justificativa de tamanho ok aqui sim para teste" --score 2
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "register com opcoes-objeto deveria passar" "$_CAPTURED_STDERR"; return 1; }
+  capture "$ON" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+
+  capture "$SCRIPT" generate --state-dir "$_sd" --paragrafo-resumo "x"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "generate exit" "esperado 0, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "**Opcoes consideradas**: (A) Comando slash no canal / (B) Mention na thread / C-string-solta" || return 1
+  for _h in "## 4. Bloqueios Humanos" "## 5. Sugestoes para Skills Globais" "## 6. Licoes Aprendidas"; do
+    assert_stdout_contains "$_h" || return 1
+  done
+  # validate sobre o artefato gravado tambem passa.
+  _out="$TMPDIR_TEST/out-141.md"
+  printf '%s\n' "$_CAPTURED_STDOUT" > "$_out"
+  capture "$SCRIPT" validate --report-file "$_out"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "validate" "esperado 0, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+}
+
+# O emit propaga falha do render (nao e pipe): contrato que a prosa do
+# orquestrador passa a usar em vez de `generate | scrub > arquivo`.
+scenario_issue141_emit_agente_00c_grava_relatorio_completo() {
+  _sd="$TMPDIR_TEST/pap-141/.claude/agente-00c-state"
+  mkdir -p "$_sd"
+  _init "$_sd"
+  capture "$ON" start --state-dir "$_sd"
+  capture "$DEC" register --state-dir "$_sd" \
+    --agente "clarify-answerer" --etapa "clarify" \
+    --contexto "Pergunta de clarify com opcoes estruturadas do asker" \
+    --opcoes '[{"rotulo":"A","descricao":"opcao A"}]' --escolha "A" \
+    --justificativa "Justificativa de tamanho ok aqui sim para teste" --score 2
+  capture "$ON" end --state-dir "$_sd" --motivo-termino etapa_concluida_avancando
+  capture "$SCRIPT" emit --flavor agente-00c --state-dir "$_sd" --paragrafo-resumo "x"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "emit exit" "esperado 0, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  [ -f "$TMPDIR_TEST/pap-141/.claude/agente-00c-report.md" ] || { _fail "relatorio nao gravado em <SD>/../agente-00c-report.md" ""; return 1; }
+  capture "$SCRIPT" validate --report-file "$TMPDIR_TEST/pap-141/.claude/agente-00c-report.md"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "validate" "$_CAPTURED_STDERR"; return 1; }
+}
+
 run_all_scenarios

--- a/tests/test_state-decisions.sh
+++ b/tests/test_state-decisions.sh
@@ -692,4 +692,56 @@ scenario_next_id_tolera_jq_com_saida_crlf() {
   assert_stdout_contains "dec-008" || return 1
 }
 
+# ==== issue #141: forma dos itens de --opcoes / --referencias ====
+scenario_issue141_register_aceita_opcoes_objeto_com_rotulo() {
+  _sd="$TMPDIR_TEST/state-141-ok"
+  _init_state "$_sd"
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --agente "clarify-answerer" --etapa "clarify" \
+    --contexto "Pergunta sobre stakeholders do projeto-alvo" \
+    --opcoes '[{"rotulo":"A","descricao":"opcao A","default_sugerido":true},{"label":"B"},"C"]' \
+    --escolha "A" \
+    --justificativa "Briefing do 00C marca uso pessoal sem stakeholders externos" --score 2
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "register" "esperado 0, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.decisions[0].options_considered[0].rotulo'
+  [ "$_CAPTURED_STDOUT" = "A" ] || { _fail "objeto preservado no state" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+}
+
+scenario_issue141_register_rejeita_forma_invalida_em_opcoes() {
+  _sd="$TMPDIR_TEST/state-141-bad"
+  _init_state "$_sd"
+  for _bad in '[1]' '[null]' '[""]' '[{"descricao":"sem rotulo"}]' '[{"rotulo":""}]' '[["A"]]'; do
+    capture "$SCRIPT" register --state-dir "$_sd" \
+      --agente "x" --etapa "clarify" \
+      --contexto "Pergunta sobre stakeholders do projeto-alvo" \
+      --opcoes "$_bad" --escolha "A" \
+      --justificativa "Briefing do 00C marca uso pessoal sem stakeholders externos"
+    [ "$_CAPTURED_EXIT" = 1 ] || { _fail "deveria rejeitar $_bad com exit 1" "obtido $_CAPTURED_EXIT"; return 1; }
+    assert_stderr_contains "cada item de --opcoes" || return 1
+  done
+  capture "$RW" get --state-dir "$_sd" --field '.decisions | length'
+  [ "$_CAPTURED_STDOUT" = "0" ] || { _fail "nenhuma decisao deveria ter sido gravada" "obtido $_CAPTURED_STDOUT"; return 1; }
+}
+
+scenario_issue141_register_rejeita_forma_invalida_em_referencias() {
+  _sd="$TMPDIR_TEST/state-141-refs"
+  _init_state "$_sd"
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --agente "x" --etapa "clarify" \
+    --contexto "Pergunta sobre stakeholders do projeto-alvo" \
+    --opcoes '["A"]' --escolha "A" \
+    --justificativa "Briefing do 00C marca uso pessoal sem stakeholders externos" \
+    --referencias '[1, null]'
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "referencias invalidas deveriam dar exit 2" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "cada item de --referencias" || return 1
+  # string e objeto chave=valor continuam aceitos (report.sh ja renderiza os dois).
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --agente "x" --etapa "clarify" \
+    --contexto "Pergunta sobre stakeholders do projeto-alvo" \
+    --opcoes '["A"]' --escolha "A" \
+    --justificativa "Briefing do 00C marca uso pessoal sem stakeholders externos" \
+    --referencias '["docs/spec.md", {"arquivo":"spec.md","linha":"12"}]'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "referencias validas" "$_CAPTURED_STDERR"; return 1; }
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Resumo

Causa raiz da #141 é a prosa: o `clarify-asker` emite `opcoes_recomendadas` como `{rotulo, descricao}` e o orquestrador passa verbatim em `--opcoes` — toda Decisão do clarify autônomo quebrava o `report.sh generate` (exit 5, `.md` sem seções 4/5/6) e o pipe `generate | scrub` engolia o exit.

- `report.sh`: `options_considered` renderiza string ou objeto `(rotulo) descricao` (mesmo tratamento de `recommended_options`, #115).
- `state-decisions.sh register`: valida a FORMA dos itens (string não-vazia ou objeto com `rotulo|label`); número/null/array/sem-rótulo → exit 1. `--referencias` idem (exit 2). Não rejeita objetos — quebraria o clarify.
- MCP `record_decision`: schema em paridade + contrato `mcp-tools.md`; 3 testes node (160/160).
- Prosa (orchestrator.md §12): `report.sh emit --flavor agente-00c` (propaga exit, scrub interno) em vez do pipe.
- CHANGELOG 8.4.1 + manifestos em lockstep (`validate-plugin-manifests.sh --version 8.4.1 --strict` OK).

## Testado

- Suite completa (`LC_ALL=C ./tests/run.sh`): **PASS 3233 / FAIL 0** (899s); `--check-coverage` zero órfãos; `cstk doctor` drift zero.
- 5 cenários shell novos + 3 node; todos falham sem o fix (mutation check).

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiHRXC83ja2JERyfeZNJqs