### PR TITLE
fix(session,commit-mode): --fill de fallback no gh pr create

### DIFF
--- a/cli/lib/session.sh
+++ b/cli/lib/session.sh
@@ -1092,9 +1092,30 @@ _session_pr() {
   # Sempre: --base <default> --head <branch>
   # Opcionais: --draft, --title, --body, --reviewer (multiplo)
   # Estrategia POSIX: usar `set --` para construir array de args.
+  #
+  # `--fill` de fallback: o `gh pr create` nao-interativo EXIGE titulo E
+  # corpo. Medido em gh 2.67.0 — com `--head` de branch inexistente, para
+  # isolar a validacao de flags de qualquer operacao git:
+  #
+  #   (sem flags)        -> "must provide `--title` and `--body` (or `--fill`
+  #                          or `fill-first` or `--fillverbose`) when not
+  #                          running interactively"  [FlagError]
+  #   --title T          -> MESMO FlagError (titulo sozinho NAO basta)
+  #   --title T --body B -> aceito
+  #   --fill             -> aceito (falha so depois, ao computar defaults)
+  #   --fill + --title/--body/--draft -> aceito (combinam)
+  #
+  # Por isso o gatilho e "faltou title OU body", nao "faltaram os dois":
+  # `cstk session pr <n> --title foo` cai na MESMA falha do caso sem flag
+  # nenhuma. Sem esse fallback o sintoma era push feito + PR nao criado,
+  # com o gh cuspindo o help (mesma classe da sug-007 em commit-mode.sh
+  # finalize, que so cobria o caso de ambos ausentes).
   set -- --base "$_default" --head "$_wt_branch"
   if [ "$_draft" = 1 ]; then
     set -- "$@" --draft
+  fi
+  if [ -z "$_title" ] || [ -z "$_body" ]; then
+    set -- "$@" --fill
   fi
   if [ -n "$_title" ]; then
     set -- "$@" --title "$_title"

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/commit-mode.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/commit-mode.sh
@@ -1094,12 +1094,26 @@ _cm_cmd_finalize() {
   # sug-007: sem --title/--body o gh nao-interativo FALHA (era a causa de
   # "push feito, PR nao criado" — caso real state-mcp-server). Default:
   # --fill (titulo/corpo derivados dos commits da branch).
+  #
+  # O gatilho do --fill era `||` (so quando AMBOS faltavam) e deixava um
+  # buraco: medido em gh 2.67.0, `--title` SOZINHO produz o mesmo FlagError
+  # que nenhuma flag ("must provide `--title` and `--body` ..."), entao
+  # `finalize --title X` sem --body reproduzia o defeito que a sug-007
+  # deveria ter fechado. Gatilho corrigido para `-z title OU -z body`;
+  # --fill combina com --title/--body (medido). Mesmo fix aplicado em
+  # cli/lib/session.sh (_session_pr), onde o sintoma foi observado.
+  # NOTA set -eu (issue #139): nada de `[ -n "$x" ] && _gh_args=...` como
+  # ULTIMO comando de um ramo — o teste falso vira exit 1 do `if` inteiro e
+  # aborta a funcao. Blocos `if` explicitos, sem `&&` terminal.
   _gh_args="--base $_default --head $_curr_branch"
-  if [ -n "$_title" ] || [ -n "$_body" ]; then
-    [ -n "$_title" ] && _gh_args="$_gh_args --title $_title"
-    [ -n "$_body" ]  && _gh_args="$_gh_args --body $_body"
-  else
+  if [ -z "$_title" ] || [ -z "$_body" ]; then
     _gh_args="$_gh_args --fill"
+  fi
+  if [ -n "$_title" ]; then
+    _gh_args="$_gh_args --title $_title"
+  fi
+  if [ -n "$_body" ]; then
+    _gh_args="$_gh_args --body $_body"
   fi
 
   _pr_url=$(eval "cd $_pap && gh pr create $_gh_args" 2>/dev/null) || _pr_url=""

--- a/tests/cstk/test_session.sh
+++ b/tests/cstk/test_session.sh
@@ -1251,4 +1251,137 @@ $_files"
   fi
 }
 
+# ==== `--fill` de fallback no gh pr create (bug observado 2026-08-25) ====
+#
+# `gh pr create` nao-interativo EXIGE titulo E corpo. `_session_pr` montava
+# `--base/--head` e so acrescentava --title/--body se o operador os passasse
+# — entao `cstk session pr <n>` sem flags falhava com FlagError e o gh
+# cuspia o help, DEPOIS do push (sintoma: "push feito, PR nao criado").
+#
+# Medido em gh 2.67.0 (com --head de branch inexistente, para isolar a
+# validacao de flags de qualquer operacao git):
+#   (sem flags)        -> FlagError "must provide `--title` and `--body` ..."
+#   --title T          -> MESMO FlagError (titulo sozinho NAO basta)
+#   --title T --body B -> aceito
+#   --fill             -> aceito; combina com --title/--body/--draft
+#
+# O stub abaixo REPRODUZ essa regra em vez de so gravar argumentos: assim o
+# cenario falha pre-fix pelo mesmo motivo que o gh real falhava.
+
+# _pr_stub_gh DIR ARGFILE -> cria stub de `gh` em DIR que aplica a regra de
+# flags do gh 2.67.0 em `pr create` e grava os argumentos recebidos em
+# ARGFILE (um por linha).
+_pr_stub_gh() {
+  mkdir -p "$1"
+  cat > "$1/gh" <<STUBGH
+#!/bin/sh
+case "\$1 \$2" in
+  "auth status") exit 0 ;;
+  "pr view") exit 1 ;;
+  "pr create")
+    shift 2
+    for _a in "\$@"; do printf '%s\n' "\$_a" >> '$2'; done
+    _has_title=0; _has_body=0; _has_fill=0
+    for _a in "\$@"; do
+      case "\$_a" in
+        --title) _has_title=1 ;;
+        --body) _has_body=1 ;;
+        --fill|--fill-first|--fillverbose) _has_fill=1 ;;
+      esac
+    done
+    if [ "\$_has_fill" = 0 ] && { [ "\$_has_title" = 0 ] || [ "\$_has_body" = 0 ]; }; then
+      printf 'must provide \`--title\` and \`--body\` (or \`--fill\` or \`fill-first\` or \`--fillverbose\`) when not running interactively\n'
+      exit 1
+    fi
+    printf 'https://github.com/stub/repo/pull/1\n'
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+STUBGH
+  chmod +x "$1/gh"
+}
+
+# _pr_setup SLUG -> monta repo + origin bare + sessao com 1 commit a frente;
+# imprime "<src>|<stub_dir>|<argfile>".
+_pr_setup() {
+  _ps_src="$TMPDIR_TEST/repo-$1"
+  _make_repo "$_ps_src"
+  _ps_bare="$TMPDIR_TEST/repo-$1-origin.git"
+  git init -q --bare "$_ps_bare"
+  ( cd "$_ps_src" && git remote add origin "$_ps_bare" && git push -q -u origin main 2>/dev/null )
+  ( cd "$_ps_src" && CSTK_LIB="$CSTK_LIB" sh "$CSTK_BIN" session start "$1" >/dev/null )
+  _ps_phys=$( cd "$TMPDIR_TEST" && pwd -P )
+  ( cd "$_ps_phys/repo-$1-$1" && git commit -q --allow-empty -m "test commit" )
+  _ps_stub="$TMPDIR_TEST/stub-gh-$1"
+  _ps_argf="$TMPDIR_TEST/gh-args-$1.txt"
+  : > "$_ps_argf"
+  _pr_stub_gh "$_ps_stub" "$_ps_argf"
+  printf '%s|%s|%s\n' "$_ps_src" "$_ps_stub" "$_ps_argf"
+}
+
+scenario_pr_sem_flags_usa_fill() {
+  _r=$(_pr_setup fillnone); _src=${_r%%|*}; _rest=${_r#*|}
+  _stub=${_rest%%|*}; _argf=${_rest#*|}
+  capture sh -c "cd '$_src' && PATH='$_stub:/usr/bin:/bin' CSTK_LIB='$CSTK_LIB' sh '$CSTK_BIN' session pr fillnone"
+  if [ "$_CAPTURED_EXIT" != 0 ]; then
+    _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if ! grep -qx -- '--fill' "$_argf"; then
+    _fail "fill" "esperado --fill nos args do gh; recebidos: $(tr '\n' ' ' < "$_argf")"
+    return 1
+  fi
+  assert_stdout_contains "PR criado" || return 1
+}
+
+# Caso que o padrao antigo (`--fill` so quando AMBOS faltam) deixava passar.
+scenario_pr_so_title_ainda_usa_fill() {
+  _r=$(_pr_setup filltitle); _src=${_r%%|*}; _rest=${_r#*|}
+  _stub=${_rest%%|*}; _argf=${_rest#*|}
+  capture sh -c "cd '$_src' && PATH='$_stub:/usr/bin:/bin' CSTK_LIB='$CSTK_LIB' sh '$CSTK_BIN' session pr filltitle --title 'Meu titulo'"
+  if [ "$_CAPTURED_EXIT" != 0 ]; then
+    _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if ! grep -qx -- '--fill' "$_argf"; then
+    _fail "fill" "esperado --fill com titulo sozinho; recebidos: $(tr '\n' ' ' < "$_argf")"
+    return 1
+  fi
+  if ! grep -qx -- 'Meu titulo' "$_argf"; then
+    _fail "title" "titulo do operador nao foi repassado"
+    return 1
+  fi
+}
+
+scenario_pr_so_body_ainda_usa_fill() {
+  _r=$(_pr_setup fillbody); _src=${_r%%|*}; _rest=${_r#*|}
+  _stub=${_rest%%|*}; _argf=${_rest#*|}
+  capture sh -c "cd '$_src' && PATH='$_stub:/usr/bin:/bin' CSTK_LIB='$CSTK_LIB' sh '$CSTK_BIN' session pr fillbody --body 'Meu corpo'"
+  if [ "$_CAPTURED_EXIT" != 0 ]; then
+    _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if ! grep -qx -- '--fill' "$_argf"; then
+    _fail "fill" "esperado --fill com corpo sozinho; recebidos: $(tr '\n' ' ' < "$_argf")"
+    return 1
+  fi
+}
+
+# Contrato negativo: com title E body o operador esta no controle — nao
+# injetar --fill (senao o corpo derivado dos commits competiria com o dele).
+scenario_pr_title_e_body_nao_injeta_fill() {
+  _r=$(_pr_setup fillboth); _src=${_r%%|*}; _rest=${_r#*|}
+  _stub=${_rest%%|*}; _argf=${_rest#*|}
+  capture sh -c "cd '$_src' && PATH='$_stub:/usr/bin:/bin' CSTK_LIB='$CSTK_LIB' sh '$CSTK_BIN' session pr fillboth --title T --body B"
+  if [ "$_CAPTURED_EXIT" != 0 ]; then
+    _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"
+    return 1
+  fi
+  if grep -qx -- '--fill' "$_argf"; then
+    _fail "fill" "--fill NAO deveria ser injetado com title+body; recebidos: $(tr '\n' ' ' < "$_argf")"
+    return 1
+  fi
+}
+
 run_all_scenarios

--- a/tests/test_commit-mode.sh
+++ b/tests/test_commit-mode.sh
@@ -1467,4 +1467,81 @@ scenario_issue139_finalize_head_na_default_exit0_skipped_default_branch() {
   [ "$_status" = "skipped-default-branch" ] || { _fail "push_pr_result.status no state" "obtido '$_status'"; return 1; }
 }
 
+# ==== --fill tambem quando SO o titulo foi dado (buraco do `||`) ====
+#
+# A sug-007 injetava --fill so quando title E body faltavam. Medido em gh
+# 2.67.0, `--title` SOZINHO produz o MESMO FlagError que nenhuma flag
+# ("must provide `--title` and `--body` (or `--fill` ...)"), entao
+# `finalize --title X` sem --body reproduzia exatamente o defeito que a
+# sug-007 deveria ter fechado.
+#
+# Havia ainda um segundo problema no mesmo bloco, da classe da issue #139:
+# `[ -n "$_body" ] && _gh_args=...` era o ULTIMO comando do ramo — com body
+# vazio o teste falso virava exit 1 do `if`, e sob `set -eu` abortava o
+# finalize. Por isso este cenario assere exit 0 alem do --fill.
+scenario_finalize_so_titulo_ainda_usa_fill() {
+  _gdir="$TMPDIR_TEST/repo-fill-t"
+  _sd="$TMPDIR_TEST/fin-fill-t"
+  _init_state "$_sd" true
+  _init_git_repo "$_gdir" "feat/fill-t"
+
+  git -C "$_gdir" branch main 2>/dev/null || :
+  git -C "$_gdir" update-ref refs/remotes/origin/main "$(git -C "$_gdir" rev-parse main)" 2>/dev/null || :
+  git -C "$_gdir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || :
+
+  _bare="$TMPDIR_TEST/origin-fill-t.git"
+  git init -q --bare "$_bare" 2>/dev/null
+  git -C "$_gdir" remote add origin "$_bare" 2>/dev/null
+
+  printf 'change\n' >> "$_gdir/README.md"
+  git -C "$_gdir" add README.md 2>/dev/null
+  git -C "$_gdir" commit -q -m "feat: change" 2>/dev/null
+
+  # gh stub que APLICA a regra de flags do gh 2.67.0, em vez de so gravar
+  # argv: assim o cenario falha pre-fix pelo mesmo motivo que o gh real.
+  _stub="$TMPDIR_TEST/stub-fill-t"
+  mkdir -p "$_stub"
+  cat > "$_stub/gh" <<GHEOF
+#!/bin/sh
+case "\$1 \$2" in
+  "auth status") exit 0 ;;
+  "pr view")     exit 1 ;;
+  "pr create")
+    printf '%s\n' "\$*" > "$_stub/pr-create-args"
+    case "\$*" in
+      *--fill*) : ;;
+      *--title*) case "\$*" in
+                   *--body*) : ;;
+                   *) printf 'must provide \`--title\` and \`--body\` (or \`--fill\`)\n'; exit 1 ;;
+                 esac ;;
+      *) printf 'must provide \`--title\` and \`--body\` (or \`--fill\`)\n'; exit 1 ;;
+    esac
+    printf 'https://example.test/pr/3\n'; exit 0 ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_stub/gh"
+
+  _orig_path="$PATH"
+  PATH="$_stub:$_orig_path"
+  export PATH
+
+  capture "$SCRIPT" finalize --state-dir "$_sd" --projeto-alvo-path "$_gdir" --title "Meu titulo"
+  _fin_exit=$_CAPTURED_EXIT
+  _fin_out=$_CAPTURED_STDOUT
+
+  PATH="$_orig_path"
+  export PATH
+
+  [ "$_fin_exit" = 0 ] || { _fail "exit esperado 0" "obtido $_fin_exit; stderr=$_CAPTURED_STDERR"; return 1; }
+  [ -f "$_stub/pr-create-args" ] \
+    || { _fail "gh pr create nao foi invocado" "stdout: $_fin_out"; return 1; }
+  grep -q -- '--fill' "$_stub/pr-create-args" \
+    || { _fail "esperado --fill com titulo sozinho" "args: $(cat "$_stub/pr-create-args")"; return 1; }
+  grep -q -- '--title' "$_stub/pr-create-args" \
+    || { _fail "titulo do operador nao foi repassado" "args: $(cat "$_stub/pr-create-args")"; return 1; }
+  printf '%s' "$_fin_out" | grep -q '"status":"pr-opened"' \
+    || { _fail "status esperado pr-opened" "stdout: $_fin_out"; return 1; }
+}
+
 run_all_scenarios


