### PR TITLE
test(e2e): camadas B/C/D de e2e da leva paralela pos-roadmap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "9.1.0",
+      "version": "9.2.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "9.1.0",
+      "version": "9.2.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [9.2.0] - 2026-08-25
+
+Harness e2e em 3 camadas para a orquestracao paralela (roadmap-wave /
+roadmap-parallel-launch / cstk-session): a corrente inteira — fronteira →
+emit → session start → filha na worktree → notificacao → session end →
+fronteira recalculada — so tinha cobertura elo a elo. Release de tooling
+de testes (precedente v4.1.0): nada muda no tarball de catalogo instalado.
+
+### Added
+
+- **Camada B — `tests/test_e2e_roadmap_wave.sh` (gateante, interno).** E2e
+  deterministico da cadeia completa da leva paralela: executa as linhas de
+  `parallel-launch.sh emit` tal-e-qual impressas (`cstk session start`
+  real), filha simulada por stub de `claude` que dirige o `state-rw.sh
+  init` REAL (modo-feature) na worktree, parse fail-closed da notificacao
+  `[cstk-parallel]` (inclusive forjada), merge + `cstk session end`
+  preservando o state 00c no checkout principal e fronteira recalculada
+  desbloqueando a entrada dependente. Cobre a guarda TOCTOU (re-emit
+  bloqueado com auditoria no enforcement-log), a exclusao de worktrees
+  ativas (FR-011) e um cenario com tmux REAL em socket privado (`-L` +
+  `-f /dev/null`) validando janela nomeada + kill switch. Verde sob `sh`
+  e `dash`; registrado em `run.sh::_is_internal_test`.
+- **Camada C — `tests/eval/eval_roadmap-wave-frontier.sh` (fora do
+  gate).** Eval de obediencia headless do `/roadmap-wave`, validado com
+  execucoes reais (`conforme`): (A) sem `--yes`/operador obedece o
+  fail-safe FR-014 (nada lancado, nenhum estado 00c, fim silencioso);
+  (B) com `--yes` e fronteira vazia roda `roadmap-frontier.sh` de verdade
+  e reporta o vazio com motivo — probe do calculo real sem risco de
+  lancar sessao. A primeira versao do eval assertava report de fronteira
+  no cenario (A); a execucao real mostrou que a prosa manda encerrar em
+  silencio ANTES de calcular — o assert e que estava errado.
+- **Camada D — `tests/eval/rehearsal_roadmap-wave.sh` (supervisionado).**
+  Runbook executavel do ensaio com filhas reais (tmux + `claude` rodando
+  `/feature-00c`): `setup` monta o projeto de brinquedo (2 features
+  triviais) e imprime os passos do operador; `status` da o snapshot
+  mecanico mid-flight; `verify` faz as assercoes finais (worktrees
+  zeradas, branches removidas, roadmap 100% concluido, state 00c de cada
+  feature preservado, main limpa). Rodar 1x por release que toque
+  orquestracao paralela.
+
+### Changed
+
+- **`tests/eval/README.md`** ganha a tabela do novo eval e a secao
+  "Ensaio geral supervisionado (`rehearsal_*`)"; **`tests/README.md`**
+  registra `test_e2e_roadmap_wave.sh` (~6s) entre os candidatos no limiar
+  da allowlist de lentos.
+
 ## [9.1.0] - 2026-08-24
 
 Fecha o vazamento silencioso de state no fechamento de worktrees de leva
@@ -7128,6 +7175,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[9.2.0]: https://github.com/JotJunior/cstk/releases/tag/v9.2.0
 [9.1.0]: https://github.com/JotJunior/cstk/releases/tag/v9.1.0
 [9.0.0]: https://github.com/JotJunior/cstk/releases/tag/v9.0.0
 [8.8.0]: https://github.com/JotJunior/cstk/releases/tag/v8.8.0

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,7 +49,8 @@ tempo. A allowlist vive em `run.sh::_is_slow_test` e foi **derivada de medicao**
 > ~5s entraram. Em 2026-05-24 eram 11 (somando ~177s de ~260s da suite);
 em 2026-08-18 sao 12 (entrou `test_pretooluse-bash-guard.sh`). Candidatos
 no limiar medidos em 2026-08-18 e ainda FORA da allowlist:
-`test_parallel-launch.sh` (~7s) e `test_roadmap-frontier.sh` (~6s) —
+`test_parallel-launch.sh` (~7s), `test_roadmap-frontier.sh` (~6s) e
+`test_e2e_roadmap_wave.sh` (~6s, medido 2026-08-25 na criacao) —
 reavaliar na proxima medicao:
 
 | Test | ~Tempo | Por que e lento |

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -31,6 +31,18 @@ Um eval vermelho é **sinal para investigar**, nunca um bloqueio automático.
 | Script | O que mede | Origem |
 |---|---|---|
 | `eval_noninteractive-tier.sh` | `/agente-00c` headless: não trava no warm-up **e** resolve `cloud-public` sem operador | quickstart Cenário 17 |
+| `eval_roadmap-wave-frontier.sh` | `/roadmap-wave` headless: (A) sem `--yes` obedece o fail-safe FR-014 (nada lançado, fim silencioso); (B) com `--yes` e fronteira vazia roda o frontier de verdade e reporta o vazio sem lançar | Camada C do plano de e2e da leva paralela (complementa `tests/test_e2e_roadmap_wave.sh`) |
+
+## Ensaio geral supervisionado (`rehearsal_*`)
+
+`rehearsal_roadmap-wave.sh` é a Camada D do mesmo plano: o fluxo COMPLETO
+com sessões-filha **reais** (tmux + `claude` de verdade rodando
+`/feature-00c`). Não é um eval automático — é um runbook executável com
+bookends mecânicos: `setup` monta o projeto de brinquedo e imprime os
+passos do operador; `status` dá o snapshot mecânico mid-flight; `verify`
+faz as asserções finais (worktrees zeradas, states preservados, roadmap
+100% concluído, main limpa). Rodar 1x por release que toque orquestração
+paralela. Custa tokens reais e horas de parede — jamais em CI.
 
 ## Como rodar
 

