### PR TITLE
docs(briefing): paridade 9.0.0 — sequencia SDD com converge

### DIFF
--- a/docs/01-briefing-discovery/briefing.md
+++ b/docs/01-briefing-discovery/briefing.md
@@ -8,7 +8,7 @@
 
 ## 1. Visao e Proposito
 
-**O que e**: Toolkit de skills, hooks e insights para [Claude Code](https://claude.ai/code), composto por um pipeline Spec-Driven Development (SDD) completo (briefing → constitution → specify → clarify → plan → checklist → create-tasks → analyze → execute-task → review-task), skills complementares (advisor, bugfix, owasp-security, etc.) e skills especificas por linguagem (Go, .NET).
+**O que e**: Toolkit de skills, hooks e insights para [Claude Code](https://claude.ai/code), composto por um pipeline Spec-Driven Development (SDD) completo (briefing → constitution → specify → clarify → plan → checklist → create-tasks → execute-task → converge → review-task, com analyze como cross-check lateral read-only), skills complementares (advisor, bugfix, owasp-security, etc.) e skills especificas por linguagem (Go, .NET).
 
 **Problema que resolve**: garantir que o fluxo de desenvolvimento seja documentado desde o d0, que o codigo seja escrito com qualidade, e que futuras correcoes sejam especificacoes validadas — nao edicoes improvisadas.
 


### PR DESCRIPTION
Fecha o ultimo residuo de paridade da v9.0.0 encontrado por varredura pos-release: a Visao do briefing listava a pipeline SDD sem a etapa `converge` e com `analyze` como etapa numerada (contra a normalizacao CHK024).

Varredura executada: sequencias `execute-task → review-task` sem converge em *.md vivos (fora specs/CHANGELOG/_archived), residuos "10 etapas", versoes hardcoded. Unico achado real: este. As mencoes a "fronteira execute-task → review-task" em converge/SKILL.md e orquestradores descrevem a POSICAO da etapa e foram auditadas limpas por 2 passadas do gate converge.

Testado: mudanca de prosa pura, sem codigo tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiHRXC83ja2JERyfeZNJqs