### PR TITLE
fix: subgraph…end em validate-docs-rendered (#156) + sha256 em Windows/Git-Bash (#157)

### DIFF
--- a/plugins/cstk/skills/agente-00c-runtime/scripts/_hash.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/_hash.sh
@@ -32,14 +32,17 @@ _hash_sha256_file() {
   fi
   _hash_os=$(uname -s 2>/dev/null)
   case "$_hash_os" in
-    Linux)
+    # MINGW*/MSYS*/CYGWIN* (Git Bash & cia no Windows) reusam o mesmo
+    # sha256sum do Linux — presente e funcional nesses ambientes (issue
+    # #157). Sem esse ramo, todo write de state falhava exit 2 no Windows.
+    Linux|MINGW*|MSYS*|CYGWIN*)
       sha256sum -- "$_hash_path" | awk '{print $1}'
       ;;
     Darwin)
       shasum -a 256 -- "$_hash_path" | awk '{print $1}'
       ;;
     *)
-      printf 'erro: SO nao suportado para sha256: %s (esperado: Linux|Darwin)\n' "$_hash_os" >&2
+      printf 'erro: SO nao suportado para sha256: %s (esperado: Linux|Darwin|MINGW*|MSYS*|CYGWIN*)\n' "$_hash_os" >&2
       return 2
       ;;
   esac
@@ -50,7 +53,8 @@ _hash_sha256_file() {
 _hash_sha256_stdin() {
   _hash_os=$(uname -s 2>/dev/null)
   case "$_hash_os" in
-    Linux)  sha256sum | awk '{print $1}' ;;
+    # Ver comentario em _hash_sha256_file sobre MINGW*/MSYS*/CYGWIN*.
+    Linux|MINGW*|MSYS*|CYGWIN*) sha256sum | awk '{print $1}' ;;
     Darwin) shasum -a 256 | awk '{print $1}' ;;
     *)
       printf 'erro: SO nao suportado para sha256: %s\n' "$_hash_os" >&2

--- a/plugins/cstk/skills/converge/scripts/converge-status.sh
+++ b/plugins/cstk/skills/converge/scripts/converge-status.sh
@@ -145,14 +145,19 @@ _cs_tasks_digest() {
   _f=$1
   _os=$(uname -s 2>/dev/null)
   case "$_os" in
-    Linux)
+    # MINGW*/MSYS*/CYGWIN* (Git Bash & cia no Windows) reusam o mesmo
+    # sha256sum do Linux — presente e funcional nesses ambientes (issue
+    # #157). Sem esse ramo, a ETAPA 7 da skill converge (gravar o
+    # ConvergenceStatusRecord) era inexecutavel no Windows, sem workaround:
+    # o marcador so pode ser escrito por este script.
+    Linux|MINGW*|MSYS*|CYGWIN*)
       sha256sum -- "$_f" | awk '{print substr($1,1,12)}'
       ;;
     Darwin)
       shasum -a 256 -- "$_f" | awk '{print substr($1,1,12)}'
       ;;
     *)
-      _cs_die_io "SO nao suportado para sha256: $_os (esperado Linux|Darwin)"
+      _cs_die_io "SO nao suportado para sha256: $_os (esperado Linux|Darwin|MINGW*|MSYS*|CYGWIN*)"
       ;;
   esac
 }

--- a/plugins/cstk/skills/converge/scripts/converge-tasks.sh
+++ b/plugins/cstk/skills/converge/scripts/converge-tasks.sh
@@ -172,14 +172,16 @@ _ct_sha256_12() {
   # Imprime 12 chars hex minusculos. Exit 1 se SO nao suportado.
   _ct_os=$(uname -s 2>/dev/null)
   case "$_ct_os" in
-    Linux)
+    # MINGW*/MSYS*/CYGWIN* (Git Bash & cia no Windows) reusam o mesmo
+    # sha256sum do Linux — presente e funcional nesses ambientes (issue #157).
+    Linux|MINGW*|MSYS*|CYGWIN*)
       printf '%s' "$1" | sha256sum | awk '{print substr($1,1,12)}'
       ;;
     Darwin)
       printf '%s' "$1" | shasum -a 256 | awk '{print substr($1,1,12)}'
       ;;
     *)