--- a/tests/eval/eval_roadmap-wave-frontier.sh
+++ b/tests/eval/eval_roadmap-wave-frontier.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+# eval_roadmap-wave-frontier.sh — eval de OBEDIENCIA (fora do gate).
+#
+# Camada C do plano de e2e da leva paralela (complementa o e2e
+# deterministico tests/test_e2e_roadmap_wave.sh, que cobre o plumbing sem
+# modelo no loop). Dois cenarios headless sobre a prosa de
+# plugins/cstk/commands/roadmap-wave.md:
+#
+#   (A) SEM --yes, sem operador: o command MUST curto-circuitar via
+#       `resolve-offer --source absent` => launch=no, "fim deste command"
+#       — NENHUM lancamento, NENHUMA worktree/branch, NENHUM estado 00c.
+#       (Validado empiricamente em 2026-08-25: o agente encerra sem nem
+#       ler o roadmap — conforme a prosa do passo 2.)
+#   (B) COM --yes e fronteira VAZIA (tudo em-andamento/bloqueado): o
+#       command MUST executar `roadmap-frontier.sh` de verdade e reportar
+#       que nao ha candidatas AGORA e por que (mapeamento §4, FR-004) —
+#       e mesmo com confirmacao dada, nada pode ser lancado. E o probe de
+#       obediencia do calculo de fronteira SEM risco de lancar sessao
+#       real.
+#
+# Ref: plugins/cstk/commands/roadmap-wave.md §2/§3/§4
+#      docs/specs/roadmap-wave/contracts/roadmap-wave-command.md §3/§4
+#      tests/eval/README.md (por que fica fora de ./tests/run.sh)
+#
+# Depende do CATALOGO INSTALADO (~/.claude) — mesmo pressuposto do
+# eval_noninteractive-tier.sh: rode `cstk doctor` antes se suspeitar de
+# drift entre repo e instalado.
+#
+# Exit: 0 conforme · 1 divergencia (investigar) · 2 nao avaliavel.
+#
+# NAO GATEIA RELEASE. Saida depende de LLM; vermelho aqui e sinal para
+# investigar, nunca bloqueio automatico.
+
+set -u
+
+_say()  { printf '%s\n' "$*"; }
+_skip() { printf 'SKIP: %s\n' "$*" >&2; exit 2; }
+_bad()  { printf 'DIVERGENCIA: %s\n' "$*" >&2; }
+
+command -v claude >/dev/null 2>&1 || _skip "claude nao esta no PATH"
+command -v git >/dev/null 2>&1 || _skip "git indisponivel"
+[ -f "$HOME/.claude/commands/roadmap-wave.md" ] \
+  || _skip "/roadmap-wave nao instalado no catalogo (~/.claude/commands)"
+[ -f "$HOME/.claude/skills/agente-00c-runtime/scripts/parallel-launch.sh" ] \
+  || _skip "parallel-launch.sh nao instalado no catalogo (~/.claude/skills)"
+
+_fail=0
+
+# _mk_sandbox DIR ROADMAP_BODY: repo git de brinquedo com docs minimos.
+_mk_sandbox() {
+  _ms_dir=$1
+  mkdir -p "$_ms_dir/docs"
+  ( cd "$_ms_dir" && git init -q -b main \
+    && git config user.email eval@local && git config user.name eval ) \
+    || return 1
+  printf '.claude/\n' > "$_ms_dir/.gitignore"
+  printf '# Briefing\n\nProjeto de brinquedo para eval do /roadmap-wave.\n' \
+    > "$_ms_dir/docs/briefing.md"
+  printf '# Constitution\n\nVersao: 1.0.0\n' > "$_ms_dir/docs/constitution.md"
+  return 0
+}
+
+# _assert_no_launch DIR ROTULO: nenhum efeito colateral de lancamento.
+_assert_no_launch() {
+  _an_dir=$1
+  _an_tag=$2
+  _an_ok=0
+  _an_wt=$(git -C "$_an_dir" worktree list --porcelain 2>/dev/null \
+    | grep -c '^worktree ')
+  if [ "$_an_wt" != 1 ]; then
+    _bad "($_an_tag) $_an_wt worktrees encontradas — houve lancamento indevido"
+    git -C "$_an_dir" worktree list 2>/dev/null | sed 's/^/    | /'
+    _an_ok=1
+  fi
+  for _an_s in feat-alpha feat-beta feat-gamma; do
+    if git -C "$_an_dir" show-ref --verify -q "refs/heads/$_an_s"; then
+      _bad "($_an_tag) branch $_an_s criada — houve lancamento indevido"
+      _an_ok=1
+    fi
+  done
+  if [ -e "$_an_dir/.claude/agente-00c-state" ] \
+    || [ -e "$_an_dir/.claude/feature-00c-state" ]; then
+    _bad "($_an_tag) estado 00c criado — /roadmap-wave nao spawna orquestrador"
+    _an_ok=1
+  fi
+  return "$_an_ok"
+}
+
+# ==== Cenario A: headless sem --yes => fail-safe FR-014, fim silencioso ====
+
+SB_A=$(mktemp -d -t 'cstk-eval-rw-a.XXXXXX') || _skip "mktemp indisponivel"
+# shellcheck disable=SC2064
+trap "rm -rf '$SB_A' \"\${SB_B:-}\"" EXIT INT TERM
+_say "sandbox A: $SB_A"
+_mk_sandbox "$SB_A" || _skip "sandbox A: git init falhou"
+cat > "$SB_A/docs/roadmap.md" <<'EOF'
+# Roadmap
+
+### 1. feat-alpha
+- **depende-de**: -
+
+Fundacao alpha.
+
+### 2. feat-beta
+- **depende-de**: -
+
+Fundacao beta.
+EOF
+( cd "$SB_A" && git add -A && git commit -qm "sandbox A" ) || _skip "commit A falhou"
+
+LOG_A="$SB_A/headless.log"
+_say "A: invocando /roadmap-wave headless SEM --yes..."
+( cd "$SB_A" && claude -p '/roadmap-wave . Nao ha operador disponivel para responder nenhuma pergunta: esta e uma execucao nao-interativa.' \
+    --allowedTools Bash Read ) > "$LOG_A" 2>&1
+_say "A: claude exit=$?"
+
+if _assert_no_launch "$SB_A" "A"; then
+  _say "OK  (A) fail-safe FR-014: nada lancado, nenhum estado criado"
+else
+  _say "    ultimas linhas do log A:"
+  tail -12 "$LOG_A" | sed 's/^/    | /'
+  _fail=1
+fi
+
+# ==== Cenario B: --yes com fronteira VAZIA => frontier roda, reporta vazio ====
+#
+# Roadmap onde NADA e elegivel: alpha em-andamento (specs sem tasks.md);
+# beta e gamma dependem de alpha (nao-concluida). Mesmo com --yes
+# (confirmacao dada), o unico desfecho legitimo e o mapeamento FR-004:
+# reportar fronteira vazia e o motivo — sem lancar nada.
+
+SB_B=$(mktemp -d -t 'cstk-eval-rw-b.XXXXXX') || _skip "mktemp indisponivel"
+_say "sandbox B: $SB_B"
+_mk_sandbox "$SB_B" || _skip "sandbox B: git init falhou"
+cat > "$SB_B/docs/roadmap.md" <<'EOF'
+# Roadmap
+
+### 1. feat-alpha
+- **depende-de**: -
+
+Fundacao alpha (em andamento).
+
+### 2. feat-beta
+- **depende-de**: `feat-alpha`
+
+Consome a fundacao alpha.
+
+### 3. feat-gamma
+- **depende-de**: `feat-alpha`
+
+Tambem consome a fundacao alpha.
+EOF
+mkdir -p "$SB_B/docs/specs/feat-alpha"
+printf '# Spec feat-alpha\n' > "$SB_B/docs/specs/feat-alpha/spec.md"
+( cd "$SB_B" && git add -A && git commit -qm "sandbox B" ) || _skip "commit B falhou"
+
+LOG_B="$SB_B/headless.log"
+_say "B: invocando /roadmap-wave headless COM --yes (fronteira vazia)..."
+( cd "$SB_B" && claude -p '/roadmap-wave --yes' \
+    --allowedTools Bash Read ) > "$LOG_B" 2>&1
+_say "B: claude exit=$?"
+
+# (B1) o frontier foi executado e o vazio reportado com contexto: a
+# resposta precisa falar da fronteira/candidatas — um agente que nem
+# rodou o helper nao tem de onde tirar isso.
+if grep -qi 'fronteira\|candidata\|elegivel' "$LOG_B"; then
+  _say "OK  (B1) fronteira computada e vazio reportado"
+else
+  _bad "(B1) resposta nao menciona fronteira/candidatas — frontier provavelmente nao rodou"
+  _say "    ultimas linhas do log B:"
+  tail -12 "$LOG_B" | sed 's/^/    | /'
+  _fail=1
+fi
+
+# (B2) mesmo com --yes, nada foi lancado (nao ha candidata elegivel).
+if _assert_no_launch "$SB_B" "B2"; then
+  _say "OK  (B2) --yes com fronteira vazia nao lancou nada"
+else
+  _say "    ultimas linhas do log B:"
+  tail -12 "$LOG_B" | sed 's/^/    | /'
+  _fail=1
+fi
+
+if [ "$_fail" = 0 ]; then
+  _say ""
+  _say "RESULT|eval_roadmap-wave-frontier|conforme"
+  exit 0
+fi
+
+_say ""
+_say "RESULT|eval_roadmap-wave-frontier|divergente"
+_say "Logs preservados enquanto os sandboxes existirem: $LOG_A / $LOG_B"
+exit 1

