### PR TITLE
fix(state-rounds): SC2015 na guarda G8 pos-mv (T-16 do release.yml)

### DIFF
--- a/plugins/cstk/skills/agente-00c-runtime/scripts/state-rounds.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/state-rounds.sh
@@ -582,8 +582,9 @@ for _rt_f in $_RT_FILES_CSV; do
     || _sr_die "mv falhou: $_rt_f -> $_RT_STAGING" 1
   if [ "$_rt_f" = "backups" ]; then
     # G8 (pos-mv): staging deve conter um diretorio real, nunca um symlink.
-    [ -d "$_RT_STAGING/backups" ] && [ ! -L "$_RT_STAGING/backups" ] \
-      || _sr_die "backups/ no staging invalido apos mv (nao-diretorio ou symlink)" 1
+    if [ ! -d "$_RT_STAGING/backups" ] || [ -L "$_RT_STAGING/backups" ]; then
+      _sr_die "backups/ no staging invalido apos mv (nao-diretorio ou symlink)" 1
+    fi
   fi
   IFS=','
 done


### PR DESCRIPTION
O shellcheck do ubuntu-latest sinaliza SC2015 (info) no padrao `[ A ] && [ B ] || die` da guarda G8 pos-mv (`state-rounds.sh:585`, introduzido pela feature round-scoped-backups), reprovando o cenario T-16 e queimando a tag v8.8.0 no `release.yml` (run 32535394883). Reescrito como `if/else` negado — semantica identica (die quando o staging nao contem diretorio real).

Testado: `shellcheck -s sh` limpo (0.11.0 local); `./tests/run.sh test_state-rounds` 30/30 verde. Apos merge: re-tag v8.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiHRXC83ja2JERyfeZNJqs