-      _ct_die_io "SO nao suportado para sha256: $_ct_os (esperado Linux|Darwin)"
+      _ct_die_io "SO nao suportado para sha256: $_ct_os (esperado Linux|Darwin|MINGW*|MSYS*|CYGWIN*)"
       ;;
   esac
 }

--- a/plugins/cstk/skills/validate-docs-rendered/scripts/validate.sh
+++ b/plugins/cstk/skills/validate-docs-rendered/scripts/validate.sh
@@ -111,11 +111,36 @@ check_mermaid() {
           }
         }
       }
-      # Checagem 1b: alt/else/loop/par sem end correspondente
-      opens = gsub(/(^|\n)[[:space:]]*(alt|loop|par|opt|critical|rect)[[:space:]]/, "&", block)
-      closes = gsub(/(^|\n)[[:space:]]*end[[:space:]]*(\n|$)/, "&", block)
+      # Checagem 1b: bloco abridor sem `end` correspondente.
+      #
+      # ATENCAO: esta checagem roda para TODO bloco mermaid, nao so para
+      # sequenceDiagram — logo a lista de abridores precisa cobrir tambem os
+      # de flowchart/graph. `subgraph` fecha com `end` exatamente como
+      # alt/loop/par (issue #156: flowchart valido com N subgraphs contava
+      # 0 abertos / N fechados e bloqueava o doc com ERRO falso).
+      # `else` e `and` NAO entram: sao continuacoes, nao abrem novo `end`.
+      #
+      # Contagem linha-a-linha, NAO gsub sobre o blob: o idioma anterior
+      # (/(^|\n)...(\n|$)/) consome o \n terminal do match, entao duas linhas
+      # ADJACENTES so eram contadas uma vez (`^` em awk casa inicio da string,
+      # nao inicio de linha). Isso subcontava `end` de subgraph aninhado —
+      # a mesma falsa acusacao da issue #156 por outro caminho.
+      nb = split(block, blines, "\n")
+      opens = 0
+      closes = 0
+      for (bi = 1; bi <= nb; bi++) {
+        bline = blines[bi]
+        sub(/^[[:space:]]+/, "", bline)
+        sub(/[[:space:]]+$/, "", bline)
+        # Sufixo ([[:space:]]|$): `subgraph` sem titulo e sintaxe valida.
+        if (bline ~ /^(alt|loop|par|opt|critical|rect|subgraph)([[:space:]]|$)/) {
+          opens++
+        } else if (bline ~ /^end$/) {
+          closes++
+        }
+      }
       if (opens != closes) {
-        printf "%s\t%d\tERRO\tMermaid\tbloco alt/loop/par/opt/rect sem `end` correspondente (%d abertos, %d fechados)\n", file, start, opens, closes
+        printf "%s\t%d\tERRO\tMermaid\tbloco alt/loop/par/opt/rect/subgraph sem `end` correspondente (%d abertos, %d fechados)\n", file, start, opens, closes
       }
       block = ""
       next

--- a/tests/test__hash.sh
+++ b/tests/test__hash.sh
@@ -80,4 +80,90 @@ scenario_sha256_file_deterministico() {
   fi
 }
 
