### PR TITLE
feat(session): preservar state 00c no session end (release 9.1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [9.1.0] - 2026-08-24
+
+Fecha o vazamento silencioso de state no fechamento de worktrees de leva
+paralela (modo roadmap): `.claude/` é gitignored, então o `state.db`/
+`state.json` da execução filha nunca chega à branch principal pelo merge do
+PR — e o `cstk session end` destruía esses artefatos sem aviso, invisíveis
+aos guards de dirty/unpushed.
+
+### Added
+
+- **`cstk session end` preserva artefatos 00c antes de remover a worktree.**
+  Copia `.claude/feature-00c-state/<short>/` (granularidade por feature,
+  incluindo `state.db`/`state.json`, rounds e backups) e os itens de
+  `_CSTK_SESSION_STATE_ARTIFACTS` (`agente-00c-state`, `agente-00c-archive`,
+  `agente-00c-report.md`, `agente-00c-suggestions.md`,
+  `enforcement-log.jsonl`) para o `.claude/` do checkout principal ANTES do
+  `git worktree remove`. Colisão nunca sobrescreve: a cópia vai para
+  `.claude/session-state-backup/<sessão>/<relpath>`. Falha de cópia bloqueia
+  a remoção (fail-closed) — worktree residual é recuperável, state deletado
+  não. Helpers `_session_preserve_state`/`_session_preserve_one` em
+  `cli/lib/session.sh`; 3 cenários novos em `tests/cstk/test_session.sh`.
+- **Flag `--discard-state` no `session end`.** Única forma de remover a
+  worktree descartando os artefatos 00c (aviso explícito em stderr);
+  `--force` continua pulando só os prompts, nunca a preservação.
+
+### Changed
+
+- **`session start` deixa de copiar `feature-00c-state` para a worktree.**
+  `feature-00c-state` entra em `_CSTK_SESSION_CLAUDE_EXCLUDES` (8 → 9
+  exclusões): state de execução é per-worktree; copiar states do checkout
+  principal para a sessão confundia a precedência do pretooluse-guard e
+  gerava colisão artificial na preservação do `end`.
+- **Prosa do modo roadmap (`agente-00c.md` §6.bis + `docs/agente-00c.md`)**
+  documenta que worktrees de leva paralela fecham SEMPRE via `cstk session
+  end` (nunca `git worktree remove` cru), explicitando a preservação de
+  state e o `--discard-state`.
+
 ## [9.0.0] - 2026-08-22
 
 Feature `pipeline-converge`: a skill `converge` deixa de ser um gate
@@ -7091,6 +7128,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[9.1.0]: https://github.com/JotJunior/cstk/releases/tag/v9.1.0
 [9.0.0]: https://github.com/JotJunior/cstk/releases/tag/v9.0.0
 [8.8.0]: https://github.com/JotJunior/cstk/releases/tag/v8.8.0
 [8.7.0]: https://github.com/JotJunior/cstk/releases/tag/v8.7.0

--- a/cli/lib/session.sh
+++ b/cli/lib/session.sh
@@ -63,9 +63,18 @@ CSTK_SESSION_MIN_GIT_MINOR=36
 # que so aceita lowercase). Lista hardcoded conforme spec FR-003.
 _CSTK_SESSION_BLOCKLIST="main master trunk head default origin"
 
-# Lista de exclusoes ao copiar .claude/ para a sessao (FR-002).
+# Lista de exclusoes ao copiar .claude/ para a sessao (FR-002 + extensao
+# 2026-08-24: feature-00c-state — state de execucao e per-worktree; copiar
+# states do checkout principal para a sessao confundia a precedencia do
+# pretooluse-guard e gerava colisao no `session end`).
 # Caminhos/nomes relativos a .claude/ — separados por espaco.
-_CSTK_SESSION_CLAUDE_EXCLUDES="agente-00c-state agente-00c-archive agente-00c-report.md agente-00c-suggestions.md settings.local.json agente-00c-whitelist .agente-00c-state.lock insights"
+_CSTK_SESSION_CLAUDE_EXCLUDES="agente-00c-state feature-00c-state agente-00c-archive agente-00c-report.md agente-00c-suggestions.md settings.local.json agente-00c-whitelist .agente-00c-state.lock insights"
+
+# Artefatos 00c preservados pelo `session end` ANTES de remover a worktree
+# (alem de .claude/feature-00c-state/<short>/, tratado por-feature).
+# .claude/ e tipicamente gitignored: os guards dirty/unpushed NAO enxergam
+# esses artefatos, e a remocao os destruiria em silencio.
+_CSTK_SESSION_STATE_ARTIFACTS="agente-00c-state agente-00c-archive agente-00c-report.md agente-00c-suggestions.md enforcement-log.jsonl"
 
 # ==== Help ====
 
@@ -77,7 +86,7 @@ USO:
   cstk session start <name> [--reset|--reuse] [--force] [--claude]
   cstk session list [--json]
   cstk session pr <name> [--draft] [--title TITLE] [--body BODY] [--reviewer USER]
-  cstk session end <name> [--force]
+  cstk session end <name> [--force] [--discard-state]
 
 SUBCOMANDOS:
   start    Cria worktree + branch + copia .claude/ filtrado.
@@ -93,6 +102,13 @@ SUBCOMANDOS:
 
   end      Remove worktree + branch local com guards (prompts para dirty,
            commits nao pushados, PR aberto). --force pula prompts.
+           Antes da remocao, PRESERVA os artefatos 00c da worktree
+           (.claude/feature-00c-state/<short>/ com state.db/state.json,
+           agente-00c-state, report, enforcement-log) copiando-os para o
+           .claude/ do checkout principal — colisao vai para
+           .claude/session-state-backup/<name>/, nunca sobrescreve.
+           Falha de copia bloqueia a remocao (fail-closed).
+           --discard-state: descarta deliberadamente esses artefatos.
 
   pr       Abre PR da branch para default branch via gh. Idempotente:
            se PR existe, retorna URL existente. Flags --draft/--title/
@@ -343,7 +359,7 @@ _session_prompt_yn() {
 }
 
 # _session_copy_claude_filtered <src> <dst>: copia <src>/.claude/ para <dst>
-# excluindo os 8 artefatos runtime/per-env listados em FR-002.
+# excluindo os 9 artefatos runtime/per-env listados em FR-002 (+extensao).
 # Estrategia: `cp -R` (POSIX) seguido de `rm -rf` da blocklist. Custo de
 # copiar arquivos que serao removidos e baixo (.claude/ tipicamente <50MB).
 # Sem rsync (nao POSIX em macOS antigo).
@@ -385,7 +401,7 @@ _session_copy_claude_filtered() {
 #   5. Local + --reset + commits    → prompt p/ confirmar descarte;
 #      nao-mergeados                  --force bypassa
 #
-# Apos worktree criada, copia .claude/ filtrado (FR-002, 8 exclusoes).
+# Apos worktree criada, copia .claude/ filtrado (FR-002, 9 exclusoes).
 # Falha parcial (cp falhou apos worktree criada): stderr orientativo,
 # exit 1 (FR-017).
 _session_start() {
@@ -748,15 +764,83 @@ _session_list() {
 #   5. Detecta PR aberto via gh (opcional — pula se gh ausente/unauth, FR-005)
 #   6. Se --force NAO passado E (dirty OR unpushed > 0 OR PR aberto):
 #      prompt interativo; cancelar = exit 10
-#   7. Executa git worktree remove + git branch -D
-#   8. Falha parcial (FR-006): se worktree remove succeed mas branch -D
+#   7. Preserva artefatos 00c da worktree (.claude/feature-00c-state/*,
+#      agente-00c-state, report, enforcement-log) copiando para o .claude/
+#      do checkout principal ANTES da remocao. Fail-closed: falha de copia
+#      aborta sem remover. --discard-state pula (descarte deliberado).
+#   8. Executa git worktree remove + git branch -D
+#   9. Falha parcial (FR-006): se worktree remove succeed mas branch -D
 #      falhou, stderr indica estado residual
+# ==== Preservacao de state 00c no `end` ====
+#
+# `.claude/` e tipicamente gitignored: state.db/state.json, rounds, backups,
+# report e enforcement-log de execucoes 00c rodadas na worktree nao tem
+# rastro no git — `git worktree remove` os destruiria em silencio. Antes da
+# remocao, copia esses artefatos para o .claude/ do checkout principal:
+#   - .claude/feature-00c-state/<short>/   (granularidade por feature)
+#   - itens de _CSTK_SESSION_STATE_ARTIFACTS
+# Colisao (destino ja existe) NUNCA sobrescreve: a copia vai para
+# .claude/session-state-backup/<session>/<relpath>. Falha de copia BLOQUEIA
+# a remocao (fail-closed) — worktree residual e recuperavel, state deletado
+# nao. Descarte deliberado exige --discard-state.
+_session_preserve_state() {
+  _ps_wt=$1
+  _ps_repo=$2
+  _ps_session=$3
+  _CSTK_SESSION_PRESERVED_COUNT=0
+  _ps_src="$_ps_wt/.claude"
+  [ -d "$_ps_src" ] || return 0
+  if [ -d "$_ps_src/feature-00c-state" ]; then
+    for _ps_dir in "$_ps_src/feature-00c-state"/*/; do
+      [ -d "$_ps_dir" ] || continue
+      _ps_short=$(basename "${_ps_dir%/}")
+      _session_preserve_one "${_ps_dir%/}" "feature-00c-state/$_ps_short" \
+        "$_ps_repo" "$_ps_session" || return 1
+    done
+  fi
+  for _ps_item in $_CSTK_SESSION_STATE_ARTIFACTS; do
+    [ -e "$_ps_src/$_ps_item" ] || continue
+    _session_preserve_one "$_ps_src/$_ps_item" "$_ps_item" \
+      "$_ps_repo" "$_ps_session" || return 1
+  done
+  return 0
+}
+
+# _session_preserve_one <src-path> <relpath> <repo> <session>
+# Copia 1 artefato para <repo>/.claude/<relpath>; se ja existe, para
+# <repo>/.claude/session-state-backup/<session>/<relpath>.
+_session_preserve_one() {
+  _po_src=$1
+  _po_rel=$2
+  _po_dest="$3/.claude/$_po_rel"
+  _po_session=$4
+  if [ -e "$_po_dest" ]; then
+    _po_dest="$3/.claude/session-state-backup/$_po_session/$_po_rel"
+    if [ -e "$_po_dest" ]; then
+      log_error "session end: destino de preservacao ja existe: $_po_dest"
+      log_error "session end: mova/remova o backup anterior e rode de novo, ou use --discard-state para descartar o state da worktree"
+      return 1
+    fi
+    log_warn "session end: '.claude/$_po_rel' ja existe no checkout principal — copia preservada em $_po_dest"
+  fi
+  _po_parent=$(dirname "$_po_dest")
+  if ! mkdir -p -- "$_po_parent" || ! cp -R -- "$_po_src" "$_po_dest"; then
+    log_error "session end: falha ao preservar '.claude/$_po_rel' — worktree NAO sera removida"
+    log_error "session end: copie manualmente ou rode com --discard-state (descarta o state)"
+    return 1
+  fi
+  _CSTK_SESSION_PRESERVED_COUNT=$((_CSTK_SESSION_PRESERVED_COUNT + 1))
+  return 0
+}
+
 _session_end() {
   _name=""
   _force=0
+  _discard_state=0
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --force) _force=1; shift ;;
+      --discard-state) _discard_state=1; shift ;;
       --) shift; break ;;
       -*) log_error "session end: flag desconhecida: $1"; return 2 ;;
       *)
@@ -852,6 +936,19 @@ _session_end() {
     }
   fi
 
+  # Preservar artefatos 00c ANTES da remocao (fail-closed). --discard-state
+  # pula deliberadamente — unica forma de remover a worktree sem trazer o
+  # state para o checkout principal.
+  _CSTK_SESSION_PRESERVED_COUNT=0
+  if [ "$_discard_state" = 1 ]; then
+    if [ -d "$_wt_path/.claude/feature-00c-state" ] \
+       || [ -d "$_wt_path/.claude/agente-00c-state" ]; then
+      log_warn "session end: --discard-state — artefatos 00c da worktree serao DESCARTADOS"
+    fi
+  elif [ -d "$_wt_path" ]; then
+    _session_preserve_state "$_wt_path" "$_repo" "$_name" || return 1
+  fi
+
   # Remover worktree (com --force se dirty/unpushed e --force foi passado;
   # OU se path nao existe mais — stale precisa de --force)
   _wtr_flags=""
@@ -877,6 +974,10 @@ _session_end() {
   worktree: $_wt_path (removida)
   branch:   $_wt_branch (deletada)
 EOF
+  if [ "${_CSTK_SESSION_PRESERVED_COUNT:-0}" -gt 0 ]; then
+    printf '  state:    %s artefato(s) 00c preservado(s) em %s/.claude\n' \
+      "$_CSTK_SESSION_PRESERVED_COUNT" "$_repo"
+  fi
   return 0
 }
 

--- a/docs/agente-00c.md
+++ b/docs/agente-00c.md
@@ -243,6 +243,16 @@ intervention. Kill switch: `tmux kill-window -t <pane>` + `cstk session end
 <short>`. Manual verification path: `cstk session list`,
 `roadmap-status.sh --json`, `tmux list-panes -a` (§6.bis).
 
+When closing a wave's worktrees, `.claude/` is gitignored — the child
+execution's `state.db`/`state.json` (rounds, backups, report,
+`enforcement-log.jsonl`) never reaches the main branch through the PR merge.
+`cstk session end` therefore copies those 00c artifacts into the main
+checkout's `.claude/` BEFORE removing the worktree (collisions land in
+`.claude/session-state-backup/<short>/`, never overwritten; a copy failure
+blocks removal). Always close worktrees via `cstk session end`, never raw
+`git worktree remove`; deliberately discarding the state requires the
+explicit `--discard-state` flag.
+
 | Component | Location |
 |-----------|----------|
 | Frontier + overlap hint | `plugins/cstk/skills/review-features/scripts/roadmap-frontier.sh` |

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/commands/agente-00c.md
+++ b/plugins/cstk/commands/agente-00c.md
@@ -942,6 +942,17 @@ trivial se necessario: `tmux kill-window -t <pane_id>` + `cstk session end
 ter disparado ou nao (FR-013) — nao depende do resultado do experimento da
 FASE 0.
 
+**Preservacao de state ao fechar worktrees**: `.claude/` e gitignored, entao
+o `state.db`/`state.json` da execucao filha (com rounds, backups, report e
+`enforcement-log.jsonl`) NAO chega a branch principal pelo merge do PR — so
+existe no filesystem da worktree. Por isso o `cstk session end` copia
+automaticamente esses artefatos 00c para o `.claude/` do checkout principal
+ANTES de remover a worktree (colisao vai para
+`.claude/session-state-backup/<short>/`, nunca sobrescreve; falha de copia
+bloqueia a remocao). Nao remova worktrees de leva paralela por
+`git worktree remove` cru — sempre via `cstk session end`; descarte
+deliberado do state exige a flag explicita `--discard-state`.
+
 ### 6.ter Oferta de leva paralela pos-roadmap (US1 — FR-002/FR-003/FR-004/FR-006/FR-011/FR-012/FR-014/FR-018, `roadmap-parallel-launch`)
 
 **Gatilho**: apos o orquestrador retornar desta onda, se

--- a/tests/cstk/test_session.sh
+++ b/tests/cstk/test_session.sh
@@ -278,6 +278,8 @@ _make_repo_with_claude() {
     && mkdir -p .claude/agente-00c-state .claude/agente-00c-archive \
                 .claude/skills .claude/insights .claude/commands \
     && echo '{"id":"x"}' > .claude/agente-00c-state/state.json \
+    && mkdir -p .claude/feature-00c-state/feat-x \
+    && echo '{"id":"fx"}' > .claude/feature-00c-state/feat-x/state.json \
     && echo "archived" > .claude/agente-00c-archive/old.md \
     && echo "report" > .claude/agente-00c-report.md \
     && echo "suggestions" > .claude/agente-00c-suggestions.md \
@@ -307,17 +309,18 @@ scenario_start_happy_path() {
   [ -f "$_wt/.claude/settings.json" ] || { _fail "settings.json" "perdido"; return 1; }
 }
 
-scenario_start_claude_excludes_validate_all_8() {
+scenario_start_claude_excludes_validate_all_9() {
   _src="$TMPDIR_TEST/repo-excl"
   _make_repo_with_claude "$_src"
   _phys=$( cd "$TMPDIR_TEST" && pwd -P )
   capture sh -c "cd '$_src' && CSTK_LIB='$CSTK_LIB' sh '$CSTK_BIN' session start excl-feat"
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start" "$_CAPTURED_STDERR"; return 1; }
   _wt="$_phys/repo-excl-excl-feat"
-  # Cada uma das 8 exclusoes deve estar ausente
-  for _excl in agente-00c-state agente-00c-archive agente-00c-report.md \
-               agente-00c-suggestions.md settings.local.json \
-               agente-00c-whitelist .agente-00c-state.lock insights; do
+  # Cada uma das 9 exclusoes deve estar ausente
+  for _excl in agente-00c-state feature-00c-state agente-00c-archive \
+               agente-00c-report.md agente-00c-suggestions.md \
+               settings.local.json agente-00c-whitelist \
+               .agente-00c-state.lock insights; do
     if [ -e "$_wt/.claude/$_excl" ]; then
       _fail "exclusao" "'$_excl' deveria estar excluido em $_wt/.claude/"
       return 1
@@ -787,6 +790,88 @@ scenario_end_session_not_found_exit_9() {
   fi
   assert_stderr_contains "nao encontrada" || return 1
   assert_stderr_contains "cstk session list" || return 1
+}
+
+# ==== Preservacao de state 00c no `end` ====
+
+# Fixture: repo com .gitignore cobrindo .claude/ (convencao dos projetos
+# 00c) — evita que artefatos de state disparem o guard de dirty.
+_make_repo_ignoring_claude() {
+  _mric_dir=$1
+  _make_repo "$_mric_dir"
+  ( cd "$_mric_dir" \
+    && printf '.claude/\n' > .gitignore \
+    && git add .gitignore && git commit -q -m "gitignore .claude" )
+}
+
+scenario_end_preserves_00c_state_to_root() {
+  _src="$TMPDIR_TEST/repo-end-keep"
+  _make_repo_ignoring_claude "$_src"
+  _phys=$( cd "$TMPDIR_TEST" && pwd -P )
+  ( cd "$_src" && CSTK_LIB="$CSTK_LIB" sh "$CSTK_BIN" session start keep >/dev/null )
+  _wt="$_phys/repo-end-keep-keep"
+  mkdir -p "$_wt/.claude/feature-00c-state/keep/rounds/r01"
+  echo "db" > "$_wt/.claude/feature-00c-state/keep/state.db"
+  echo "round" > "$_wt/.claude/feature-00c-state/keep/rounds/r01/x"
+  echo "report" > "$_wt/.claude/agente-00c-report.md"
+  echo "{}" > "$_wt/.claude/enforcement-log.jsonl"
+  capture sh -c "cd '$_src' && CSTK_LIB='$CSTK_LIB' sh '$CSTK_BIN' session end keep"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  [ ! -d "$_wt" ] || { _fail "worktree" "ainda existe apos end"; return 1; }
+  [ -f "$_src/.claude/feature-00c-state/keep/state.db" ] \
+    || { _fail "state" "state.db nao preservado no checkout principal"; return 1; }
+  [ -f "$_src/.claude/feature-00c-state/keep/rounds/r01/x" ] \
+    || { _fail "state" "rounds/ nao preservado"; return 1; }
+  [ -f "$_src/.claude/agente-00c-report.md" ] \
+    || { _fail "state" "report nao preservado"; return 1; }
+  [ -f "$_src/.claude/enforcement-log.jsonl" ] \
+    || { _fail "state" "enforcement-log nao preservado"; return 1; }
+  assert_stdout_contains "preservado" || return 1
+}
+
+scenario_end_preserve_collision_goes_to_backup() {
+  _src="$TMPDIR_TEST/repo-end-coll"
+  _make_repo_ignoring_claude "$_src"
+  _phys=$( cd "$TMPDIR_TEST" && pwd -P )
+  # State pre-existente no checkout principal (gitignored, so filesystem)
+  mkdir -p "$_src/.claude/feature-00c-state/foo"
+  echo "root-version" > "$_src/.claude/feature-00c-state/foo/state.db"
+  ( cd "$_src" && CSTK_LIB="$CSTK_LIB" sh "$CSTK_BIN" session start coll >/dev/null )
+  _wt="$_phys/repo-end-coll-coll"
+  # Worktree diverge do principal (simula execucao rodada na sessao)
+  mkdir -p "$_wt/.claude/feature-00c-state/foo"
+  echo "wt-version" > "$_wt/.claude/feature-00c-state/foo/state.db"
+  capture sh -c "cd '$_src' && CSTK_LIB='$CSTK_LIB' sh '$CSTK_BIN' session end coll"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  # Original do principal intacto (nunca sobrescreve)
+  _orig=$(cat "$_src/.claude/feature-00c-state/foo/state.db")
+  [ "$_orig" = "root-version" ] \
+    || { _fail "collision" "state do principal foi sobrescrito: $_orig"; return 1; }
+  # Copia da worktree foi para o backup por-sessao
+  _bkp="$_src/.claude/session-state-backup/coll/feature-00c-state/foo/state.db"
+  [ -f "$_bkp" ] || { _fail "collision" "backup nao criado em $_bkp"; return 1; }
+  _bkp_content=$(cat "$_bkp")
+  [ "$_bkp_content" = "wt-version" ] \
+    || { _fail "collision" "conteudo do backup errado: $_bkp_content"; return 1; }
+  assert_stderr_contains "ja existe no checkout principal" || return 1
+}
+
+scenario_end_discard_state_skips_preservation() {
+  _src="$TMPDIR_TEST/repo-end-disc"
+  _make_repo_ignoring_claude "$_src"
+  _phys=$( cd "$TMPDIR_TEST" && pwd -P )
+  ( cd "$_src" && CSTK_LIB="$CSTK_LIB" sh "$CSTK_BIN" session start disc >/dev/null )
+  _wt="$_phys/repo-end-disc-disc"
+  mkdir -p "$_wt/.claude/feature-00c-state/disc"
+  echo "db" > "$_wt/.claude/feature-00c-state/disc/state.db"
+  capture sh -c "cd '$_src' && CSTK_LIB='$CSTK_LIB' sh '$CSTK_BIN' session end disc --discard-state"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  [ ! -d "$_wt" ] || { _fail "worktree" "ainda existe apos end"; return 1; }
+  if [ -e "$_src/.claude/feature-00c-state/disc" ]; then
+    _fail "discard" "state copiado apesar de --discard-state"
+    return 1
+  fi
+  assert_stderr_contains "DESCARTADOS" || return 1
 }
 
 # ====================================================================


### PR DESCRIPTION
## Resumo

Fecha o vazamento silencioso de state no fechamento de worktrees de leva paralela (modo roadmap): `.claude/` é gitignored, então o `state.db`/`state.json` da execução filha nunca chega à branch principal pelo merge do PR — e o `cstk session end` destruía esses artefatos sem aviso.

- **`session end` preserva artefatos 00c** (`feature-00c-state/<short>/`, `agente-00c-state`, archive, report, suggestions, `enforcement-log.jsonl`) copiando-os para o `.claude/` do checkout principal antes do `git worktree remove`. Colisão → `.claude/session-state-backup/<sessão>/` (nunca sobrescreve); falha de cópia bloqueia a remoção (fail-closed).
- **Flag `--discard-state`**: única forma de descartar o state deliberadamente (`--force` segue pulando só os prompts).
- **`session start` deixa de copiar `feature-00c-state`** do principal para a worktree (`_CSTK_SESSION_CLAUDE_EXCLUDES`, 8 → 9 exclusões).
- Prosa do modo roadmap (`agente-00c.md` §6.bis + `docs/agente-00c.md`) + CHANGELOG 9.1.0 + manifestos de plugin em lockstep (gate MP-5 validado local).

## Testado

- Suíte completa local: **3409 PASS / 0 FAIL** (978s, `LC_ALL=C`).
- `tests/cstk/test_session.sh`: 65/65 (3 cenários novos: preservação, colisão→backup, `--discard-state`).
- `./tests/run.sh --check-coverage`: zero órfãos. shellcheck limpo.
- `./scripts/validate-plugin-manifests.sh --version 9.1.0 --strict`: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiHRXC83ja2JERyfeZNJqs