### PR TITLE
release 8.5.0: issue.sh redigido + draft/publish (#143); state-decisions mark-invalid (#144)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "8.4.1",
+      "version": "8.5.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "8.4.1",
+      "version": "8.5.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,79 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [8.5.0] - 2026-08-19
+
+Dois desdobramentos da #141: o bug report automático do toolkit deixa de
+publicar contexto do projeto-alvo sem consentimento (#143, Princípio IV), e
+uma Decisão errada ganha um caminho suportado e auditável para ser
+desautorizada sem SQL cru no `state.db` (#144, Princípio I). Sem breaking;
+sem skill nova. Subcomando novo (`mark-invalid`) → MINOR.
+
+### Added
+
+- **`state-decisions.sh mark-invalid --state-dir DIR --decisao-id dec-NNN
+  --motivo TEXT(>=20) [--agente A]`** (#144): invalidação **append-only**.
+  Nunca altera a linha original (Decisões são imutáveis por desenho);
+  registra, via `register` (backend-agnóstico — JSON e SQLite —, backup +
+  `sha256`), uma NOVA Decisão com convenção determinística: contexto
+  `INVALIDACAO de dec-NNN: <motivo>`, opções `["manter-dec-NNN",
+  "invalidar-dec-NNN"]`, escolha `invalidar-dec-NNN`, justificativa = motivo,
+  `originating_artifact = dec-NNN`, score ausente (humano). Recusa com
+  exit 1: Decisão inexistente, já invalidada, ou que é ela mesma uma
+  invalidação (não se encadeia); motivo < 20 chars. Imprime o id da
+  invalidação. É a alternativa menor da issue — o "amend" completo fica
+  para quando houver demanda além do caso da #141.
+- **`report.sh` (seção 3)** detecta o par (`originating_artifact == dec-NNN`
+  ∧ `choice == invalidar-dec-NNN`) e renderiza a original com
+  `— **INVALIDADA por dec-MMM**` no heading + blockquote com timestamp e
+  motivo ("conteúdo histórico, NÃO decisão vigente"); a invalidação aparece
+  como Decisão normal. `recall` a ingere como qualquer Decisão (sem schema
+  novo).
+- **`issue.sh create --draft FILE`** (#143): grava `Title: …` + corpo FINAL
+  (secrets-filter aplicado; exatamente o que seria publicado) e NÃO toca o
+  GitHub (sem dedup remoto; exit 0; imprime o path). É o único caminho que o
+  orquestrador autônomo usa a partir desta release.
+- **`issue.sh publish --from FILE [--state-dir DIR --suggestion-id SUG]
+  [--env-file F] [--dry-run]`** (#143): ação do **operador** — lê o rascunho,
+  re-aplica o secrets-filter (o arquivo pode ter sido editado à mão), dedup
+  pelo hash embutido no título, labels, `suggestions.sh mark-issue` quando
+  `--state-dir/--suggestion-id` forem passados. Rascunho sem `Title:` →
+  exit 1.
+
+### Changed
+
+- **`issue.sh create` redige o corpo por default** (#143): descrição do
+  projeto-alvo, ID da execução, trechos de Decisões e paths absolutos da
+  máquina viram `(omitido — …)` / `<projeto-alvo>/…`; o prefixo `$HOME` do
+  "Caminho instalado" vira `~`. O secrets-filter continua 2x (credenciais),
+  mas ele nunca cobriu contexto de negócio nem paths — caso real: a #141
+  precisou ser editada à mão DEPOIS de publicada.
+  `--include-project-context` restaura o corpo completo (opt-in explícito do
+  operador; o orquestrador nunca o passa).
+- **Prosa dos orquestradores** (`agente-00c-orchestrator.md` passo 12;
+  `agente-00c-feature-orchestrator.md` §Gh issue exclusivo — que ainda citava
+  `--flavor feature-00c`, flag inexistente): sugestão `impeditiva` →
+  `issue.sh create … --draft <PAP>/.claude/agente-00c-issues/<sug>.md`,
+  Decisão informativa com o path e bloco "Rascunhos de issue aguardando o
+  operador" no sumário; nunca `publish` nem `--include-project-context`.
+  Tabelas de helpers atualizadas (`issue.sh create --draft/publish`,
+  `state-decisions.sh … mark-invalid`).
+- **`docs/agente-00c.md` / `.pt-BR.md`**: `gh` autenticado só é exigido de
+  quem publica o bug report; o orquestrador apenas rascunha.
+
+### Tests
+
+- `tests/test_issue.sh`: 5 cenários novos (redação default; `--include-
+  project-context`; `--draft` grava redigido e não chama `gh` — stub que
+  falha se invocado; `publish --dry-run` lê rascunho e re-scruba token
+  inserido à mão; rascunho inválido/sem `--from`). Os 2 cenários de leitor
+  (pt-BR legado / SQLite) passam `--include-project-context` porque testam
+  que o contexto flui pelo reader.
+- `tests/test_state-decisions.sh`: 3 cenários (JSON: original intacta +
+  convenção + `decisions_total`; recusas; SQLite: paridade + anti-mirror).
+  `tests/test_report.sh`: 1 cenário (heading INVALIDADA + motivo; a
+  invalidação não é marcada; relatório completo).
+
 ## [8.4.1] - 2026-08-19
 
 Bugfix da issue #141 (aberta pelo próprio agente-00C): uma Decisão com
@@ -6805,6 +6878,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[8.5.0]: https://github.com/JotJunior/cstk/releases/tag/v8.5.0
 [8.4.1]: https://github.com/JotJunior/cstk/releases/tag/v8.4.1
 [8.4.0]: https://github.com/JotJunior/cstk/releases/tag/v8.4.0
 [8.3.1]: https://github.com/JotJunior/cstk/releases/tag/v8.3.1

--- a/docs/agente-00c.md
+++ b/docs/agente-00c.md
@@ -52,8 +52,10 @@ you can review the route, instead of blindly trusting the chain of steps.
 
 - **Claude Code** (Opus 4.x or Sonnet 4.6 recommended), **Auto mode**
   enabled to reduce interruptions.
-- **Authenticated `gh` CLI** (required for automatic issue opening on the
-  toolkit in case of a bug in a global skill — FR-021).
+- **Authenticated `gh` CLI** (only needed when *you* publish a toolkit bug
+  report — FR-021: the orchestrator only **drafts** the issue under
+  `<target>/.claude/agente-00c-issues/<sug>.md`, with project context
+  redacted; you review and run `issue.sh publish --from <file>`).
 - **`git` on the PATH** (local commit between waves).
 - **Local Docker** (only if the suggested stack uses containers; the
   orchestrator refuses any `docker push`/external deploy — Principle V of the

--- a/docs/agente-00c.pt-BR.md
+++ b/docs/agente-00c.pt-BR.md
@@ -53,8 +53,10 @@ de etapas.
 
 - **Claude Code** (Opus 4.x ou Sonnet 4.6 recomendado), **Auto mode**
   ativo para reduzir interrupções.
-- **`gh` CLI autenticado** (necessário para abertura automática de issue
-  no toolkit em caso de bug em skill global — FR-021).
+- **`gh` CLI autenticado** (só necessário quando *você* publica um bug
+  report do toolkit — FR-021: o orquestrador apenas **rascunha** a issue em
+  `<alvo>/.claude/agente-00c-issues/<sug>.md`, com o contexto do projeto
+  redigido; você revisa e roda `issue.sh publish --from <arquivo>`).
 - **`git` no PATH** (commit local entre ondas).
 - **Docker local** (apenas se a stack-sugerida usar containers; orquestrador
   recusa qualquer `docker push`/deploy externo — Princípio V da feature).

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "8.4.1",
+  "version": "8.5.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "8.4.1",
+  "version": "8.5.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/agents/agente-00c-feature-orchestrator.md
+++ b/plugins/cstk/agents/agente-00c-feature-orchestrator.md
@@ -104,7 +104,7 @@ cada chamada).
 | `retro.sh consume\|check` | controle de retro-execucoes (FR-010, limite 2) |
 | `report.sh emit --flavor feature-00c --state-dir DIR` | gerar relatorio (FR-018; resolve path por flavor + secrets-filter interno) |
 | `suggestions.sh register` | registrar sugestao p/ skill global (FR-020) |
-| `issue.sh create` | abrir issue no toolkit (apenas severidade=impeditiva — FR-035) |
+| `issue.sh create --draft` | RASCUNHAR issue do toolkit (apenas severidade=impeditiva — FR-035; publicar e do operador, issue #143) |
 | `feature-00c-preflight.sh check --state-dir DIR` | gate spec→plan (FR-010A) |
 | `secrets-filter.sh for-backup --wave-number N` | gerar backup filtrado (FR-029 §extensao + FR-034) |
 | `_log.sh` (sourceable) | log_err / log_out com filtro de stderr/stdout (FR-036) |
@@ -1633,16 +1633,27 @@ Quando uma sugestao para skill global e classificada como
    repo = registrar decisao "violacao blast radius" + abortar.
 
 2. Filtrar conteudo: corpo da issue passa por `secrets-filter.sh scrub`
-   ANTES de invocar `gh`. Body inclui apenas:
+   (o `issue.sh` faz isso internamente, 2x). Por default (issue #143 /
+   Principio IV) o corpo e REDIGIDO — inclui apenas:
    - skill afetada
-   - diagnostico (filtrado)
-   - proposta (filtrada)
-   - link LOCAL ao relatorio (NAO upload do relatorio)
+   - diagnostico / reproducao / por-que-impeditivo / proposta (filtrados)
+   - link LOCAL ao relatorio com path GENERICO `<projeto-alvo>/...` (NAO
+     upload do relatorio; NAO descricao do projeto-alvo, NAO ID da
+     execucao, NAO trechos de Decisoes, NAO paths da maquina)
 
-3. Invocar `issue.sh create --suggestion-id <SUG> --state-dir
-   $STATE_DIR --flavor feature-00c`.
+3. RASCUNHAR, nunca publicar:
+   `issue.sh create --state-dir $STATE_DIR --suggestion-id <SUG>
+   --skill <SKILL> --diagnostico "<...>" --proposta "<...>"
+   --por-que-impeditivo "<...>" --reproducao "<...>" --env-file <PAP>/.env
+   --draft <PAP>/.claude/agente-00c-issues/<SUG>.md`. Voce NUNCA passa
+   `--include-project-context` nem chama `issue.sh publish` — sao acoes
+   do operador.
 
-4. Registrar a issue criada no state.json (numero + URL).
+4. Registrar Decisao informativa com o path do rascunho e cita-lo no
+   sumario de retorno ("Rascunhos de issue aguardando o operador"). O
+   operador revisa e publica com `issue.sh publish --from <arquivo>
+   --state-dir $STATE_DIR --suggestion-id <SUG>` (dedup por hash,
+   secrets-filter de novo, `mark-issue` no state).
 
 Severidade `informativa` ou `aviso` NAO abre issue — apenas
 registrada via `suggestions.sh register` (ver "## Sugestoes para skills

--- a/plugins/cstk/agents/agente-00c-orchestrator.md
+++ b/plugins/cstk/agents/agente-00c-orchestrator.md
@@ -125,7 +125,7 @@ infraestrutura interna deste agente.
 | `whitelist-validate.sh` | check/list | FR-031 (rejeita patterns overly broad como `**`, `*://*`, `https://*`) |
 | `report.sh` | emit --flavor agente-00c/validate | FR-011 + SC-001 (relatorio com 6 secoes; validate por regex de headings) |
 | `suggestions.sh` | register/list/count/next-id/mark-issue/render-md | FR-020 (sugestoes para skills globais — 3 severidades) |
-| `issue.sh` | create/check-duplicate/hash | FR-021 (abertura automatica de issue no toolkit, com dedup + secrets-filter 2x) |
+| `issue.sh` | create --draft/publish/check-duplicate/hash | FR-021 (issue no toolkit: o orquestrador so RASCUNHA — redigido + secrets-filter 2x; publicar e acao do operador, issue #143) |
 
 ## Orientacao MCP-vs-Bash (uso das 7 tools `mcp__cstk-state__*`)
 
@@ -2263,17 +2263,25 @@ longas — o texto do turno e o recurso mais escasso da onda. Regras duras:
       --proposta "<mudanca concreta sugerida>" \
       --referencias '[<paths relativos>]'
 
-    # 2. Para impeditivas, abra issue no toolkit (apenas para impeditivas)
+    # 2. Para impeditivas, RASCUNHE a issue do toolkit — NUNCA publique
+    #    (issue #143 / Principio IV): quem publica e o operador, depois de ler.
     issue.sh create --state-dir <SD> --suggestion-id <sug-NNN> \
       --skill <SKILL> --diagnostico "<...>" --proposta "<...>" \
       --por-que-impeditivo "<analise>" \
       --reproducao "<contexto especifico>" \
-      --env-file <PAP>/.env
+      --env-file <PAP>/.env \
+      --draft <PAP>/.claude/agente-00c-issues/<sug-NNN>.md
     ```
 
-    `issue.sh create` ja faz dedup via hash + aplica secrets-filter 2x;
-    em caso de falha (sem internet, rate limit), registra ERRO no estado
-    e o operador pode re-tentar manualmente.
+    `--draft` grava title+body FINAIS (secrets-filter aplicado; corpo
+    REDIGIDO por default — sem descricao do projeto-alvo, ID da execucao,
+    trechos de Decisoes nem paths da maquina) e NAO toca o GitHub. Voce
+    NUNCA passa `--include-project-context` nem chama `issue.sh publish`
+    — sao acoes do operador. Registre Decisao informativa com o path do
+    rascunho e cite-o no sumario de retorno (bloco "Rascunhos de issue
+    aguardando o operador: <paths>"); o operador revisa e publica com
+    `issue.sh publish --from <arquivo> --state-dir <SD> --suggestion-id
+    <sug-NNN>` (dedup por hash + secrets-filter de novo + mark-issue).
 
 13. **Retorno** (o lock e liberado pelo command pai apos voce retornar —
     NAO chame `state-lock.sh release`; ver "Fronteira command↔orquestrador"):

--- a/plugins/cstk/agents/agente-00c-orchestrator.md
+++ b/plugins/cstk/agents/agente-00c-orchestrator.md
@@ -106,7 +106,7 @@ infraestrutura interna deste agente.
 | `state-validate.sh` | (sem subcmds) `--state-dir DIR` | Validador FR-008 read-only (10 checagens, sem auto-correcao) |
 | `state-lock.sh` | acquire/release/check/check-execution-busy | Lock anti-concorrencia via mkdir atomico. **acquire/release sao do command PAI** (ver "Fronteira command↔orquestrador") — o orquestrador NAO os chama. Sob backend `state.db` (feature `state-db-foundation`), o lock deixa de ser o serializador primario — quem serializa escritas concorrentes e o modo WAL do SQLite (PRAGMAs + retry/backoff em `_state-db.sh`, contracts/primitives.md §C6, FR-011); o lock segue disponivel como camada extra opcional, superficie inalterada (contracts/primitives.md §C11) |
 | `pipeline.sh` | stages/next-stage/prev-stage/detect-completion/skill-conflict | State machine canonica das 10 etapas SDD |
-| `state-decisions.sh` | register/count/next-id/list | Registro auditavel (Principio I — 5 campos obrigatorios) |
+| `state-decisions.sh` | register/count/next-id/list/mark-invalid | Registro auditavel (Principio I — 5 campos obrigatorios); `mark-invalid` = invalidacao append-only de Decisao errada (issue #144; acao do operador — nunca UPDATE na original) |
 | `spawn-tracker.sh` | check/enter/leave/current | Tracker de profundidade de subagentes (FR-013, MAX 3) |
 | `state-ondas.sh` | start/end/tool-call-tick/current-id/git-commit | Ciclo de vida de Ondas + commit local (NUNCA push direto — push via commit-mode.sh finalize no terminal) |
 | `commit-mode.sh` | is-enabled/set-enabled/guard-branch/stage-message/task-message/finalize | Modo atomic-commit opt-in: commit por etapa, commit por task, push+PR terminal (FR-003/004/008 — atomic-commit-pr) |

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/issue.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/issue.sh
@@ -14,9 +14,20 @@
 #   issue.sh create --state-dir DIR --suggestion-id SUG
 #       --skill SKILL --diagnostico TEXT --proposta TEXT
 #       [--por-que-impeditivo TEXT] [--reproducao TEXT]
-#       [--env-file FILE] [--dry-run]
+#       [--env-file FILE] [--dry-run] [--draft FILE]
+#       [--include-project-context]
 #       — Aplica template de issue-template.md, abre issue via gh,
 #         atualiza state via suggestions.sh mark-issue.
+#       — PRIVACIDADE (issue #143, Principio IV): por DEFAULT o corpo e
+#         REDIGIDO — omite descricao do projeto-alvo, ID da execucao,
+#         trechos de Decisoes e paths absolutos da maquina (o
+#         secrets-filter so cobre credenciais, nao contexto de negocio).
+#         `--include-project-context` restaura o corpo completo (opt-in
+#         explicito do operador, nunca do orquestrador).
+#       — `--draft FILE`: grava title+body FINAIS (ja filtrados, exatamente
+#         o que seria publicado) em FILE e NAO abre issue (exit 0, imprime
+#         FILE). E o caminho que o orquestrador autonomo usa: quem publica
+#         e o operador, depois de ler, via `issue.sh publish --from FILE`.
 #       — Defesa em profundidade: secrets-filter aplicado 2x
 #         (no build do body + antes do gh create).
 #       — Dedup via gh issue list --search com hash 8-chars do diagnostico
@@ -25,6 +36,14 @@
 #         existirem, cria-as antes do issue create.
 #       — `--dry-run` imprime body + comando que SERIA executado, NAO
 #         abre issue real.
+#
+#   issue.sh publish --from FILE [--state-dir DIR --suggestion-id SUG]
+#       [--env-file FILE] [--dry-run]
+#       — Publica um rascunho gerado por `create --draft` (linha 1
+#         `Title: ...`, linha em branco, corpo). Reaplica secrets-filter,
+#         dedup por hash (do titulo), labels, e `suggestions.sh mark-issue`
+#         quando --state-dir/--suggestion-id forem passados. Acao do
+#         OPERADOR — o orquestrador autonomo nunca a invoca.
 #
 #   issue.sh check-duplicate --skill SKILL --diagnostico TEXT
 #       — Calcula hash, faz gh issue list --search, retorna URL da issue
@@ -145,22 +164,37 @@ _ish_apply_secrets() {
   fi
 }
 
-# _ish_build_body STATE_DIR SUGID SKILL DIAG PROP IMPED REP ENV
+# _ish_build_body STATE_DIR SUGID SKILL DIAG PROP IMPED REP ENV [CTX]
 # Imprime corpo da issue em stdout (com filtro de secrets aplicado 1x).
 # Caller aplica filtro novamente antes do gh create (defense in depth).
+# CTX=1 (--include-project-context) inclui descricao do projeto-alvo, ID da
+# execucao, trechos de Decisoes e paths absolutos; CTX=0 (default, issue
+# #143) REDIGE tudo isso — so o conteudo tecnico escrito pelo orquestrador
+# (diagnostico/reproducao/impeditivo/proposta) e a skill afetada saem.
 _ish_build_body() {
   _sd=$1; _sug=$2; _skill=$3; _diag=$4; _prop=$5; _imped=$6; _rep=$7; _env=$8
+  _ctx=${9:-0}
   _ish_get_state "$_sd"
   _now=$(date -u +%FT%TZ)
 
-  # Sumario das decisoes recentes que evidenciam o bug (max 5) — le do
-  # documento materializado por _ish_get_state (interface canonica).
-  _rel_decs=$(jq -r '
-    ((.decisions // .decisoes) // []) | reverse | .[0:5]
-    | map("- Decisao `\(.id)`: \((.context // .contexto) | .[0:100])")
-    | join("\n")
-  ' "$_ISH_SF")
-  [ -z "$_rel_decs" ] && _rel_decs="- (nenhuma decisao registrada ainda)"
+  if [ "$_ctx" = 1 ]; then
+    _show_exec="$_ISH_EXEC_ID"
+    _show_desc="$_ISH_PROJ_DESC"
+    _show_pap="$_ISH_PAP"
+    # Sumario das decisoes recentes que evidenciam o bug (max 5) — le do
+    # documento materializado por _ish_get_state (interface canonica).
+    _rel_decs=$(jq -r '
+      ((.decisions // .decisoes) // []) | reverse | .[0:5]
+      | map("- Decisao `\(.id)`: \((.context // .contexto) | .[0:100])")
+      | join("\n")
+    ' "$_ISH_SF")
+    [ -z "$_rel_decs" ] && _rel_decs="- (nenhuma decisao registrada ainda)"
+  else
+    _show_exec="(omitido — privacidade do projeto-alvo; issue #143)"
+    _show_desc="(omitido — descricao do projeto-alvo nao e publicada por default; passe --include-project-context para incluir)"
+    _show_pap="<projeto-alvo>"
+    _rel_decs="- (omitidas — trechos de Decisoes do projeto-alvo nao sao publicados por default; passe --include-project-context para incluir)"
+  fi
 
   # Reproducao default — orquestrador pode passar via --reproducao
   if [ -z "$_rep" ]; then
@@ -178,10 +212,18 @@ _ish_build_body() {
   # Artefato 5) — nunca fabrica um path adivinhado no corpo da issue.
   _ish_base=$(_ish_skills_base) \
     || _ish_die "raiz de agente-00c-runtime irresolvivel (classico/plugin) — nao e possivel montar 'Caminho instalado' sem inventar dado (Constitution VI)" 1
+  # Redigido: o caminho do catalogo comeca pelo $HOME do operador (usuario da
+  # maquina) — troca o prefixo por `~` sem perder a informacao util
+  # (classico vs plugin, versao do layout).
+  if [ "$_ctx" != 1 ] && [ -n "${HOME:-}" ]; then
+    case "$_ish_base" in
+      "$HOME"/*) _ish_base="~${_ish_base#"$HOME"}" ;;
+    esac
+  fi
 
   cat <<BODY | _ish_apply_secrets "$_env"
 > Issue aberta automaticamente pelo agente-00C durante execucao
-> \`$_ISH_EXEC_ID\` em \`$_now\`.
+> \`$_show_exec\` em \`$_now\`.
 
 ## Skill afetada
 
@@ -197,8 +239,8 @@ $_diag
 
 A execucao do agente-00C que detectou o bug:
 
-- ID: \`$_ISH_EXEC_ID\`
-- Projeto-alvo: $_ISH_PROJ_DESC
+- ID: \`$_show_exec\`
+- Projeto-alvo: $_show_desc
 - Etapa: \`$_ISH_ETAPA\`
 - Onda: \`$_ISH_ONDA\`
 
@@ -219,11 +261,11 @@ $_prop
 ## Anexos
 
 - Path do relatorio (no projeto-alvo, NAO anexado a esta issue):
-  \`$_ISH_PAP/.claude/agente-00c-report.md\`
+  \`$_show_pap/.claude/agente-00c-report.md\`
 - Path da sugestao detalhada:
-  \`$_ISH_PAP/.claude/agente-00c-suggestions.md#$_sug\`
+  \`$_show_pap/.claude/agente-00c-suggestions.md#$_sug\`
 - Path do estado no momento da deteccao (backup):
-  \`$_ISH_PAP/.claude/agente-00c-state/state-history/$_ISH_ONDA-<timestamp>.json\`
+  \`$_show_pap/.claude/agente-00c-state/state-history/$_ISH_ONDA-<timestamp>.json\`
 
 > Estes anexos vivem na maquina do operador. Esta issue NAO uploada o
 > relatorio nem o estado — alinhado com Principio IV do toolkit (zero
@@ -271,6 +313,8 @@ _ish_cmd_create() {
   _rep=""
   _env=""
   _dry=0
+  _draft=""
+  _ctx=0
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --state-dir)            _sd=$2;    shift 2 ;;
@@ -282,6 +326,8 @@ _ish_cmd_create() {
       --reproducao)           _rep=$2;   shift 2 ;;
       --env-file)             _env=$2;   shift 2 ;;
       --dry-run)              _dry=1;    shift ;;
+      --draft)                _draft=$2; shift 2 ;;
+      --include-project-context) _ctx=1; shift ;;
       *) _ish_die_usage "create: flag desconhecida: $1" ;;
     esac
   done
@@ -292,11 +338,14 @@ _ish_cmd_create() {
   [ -n "$_prop" ]  || _ish_die_usage "create: --proposta obrigatorio"
   _ish_require_jq
 
-  # Dedup check
-  if _existing=$(_ish_check_duplicate "$_skill" "$_diag"); then
-    printf '%s: duplicata encontrada — %s\n' "$_ISH_NAME" "$_existing" >&2
-    printf '%s\n' "$_existing"
-    return 0
+  # Dedup check — so quando vai de fato tocar o GitHub (draft e local e
+  # pode ser produzido offline; o publish re-checa).
+  if [ -z "$_draft" ]; then
+    if _existing=$(_ish_check_duplicate "$_skill" "$_diag"); then
+      printf '%s: duplicata encontrada — %s\n' "$_ISH_NAME" "$_existing" >&2
+      printf '%s\n' "$_existing"
+      return 0
+    fi
   fi
 
   # Build title (skill + hash + resumo curto da diag — primeiras palavras)
@@ -305,7 +354,7 @@ _ish_cmd_create() {
   _title="[agente-00C] Bug em $_skill ($_hash): $_resumo"
 
   # Build body (com filtro de secrets aplicado 1x via _ish_apply_secrets)
-  _body=$(_ish_build_body "$_sd" "$_sug" "$_skill" "$_diag" "$_prop" "$_imped" "$_rep" "$_env")
+  _body=$(_ish_build_body "$_sd" "$_sug" "$_skill" "$_diag" "$_prop" "$_imped" "$_rep" "$_env" "$_ctx")
   # Trunca body se ultrapassar limite (~4000 chars)
   _bsize=$(printf '%s' "$_body" | wc -c | tr -d ' ')
   if [ "$_bsize" -gt 4000 ]; then
@@ -327,13 +376,44 @@ _ish_cmd_create() {
     return 0
   fi
 
+  # --draft: grava o rascunho FINAL (exatamente o que seria publicado) e
+  # para. Publicar e acao do operador (`issue.sh publish --from FILE`).
+  if [ -n "$_draft" ]; then
+    _ish_write_draft "$_draft" "$_title" "$_body_safe"
+    printf '%s: rascunho gravado (NAO publicado) — revise e publique com: issue.sh publish --from %s\n' "$_ISH_NAME" "$_draft" >&2
+    printf '%s\n' "$_draft"
+    return 0
+  fi
+
+  _ish_publish_body "$_title" "$_body_safe" "$_sd" "$_sug"
+}
+
+# _ish_write_draft FILE TITLE BODY — formato do rascunho: `Title: <t>`, linha
+# em branco, corpo. Escrita atomica (mktemp + mv) no diretorio de destino;
+# cria o diretorio se faltar.
+_ish_write_draft() {
+  _wd_file=$1; _wd_title=$2; _wd_body=$3
+  _wd_dir=$(dirname -- "$_wd_file")
+  mkdir -p -- "$_wd_dir" 2>/dev/null || _ish_die "draft: nao consegui criar $_wd_dir" 1
+  _wd_tmp=$(mktemp "$_wd_dir/.issue-draft.XXXXXX") || _ish_die "draft: mktemp falhou em $_wd_dir" 1
+  {
+    printf 'Title: %s\n\n' "$_wd_title"
+    printf '%s\n' "$_wd_body"
+  } > "$_wd_tmp" || { rm -f -- "$_wd_tmp"; _ish_die "draft: escrita falhou" 1; }
+  mv -- "$_wd_tmp" "$_wd_file" || { rm -f -- "$_wd_tmp"; _ish_die "draft: mv falhou" 1; }
+}
+
+# _ish_publish_body TITLE BODY_SAFE [STATE_DIR SUGID] — gh issue create +
+# mark-issue. Fatorado para ser compartilhado por create e publish.
+_ish_publish_body() {
+  _pb_title=$1; _pb_body=$2; _pb_sd=${3:-}; _pb_sug=${4:-}
   _ish_require_gh
   _ish_ensure_labels
 
   # gh issue create. Captura URL retornado.
-  _url=$(printf '%s' "$_body_safe" \
+  _url=$(printf '%s' "$_pb_body" \
     | gh issue create --repo "$_ISH_REPO" \
-        --title "$_title" \
+        --title "$_pb_title" \
         --label "agente-00c,bug,skill-global" \
         --body-file - 2>&1) || {
     printf '%s: gh issue create falhou:\n%s\n' "$_ISH_NAME" "$_url" >&2
@@ -342,12 +422,63 @@ _ish_cmd_create() {
 
   # Atualiza state via suggestions.sh mark-issue
   _sg_script="$(dirname -- "$0")/suggestions.sh"
-  if [ -x "$_sg_script" ]; then
-    "$_sg_script" mark-issue --state-dir "$_sd" --suggestion-id "$_sug" \
+  if [ -n "$_pb_sd" ] && [ -n "$_pb_sug" ] && [ -x "$_sg_script" ]; then
+    "$_sg_script" mark-issue --state-dir "$_pb_sd" --suggestion-id "$_pb_sug" \
       --issue "$_url" >/dev/null 2>&1 || :
   fi
 
   printf '%s\n' "$_url"
+}
+
+# publish --from FILE [--state-dir DIR --suggestion-id SUG] [--env-file F] [--dry-run]
+_ish_cmd_publish() {
+  _from=""; _sd=""; _sug=""; _env=""; _dry=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --from)          _from=$2; shift 2 ;;
+      --state-dir)     _sd=$2;   shift 2 ;;
+      --suggestion-id) _sug=$2;  shift 2 ;;
+      --env-file)      _env=$2;  shift 2 ;;
+      --dry-run)       _dry=1;   shift ;;
+      *) _ish_die_usage "publish: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_from" ] || _ish_die_usage "publish: --from FILE obrigatorio"
+  [ -f "$_from" ] || _ish_die "publish: rascunho nao encontrado: $_from" 1
+  _ish_require_jq
+
+  _title=$(sed -n '1s/^Title: //p' "$_from")
+  [ -n "$_title" ] || _ish_die "publish: rascunho invalido — linha 1 deve ser 'Title: ...' (gerado por issue.sh create --draft)" 1
+  # Corpo = tudo apos a primeira linha em branco. Re-scrub: o rascunho pode
+  # ter sido editado a mao entre o draft e o publish.
+  _body_safe=$(awk 'f{print} /^$/ && !f{f=1}' "$_from" | _ish_apply_secrets "$_env")
+  [ -n "$_body_safe" ] || _ish_die "publish: rascunho sem corpo" 1
+
+  # Dedup pelo hash que o create embutiu no titulo ("... (<hash>): ...").
+  _hash=$(printf '%s' "$_title" | sed -n 's/.*(\([0-9a-f]\{8\}\)):.*/\1/p')
+  _skill=$(printf '%s' "$_title" | sed -n 's/^\[agente-00C\] Bug em \([^ ]*\) (.*/\1/p')
+  if [ -n "$_hash" ] && [ -n "$_skill" ] && [ "$_dry" = 0 ]; then
+    _ish_require_gh
+    _existing=$(gh issue list --repo "$_ISH_REPO" --state open \
+      --search "agente-00C $_skill $_hash" --json number,url,title 2>/dev/null \
+      | jq -r --arg s "$_skill" --arg h "$_hash" '.[] | select(.title | (contains($s) and contains($h))) | .url' 2>/dev/null | head -1) || _existing=""
+    if [ -n "$_existing" ]; then
+      printf '%s: duplicata encontrada — %s\n' "$_ISH_NAME" "$_existing" >&2
+      printf '%s\n' "$_existing"
+      return 0
+    fi
+  fi
+
+  if [ "$_dry" = 1 ]; then
+    printf '=== DRY-RUN ===\n'
+    printf 'Title: %s\n' "$_title"
+    printf 'Repo: %s\n' "$_ISH_REPO"
+    printf 'Labels: agente-00c,bug,skill-global\n'
+    printf '\n=== BODY ===\n%s\n' "$_body_safe"
+    return 0
+  fi
+
+  _ish_publish_body "$_title" "$_body_safe" "$_sd" "$_sug"
 }
 
 _ish_cmd_check_duplicate() {
@@ -391,12 +522,20 @@ USO:
   issue.sh create --state-dir DIR --suggestion-id SUG --skill SKILL \
     --diagnostico TEXT --proposta TEXT \
     [--por-que-impeditivo TEXT] [--reproducao TEXT] \
+    [--env-file FILE] [--dry-run] [--draft FILE] [--include-project-context]
+  issue.sh publish --from FILE [--state-dir DIR --suggestion-id SUG] \
     [--env-file FILE] [--dry-run]
   issue.sh check-duplicate --skill SKILL --diagnostico TEXT
   issue.sh hash --diagnostico TEXT
 
 Toolkit-repo hardcoded: JotJunior/cstk (excecao escopada ao
 Principio V — bug report curado, sem upload de relatorio/estado).
+
+Privacidade (issue #143): por default o corpo e REDIGIDO (sem descricao
+do projeto-alvo, ID da execucao, trechos de Decisoes ou paths absolutos);
+--include-project-context restaura. O orquestrador autonomo usa
+--draft FILE (nada publicado); o operador revisa e publica com
+`issue.sh publish --from FILE`.
 
 EXIT:
   0 sucesso (issue criada OU duplicata encontrada)
@@ -411,6 +550,7 @@ shift
 
 case "$_ISH_SUBCMD" in
   create)            _ish_cmd_create "$@" ;;
+  publish)           _ish_cmd_publish "$@" ;;
   check-duplicate)   _ish_cmd_check_duplicate "$@" ;;
   hash)              _ish_cmd_hash "$@" ;;
   -h|--help|help)    exit 0 ;;

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/report.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/report.sh
@@ -248,7 +248,22 @@ _rp_render_secao_3() {
           "(Nenhuma decisao registrada nesta execucao.)"
         else
           ($decs[] |
-            "#### \(.id) — \(.stage // .etapa) — \(.agent // .agente) — \(.timestamp)",
+            # Issue #144: invalidacao append-only — a Decisao dec-MMM com
+            # originating_artifact == dec-NNN e escolha "invalidar-dec-NNN"
+            # (state-decisions.sh mark-invalid) marca a original como
+            # INVALIDADA sem tocar a linha dela.
+            (.id as $oid
+              | ($decs | map(select(((.originating_artifact // .artefato_originador) == $oid)
+                                    and ((.choice // .escolha) == ("invalidar-" + $oid))))
+                 | .[0]) as $inv
+              | if $inv == null then "#### \(.id) — \(.stage // .etapa) — \(.agent // .agente) — \(.timestamp)"
+                else "#### \(.id) — \(.stage // .etapa) — \(.agent // .agente) — \(.timestamp) — **INVALIDADA por \($inv.id)**" end),
+            (.id as $oid
+              | ($decs | map(select(((.originating_artifact // .artefato_originador) == $oid)
+                                    and ((.choice // .escolha) == ("invalidar-" + $oid))))
+                 | .[0]) as $inv
+              | if $inv == null then empty
+                else "", "> **INVALIDADA** por \($inv.id) (\($inv.timestamp)) — motivo: \($inv.rationale // $inv.justificativa). O conteudo abaixo e historico e NAO deve ser lido como decisao vigente." end),
             "",
             "**Contexto**: \(.context // .contexto)",
             "",

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/state-decisions.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/state-decisions.sh
@@ -34,6 +34,24 @@
 #   state-decisions.sh list --state-dir DIR [--agente A] [--etapa S]
 #       — Lista TSV: id\twave_id\tagent\tstage\tchoice
 #
+#   state-decisions.sh mark-invalid --state-dir DIR --decisao-id dec-NNN
+#       --motivo TEXT(>=20) [--agente A]
+#       — Issue #144: caminho SUPORTADO para desautorizar uma Decisao
+#         malformada/errada SEM tocar a linha original (Decisoes sao
+#         append-only — Principio I). Registra uma NOVA Decisao via
+#         `register` com a convencao deterministica:
+#           contexto   = "INVALIDACAO de dec-NNN: <motivo>"
+#           opcoes     = ["manter-dec-NNN","invalidar-dec-NNN"]
+#           escolha    = "invalidar-dec-NNN"
+#           justif.    = <motivo>
+#           artefato-originador = "dec-NNN"   (score ausente = humano)
+#         Leitores (report.sh secao 3) detectam o par
+#         (originating_artifact == dec-NNN AND choice == invalidar-dec-NNN)
+#         e renderizam a original como INVALIDADA. Backend-agnostico
+#         (passa por register => state-rw). Recusa: decisao inexistente,
+#         ja invalidada, ou que e ela mesma uma invalidacao (exit 1).
+#         stdout: id da Decisao de invalidacao.
+#
 # Exit codes:
 #   0 sucesso
 #   1 violacao Principio I OU erro generico
@@ -381,6 +399,57 @@ _sd_cmd_list() {
   ' "$_sf"
 }
 
+# ---------- subcomando: mark-invalid (issue #144) ----------
+_sd_cmd_mark_invalid() {
+  _sdir=""
+  _did=""
+  _motivo=""
+  _ag="operador"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --state-dir)  _sdir=$2;   shift 2 ;;
+      --decisao-id) _did=$2;    shift 2 ;;
+      --motivo)     _motivo=$2; shift 2 ;;
+      --agente)     _ag=$2;     shift 2 ;;
+      *) _sd_die_usage "mark-invalid: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_sdir" ]   || _sd_die_usage "mark-invalid: --state-dir obrigatorio"
+  [ -n "$_did" ]    || _sd_die_usage "mark-invalid: --decisao-id obrigatorio"
+  [ -n "$_motivo" ] || _sd_die_usage "mark-invalid: --motivo obrigatorio"
+  case "$_did" in dec-[0-9][0-9][0-9]*) ;; *) _sd_die_usage "mark-invalid: --decisao-id invalido (esperado dec-NNN): '$_did'" ;; esac
+  if [ "$(printf '%s' "$_motivo" | wc -c | tr -d ' ')" -lt 20 ]; then
+    _sd_die "mark-invalid: --motivo < 20 chars (Principio I — justificativa auditavel)" 1
+  fi
+  _sd_require_jq
+
+  # Documento materializado nos dois backends (interface canonica de leitura).
+  _mi_doc=$(sh "$_SD_DIR/state-rw.sh" read --state-dir "$_sdir") \
+    || _sd_die "mark-invalid: falha ao ler estado em $_sdir" 1
+  _mi_orig=$(printf '%s' "$_mi_doc" | jq -c --arg id "$_did" '
+    ((.decisions // .decisoes) // []) | map(select(.id == $id)) | .[0] // empty')
+  [ -n "$_mi_orig" ] || _sd_die "mark-invalid: decisao '$_did' nao encontrada" 1
+  _mi_orig_choice=$(printf '%s' "$_mi_orig" | jq -r '(.choice // .escolha) // ""')
+  case "$_mi_orig_choice" in
+    invalidar-dec-*) _sd_die "mark-invalid: '$_did' e ela mesma uma invalidacao (escolha '$_mi_orig_choice') — invalidacao nao se encadeia; registre nova Decisao normal se a invalidacao foi indevida" 1 ;;
+  esac
+  _mi_prev=$(printf '%s' "$_mi_doc" | jq -r --arg id "$_did" '
+    ((.decisions // .decisoes) // [])
+    | map(select(((.originating_artifact // .artefato_originador) == $id)
+                 and ((.choice // .escolha) == ("invalidar-" + $id))))
+    | .[0].id // empty')
+  [ -z "$_mi_prev" ] || _sd_die "mark-invalid: '$_did' ja invalidada por $_mi_prev" 1
+  _mi_stage=$(printf '%s' "$_mi_orig" | jq -r '(.stage // .etapa) // "desconhecida"')
+
+  _sd_cmd_register --state-dir "$_sdir" \
+    --agente "$_ag" --etapa "$_mi_stage" \
+    --contexto "INVALIDACAO de $_did: $_motivo" \
+    --opcoes "[\"manter-$_did\",\"invalidar-$_did\"]" \
+    --escolha "invalidar-$_did" \
+    --justificativa "$_motivo" \
+    --artefato-originador "$_did"
+}
+
 # ---------- Dispatch ----------
 
 if [ "$#" -lt 1 ]; then
@@ -395,6 +464,8 @@ USO:
   state-decisions.sh count --state-dir DIR [--agente A]
   state-decisions.sh next-id --state-dir DIR
   state-decisions.sh list --state-dir DIR [--agente A] [--etapa S]
+  state-decisions.sh mark-invalid --state-dir DIR --decisao-id dec-NNN \
+    --motivo TEXT(>=20) [--agente A]     # issue #144: invalidacao append-only
 
 NOTA: --score 3 EXIGE --evidencia (>=20 chars) com comando empirico
 executado + fragmento literal do output. Sem evidencia empirica,
@@ -416,6 +487,7 @@ case "$_SD_SUBCMD" in
   count)           _sd_cmd_count "$@" ;;
   next-id)         _sd_cmd_next_id "$@" ;;
   list)            _sd_cmd_list "$@" ;;
+  mark-invalid)    _sd_cmd_mark_invalid "$@" ;;
   -h|--help|help)  exec sh -c "exit 0" ;;
   *) _sd_die_usage "subcomando desconhecido: $_SD_SUBCMD" ;;
 esac

--- a/tests/test_issue.sh
+++ b/tests/test_issue.sh
@@ -167,6 +167,9 @@ _write_legacy_ptbr_state() {
 PTBR
 }
 
+# (Os dois cenarios de leitor abaixo testam que o contexto do projeto-alvo
+# FLUI pelo reader — por isso passam --include-project-context; o default
+# redigido e coberto em scenario_issue143_*.)
 scenario_ptbr_legado_reader_fallback() {
   # _ish_get_state le execucao.id / projeto_alvo_descricao / etapa_corrente /
   # ondas[-1].id via fallback; _ish_build_body le decisoes[].contexto via
@@ -177,7 +180,7 @@ scenario_ptbr_legado_reader_fallback() {
     --skill "clarify" \
     --diagnostico "Skill clarify falhou em estado legado pt-BR para validar fallback" \
     --proposta "fix proposta detalhada" \
-    --dry-run
+    --dry-run --include-project-context
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "dry-run pt-BR" "$_CAPTURED_STDERR"; return 1; }
   # execucao.id (fallback) aparece no cabecalho do body
   assert_stdout_contains "exec-legado-ptbr" || return 1
@@ -229,7 +232,7 @@ scenario_sqlite_dry_run_le_estado_do_state_db() {
     --skill "clarify" \
     --diagnostico "Skill clarify gerou opcoes contraditorias entre perguntas Q3 e Q5 no cenario sqlite" \
     --proposta "Adicionar etapa de cross-check entre perguntas" \
-    --dry-run
+    --dry-run --include-project-context
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "dry-run sqlite" "exit $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
   case "$_CAPTURED_STDERR" in
     *"state.json ausente"*) _fail "dry-run sqlite" "degradou com 'state.json ausente'"; return 1 ;;
@@ -321,6 +324,99 @@ scenario_falha_caminho_instalado_irresolvivel_bloqueia_create() {
     *"claude/skills"*) _fail "fabricacao" "corpo da issue nao deveria ter sido emitido: $_CAPTURED_STDOUT"; return 1 ;;
   esac
   assert_stderr_contains "irresolvivel" || return 1
+}
+
+# ==== issue #143: privacidade por default + draft/publish ====
+scenario_issue143_default_redige_contexto_do_projeto() {
+  _sd="$TMPDIR_TEST/state"; _md="$TMPDIR_TEST/sug.md"
+  _setup "$_sd" "$_md" || { _error "fixture" ""; return 2; }
+  capture "$SCRIPT" create --state-dir "$_sd" --suggestion-id "sug-001" \
+    --skill "clarify" \
+    --diagnostico "Skill clarify gerou opcoes contraditorias entre perguntas Q3 e Q5 para o mesmo escopo de armazenamento" \
+    --proposta "Adicionar etapa de cross-check entre perguntas" \
+    --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "dry-run exit" "$_CAPTURED_STDERR"; return 1; }
+  # Conteudo tecnico continua la...
+  assert_stdout_contains "## Diagnostico" || return 1
+  assert_stdout_contains "Skill clarify gerou opcoes contraditorias" || return 1
+  assert_stdout_contains "Etapa: \`" || return 1
+  # ...mas descricao do projeto, ID da execucao, Decisoes e path absoluto NAO.
+  case "$_CAPTURED_STDOUT" in
+    *"POC issue tests"*) _fail "descricao do projeto vazou" ""; return 1 ;;
+    *"exec-issue-test"*) _fail "ID da execucao vazou" ""; return 1 ;;
+    *"Tentou avancar pipeline"*) _fail "trecho de Decisao vazou" ""; return 1 ;;
+    *"/tmp/p/.claude"*) _fail "path absoluto do projeto vazou" ""; return 1 ;;
+  esac
+  assert_stdout_contains "omitid" || return 1
+  assert_stdout_contains "<projeto-alvo>/.claude/agente-00c-report.md" || return 1
+}
+
+scenario_issue143_include_project_context_restaura_corpo_completo() {
+  _sd="$TMPDIR_TEST/state"; _md="$TMPDIR_TEST/sug.md"
+  _setup "$_sd" "$_md" || { _error "fixture" ""; return 2; }
+  capture "$SCRIPT" create --state-dir "$_sd" --suggestion-id "sug-001" \
+    --skill "clarify" \
+    --diagnostico "Skill clarify gerou opcoes contraditorias entre perguntas Q3 e Q5 para o mesmo escopo de armazenamento" \
+    --proposta "Adicionar etapa de cross-check entre perguntas" \
+    --dry-run --include-project-context
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "dry-run exit" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "POC issue tests" || return 1
+  assert_stdout_contains "exec-issue-test" || return 1
+  assert_stdout_contains "Tentou avancar pipeline" || return 1
+  assert_stdout_contains "/tmp/p/.claude/agente-00c-report.md" || return 1
+}
+
+scenario_issue143_draft_grava_arquivo_e_nao_publica() {
+  _sd="$TMPDIR_TEST/state"; _md="$TMPDIR_TEST/sug.md"
+  _setup "$_sd" "$_md" || { _error "fixture" ""; return 2; }
+  _draft="$TMPDIR_TEST/pap/.claude/agente-00c-issues/sug-001.md"
+  # gh stub que FALHA se for chamado: draft nunca pode tocar o GitHub.
+  _stub="$TMPDIR_TEST/stub-gh-draft"; mkdir -p "$_stub"
+  printf '#!/bin/sh\necho "gh NAO deveria ser chamado: $*" >&2; exit 99\n' > "$_stub/gh"; chmod +x "$_stub/gh"
+  capture env PATH="$_stub:$PATH" "$SCRIPT" create --state-dir "$_sd" --suggestion-id "sug-001" \
+    --skill "clarify" \
+    --diagnostico "Skill clarify gerou opcoes contraditorias entre perguntas Q3 e Q5 para o mesmo escopo de armazenamento" \
+    --proposta "Adicionar etapa de cross-check entre perguntas" \
+    --draft "$_draft"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "draft exit" "$_CAPTURED_STDERR"; return 1; }
+  [ "$_CAPTURED_STDOUT" = "$_draft" ] || { _fail "stdout deveria ser o path do rascunho" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+  assert_stderr_contains "NAO publicado" || return 1
+  [ -f "$_draft" ] || { _fail "rascunho nao gravado" ""; return 1; }
+  head -1 "$_draft" | grep -q '^Title: \[agente-00C\] Bug em clarify (' || { _fail "linha 1 do rascunho" "$(head -1 "$_draft")"; return 1; }
+  grep -q '^## Diagnostico' "$_draft" || { _fail "corpo do rascunho" ""; return 1; }
+  # Default redigido tambem no draft.
+  if grep -q "POC issue tests" "$_draft"; then _fail "descricao do projeto vazou no draft" ""; return 1; fi
+  case "$_CAPTURED_STDERR" in *"gh NAO deveria"*) _fail "draft chamou gh" ""; return 1 ;; esac
+}
+
+scenario_issue143_publish_dry_run_le_rascunho_e_rescruba() {
+  _sd="$TMPDIR_TEST/state"; _md="$TMPDIR_TEST/sug.md"
+  _setup "$_sd" "$_md" || { _error "fixture" ""; return 2; }
+  _draft="$TMPDIR_TEST/drafts/sug-001.md"
+  capture "$SCRIPT" create --state-dir "$_sd" --suggestion-id "sug-001" \
+    --skill "clarify" \
+    --diagnostico "Skill clarify gerou opcoes contraditorias entre perguntas Q3 e Q5 para o mesmo escopo de armazenamento" \
+    --proposta "Adicionar etapa de cross-check entre perguntas" \
+    --draft "$_draft"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "draft" "$_CAPTURED_STDERR"; return 1; }
+  # Operador edita o rascunho a mao e deixa escapar um token: publish re-scruba.
+  printf '\nNota do operador: api_key=abcdef1234567890123456789xyz\n' >> "$_draft"
+  capture "$SCRIPT" publish --from "$_draft" --dry-run
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "publish dry-run" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "Title: [agente-00C] Bug em clarify (" || return 1
+  assert_stdout_contains "## Diagnostico" || return 1
+  case "$_CAPTURED_STDOUT" in *abcdef1234567890123456789xyz*) _fail "publish nao re-scrubou" ""; return 1 ;; esac
+  assert_stdout_contains "REDACTED" || return 1
+}
+
+scenario_issue143_publish_rascunho_invalido_falha() {
+  _bad="$TMPDIR_TEST/bad-draft.md"
+  printf 'sem linha Title\n\ncorpo\n' > "$_bad"
+  capture "$SCRIPT" publish --from "$_bad" --dry-run
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "rascunho invalido" || return 1
+  capture "$SCRIPT" publish --dry-run
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit sem --from" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
 }
 
 run_all_scenarios

--- a/tests/test_report.sh
+++ b/tests/test_report.sh
@@ -865,4 +865,26 @@ scenario_issue141_emit_agente_00c_grava_relatorio_completo() {
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "validate" "$_CAPTURED_STDERR"; return 1; }
 }
 
+# ==== issue #144: Decisao invalidada via mark-invalid aparece como INVALIDADA ====
+scenario_issue144_generate_marca_decisao_invalidada() {
+  _sd="$TMPDIR_TEST/state-144"
+  _init "$_sd"
+  _run_wave_with_decision "$_sd"
+  capture "$DEC" mark-invalid --state-dir "$_sd" --decisao-id dec-001 \
+    --motivo "decisao registrada com a escolha errada por engano"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "mark-invalid" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" generate --state-dir "$_sd" --paragrafo-resumo "x"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "generate" "$_CAPTURED_STDERR"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^#### dec-001 — .* — \*\*INVALIDADA por dec-002\*\*$' \
+    || { _fail "heading da original" "$(printf '%s\n' "$_CAPTURED_STDOUT" | grep '^#### dec-001')"; return 1; }
+  assert_stdout_contains "> **INVALIDADA** por dec-002" || return 1
+  assert_stdout_contains "motivo: decisao registrada com a escolha errada por engano" || return 1
+  # A invalidacao em si e uma Decisao normal (nao marcada como invalidada).
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^#### dec-002 — .*INVALIDADA' \
+    && { _fail "dec-002 nao deveria aparecer como invalidada" ""; return 1; }
+  assert_stdout_contains "**Escolha**: invalidar-dec-001" || return 1
+  # Relatorio segue completo.
+  assert_stdout_contains "## 6. Licoes Aprendidas" || return 1
+}
+
 run_all_scenarios

--- a/tests/test_state-decisions.sh
+++ b/tests/test_state-decisions.sh
@@ -744,4 +744,72 @@ scenario_issue141_register_rejeita_forma_invalida_em_referencias() {
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "referencias validas" "$_CAPTURED_STDERR"; return 1; }
 }
 
+# ==== issue #144: mark-invalid (invalidacao append-only) ====
+scenario_issue144_mark_invalid_registra_nova_decisao_e_preserva_original() {
+  _sd="$TMPDIR_TEST/state-144"
+  _init_state "$_sd"
+  _register_default "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "register" "$_CAPTURED_STDERR"; return 1; }
+  _orig_before=$(capture "$RW" get --state-dir "$_sd" --field '.decisions[0]'; printf '%s' "$_CAPTURED_STDOUT")
+
+  capture "$SCRIPT" mark-invalid --state-dir "$_sd" --decisao-id dec-001 \
+    --motivo "escolha registrada com typo, decisao real foi Time pequeno"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "mark-invalid" "$_CAPTURED_STDERR"; return 1; }
+  [ "$_CAPTURED_STDOUT" = "dec-002" ] || { _fail "stdout" "esperado dec-002, obtido '$_CAPTURED_STDOUT'"; return 1; }
+
+  # Original INTACTA (append-only — Principio I).
+  capture "$RW" get --state-dir "$_sd" --field '.decisions[0]'
+  [ "$_CAPTURED_STDOUT" = "$_orig_before" ] || { _fail "dec-001 foi alterada" "$_CAPTURED_STDOUT"; return 1; }
+  # Nova Decisao com a convencao deterministica.
+  capture "$RW" get --state-dir "$_sd" --field '.decisions[1] | [.choice, .originating_artifact, .stage, .agent, (.options_considered|join(","))] | join("|")'
+  [ "$_CAPTURED_STDOUT" = "invalidar-dec-001|dec-001|briefing|operador|manter-dec-001,invalidar-dec-001" ] \
+    || { _fail "convencao da invalidacao" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.decisions[1].context'
+  case "$_CAPTURED_STDOUT" in "INVALIDACAO de dec-001: escolha registrada"*) ;; *) _fail "contexto" "$_CAPTURED_STDOUT"; return 1 ;; esac
+  capture "$RW" get --state-dir "$_sd" --field '.accumulated_metrics.decisions_total'
+  [ "$_CAPTURED_STDOUT" = "2" ] || { _fail "decisions_total" "obtido $_CAPTURED_STDOUT"; return 1; }
+}
+
+scenario_issue144_mark_invalid_recusa_inexistente_duplicada_encadeada_e_motivo_curto() {
+  _sd="$TMPDIR_TEST/state-144-bad"
+  _init_state "$_sd"
+  _register_default "$_sd"
+  capture "$SCRIPT" mark-invalid --state-dir "$_sd" --decisao-id dec-077 --motivo "decisao que nao existe para testar erro"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "inexistente" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "nao encontrada" || return 1
+  capture "$SCRIPT" mark-invalid --state-dir "$_sd" --decisao-id dec-001 --motivo "curto"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "motivo curto" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "< 20 chars" || return 1
+  capture "$SCRIPT" mark-invalid --state-dir "$_sd" --decisao-id dec-001 --motivo "primeira invalidacao valida com motivo longo"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "1a invalidacao" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" mark-invalid --state-dir "$_sd" --decisao-id dec-001 --motivo "segunda tentativa de invalidar a mesma decisao"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "duplicada" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "ja invalidada por dec-002" || return 1
+  # Invalidar a propria invalidacao nao se encadeia.
+  capture "$SCRIPT" mark-invalid --state-dir "$_sd" --decisao-id dec-002 --motivo "tentando invalidar a invalidacao dec-002"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "encadeada" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "ela mesma uma invalidacao" || return 1
+  capture "$SCRIPT" mark-invalid --state-dir "$_sd" --decisao-id dec-001
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "sem --motivo" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+  capture "$RW" get --state-dir "$_sd" --field '.decisions | length'
+  [ "$_CAPTURED_STDOUT" = "2" ] || { _fail "so 2 decisoes deveriam existir" "obtido $_CAPTURED_STDOUT"; return 1; }
+}
+
+scenario_issue144_sqlite_mark_invalid_backend_agnostico() {
+  _sd="$TMPDIR_TEST/state-144-sqlite"
+  _seed_sqlite_backend "$_sd" || return 1
+  sqlite3 "$_sd/state.db" "INSERT INTO wave (id,execution_id,seq,started_at) VALUES ('onda-001','exec-1',1,'2026-07-30T00:00:00Z');" \
+    || { _fail "seed wave" ""; return 1; }
+  _register_default "$_sd" "orquestrador-00c" "plan"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "register sqlite" "$_CAPTURED_STDERR"; return 1; }
+  capture "$SCRIPT" mark-invalid --state-dir "$_sd" --decisao-id dec-001 \
+    --motivo "invalidacao sob backend sqlite para teste de paridade" --agente "revisor"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "mark-invalid sqlite" "$_CAPTURED_STDERR"; return 1; }
+  [ "$_CAPTURED_STDOUT" = "dec-002" ] || { _fail "id" "obtido '$_CAPTURED_STDOUT'"; return 1; }
+  _row=$(sqlite3 "$_sd/state.db" "SELECT choice||'|'||originating_artifact||'|'||stage||'|'||agent FROM decision WHERE id='dec-002';")
+  [ "$_row" = "invalidar-dec-001|dec-001|plan|revisor" ] || { _fail "linha sqlite" "obtido '$_row'"; return 1; }
+  [ -e "$_sd/state.json" ] && { _fail "anti-mirror" "mark-invalid criou state.json no state-dir sqlite"; return 1; }
+  return 0
+}
+
 run_all_scenarios


### PR DESCRIPTION
## Resumo

- **#143** `issue.sh`: corpo **redigido por default** (sem descrição do projeto-alvo, ID da execução, trechos de Decisões, paths absolutos; `$HOME` → `~`), `--include-project-context` restaura; `create --draft FILE` (rascunho local, nunca toca o GitHub) + `publish --from FILE` (ação do operador: re-scrub, dedup por hash, mark-issue). Prosa dos dois orquestradores passa a só rascunhar (e o feature-orchestrator citava `--flavor feature-00c`, inexistente — corrigido). docs: `gh` só é exigido de quem publica.
- **#144** `state-decisions.sh mark-invalid`: invalidação **append-only** (nova Decisão com convenção determinística referenciando a original via `originating_artifact`; original intacta; backend-agnóstico); `report.sh` marca a original como INVALIDADA com motivo. Alternativa menor da issue; amend completo fica para demanda futura.
- CHANGELOG 8.5.0 + manifestos em lockstep (`validate-plugin-manifests.sh --version 8.5.0 --strict` OK).

## Testado

- Suite completa (`LC_ALL=C ./tests/run.sh`): **PASS 3242 / FAIL 0** (941s); `--check-coverage` zero órfãos; `cstk doctor` drift zero.
- 9 cenários shell novos (5 issue, 3 state-decisions, 1 report).

Closes #143
Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiHRXC83ja2JERyfeZNJqs