+# ==== Issue #157: sha256 em Windows/Git-Bash (MINGW*/MSYS*/CYGWIN*) ====
+#
+# Antes do fix, `uname -s` = MINGW64_NT-* caia no ramo `*)` e devolvia exit 2
+# ("SO nao suportado"), mesmo com sha256sum presente e funcional — o que
+# inviabilizava TODO write de state no Windows.
+#
+# Os scenarios abaixo shadowam `uname` via PATH stub (o SUT invoca `uname`
+# sem qualificar path, entao o stub vence). PATH original preservado a
+# direita para que sha256sum/shasum/awk continuem resolvendo.
+
+# _hash_stub_uname VALOR -> cria stub de `uname -s` em $TMPDIR_TEST/bin e
+# exporta PATH com ele na frente. Escopo: subshell do scenario corrente.
+_hash_stub_uname() {
+  mkdir -p "$TMPDIR_TEST/bin" || return 1
+  cat >"$TMPDIR_TEST/bin/uname" <<EOF
+#!/bin/sh
+if [ "\$1" = "-s" ]; then
+  printf '%s\\n' '$1'
+  exit 0
+fi
+exec /usr/bin/uname "\$@"
+EOF
+  chmod +x "$TMPDIR_TEST/bin/uname" || return 1
+  PATH="$TMPDIR_TEST/bin:$PATH"
+  export PATH
+}
+
+scenario_sha256_file_mingw_suportado() {
+  _hash_stub_uname "MINGW64_NT-10.0-26200" || return 2
+  _f="$TMPDIR_TEST/w.txt"
+  printf 'hello world\n' >"$_f"
+  _h=$(_hash_sha256_file "$_f")
+  _rc=$?
+  _expected="a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447"
+  if [ "$_rc" != "0" ]; then
+    _fail "exit esperado 0 sob MINGW64, got $_rc"
+    return 1
+  fi
+  if [ "$_h" != "$_expected" ]; then
+    _fail "hash inesperado sob MINGW64: $_h (esperado $_expected)"
+    return 1
+  fi
+}
+
+scenario_sha256_stdin_mingw_suportado() {
+  _hash_stub_uname "MINGW64_NT-10.0-26200" || return 2
+  _h=$(printf 'hello world\n' | _hash_sha256_stdin)
+  _expected="a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447"
+  if [ "$_h" != "$_expected" ]; then
+    _fail "hash inesperado sob MINGW64 (stdin): $_h (esperado $_expected)"
+    return 1
+  fi
+}
+
+scenario_sha256_stdin_msys_suportado() {
+  _hash_stub_uname "MSYS_NT-10.0-26200" || return 2
+  _h=$(printf 'hello world\n' | _hash_sha256_stdin)
+  _expected="a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447"
+  if [ "$_h" != "$_expected" ]; then
+    _fail "hash inesperado sob MSYS: $_h (esperado $_expected)"
+    return 1
+  fi
+}
+
+scenario_sha256_stdin_cygwin_suportado() {
+  _hash_stub_uname "CYGWIN_NT-10.0" || return 2
+  _h=$(printf 'hello world\n' | _hash_sha256_stdin)
+  _expected="a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447"
+  if [ "$_h" != "$_expected" ]; then
+    _fail "hash inesperado sob CYGWIN: $_h (esperado $_expected)"
+    return 1
+  fi
+}
+
+# Contrato negativo: o fail-closed do ramo `*)` NAO foi afrouxado — um SO
+# genuinamente desconhecido continua exit 2, sem degradar mudo.
+scenario_sha256_stdin_so_desconhecido_exit_2() {
+  _hash_stub_uname "Plan9" || return 2
+  printf 'x\n' | _hash_sha256_stdin >/dev/null 2>&1
+  _rc=$?
+  if [ "$_rc" != "2" ]; then
+    _fail "exit esperado 2 em SO desconhecido, got $_rc"
+    return 1
+  fi
+}
+
 run_all_scenarios

--- a/tests/test_converge-status.sh
+++ b/tests/test_converge-status.sh
@@ -590,4 +590,62 @@ scenario_help_exit0() {
   assert_stderr_contains "Uso:" || return 1
 }
 
