### PR TITLE
chore(release): 9.2.2 — --fill de fallback no gh pr create

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "9.2.1",
+      "version": "9.2.2",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "9.2.1",
+      "version": "9.2.2",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [9.2.2] - 2026-08-25
+
+Corrige o `cstk session pr` e o `commit-mode.sh finalize`, que montavam um
+`gh pr create` sem titulo nem corpo e por isso falhavam de forma
+nao-interativa DEPOIS de ja terem empurrado a branch — o operador ficava com
+push feito e PR nao criado, vendo apenas o help do `gh`. Defeito observado ao
+abrir o PR #158 desta mesma linha de trabalho.
+
+### Fixed
+
+- **`cstk session pr`: `--fill` de fallback no `gh pr create`.** O
+  `gh pr create` nao-interativo exige titulo E corpo; `_session_pr`
+  (`cli/lib/session.sh`) montava apenas `--base`/`--head` e so acrescentava
+  `--title`/`--body` quando o operador os passava. Regra do `gh` medida
+  empiricamente na versao 2.67.0, usando `--head` de branch inexistente para
+  isolar a validacao de flags de qualquer operacao git: sem flags e com
+  `--title` sozinho o `gh` responde o mesmo FlagError ("must provide
+  `--title` and `--body` (or `--fill` or `fill-first` or `--fillverbose`)
+  when not running interactively"); `--fill` e aceito e combina com
+  `--title`, `--body` e `--draft`. O gatilho do fallback e, portanto,
+  "faltou titulo OU corpo" — nao "faltaram os dois".
+- **`commit-mode.sh finalize`: mesmo buraco no gatilho da sug-007.** O
+  `--fill` ja existia ali, mas so era injetado quando titulo E corpo
+  faltavam (`||`), entao `finalize --title X` sem `--body` reproduzia
+  exatamente o defeito que a sug-007 deveria ter fechado. Corrigido na mesma
+  release: corrigir so o sitio observado repetiria a licao da #157.
+- **Aborto silencioso da classe da issue #139 no mesmo bloco.** Em
+  `commit-mode.sh`, `[ -n "$_body" ] && _gh_args=...` era o ULTIMO comando de
+  um ramo do `if`: com corpo vazio o teste falso virava exit 1 do `if` e, sob
+  o `set -eu` do script, abortava o `finalize`. Reescrito com blocos `if`
+  explicitos, sem `&&` terminal.
+
+### Added
+
+- **5 cenarios de regressao** — 4 em `tests/cstk/test_session.sh` (sem flags,
+  so `--title`, so `--body`, e o contrato negativo de que titulo + corpo NAO
+  injeta `--fill`) e 1 em `tests/test_commit-mode.sh` (`finalize --title` sem
+  `--body`). Os stubs de `gh` APLICAM a regra de flags do gh 2.67.0 em vez de
+  apenas gravar argv, entao falham pre-fix pelo mesmo motivo que o `gh` real
+  falhava. Mutation test executado: revertendo o fix, 4 dos 5 falham (o 5o e
+  o contrato negativo, inalterado por desenho).
+
 ## [9.2.1] - 2026-08-25
 
 Corrige dois bugs abertos automaticamente pelo agente-00C rodando em
@@ -7229,6 +7271,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[9.2.2]: https://github.com/JotJunior/cstk/releases/tag/v9.2.2
 [9.2.1]: https://github.com/JotJunior/cstk/releases/tag/v9.2.1
 [9.2.0]: https://github.com/JotJunior/cstk/releases/tag/v9.2.0
 [9.1.0]: https://github.com/JotJunior/cstk/releases/tag/v9.1.0

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"


### PR DESCRIPTION
Release de correcao do `cstk session pr` / `commit-mode.sh finalize`
(PR #164 ja mergeado).

- `CHANGELOG.md`: secao `## [9.2.2]` + link ref no rodape (checagem de
  headers sem ref sai vazia).
- Manifestos de plugin em `9.2.2` nas 4 ocorrencias — gate MP-5 validado
  local: `OK (0 aviso(s))`, exit 0.

## Escopo

PATCH: so correcao. Nenhuma skill nova, nenhuma flag nova, nenhum contrato
de CLI alterado — `--fill` e injetado internamente como fallback, e a
superficie de flags do `cstk session pr` continua identica.

## Validacao

- Suite completa: `PASS: 3433  FAIL: 0  ERROR: 0  ORPHANS: 0` (993s).
- **Dogfooding**: o PR #164 foi aberto pelo PROPRIO `cstk session pr`
  corrigido, com `--title` sozinho — exatamente a invocacao que produzia o
  FlagError. Titulo explicito respeitado e corpo derivado dos commits pelo
  `--fill`.
- Regra do `gh` 2.67.0 medida empiricamente, nao suposta (detalhe no
  CHANGELOG e no commit).

## Nota sobre sync

Esta release toca AS DUAS metades da instalacao: `cli/lib/session.sh` e
runtime (exige `cstk self-update`) e `commit-mode.sh` e catalogo (exige
`cstk update`). Atualizar so uma reproduz o sintoma "funciona no repo mas
nao na sessao".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CswUhKJf9bDArX7hXj42Dd