### PR DESCRIPTION
`gh pr create` nao-interativo EXIGE titulo E corpo. `_session_pr` montava
apenas `--base/--head` e so acrescentava `--title`/`--body` quando o
operador os passava — entao `cstk session pr <nome>` sem flags falhava com
FlagError DEPOIS do push, e o gh cuspia o help. Sintoma: "push feito, PR
nao criado". Observado nesta sessao ao abrir o PR #158.

Regra do gh medida empiricamente (gh 2.67.0), usando `--head` de branch
inexistente para isolar a validacao de flags de qualquer operacao git:

  (sem flags)        -> FlagError "must provide `--title` and `--body`
                        (or `--fill` or `fill-first` or `--fillverbose`)
                        when not running interactively"
  --title T          -> MESMO FlagError (titulo sozinho NAO basta)
  --title T --body B -> aceito
  --fill             -> aceito
  --fill + --title/--body/--draft -> aceito (combinam)

Por isso o gatilho e "faltou title OU body", nao "faltaram os dois".

O mesmo buraco existia em commit-mode.sh finalize: a sug-007 ja injetava
`--fill`, mas so quando AMBOS faltavam (`||`) — logo `finalize --title X`
sem `--body` reproduzia o defeito que a sug-007 deveria ter fechado.
Corrigido junto; deixar metade quebrada repetiria a licao da issue #157
(corrigir so o sitio reportado e travar um passo adiante).

Bonus da mesma classe da issue #139: no bloco antigo do commit-mode,
`[ -n "$_body" ] && _gh_args=...` era o ULTIMO comando de um ramo — com
body vazio o teste falso virava exit 1 do `if` e, sob `set -eu`, abortava
o finalize. Reescrito com blocos `if` explicitos, sem `&&` terminal.

Testes: 5 cenarios (4 em tests/cstk/test_session.sh, 1 em
tests/test_commit-mode.sh). Os stubs de `gh` APLICAM a regra de flags do
gh 2.67.0 em vez de so gravar argv, entao falham pre-fix pelo mesmo motivo
que o gh real falhava. Inclui contrato negativo: com title E body o
operador esta no controle e `--fill` NAO e injetado. Mutation test:
revertendo o fix, 4 dos 5 falham (o 5o e o negativo, inalterado por
desenho).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CswUhKJf9bDArX7hXj42Dd