+# ==== Issue #157: sha256 em Windows/Git-Bash (MINGW*/MSYS*/CYGWIN*) ====
+#
+# Antes do fix, `uname -s` = MINGW64_NT-* caia no ramo `*)` do case de
+# sha256 e abortava exit 1 ("SO nao suportado"), mesmo com sha256sum
+# presente e funcional. No converge isso tornava a ETAPA 7 (gravar o
+# ConvergenceStatusRecord) INEXECUTAVEL no Windows, sem workaround: o
+# marcador so pode ser escrito por este script.
+#
+# O stub shadowa `uname` via PATH (o SUT o invoca sem qualificar path).
+# PATH original preservado a direita para sha256sum/awk continuarem
+# resolvendo. _cs_run repassa $PATH para o `env -i`, entao exportar PATH
+# no scenario basta.
+
+# _cs_stub_uname VALOR -> cria stub de `uname -s` e o poe na frente
+# do PATH. Escopo: subshell do scenario corrente.
+_cs_stub_uname() {
+  mkdir -p "$TMPDIR_TEST/stubbin" || return 1
+  {
+    printf '#!/bin/sh\n'
+    printf 'if [ "$1" = "-s" ]; then\n'
+    printf "  printf '%%s\\\\n' '%s'\n" "$1"
+    printf '  exit 0\n'
+    printf 'fi\n'
+    printf 'exec /usr/bin/uname "$@"\n'
+  } >"$TMPDIR_TEST/stubbin/uname"
+  chmod +x "$TMPDIR_TEST/stubbin/uname" || return 1
+  PATH="$TMPDIR_TEST/stubbin:$PATH"
+  export PATH
+}
+
+scenario_record_funciona_sob_mingw() {
+  _cs_stub_uname "MINGW64_NT-10.0-26200" || return 2
+  _repo=$(_cs_make_repo)
+  _fd=$(_cs_make_feature "$_repo" feat-mingw)
+  _cs_run "$_repo" record --feature-dir "$_fd" --outcome clean --provenance gate --actionable 0
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 sob MINGW64, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
+  grep -Eq '^<!-- converge-status: outcome=clean; provenance=gate; at=.*; actionable=0; tasks-digest=[0-9a-f]{12} -->$' \
+    "$_fd/converge-report.md" || { _fail "format" "marcador nao gravado/malformado sob MINGW64"; return 1; }
+}
+
+scenario_record_funciona_sob_cygwin() {
+  _cs_stub_uname "CYGWIN_NT-10.0" || return 2
+  _repo=$(_cs_make_repo)
+  _fd=$(_cs_make_feature "$_repo" feat-cygwin)
+  _cs_run "$_repo" record --feature-dir "$_fd" --outcome clean --provenance gate --actionable 0
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 sob CYGWIN, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
+}
+
+# Contrato negativo: o fail-closed do ramo `*)` NAO foi afrouxado.
+scenario_record_so_desconhecido_ainda_falha() {
+  _cs_stub_uname "Plan9" || return 2
+  _repo=$(_cs_make_repo)
+  _fd=$(_cs_make_feature "$_repo" feat-plan9)
+  _cs_run "$_repo" record --feature-dir "$_fd" --outcome clean --provenance gate --actionable 0
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "exit" "esperado falha em SO desconhecido, obtido 0"; return 1; }
+  assert_stderr_contains "SO nao suportado para sha256" || return 1
+}
+
 run_all_scenarios

--- a/tests/test_converge-tasks.sh
+++ b/tests/test_converge-tasks.sh
@@ -377,4 +377,53 @@ scenario_next_phase_sem_flag_tasks_exit2() {
   [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
 }
 
+# ==== Issue #157: sha256 em Windows/Git-Bash (MINGW*/MSYS*/CYGWIN*) ====
+#
+# _ct_sha256_12 (usado por gap-key) tinha o mesmo case Linux|Darwin de
+# converge-status.sh: sob `uname -s` = MINGW64_NT-* caia no ramo `*)` e
+# abortava exit 1, mesmo com sha256sum presente. O stub shadowa `uname`
+# via PATH (o SUT o invoca sem qualificar path); PATH original preservado
+# a direita para sha256sum/awk continuarem resolvendo.
+
+# _ct_stub_uname VALOR -> cria stub de `uname -s` e o poe na frente do
+# PATH. Escopo: subshell do scenario corrente.
+_ct_stub_uname() {
+  mkdir -p "$TMPDIR_TEST/stubbin" || return 1
+  {
+    printf '#!/bin/sh\n'
+    printf 'if [ "$1" = "-s" ]; then\n'
+    printf "  printf '%%s\\\\n' '%s'\n" "$1"
+    printf '  exit 0\n'
+    printf 'fi\n'
+    printf 'exec /usr/bin/uname "$@"\n'
+  } >"$TMPDIR_TEST/stubbin/uname"
+  chmod +x "$TMPDIR_TEST/stubbin/uname" || return 1
+  PATH="$TMPDIR_TEST/stubbin:$PATH"
+  export PATH
+}
+
+scenario_gap_key_funciona_sob_mingw() {
+  _ct_stub_uname "MINGW64_NT-10.0-26200" || return 2
+  capture "$SCRIPT" gap-key --path "scripts/foo.sh" --type missing --origin "FR-007"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 sob MINGW64, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) : ;;
+    *) _fail "formato" "esperado 12 chars hex sob MINGW64, obtido: $_CAPTURED_STDOUT"; return 1 ;;
+  esac
+}
+
+scenario_gap_key_funciona_sob_msys() {
+  _ct_stub_uname "MSYS_NT-10.0-26200" || return 2
+  capture "$SCRIPT" gap-key --path "scripts/foo.sh" --type missing --origin "FR-007"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 sob MSYS, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
+}
+
+# Contrato negativo: o fail-closed do ramo `*)` NAO foi afrouxado.
+scenario_gap_key_so_desconhecido_ainda_falha() {
+  _ct_stub_uname "Plan9" || return 2
+  capture "$SCRIPT" gap-key --path "scripts/foo.sh" --type missing --origin "FR-007"
+  [ "$_CAPTURED_EXIT" != 0 ] || { _fail "exit" "esperado falha em SO desconhecido, obtido 0"; return 1; }
+  assert_stderr_contains "SO nao suportado para sha256" || return 1
+}
+
 run_all_scenarios