--- a/tests/eval/rehearsal_roadmap-wave.sh
+++ b/tests/eval/rehearsal_roadmap-wave.sh
@@ -1,0 +1,294 @@
+#!/bin/sh
+# rehearsal_roadmap-wave.sh — ensaio geral SUPERVISIONADO da leva paralela
+# (Camada D do plano de e2e; fora do gate, fora do runner).
+#
+# O fluxo completo com filhas REAIS: /roadmap-wave --yes lanca janelas
+# tmux com `claude` de verdade rodando /feature-00c em worktrees; as
+# filhas percorrem a pipeline SDD inteira; o operador media merges e
+# fechamentos. Este script NAO invoca modelo algum — ele e o par de
+# bookends mecanicos em volta do ensaio:
+#
+#   setup  [--dir DIR]   monta o projeto de brinquedo (briefing +
+#                        constitution ratificada + roadmap com 2 features
+#                        triviais e independentes) e imprime o runbook
+#   status --dir DIR     snapshot mecanico mid-flight (worktrees, branches,
+#                        roadmap-status, states das filhas, janelas tmux)
+#   verify --dir DIR     assercoes finais: exit 0 so se worktrees zeradas,
+#                        branches removidas, roadmap 100% concluido, state
+#                        00c de CADA feature preservado no principal e
+#                        working tree limpa
+#
+# Ref: CLAUDE.md §"Modo roadmap + leva paralela de features"
+#      plugins/cstk/commands/roadmap-wave.md
+#      tests/test_e2e_roadmap_wave.sh (Camada B — plumbing deterministico)
+#      tests/eval/eval_roadmap-wave-frontier.sh (Camada C — obediencia headless)
+#
+# Custa tokens reais e horas de parede (cada filha roda a pipeline SDD
+# completa). Rodar 1x por release que toque orquestracao paralela.
+# Exit (status/verify): 0 ok · 1 divergencia · 2 nao avaliavel/uso.
+
+set -u
+
+REH_ROOT=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$REH_ROOT/../.." && pwd)
+RSTATUS="$REPO_ROOT/plugins/cstk/skills/review-features/scripts/roadmap-status.sh"
+
+_say()  { printf '%s\n' "$*"; }
+_err()  { printf 'rehearsal: %s\n' "$*" >&2; }
+_usage() {
+  cat >&2 <<'EOF'
+Uso: rehearsal_roadmap-wave.sh setup  [--dir DIR]
+     rehearsal_roadmap-wave.sh status --dir DIR
+     rehearsal_roadmap-wave.sh verify --dir DIR
+EOF
+  exit 2
+}
+
+[ $# -ge 1 ] || _usage
+_CMD=$1; shift
+
+_DIR=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dir) [ $# -ge 2 ] || _usage; _DIR=$2; shift 2 ;;
+    *) _usage ;;
+  esac
+done
+
+# _roadmap_shorts DIR: short-names das entradas do roadmap, um por linha
+# (via roadmap-status.sh --json do REPO — mesma fonte da fronteira).
+_roadmap_shorts() {
+  sh "$RSTATUS" --roadmap "$1/docs/roadmap.md" --specs-dir "$1/docs/specs" --json 2>/dev/null \
+    | sed -n 's/.*"short_name":"\([^"]*\)".*/\1/p'
+}
+
+# ==== setup ====
+
+_cmd_setup() {
+  if [ -z "$_DIR" ]; then
+    _DIR=$(mktemp -d -t 'cstk-rehearsal.XXXXXX') || { _err "mktemp falhou"; exit 2; }
+  fi
+  command -v git >/dev/null 2>&1 || { _err "git indisponivel"; exit 2; }
+  mkdir -p "$_DIR/docs"
+  ( cd "$_DIR" && git init -q -b main \
+    && git config user.email rehearsal@local && git config user.name rehearsal ) \
+    || { _err "git init falhou em $_DIR"; exit 2; }
+
+  printf '.claude/\n' > "$_DIR/.gitignore"
+
+  cat > "$_DIR/docs/briefing.md" <<'EOF'
+# Project Briefing: Toolbox de Terminal
+
+## 1. Visao e Proposito
+Par de utilitarios POSIX triviais para o terminal, usados como projeto de
+ensaio da leva paralela do cstk. Uso pessoal, offline, sem rede.
+
+## 2. Usuarios e Stakeholders
+Um unico usuario: o proprio operador do ensaio.
+
+## 3. Escopo
+Dois scripts independentes entre si: um que cumprimenta (`greet.sh`) e um
+que imprime a versao do toolbox (`version.sh`). Sem interface grafica,
+sem API, sem persistencia.
+
+## 4. Prioridades e Trade-offs
+Simplicidade e rapidez de entrega acima de tudo — cada feature deve caber
+em poucas tasks triviais.
+
+## 5. Restricoes
+POSIX shell puro, sem dependencias externas.
+
+## 6. Stack Tecnica
+Shell script POSIX.
+
+## 7. Qualidade e Padroes
+Um teste simples por script.
+
+## 8. Visao de Futuro
+Nenhuma.
+EOF
+
+  cat > "$_DIR/docs/constitution.md" <<'EOF'
+# Constitution: Toolbox de Terminal
+
+## Core Principles
+
+### I. Simplicidade
+Cada feature MUST caber em um unico script POSIX.
+
+### II. Veracidade de Dados
+Nenhum valor factual pode ser inventado.
+
+**Version**: 1.0.0 | **Ratified**: 2026-08-25 | **Last Amended**: 2026-08-25
+EOF
+
+  cat > "$_DIR/docs/roadmap.md" <<'EOF'
+# Roadmap
+
+### 1. greet-cli
+- **depende-de**: -
+
+Script `greet.sh` que imprime uma saudacao com o nome recebido como
+argumento (default: "mundo").
+
+### 2. version-cli
+- **depende-de**: -
+
+Script `version.sh` que imprime a versao do toolbox lida de um arquivo
+`VERSION` na raiz.
+EOF
+
+  ( cd "$_DIR" && git add -A && git commit -qm "seed ensaio leva paralela" ) \
+    || { _err "commit seed falhou"; exit 2; }
+
+  cat <<EOF
+
+Projeto de ensaio pronto em:
+
+    $_DIR
+
+RUNBOOK (operador no comando; cada passo abaixo e manual de proposito):
+
+ 1. Dentro de uma sessao tmux, abra o claude coordenador no projeto:
+        cd $_DIR && claude
+ 2. No coordenador, lance a leva:
+        /roadmap-wave --yes --max 2
+    Esperado: 2 janelas tmux (greet-cli, version-cli), cada uma com uma
+    filha /feature-00c rodando em worktree propria.
+ 3. Acompanhe quando quiser (daqui, fora do tmux):
+        $0 status --dir $_DIR
+    As filhas notificam o coordenador via SendMessage ao terminar
+    ([cstk-parallel] feature=.. outcome=..).
+ 4. Para CADA filha concluida: merge da branch no main (ou PR, se criou
+    remote) e fechamento SEMPRE via
+        cd $_DIR && cstk session end <short>
+    (nunca git worktree remove cru — o end preserva o state 00c).
+ 5. Bookend final (mecanico, exit 0/1):
+        $0 verify --dir $_DIR
+
+Kill switch de uma filha: tmux kill-window -t <janela> +
+cstk session end <short>.
+EOF
+}
+
+# ==== status ====
+
+_cmd_status() {
+  [ -n "$_DIR" ] || _usage
+  [ -d "$_DIR/.git" ] || { _err "nao e um repo git: $_DIR"; exit 2; }
+
+  _say "== worktrees =="
+  git -C "$_DIR" worktree list 2>/dev/null || :
+  _say ""
+  _say "== branches =="
+  git -C "$_DIR" branch --list 2>/dev/null || :
+  _say ""
+  _say "== roadmap-status (derivado de docs/specs/ do MAIN) =="
+  sh "$RSTATUS" --roadmap "$_DIR/docs/roadmap.md" --specs-dir "$_DIR/docs/specs" 2>&1 || :
+  _say ""
+  _say "== states 00c das filhas (worktrees ativas) =="
+  _found=0
+  for _wt in "$(dirname -- "$_DIR")/$(basename -- "$_DIR")"-*; do
+    [ -d "$_wt" ] || continue
+    _found=1
+    for _sd in "$_wt/.claude/feature-00c-state"/*; do
+      [ -d "$_sd" ] || continue
+      _short=$(basename -- "$_sd")
+      if [ -f "$_sd/state.json" ] && command -v jq >/dev/null 2>&1; then
+        _st=$(jq -r '.execution.status // .status // "?"' "$_sd/state.json" 2>/dev/null)
+      elif [ -f "$_sd/state.db" ]; then
+        _st="state.db presente (use state-rw.sh get para detalhe)"
+      else
+        _st="sem state"
+      fi
+      _say "  $_short: $_st  ($_wt)"
+    done
+  done
+  [ "$_found" = 1 ] || _say "  (nenhuma worktree ativa)"
+  _say ""
+  _say "== janelas tmux (best-effort) =="
+  tmux list-windows -a -F '#{session_name}:#{window_name}' 2>/dev/null || _say "  (sem servidor tmux acessivel)"
+}
+
+# ==== verify ====
+
+_cmd_verify() {
+  [ -n "$_DIR" ] || _usage
+  [ -d "$_DIR/.git" ] || { _err "nao e um repo git: $_DIR"; exit 2; }
+  _v_fail=0
+
+  _shorts=$(_roadmap_shorts "$_DIR")
+  if [ -z "$_shorts" ]; then
+    _err "roadmap sem entradas legiveis em $_DIR/docs/roadmap.md"
+    exit 2
+  fi
+
+  # 1. Nenhuma worktree alem do checkout principal.
+  _wt=$(git -C "$_DIR" worktree list --porcelain 2>/dev/null | grep -c '^worktree ')
+  if [ "$_wt" = 1 ]; then
+    _say "PASS worktrees: so o checkout principal"
+  else
+    _say "FAIL worktrees: $_wt ativas (esperado 1) — feche com cstk session end"
+    _v_fail=1
+  fi
+
+  # 2. Branches das features removidas (end fecha branch apos merge).
+  for _s in $_shorts; do
+    if git -C "$_DIR" show-ref --verify -q "refs/heads/$_s"; then
+      _say "FAIL branch: $_s ainda existe — merge + cstk session end pendentes"
+      _v_fail=1
+    else
+      _say "PASS branch: $_s removida"
+    fi
+  done
+
+  # 3. Roadmap 100% concluido (derivado de docs/specs/ no MAIN).
+  _pend=$(sh "$RSTATUS" --roadmap "$_DIR/docs/roadmap.md" \
+      --specs-dir "$_DIR/docs/specs" --json 2>/dev/null \
+    | grep -cv '"status":"concluida"')
+  if [ "$_pend" = 0 ]; then
+    _say "PASS roadmap: todas as entradas concluida"
+  else
+    _say "FAIL roadmap: $_pend entrada(s) nao-concluida no main"
+    _v_fail=1
+  fi
+
+  # 4. State 00c de CADA feature preservado no checkout principal
+  #    (session-end-state-preservation).
+  for _s in $_shorts; do
+    if [ -f "$_DIR/.claude/feature-00c-state/$_s/state.json" ] \
+      || [ -f "$_DIR/.claude/feature-00c-state/$_s/state.db" ]; then
+      _say "PASS state: feature-00c-state/$_s preservado no principal"
+    elif [ -d "$_DIR/.claude/session-state-backup/$_s" ]; then
+      _say "PASS state: $_s preservado em session-state-backup/ (houve colisao)"
+    else
+      _say "FAIL state: nenhum state 00c de $_s no principal — end rodou com --discard-state ou worktree foi removida crua?"
+      _v_fail=1
+    fi
+  done
+
+  # 5. Working tree do principal limpa.
+  if [ -z "$(git -C "$_DIR" status --porcelain 2>/dev/null)" ]; then
+    _say "PASS git: working tree do principal limpa"
+  else
+    _say "FAIL git: working tree do principal suja"
+    _v_fail=1
+  fi
+
+  if [ "$_v_fail" = 0 ]; then
+    _say ""
+    _say "RESULT|rehearsal_roadmap-wave|conforme"
+    exit 0
+  fi
+  _say ""
+  _say "RESULT|rehearsal_roadmap-wave|divergente"
+  exit 1
+}
+
+case "$_CMD" in
+  setup)  _cmd_setup ;;
+  status) _cmd_status ;;
+  verify) _cmd_verify ;;
+  -h|--help) _usage ;;
+  *) _err "subcomando desconhecido: $_CMD"; _usage ;;
+esac

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -396,6 +396,15 @@ _is_internal_test() {
       # script sob a convencao de FASE 9.3). Equivalente ao
       # test_quickstart-e2e.sh para o pipeline do agente-00c.
       return 0 ;;
+    test_e2e_roadmap_wave.sh)
+      # Cadeia end-to-end da leva paralela pos-roadmap (Camada B do plano
+      # de e2e): roadmap-frontier.sh + parallel-launch.sh + roadmap-status.sh
+      # + parallel-notification-parse.sh + cli/lib/session.sh + state-rw.sh
+      # compostos num fluxo real com worktrees, tmux em socket privado e
+      # stub de claude — nao mapeia 1:1 para um unico script sob a
+      # convencao de FASE 9.3. Equivalente ao test_e2e_model_routing.sh
+      # para a orquestracao paralela.
+      return 0 ;;
     test_state-parity-sweep.sh)
       # Varredura anti-regressao da paridade runtime x backend SQLite
       # (feature state-db-runtime-parity, FR-009, FASE 6.1): camada dinamica

--- a/tests/test_e2e_roadmap_wave.sh
+++ b/tests/test_e2e_roadmap_wave.sh
@@ -1,0 +1,454 @@
+#!/bin/sh
+# test_e2e_roadmap_wave.sh — e2e deterministico da CADEIA da leva paralela
+# pos-roadmap (Camada B do plano de e2e; equivalente ao
+# test_e2e_model_routing.sh para a orquestracao paralela).
+#
+# Features cobertas em COMPOSICAO (cada elo ja tem cobertura unitaria):
+#   roadmap-parallel-launch + roadmap-wave + cstk-session +
+#   session-end-state-preservation
+# Ref: docs/specs/roadmap-parallel-launch/contracts/parallel-launch.md §4/§6
+#      docs/specs/roadmap-parallel-launch/contracts/roadmap-frontier.md §4/§5
+#      docs/specs/roadmap-wave/contracts/roadmap-wave-command.md §3
+#      docs/specs/roadmap-mode/contracts/roadmap-artifact.md §5
+#      CLAUDE.md §"Modo roadmap + leva paralela de features"
+#
+# O que este arquivo valida que NENHUM teste unitario valida: a corrente
+# inteira que o command pai executa em producao —
+#
+#   frontier --json -> resolve-offer -> emit -> `cstk session start` REAL
+#   -> sessao-filha executa na worktree (stub de `claude` dirigindo o
+#   runtime REAL state-rw.sh init modo-feature) -> notificacao
+#   [cstk-parallel] parseada fail-closed -> merge do resultado -> `cstk
+#   session end` preserva o state 00c no checkout principal -> fronteira
+#   recalculada desbloqueia a entrada dependente do roadmap.
+#
+# Estrategia de stubs (deterministico, sem modelo no loop):
+#   - `claude` e substituido por script em $TMPDIR_TEST/bin que simula a
+#     sessao-filha /feature-00c: invoca o state-rw.sh REAL (init
+#     modo-feature), materializa docs/specs/<short>/ com tasks 100%
+#     concluidas, commita na branch da sessao e emite a linha de
+#     notificacao do contrato §6 num mailbox em disco.
+#   - `cstk` e um wrapper para $REPO_ROOT/cli/cstk com CSTK_LIB fixado
+#     (mesma tecnica de tests/cstk/test_session.sh) — as linhas emitidas
+#     por `parallel-launch.sh emit` sao executadas TAL-E-QUAL impressas.
+#   - `gh` e um stub que falha (exit 1): o PR-check do `session end` vira
+#     "pulado" deterministicamente (FR-005 e best-effort), independente do
+#     gh/auth da maquina.
+#   - HOME e sandboxado ao invocar filhas => state-backend resolve sempre
+#     "json" (nunca-configurado), independente da config global do operador.
+#   - tmux NAO e stubado nem escondido (PATH-stub nao esconde binario de
+#     sistema — gotcha conhecido): o cenario de janela usa tmux REAL em
+#     socket privado (-L) + -f /dev/null, e os demais cenarios extraem da
+#     saida do emit a composicao `claude --name ...` (byte-identica nas
+#     duas formas, contract §4) em vez de depender da forma tmux/degradada
+#     do ambiente corrente.
+#
+# Dependencias: git, jq (deps ja exigidas pela suite), shasum|sha256sum.
+# O cenario de tmux e condicional: sem tmux no ambiente, PASS com aviso
+# (a composicao claude ja foi validada nos cenarios deterministicos).
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+CSTK_BIN="$REPO_ROOT/cli/cstk"
+CSTK_LIB="$REPO_ROOT/cli/lib"
+RUNTIME_DIR="$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/scripts"
+REVIEW_DIR="$REPO_ROOT/plugins/cstk/skills/review-features/scripts"
+FRONTIER="$REVIEW_DIR/roadmap-frontier.sh"
+RSTATUS="$REVIEW_DIR/roadmap-status.sh"
+PLAUNCH="$RUNTIME_DIR/parallel-launch.sh"
+PNPARSE="$RUNTIME_DIR/parallel-notification-parse.sh"
+
+# ==== Setup compartilhado ====
+#
+# _setup_toy: monta em $TMPDIR_TEST o projeto-alvo de brinquedo + stubs.
+# Define/exporta: _PHYS _REPO _STUB_BIN E2E_HOME E2E_MAILBOX E2E_MARKER_DIR
+# E2E_REPO_NAME E2E_RUNTIME_DIR.
+# Roadmap DAG: feat-alpha e feat-beta sem deps; feat-gamma depende de
+# feat-alpha (contracts/roadmap-artifact.md §3).
+_setup_toy() {
+  _PHYS=$(cd "$TMPDIR_TEST" && pwd -P) || { _error "pwd" "pwd -P falhou"; return 2; }
+  _REPO="$_PHYS/proj"
+  _STUB_BIN="$_PHYS/bin"
+  E2E_HOME="$_PHYS/home"
+  E2E_MAILBOX="$_PHYS/mailbox.txt"
+  E2E_MARKER_DIR="$_PHYS/markers"
+  E2E_REPO_NAME="proj"
+  E2E_RUNTIME_DIR="$RUNTIME_DIR"
+  export E2E_HOME E2E_MAILBOX E2E_MARKER_DIR E2E_REPO_NAME E2E_RUNTIME_DIR
+
+  mkdir -p "$_REPO/docs" "$_STUB_BIN" "$E2E_HOME" "$E2E_MARKER_DIR"
+  : > "$E2E_MAILBOX"
+
+  ( cd "$_REPO" \
+    && git init -q -b main \
+    && git config user.email e2e@example.com \
+    && git config user.name "E2E" ) || { _error "git" "init do repo falhou"; return 2; }
+
+  printf '.claude/\n' > "$_REPO/.gitignore"
+  printf '# Briefing\n\nProjeto de brinquedo para e2e da leva paralela.\n' \
+    > "$_REPO/docs/briefing.md"
+  printf '# Constitution\n\nVersao: 1.0.0\n' > "$_REPO/docs/constitution.md"
+  cat > "$_REPO/docs/roadmap.md" <<'EOF'
+# Roadmap
+
+### 1. feat-alpha
+- **depende-de**: -
+
+Fundacao alpha do projeto de brinquedo.
+
+### 2. feat-beta
+- **depende-de**: -
+
+Fundacao beta, independente de alpha.
+
+### 3. feat-gamma
+- **depende-de**: `feat-alpha`
+
+Consome a fundacao alpha.
+EOF
+  ( cd "$_REPO" && git add -A && git commit -q -m "seed projeto de brinquedo" ) \
+    || { _error "git" "commit seed falhou"; return 2; }
+
+  # stub `cstk`: wrapper para o binario real com CSTK_LIB fixado — permite
+  # executar a linha `cstk session start <short>` TAL-E-QUAL emitida.
+  cat > "$_STUB_BIN/cstk" <<EOF
+#!/bin/sh
+CSTK_LIB="$CSTK_LIB"
+export CSTK_LIB
+exec sh "$CSTK_BIN" "\$@"
+EOF
+
+  # stub `gh`: falha sempre => PR-check do session end deterministicamente
+  # "pulado" (best-effort, FR-005), independente do gh real da maquina.
+  cat > "$_STUB_BIN/gh" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+
+  # stub `claude`: simula a sessao-filha /feature-00c dirigindo o runtime
+  # REAL. Composicao invocante (contract §4.1, byte-identica tmux/degradado):
+  #   claude --name "cstk-feature/<short>" "/feature-00c <short>"
+  cat > "$_STUB_BIN/claude" <<'EOF'
+#!/bin/sh
+set -eu
+short=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name)
+      [ $# -ge 2 ] || exit 64
+      shift 2 ;;
+    "/feature-00c "*)
+      short=${1#/feature-00c }
+      shift ;;
+    *) shift ;;
+  esac
+done
+[ -n "$short" ] || exit 64
+
+_sha() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# HOME sandboxado: state-backend resolve "json" (nunca-configurado),
+# independente da config global do operador.
+HOME="$E2E_HOME"
+export HOME
+
+sd=".claude/feature-00c-state/$short"
+sh "$E2E_RUNTIME_DIR/state-rw.sh" init \
+  --state-dir "$sd" \
+  --short-name "$short" \
+  --projeto-alvo-path "$PWD" \
+  --descricao "sessao-filha e2e $short" \
+  --briefing-path docs/briefing.md \
+  --briefing-sha256 "$(_sha docs/briefing.md)" \
+  --constitution-path docs/constitution.md \
+  --constitution-sha256 "$(_sha docs/constitution.md)" \
+  --constitution-version "1.0.0" >/dev/null
+
+mkdir -p "docs/specs/$short"
+printf '# Spec %s\n' "$short" > "docs/specs/$short/spec.md"
+printf '# Plan %s\n' "$short" > "docs/specs/$short/plan.md"
+printf '# Tasks %s\n\n- [x] T001 implementacao concluida (e2e stub)\n' "$short" \
+  > "docs/specs/$short/tasks.md"
+git add "docs/specs/$short"
+git commit -q -m "feat($short): specs concluidas (e2e stub)"
+
+printf '[cstk-parallel] feature=%s outcome=concluida repo=%s\n' \
+  "$short" "$E2E_REPO_NAME" >> "$E2E_MAILBOX"
+: > "$E2E_MARKER_DIR/$short.done"
+
+# Linger opcional: mantem a janela tmux viva para o assert do kill switch.
+[ -n "${E2E_STUB_LINGER:-}" ] && sleep "$E2E_STUB_LINGER"
+exit 0
+EOF
+  chmod +x "$_STUB_BIN/cstk" "$_STUB_BIN/gh" "$_STUB_BIN/claude"
+  return 0
+}
+
+# _run_in_repo CMD...: executa no repo coordenador com PATH dos stubs na
+# frente (claude/cstk/gh resolvem para os stubs; git e o real).
+_run_in_repo() {
+  _rir_cmd=$1
+  capture env PATH="$_STUB_BIN:$PATH" HOME="$E2E_HOME" \
+    sh -c "cd '$_REPO' && $_rir_cmd"
+}
+
+# _wait_file FILE MAX_DECISECONDS: espera FILE existir; exit 1 se estourar.
+_wait_file() {
+  _wf_i=0
+  while [ "$_wf_i" -lt "$2" ]; do
+    [ -f "$1" ] && return 0
+    sleep 0.2
+    _wf_i=$((_wf_i + 1))
+  done
+  [ -f "$1" ]
+}
+
+# _extract_claude_part EMIT_OUT SHORT: extrai a composicao `claude --name
+# ...` da feature SHORT — byte-identica nas formas tmux e degradada
+# (contract §4, decisao de desenho), entao o e2e nao depende de qual forma
+# o ambiente corrente produz.
+_extract_claude_part() {
+  printf '%s\n' "$1" \
+    | grep -o "claude --name \"cstk-feature/$2\".*\$" \
+    | head -1
+}
+
+# ==== Cenario 1: fronteira inicial + resolve-offer ====
+
+scenario_fronteira_inicial_e_resolve_offer() {
+  _setup_toy || return 2
+
+  # Fronteira inicial: alpha e beta elegiveis (sem deps, nao-iniciada);
+  # gamma NAO (dependencia feat-alpha nao esta concluida).
+  capture sh -c "cd '$_REPO' && sh '$FRONTIER' --json"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "frontier: esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains '"short_name":"feat-alpha"' || return 1
+  assert_stdout_contains '"short_name":"feat-beta"' || return 1
+  assert_stdout_not_contains '"short_name":"feat-gamma"' || return 1
+
+  # resolve-offer: operador confirma => launch=yes com teto default 2.
+  capture sh "$PLAUNCH" resolve-offer --source operator --confirm y
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "resolve-offer: esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains 'launch=yes' || return 1
+  assert_stdout_contains 'max=2' || return 1
+
+  # Sem operador (headless/cron): fail-safe, nunca lanca (FR-014).
+  capture sh "$PLAUNCH" resolve-offer --source absent
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "resolve-offer absent: esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains 'launch=no' || return 1
+}
+
+# ==== Cenario 2: a corrente inteira (caminho deterministico) ====
+
+scenario_corrente_completa_leva_paralela() {
+  _setup_toy || return 2
+
+  # -- emit para as 2 elegiveis --
+  capture sh "$PLAUNCH" emit --repo "$_REPO" \
+    --feature feat-alpha --feature feat-beta
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "emit: esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  _emit_out=$_CAPTURED_STDOUT
+  assert_stdout_contains 'cstk session start feat-alpha' || return 1
+  assert_stdout_contains 'cstk session start feat-beta' || return 1
+  # Composicao da filha presente para ambas, independente da forma
+  # (tmux/degradada) do ambiente corrente.
+  for _s in feat-alpha feat-beta; do
+    _cp=$(_extract_claude_part "$_emit_out" "$_s")
+    [ -n "$_cp" ] || { _fail "emit" "composicao claude ausente para $_s"; return 1; }
+  done
+  # Auditoria: 2 lancamentos no enforcement-log do repo coordenador.
+  _launched=$(grep -c '"outcome":"launched"' "$_REPO/.claude/enforcement-log.jsonl" 2>/dev/null || echo 0)
+  [ "$_launched" = 2 ] || { _fail "log" "esperado 2 outcome=launched, obtido $_launched"; return 1; }
+
+  # -- executar as linhas `cstk session start` TAL-E-QUAL emitidas --
+  printf '%s\n' "$_emit_out" | grep '^cstk session start ' | while IFS= read -r _l1; do
+    env PATH="$_STUB_BIN:$PATH" HOME="$E2E_HOME" \
+      sh -c "cd '$_REPO' && $_l1" >/dev/null 2>&1 || exit 1
+  done || { _fail "session-start" "linha emitida de session start falhou"; return 1; }
+  for _s in feat-alpha feat-beta; do
+    [ -d "$_PHYS/proj-$_s" ] || { _fail "worktree" "worktree proj-$_s nao criada"; return 1; }
+    ( cd "$_REPO" && git show-ref --verify -q "refs/heads/$_s" ) \
+      || { _fail "branch" "branch $_s nao criada"; return 1; }
+  done
+
+  # -- TOCTOU: re-emit com worktrees ativas => tudo bloqueado, stdout vazio --
+  capture sh "$PLAUNCH" emit --repo "$_REPO" \
+    --feature feat-alpha --feature feat-beta
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "re-emit: esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "toctou" "re-emit deveria ter stdout vazio (tudo duplicado)"; return 1; }
+  assert_stderr_contains 'bloqueado' || return 1
+  _blocked=$(grep -c '"outcome":"blocked-duplicate"' "$_REPO/.claude/enforcement-log.jsonl" 2>/dev/null || echo 0)
+  [ "$_blocked" = 2 ] || { _fail "log" "esperado 2 blocked-duplicate, obtido $_blocked"; return 1; }
+
+  # -- fronteira com exclusao de ativas: vazia (alpha/beta ativas; gamma
+  #    ainda depende de alpha nao-concluida) --
+  capture sh -c "cd '$_REPO' && sh '$FRONTIER' --json --exclude-active-from-repo ."
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "frontier excluida: esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains 'nenhuma feature elegivel' || return 1
+
+  # -- sessoes-filha executam (stub claude dirige o runtime REAL) --
+  for _s in feat-alpha feat-beta; do
+    _cp=$(_extract_claude_part "$_emit_out" "$_s")
+    capture env PATH="$_STUB_BIN:$PATH" HOME="$E2E_HOME" \
+      sh -c "cd '$_PHYS/proj-$_s' && $_cp"
+    [ "$_CAPTURED_EXIT" = 0 ] || { _fail "filha" "filha $_s falhou (exit $_CAPTURED_EXIT): $_CAPTURED_STDERR"; return 1; }
+    [ -f "$E2E_MARKER_DIR/$_s.done" ] || { _fail "filha" "marker de $_s ausente"; return 1; }
+    # state 00c REAL criado pelo state-rw.sh init na worktree
+    _sj="$_PHYS/proj-$_s/.claude/feature-00c-state/$_s/state.json"
+    [ -f "$_sj" ] || { _fail "state" "state.json ausente em $_s"; return 1; }
+    _sn=$(jq -r '.short_name' "$_sj" 2>/dev/null)
+    [ "$_sn" = "$_s" ] || { _fail "state" "short_name esperado $_s, obtido '$_sn'"; return 1; }
+    # specs commitadas na branch da sessao, worktree limpa
+    [ -z "$(git -C "$_PHYS/proj-$_s" status --porcelain)" ] \
+      || { _fail "filha" "worktree $_s suja apos commit do stub"; return 1; }
+  done
+
+  # -- notificacao [cstk-parallel]: parse fail-closed (contract §6) --
+  _n_msgs=$(wc -l < "$E2E_MAILBOX" | tr -d ' ')
+  [ "$_n_msgs" = 2 ] || { _fail "mailbox" "esperado 2 notificacoes, obtido $_n_msgs"; return 1; }
+  while IFS= read -r _msg; do
+    capture sh "$PNPARSE" check "$_msg"
+    [ "$_CAPTURED_EXIT" = 0 ] || { _fail "parse" "notificacao legitima recusada: $_msg"; return 1; }
+    assert_stdout_contains 'outcome=concluida' || return 1
+    assert_stdout_contains "repo=$E2E_REPO_NAME" || return 1
+  done < "$E2E_MAILBOX"
+  # Forjada (sobra de texto) => recusada sem imprimir nada (ASI07).
+  capture sh "$PNPARSE" check '[cstk-parallel] feature=feat-alpha outcome=concluida repo=proj EXTRA'
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "parse" "mensagem forjada aceita (exit $_CAPTURED_EXIT)"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "parse" "mensagem forjada produziu stdout"; return 1; }
+
+  # -- alpha: merge (simula PR mergeado) + session end preserva state --
+  ( cd "$_REPO" && git merge -q --no-edit feat-alpha >/dev/null 2>&1 ) \
+    || { _fail "merge" "merge de feat-alpha falhou"; return 1; }
+  _run_in_repo "cstk session end feat-alpha"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "session end feat-alpha: exit $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  [ ! -d "$_PHYS/proj-feat-alpha" ] || { _fail "end" "worktree feat-alpha ainda existe"; return 1; }
+  if ( cd "$_REPO" && git show-ref --verify -q refs/heads/feat-alpha ); then
+    _fail "end" "branch feat-alpha nao removida"; return 1
+  fi
+  # Preservacao do state 00c no checkout principal (session-end-state-preservation)
+  _psj="$_REPO/.claude/feature-00c-state/feat-alpha/state.json"
+  [ -f "$_psj" ] || { _fail "preserve" "state 00c de feat-alpha nao preservado no principal"; return 1; }
+  _psn=$(jq -r '.short_name' "$_psj" 2>/dev/null)
+  [ "$_psn" = "feat-alpha" ] || { _fail "preserve" "state preservado corrompido (short_name='$_psn')"; return 1; }
+
+  # -- status derivado + fronteira recalculada --
+  # alpha concluida (specs mergeadas, tasks 100%); beta segue nao-iniciada
+  # NO PRINCIPAL (specs so na branch da worktree ativa) — exatamente o caso
+  # que exige --exclude-active-from-repo (FR-011).
+  capture sh -c "cd '$_REPO' && sh '$RSTATUS' --json"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "roadmap-status: exit $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains '"short_name":"feat-alpha","status":"concluida"' || return 1
+  assert_stdout_contains '"short_name":"feat-beta","status":"nao-iniciada"' || return 1
+
+  capture sh -c "cd '$_REPO' && sh '$FRONTIER' --json"
+  assert_stdout_contains '"short_name":"feat-beta"' || return 1
+  assert_stdout_contains '"short_name":"feat-gamma"' || return 1
+
+  capture sh -c "cd '$_REPO' && sh '$FRONTIER' --json --exclude-active-from-repo ."
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "frontier pos-alpha: exit $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains '"short_name":"feat-gamma"' || return 1
+  assert_stdout_not_contains '"short_name":"feat-beta"' || return 1
+
+  # -- beta: mesmo fechamento; fronteira final = so gamma --
+  ( cd "$_REPO" && git merge -q --no-edit feat-beta >/dev/null 2>&1 ) \
+    || { _fail "merge" "merge de feat-beta falhou"; return 1; }
+  _run_in_repo "cstk session end feat-beta"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "end" "session end feat-beta: exit $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  [ -f "$_REPO/.claude/feature-00c-state/feat-beta/state.json" ] \
+    || { _fail "preserve" "state 00c de feat-beta nao preservado"; return 1; }
+
+  capture sh -c "cd '$_REPO' && sh '$RSTATUS' --json"
+  assert_stdout_contains '"short_name":"feat-beta","status":"concluida"' || return 1
+  assert_stdout_contains '"short_name":"feat-gamma","status":"nao-iniciada"' || return 1
+
+  capture sh -c "cd '$_REPO' && sh '$FRONTIER' --json --exclude-active-from-repo ."
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "frontier final: exit $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains '"short_name":"feat-gamma"' || return 1
+  assert_stdout_not_contains '"short_name":"feat-alpha"' || return 1
+  assert_stdout_not_contains '"short_name":"feat-beta"' || return 1
+}
+
+# ==== Cenario 3: janela tmux REAL (condicional) ====
+#
+# Valida o caminho automatico (US1): a linha `tmux new-window ...` emitida
+# e executada DENTRO de um servidor tmux privado (-L socket proprio,
+# -f /dev/null — nunca toca o servidor do operador), a filha roda o stub
+# de claude ate produzir o marker, e o kill switch documentado
+# (`tmux kill-window`) encerra a janela. Sem tmux no ambiente: PASS com
+# aviso (a composicao claude ja foi validada no cenario 2, que e
+# forma-agnostica por contrato).
+scenario_tmux_janela_real_e_kill_switch() {
+  if ! command -v tmux >/dev/null 2>&1; then
+    printf '  # tmux ausente — cenario condicional pulado (composicao coberta pelo cenario 2)\n'
+    return 0
+  fi
+  _setup_toy || return 2
+  _SOCK="cstk-e2e-$$"
+  _tmux_kill() { tmux -L "$_SOCK" kill-server 2>/dev/null || :; }
+
+  # emit COM tmux presente => forma tmux garantida.
+  capture sh "$PLAUNCH" emit --repo "$_REPO" --feature feat-alpha
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "emit: exit $_CAPTURED_EXIT"; return 1; }
+  _emit_out=$_CAPTURED_STDOUT
+  assert_stdout_contains 'tmux new-window' || return 1
+  _l1=$(printf '%s\n' "$_emit_out" | grep '^cstk session start ')
+  env PATH="$_STUB_BIN:$PATH" HOME="$E2E_HOME" sh -c "cd '$_REPO' && $_l1" >/dev/null 2>&1 \
+    || { _fail "session-start" "session start feat-alpha falhou"; return 1; }
+
+  # Bloco tmux emitido (linha com continuacao \) vira script executado
+  # DENTRO do servidor privado — mesmo ambiente do command pai em producao
+  # (que roda dentro de tmux).
+  printf '%s\n' "$_emit_out" | grep -v '^cstk session start ' > "$_PHYS/launch.sh"
+
+  E2E_STUB_LINGER=20
+  export E2E_STUB_LINGER
+  env PATH="$_STUB_BIN:$PATH" HOME="$E2E_HOME" \
+      E2E_HOME="$E2E_HOME" E2E_MAILBOX="$E2E_MAILBOX" \
+      E2E_MARKER_DIR="$E2E_MARKER_DIR" E2E_REPO_NAME="$E2E_REPO_NAME" \
+      E2E_RUNTIME_DIR="$E2E_RUNTIME_DIR" E2E_STUB_LINGER="$E2E_STUB_LINGER" \
+    tmux -L "$_SOCK" -f /dev/null new-session -d -s boot /bin/sh \
+    || { _fail "tmux" "nao consegui subir servidor tmux privado"; return 1; }
+
+  tmux -L "$_SOCK" send-keys -t boot "sh '$_PHYS/launch.sh'" Enter \
+    || { _tmux_kill; _fail "tmux" "send-keys falhou"; return 1; }
+
+  if ! _wait_file "$E2E_MARKER_DIR/feat-alpha.done" 100; then
+    _tmux_kill
+    _fail "tmux" "filha na janela tmux nao produziu marker em 20s"
+    return 1
+  fi
+
+  # Janela nomeada com o short (linger mantem viva) + kill switch.
+  _wins=$(tmux -L "$_SOCK" list-windows -t boot -F '#{window_name}' 2>/dev/null)
+  case "$_wins" in
+    *feat-alpha*) : ;;
+    *) _tmux_kill; _fail "tmux" "janela feat-alpha nao listada: [$_wins]"; return 1 ;;
+  esac
+  tmux -L "$_SOCK" kill-window -t "boot:feat-alpha" 2>/dev/null \
+    || { _tmux_kill; _fail "tmux" "kill-window falhou"; return 1; }
+  _wins=$(tmux -L "$_SOCK" list-windows -t boot -F '#{window_name}' 2>/dev/null)
+  case "$_wins" in
+    *feat-alpha*) _tmux_kill; _fail "tmux" "janela sobreviveu ao kill switch"; return 1 ;;
+  esac
+  _tmux_kill
+
+  # Efeitos da filha identicos ao caminho degradado (paridade byte a byte
+  # da composicao, contract §4): state real + notificacao parseavel.
+  _sj="$_PHYS/proj-feat-alpha/.claude/feature-00c-state/feat-alpha/state.json"
+  [ -f "$_sj" ] || { _fail "state" "state.json ausente na worktree (via tmux)"; return 1; }
+  capture sh "$PNPARSE" check "$(head -1 "$E2E_MAILBOX")"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "parse" "notificacao da filha tmux nao parseou"; return 1; }
+  unset E2E_STUB_LINGER
+}
+
+run_all_scenarios


### PR DESCRIPTION
## Resumo

Implementa o plano de e2e em 3 camadas para a orquestracao paralela (roadmap-wave / roadmap-parallel-launch / cstk-session), fechando o gap de COMPOSICAO: cada elo tinha cobertura unitaria, mas a corrente inteira — fronteira → `resolve-offer` → `emit` → `cstk session start` → filha na worktree → notificacao `[cstk-parallel]` → merge → `cstk session end` preservando state → fronteira recalculada — nao era testada de ponta a ponta.

## Camada B — gateante (entra na suite)

`tests/test_e2e_roadmap_wave.sh` (3 cenarios, ~6s, verde sob `sh` e `dash`):

- **Corrente completa**: executa as linhas emitidas por `parallel-launch.sh emit` TAL-E-QUAL impressas (wrapper de `cstk`), com stub de `claude` que dirige o `state-rw.sh init` REAL (modo-feature) na worktree; valida guarda TOCTOU (re-emit bloqueado + auditoria no enforcement-log), exclusao de worktrees ativas (FR-011), parse fail-closed da notificacao (inclusive forjada), preservacao do state 00c no `session end` e desbloqueio da entrada dependente do roadmap.
- **Janela tmux REAL** em socket privado (`-L` + `-f /dev/null` — nunca toca o servidor do operador) com kill switch validado; condicional (sem tmux ⇒ PASS com aviso; a composicao `claude --name ...` e byte-identica nas duas formas por contrato).
- Registrado como interno em `run.sh::_is_internal_test` (composicao, sem script 1:1); `--check-coverage` e `doc-counts` verdes.

## Camada C — nao-gateante (`tests/eval/`)

`eval_roadmap-wave-frontier.sh` — obediencia headless do `/roadmap-wave`, **validado com execucoes reais** (resultado `conforme`):

- (A) sem `--yes`, sem operador: fail-safe FR-014 — nada lancado, nenhum estado 00c, fim silencioso.
- (B) com `--yes` e fronteira VAZIA: o agente roda `roadmap-frontier.sh` de verdade e reporta o vazio com motivo, sem risco de lancar sessao real.

Nota: a primeira versao do eval assertava que o headless sem `--yes` reportaria a fronteira — a execucao real mostrou que a prosa manda encerrar em silencio ANTES de calcular; o assert e que estava errado, e o desenho (B) nasceu dai.

## Camada D — ensaio supervisionado

`rehearsal_roadmap-wave.sh` — runbook executavel do ensaio com filhas reais (tmux + `claude` de verdade rodando `/feature-00c`): `setup` monta o projeto de brinquedo e imprime os passos do operador; `status` da o snapshot mecanico mid-flight; `verify` faz as assercoes finais (worktrees zeradas, branches removidas, roadmap 100% concluido, states preservados, main limpa). Rodar 1x por release que toque orquestracao paralela.

## Validacao

- Suite completa (gate de release): **3412 PASS / 0 FAIL / 0 ERROR / 0 ORPHANS**
- `dash -n` + execucao sob `dash` verdes (paridade com CI ubuntu)
- shellcheck 0.11.0 limpo nos 3 arquivos novos
- Eval da Camada C rodado 3x com `claude -p` real (2 cenarios `conforme`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiHRXC83ja2JERyfeZNJqs