--- a/tests/test_validate.sh
+++ b/tests/test_validate.sh
@@ -129,4 +129,83 @@ scenario_stderr_limpo_em_docs_validos() {
   esac
 }
 
+# ==== Issue #156: subgraph...end em flowchart/graph ====
+#
+# A checagem 1b (balanco de blocos) roda para TODO bloco mermaid, nao so
+# para sequenceDiagram. Antes do fix ela so reconhecia alt|loop|par|opt|
+# critical|rect como abridores, mas contava QUALQUER `end` isolado como
+# fechador — logo um flowchart com N subgraphs validos reportava
+# "0 abertos, N fechados" e bloqueava o doc com ERRO falso (exit 1).
+#
+# Um segundo defeito, da mesma checagem, foi encontrado ao corrigir o
+# primeiro: o idioma gsub(/(^|\n)...(\n|$)/) consumia o \n terminal do
+# match, entao linhas ADJACENTES so contavam uma vez (`^` em awk casa
+# inicio da STRING, nao de linha). Isso subcontava o `end` de subgraph
+# ANINHADO. Por isso ha scenario dedicado para o caso aninhado.
+
+# _vd_write_mermaid ARQUIVO CORPO -> escreve um .md com um unico bloco
+# ```mermaid contendo CORPO em $TMPDIR_TEST.
+_vd_write_mermaid() {
+  {
+    printf '# Doc\n\n'
+    printf '```mermaid\n'
+    printf '%s\n' "$2"
+    printf '```\n'
+  } >"$TMPDIR_TEST/$1"
+}
+
+scenario_mermaid_flowchart_subgraph_valido() {
+  _vd_write_mermaid "flow.md" 'flowchart TD
+  subgraph A[Front]
+    A1[UI] --> A2[API]
+  end
+  subgraph B[Back]
+    B1[svc] --> B2[db]
+  end
+  A2 --> B1'
+  assert_exit 0 sh "$SCRIPT" "$TMPDIR_TEST/flow.md" || return 1
+  assert_stdout_not_contains "sem \`end\` correspondente" || return 1
+}
+
+scenario_mermaid_subgraph_aninhado_valido() {
+  _vd_write_mermaid "nested.md" 'flowchart TD
+  subgraph Out[Externo]
+    subgraph In[Interno]
+      X --> Y
+    end
+  end'
+  assert_exit 0 sh "$SCRIPT" "$TMPDIR_TEST/nested.md" || return 1
+  assert_stdout_not_contains "sem \`end\` correspondente" || return 1
+}
+
+scenario_mermaid_subgraph_sem_titulo_valido() {
+  _vd_write_mermaid "bare.md" 'graph LR
+  subgraph
+    X --> Y
+  end'
+  assert_exit 0 sh "$SCRIPT" "$TMPDIR_TEST/bare.md" || return 1
+  assert_stdout_not_contains "sem \`end\` correspondente" || return 1
+}
+
+# Contratos negativos: o fix NAO pode cegar a checagem. Desbalanco real
+# — em subgraph ou em alt — continua sendo ERRO com exit 1.
+
+scenario_mermaid_subgraph_sem_end_ainda_erro() {
+  _vd_write_mermaid "unclosed-subgraph.md" 'flowchart TD
+  subgraph A[Front]
+    X --> Y'
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/unclosed-subgraph.md" || return 1
+  assert_stdout_contains "sem \`end\` correspondente" || return 1
+}
+
+scenario_mermaid_alt_sem_end_ainda_erro() {
+  _vd_write_mermaid "unclosed-alt.md" 'sequenceDiagram
+  participant A
+  participant B
+  alt caso
+    A->>B: x'
+  assert_exit 1 sh "$SCRIPT" "$TMPDIR_TEST/unclosed-alt.md" || return 1
+  assert_stdout_contains "sem \`end\` correspondente" || return 1
+}
+
 run_all_scenarios


### PR DESCRIPTION
Corrige as duas issues abertas automaticamente pelo agente-00C. Ambas foram
reproduzidas empiricamente antes de qualquer edicao.

## #156 — `validate-docs-rendered`: `subgraph…end` contado como `end` orfao

A checagem 1b (balanco de blocos mermaid) roda para **todo** bloco
` ```mermaid `, nao so para `sequenceDiagram` — mas so reconhecia
`alt|loop|par|opt|critical|rect` como abridores, contando qualquer `end`
isolado como fechador. Flowchart com N subgraphs validos => `0 abertos, N
fechados`, exit 1.

**Segundo defeito, achado ao corrigir o primeiro** (nao esta na issue): o
idioma `gsub(/(^|\n)…(\n|$)/)` consome o `\n` terminal do match, e `^` em
awk casa inicio da **string**, nao de linha — entao linhas **adjacentes**
contavam uma so vez. Medido: `end\n  end` -> 1. Ou seja, `subgraph`
**aninhado** seguiria falso-positivo mesmo aplicando so o fix proposto na
issue.

A contagem passou a ser linha-a-linha, com `subgraph` entre os abridores.
`else`/`and` ficam de fora de proposito: sao continuacoes, nao abrem novo
`end`.

Efeito medido em docs **deste proprio repo**, que a propria skill bloqueava:

| Doc | antes | depois |
|---|---|---|
| `docs/fluxo-orquestradores-00c.md` | exit 1, 2 `end` falsos | exit 0 |
| `CONTRIBUTING.md` | exit 1, 1 falso | exit 0 |
| `CONTRIBUTING.pt-BR.md` | exit 1, 1 falso | exit 0 |

**Limitacao deliberada**: `box … end` (agrupamento de participants em
`sequenceDiagram`) tem o mesmo problema, mas incluir `box` criaria
falso-positivo em flowchart com no chamado `box` — `subgraph` e palavra
reservada, `box` nao. Ficou fora.

## #157 — sha256 so reconhecia `Linux|Darwin`

Em Git Bash no Windows (`MINGW64_NT-*`) o `case` caia no ramo `*)` e
abortava, mesmo com `sha256sum` presente e funcional em `/usr/bin`.

A issue cita `converge-status.sh` e o impacto na ETAPA 7 da skill
`converge` (gravar o `ConvergenceStatusRecord`, sem workaround possivel).
Mas **o mesmo `case` existe em 4 sitios**, e `_hash.sh` esta no caminho de
**todo write de state 00c** — corrigir so o sitio citado faria a onda
travar um passo adiante:

- `converge/scripts/converge-status.sh` — `_cs_tasks_digest`
- `converge/scripts/converge-tasks.sh` — `_ct_sha256_12`
- `agente-00c-runtime/scripts/_hash.sh` — `_hash_sha256_file`, `_hash_sha256_stdin`

Varredura confirma que nao ha 5o sitio: `cli/lib/00c-bootstrap.sh:441` usa
`uname -s` so para escolher a mensagem de "instale jq", e seu `*)` generico
ja cobre o caso.

O **fail-closed do ramo `*)` nao foi afrouxado** — SO genuinamente
desconhecido (ex.: `Plan9`) continua falhando. Nao adotei deteccao por
capacidade (`command -v`) para nao trocar semantica de erro deterministica
por degradacao silenciosa.

## Verificacao

- **Mutation test**: revertendo os fixes, os 12 cenarios novos falham; com
  eles, passam. Nenhum e um teste que passaria de qualquer jeito.
- **Contratos negativos** cobertos: desbalanco real de `subgraph`/`alt`
  continua ERRO; SO desconhecido continua exit != 0.
- **Suite completa**: `PASS: 3425  FAIL: 0  ERROR: 0  ORPHANS: 0` (999s).
- **shellcheck** limpo nos arquivos tocados (`SC2329` em `report()` e
  pre-existente na `main`).

CHANGELOG nao foi tocado — neste repo a entrada de versao entra no commit
`docs(changelog)` do release.

Closes #156
Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CswUhKJf9bDArX7hXj42Dd
