### PR TITLE
fix: gate do loose-usage visivel (#162) e dica de exclude cobrindo .bak (#163)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "9.2.2",
+      "version": "9.2.3",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "9.2.2",
+      "version": "9.2.3",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,78 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [9.2.3] - 2026-08-26
+
+Fecha duas issues de **diagnostico e documentacao enganosos** — nenhuma das
+duas quebrava codigo, as duas faziam o toolkit afirmar "ok" para um estado
+que nao era ok. Mesma classe da 3a coluna do `guard-hooks-status.sh`
+(hook stale reportado como "3/3 ativos" com `tool_calls` zerado por 15
+ondas): ausencia tem que aparecer como ausencia, nunca como zero fabricado
+nem como "configurado".
+
+### Fixed
+
+- **Issue #162 — captura de consumo avulso inerte reportada como
+  `current`.** O `posttooluse-loose-usage.sh` gateia duro em
+  `CSTK_OTEL_ENDPOINT` (Passo 1) e sai `0` mudo sem ela; o
+  `guard-hooks-status.sh --include-loose-usage` respondia
+  `present registered current` para um hook que capturava ZERO, e a doc
+  afirmava o contrario ("no second toggle" / "sem um segundo toggle").
+  Assimetria que fazia o setup pela metade passar despercebido: o caminho de
+  custo por onda (`otel-usage.sh`) cai no default
+  `http://127.0.0.1:9464/metrics` e continua medindo, entao o painel dava a
+  impressao de telemetria configurada.
+  - **Diagnostico**: a linha de `posttooluse-loose-usage.sh` ganhou uma 5a
+    coluna TSV de GATE — `endpoint-set` | `endpoint-unset` — mais aviso em
+    stderr quando o hook esta present+registered e ainda assim capturaria
+    nada. Nao afeta o exit code (hook opt-in, ausencia nunca e anomalia) nem
+    a saida sem a flag. Os tokens sao OBSERVACAO, nao veredito: o ambiente
+    que decide o gate e o do processo `claude`, e nao necessariamente o da
+    invocacao do diagnostico — rodado de um terminal comum com o wrapper
+    `claude()` instalado, `endpoint-unset` e honesto sobre aquele terminal,
+    e o stderr diz exatamente isso.
+  - **Divergencia pre-existente contrato-vs-codigo, corrigida no mesmo
+    ponto**: o cabecalho do `guard-hooks-status.sh` ja afirmava que a linha
+    de loose-usage "NUNCA ganha a 5a coluna mesmo com
+    `--verify-registration`", mas o codigo emitia
+    `canonical`/`divergent` ali quando as duas flags eram combinadas. Caminho
+    na pratica morto — as duas flags nunca sao combinadas (achado SEC-03,
+    gateado por teste) e o unico consumidor (`cli/lib/setup.sh`) le so as
+    colunas 2..4 — mas era o contrato mentindo sobre o codigo. Agora a 5a
+    posicao dessa linha e, e so e, a dimensao de gate.
+  - **`cstk setup`**: `loose_usage_status` ganhou o valor `configured-inert`
+    para esse estado. Runtime antigo (4 colunas, 5a vazia) preserva
+    `configured` — o gate fica desconhecido, jamais fabricado.
+  - **Doc**: `docs/cstk-usage.md`/`.pt-BR.md` perderam a afirmacao "no
+    second toggle" e ganharam uma secao Requisitos listando as DUAS
+    condicoes (hook instalado + `CSTK_OTEL_ENDPOINT` no ambiente do processo
+    `claude`), o motivo de o gate ser deliberado, a assimetria com o caminho
+    de onda e como conferir se a captura esta armada. Nos READMEs, o wrapper
+    `claude()` deixou de ser apresentado so como conveniencia para
+    multi-processo e passou a constar como requisito duro do loose-usage.
+    Mesmo aviso no `--help` de `cstk hooks install`.
+- **Issue #163 — a dica de `.git/info/exclude` nao cobria o `.bak` que o
+  proprio comando cria.** Seguindo a dica ao pe da letra, o
+  `.claude/settings.local.json.bak` gerado pelo merge do snippet aparecia no
+  `git status` do cliente e entrava num `git add -A` distraido — exatamente o
+  que a #135 quis eliminar. A dica passou a incluir `.claude/*.bak` e
+  `.claude/*.bak-pre-dedup` (este ultimo cobre o backup do dedup do
+  `--remove-classic`, que o glob `.bak` nao casa), com a explicacao de que os
+  backups sao do proprio fluxo. Corrigido nos tres sitios: `--help` de
+  `cstk hooks install` (`cli/lib/hooks.sh`), `README.md` e `README.pt-BR.md`.
+
+### Tests
+
+- `tests/test_guard-hooks-status.sh`: 4 cenarios novos de gate
+  (`endpoint-unset` avisa, `endpoint-set` silencioso, `--quiet` suprime o
+  aviso mas nunca a coluna, `--verify-registration` nao transforma a 5a
+  coluna da linha loose em `canonical`/`divergent`). O helper `_ghs` passou a
+  pinar `CSTK_OTEL_ENDPOINT` vazia — sem isso os cenarios ficariam verdes na
+  maquina sem o wrapper e vermelhos na maquina com ele.
+- `tests/cstk/test_setup.sh`: 3 cenarios novos (`configured-inert`,
+  `configured` com a variavel setada, e runtime antigo sem a coluna
+  preservando `configured`).
+
 ## [9.2.2] - 2026-08-25
 
 Corrige o `cstk session pr` e o `commit-mode.sh finalize`, que montavam um
@@ -7271,6 +7343,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[9.2.3]: https://github.com/JotJunior/cstk/releases/tag/v9.2.3
 [9.2.2]: https://github.com/JotJunior/cstk/releases/tag/v9.2.2
 [9.2.1]: https://github.com/JotJunior/cstk/releases/tag/v9.2.1
 [9.2.0]: https://github.com/JotJunior/cstk/releases/tag/v9.2.0

--- a/README.md
+++ b/README.md
@@ -316,7 +316,9 @@ Enable the plugin and open a new session in any project — skills, the 7
 §Clarifications, assumption A1). `posttooluse-loose-usage.sh` (opt-in
 consumption capture) is deliberately **not** part of the plugin's
 `hooks.json` — it stays an explicit opt-in via `cstk hooks install
---with-loose-usage`.
+--with-loose-usage`, and it also needs `CSTK_OTEL_ENDPOINT` in the `claude`
+process environment or it captures nothing
+([docs/cstk-usage.md](./docs/cstk-usage.md#requirements)).
 
 **Choosing between the two paths:**
 
@@ -370,8 +372,14 @@ keep them out of the client's `git status` without touching their
 `.gitignore`:
 
 ```bash
-printf '.claude/hooks/\n.claude/settings.local.json\n' >> .git/info/exclude
+printf '.claude/hooks/\n.claude/settings.local.json\n.claude/*.bak\n.claude/*.bak-pre-dedup\n' >> .git/info/exclude
 ```
+
+The two `.bak` patterns cover the backups the command **itself** writes —
+`settings.json.bak` / `settings.local.json.bak` when it merges the
+registration, and `settings.json.bak-pre-dedup` when it removes a duplicate
+classic block. Without them the backup shows up in the client's
+`git status` and rides along in a distracted `git add -A` (issue #163).
 
 Idempotent like the default flow. If the *other* file already registers
 the 00c hooks (both would fire, double-counting every tool call) the
@@ -475,6 +483,15 @@ claude() {
   fi
 }
 ```
+
+> **The wrapper is also a hard requirement for loose-usage capture**
+> (`cstk usage`, issue #162), not just a multi-process convenience:
+> `posttooluse-loose-usage.sh` gates on `CSTK_OTEL_ENDPOINT` and exits `0`
+> in silence without it. Unlike the per-wave path — which falls back to the
+> fixed default port — loose capture has **no** fallback, so without the
+> variable (or an equivalent manual `export`) it stays inert and `cstk usage`
+> answers `nao medido`. See
+> [docs/cstk-usage.md](./docs/cstk-usage.md#requirements).
 
 Zero per-session configuration: each `claude` you type gets an isolated
 exporter and an isolated measurement. As a bonus, the delta's

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -316,7 +316,9 @@ Habilite o plugin e abra uma sessão nova em qualquer projeto — as skills, os
 §Clarifications, assumption A1). O `posttooluse-loose-usage.sh` (captura
 opt-in de consumo) deliberadamente **não** faz parte do `hooks.json` do
 plugin — segue sendo opt-in explícito via `cstk hooks install
---with-loose-usage`.
+--with-loose-usage`, e ainda exige `CSTK_OTEL_ENDPOINT` no ambiente do
+processo `claude`, senão não captura nada
+([docs/cstk-usage.pt-BR.md](./docs/cstk-usage.pt-BR.md#requisitos)).
 
 **Escolhendo entre os dois caminhos:**
 
@@ -372,8 +374,14 @@ continuam em `.claude/hooks/`; para não sujar o `git status` do cliente
 sem mexer no `.gitignore` dele:
 
 ```bash
-printf '.claude/hooks/\n.claude/settings.local.json\n' >> .git/info/exclude
+printf '.claude/hooks/\n.claude/settings.local.json\n.claude/*.bak\n.claude/*.bak-pre-dedup\n' >> .git/info/exclude
 ```
+
+Os dois padrões `.bak` cobrem os backups que o **próprio comando** grava —
+`settings.json.bak` / `settings.local.json.bak` ao mesclar o registro, e
+`settings.json.bak-pre-dedup` ao remover um bloco clássico duplicado. Sem
+eles o backup aparece no `git status` do cliente e pega carona num
+`git add -A` distraído (issue #163).
 
 Idempotente como o fluxo padrão. Se o *outro* arquivo já registrar os
 hooks 00c (os dois disparariam, contando cada tool call em dobro) o comando
@@ -479,6 +487,14 @@ claude() {
   fi
 }
 ```
+
+> **O wrapper também é requisito duro da captura de consumo avulso**
+> (`cstk usage`, issue #162), não só conveniência para multi-processo: o
+> `posttooluse-loose-usage.sh` gateia em `CSTK_OTEL_ENDPOINT` e sai `0` mudo
+> sem ela. Diferente do caminho por onda — que cai na porta default fixa — a
+> captura avulsa **não** tem fallback: sem a variável (ou um `export`
+> equivalente à mão) ela fica inerte e o `cstk usage` responde `nao medido`.
+> Ver [docs/cstk-usage.pt-BR.md](./docs/cstk-usage.pt-BR.md#requisitos).
 
 Zero configuração por sessão: cada `claude` que você digita ganha um exporter
 isolado e uma medição isolada. De bônus, o guard "exatamente uma sessão

--- a/cli/cstk
+++ b/cli/cstk
@@ -267,6 +267,24 @@ Verificacao (de dentro de uma sessao claude lancada pelo wrapper):
   ~/.claude/skills/agente-00c-runtime/scripts/otel-usage.sh preflight
   # esperado: status=ok  (fora de sessao: disabled e normal)
 
+CSTK_OTEL_ENDPOINT e requisito DURO da captura de consumo avulso
+(`cstk usage`, issue #162), nao so conveniencia para multi-processo: o hook
+posttooluse-loose-usage.sh gateia nessa variavel e sai 0 mudo sem ela.
+Diferente do custo por onda — que cai na porta default fixa 9464 e continua
+medindo — a captura avulsa NAO tem fallback: sem a variavel ela fica inerte
+e `cstk usage` responde "nao medido".
+
+  ATENCAO ao ramo sem python3 do wrapper acima: ele liga
+  CLAUDE_CODE_ENABLE_TELEMETRY + OTEL_METRICS_EXPORTER mas NAO define
+  CSTK_OTEL_ENDPOINT. Nessa maquina o custo por onda funciona (default) e a
+  captura avulsa NAO — instalar o wrapper nao e, por si so, garantia.
+
+Conferir se a captura esta armada (de dentro da sessao, ou do shell de onde
+voce lanca o claude):
+  ~/.claude/skills/agente-00c-runtime/scripts/guard-hooks-status.sh check \
+    --projeto-alvo-path . --include-loose-usage
+  # 5a coluna: endpoint-set (armado) | endpoint-unset (inerte)
+
 Snippet canonico: identico ao de cli/install.sh (telemetry_snippet) —
 teste de paridade em tests/cstk/test_cstk-main.sh gateia drift entre os dois.
 TELHELP

--- a/cli/lib/hooks.sh
+++ b/cli/lib/hooks.sh
@@ -708,7 +708,12 @@ settings.local.json com --local) ja registrar os hooks 00c, os dois ficam
 ativos e cada tool call e contada em dobro — o comando avisa e oferece a
 remocao (mesmo dedup do plugin; --remove-classic remove sem perguntar).
 Dica para nao sujar o git status do cliente com os scripts:
-  printf '.claude/hooks/\n.claude/settings.local.json\n' >> .git/info/exclude
+  printf '.claude/hooks/\n.claude/settings.local.json\n.claude/*.bak\n.claude/*.bak-pre-dedup\n' >> .git/info/exclude
+Os dois padroes .bak cobrem os backups que o PROPRIO comando gera: ao
+mesclar o registro (settings.json.bak / settings.local.json.bak) e ao
+deduplicar (settings.json.bak-pre-dedup). Sem eles o backup fica visivel no
+git status do cliente e entra num `git add -A` distraido — exatamente o que
+a dica existe para evitar (issue #163).
 
 status: diagnostico READ-ONLY (exit 0 sempre) — para cada hook 00c,
 script presente em .claude/hooks/ e em QUAL arquivo esta o registro
@@ -718,6 +723,14 @@ script presente em .claude/hooks/ e em QUAL arquivo esta o registro
 posttooluse-loose-usage.sh, hook que captura consumo avulso (fora de
 execucoes agente-00c/feature-00c) num sidecar local. Sem a flag,
 comportamento identico a antes desta opcao existir.
+ATENCAO (issue #162): provisionar o hook NAO basta — ele gateia em
+CSTK_OTEL_ENDPOINT (Passo 1) e sai 0 mudo sem ela, entao a captura fica
+INERTE e `cstk usage` responde "nao medido". A variavel precisa existir no
+ambiente do processo `claude` (wrapper de `cstk help telemetry`, ou export
+manual). Diferente do custo por onda, aqui NAO ha porta default de
+fallback. Para conferir:
+  guard-hooks-status.sh check --projeto-alvo-path PATH --include-loose-usage
+  -> 5a coluna endpoint-set (armado) | endpoint-unset (inerte)
 
 Quando o plugin 'cstk' ja prove os hooks, o provisionamento classico e
 pulado (dedup, plugin vence). Se AINDA houver registro classico no

--- a/cli/lib/setup.sh
+++ b/cli/lib/setup.sh
@@ -319,7 +319,14 @@ _setup_area_ok() {
 #   _SU_HOOKS_MANDATORY_STATUS  configured|not-configured|divergent|unavailable
 #   _SU_HOOKS_MANDATORY_REASON  motivo legivel (vazio quando configured)
 #   _SU_HOOKS_DIVERGENT_NAMES   basenames divergentes, espaco-separado
-#   _SU_HOOKS_LOOSE_STATUS      configured|not-configured|indeterminate
+#   _SU_HOOKS_LOOSE_STATUS      configured|configured-inert|not-configured|
+#                               indeterminate
+#     `configured-inert` (issue #162): hook present+registered+nao-stale,
+#     mas a 5a coluna do TSV reporta `endpoint-unset` — o hook gateia duro
+#     em CSTK_OTEL_ENDPOINT e sai 0 mudo sem ela, entao a captura nao
+#     acontece. Reportar isso como `configured` era dizer "ok" para um
+#     caminho que grava zero. Runtime antigo (4 colunas, sem gate) devolve
+#     coluna vazia -> preserva `configured`, nunca inventa `-inert`.
 #
 # Regra de escalada (I5 do data-model, achados SEC-01/SEC-02): a chamada
 # --verify-registration so pode ESCALAR o veredito da baseline, nunca
@@ -425,8 +432,14 @@ SDHVR
       _sdh_l_present=$(printf '%s' "$_sdh_loose_line" | awk -F'\t' '{print $2}')
       _sdh_l_reg=$(printf '%s' "$_sdh_loose_line" | awk -F'\t' '{print $3}')
       _sdh_l_fresh=$(printf '%s' "$_sdh_loose_line" | awk -F'\t' '{print $4}')
+      # 5a coluna (gate de ambiente, issue #162). Vazia em runtime antigo.
+      _sdh_l_gate=$(printf '%s' "$_sdh_loose_line" | awk -F'\t' '{print $5}')
       if [ "$_sdh_l_present" = "present" ] && [ "$_sdh_l_reg" = "registered" ] && [ "$_sdh_l_fresh" != "stale" ]; then
-        _SU_HOOKS_LOOSE_STATUS="configured"
+        if [ "$_sdh_l_gate" = "endpoint-unset" ]; then
+          _SU_HOOKS_LOOSE_STATUS="configured-inert"
+        else
+          _SU_HOOKS_LOOSE_STATUS="configured"
+        fi
       else
         _SU_HOOKS_LOOSE_STATUS="not-configured"
       fi
@@ -514,6 +527,9 @@ _setup_run_hooks_area() {
     _setup_info "setup: [hooks] motivo: $_SU_HOOKS_MANDATORY_REASON"
   fi
   _setup_info "setup: [hooks] loose usage (opt-in, escolha distinta — FR-008): $_SU_HOOKS_LOOSE_STATUS"
+  if [ "$_SU_HOOKS_LOOSE_STATUS" = "configured-inert" ]; then
+    _setup_info "setup: [hooks] loose usage INERTE: hook provisionado, mas CSTK_OTEL_ENDPOINT ausente no ambiente desta invocacao — o hook gateia nessa variavel e sai 0 mudo, entao 'cstk usage' vai responder 'nao medido' (issue #162). Remediacao: wrapper 'claude()' de 'cstk help telemetry'."
+  fi
 
   case "$_SU_HOOKS_MANDATORY_STATUS" in
     configured)
@@ -998,7 +1014,7 @@ _setup_show_telemetry_instructions() {
   _setup_info "setup: [telemetry]   export CLAUDE_CODE_ENABLE_TELEMETRY=1"
   _setup_info "setup: [telemetry]   export OTEL_METRICS_EXPORTER=prometheus"
   _setup_info "setup: [telemetry] o exporter local escuta em 127.0.0.1:9464 por padrao — nada sai da maquina."
-  _setup_info "setup: [telemetry] mais de um processo Claude Code ao mesmo tempo? So UM pode usar a porta fixa 9464. De a cada processo sua propria porta com OTEL_EXPORTER_PROMETHEUS_PORT (porta sorteada) + CSTK_OTEL_ENDPOINT (URL correspondente) — README.md documenta um wrapper 'claude()' de exemplo para ~/.zshrc que sorteia porta livre a cada lancamento."
+  _setup_info "setup: [telemetry] mais de um processo Claude Code ao mesmo tempo? So UM pode usar a porta fixa 9464. De a cada processo sua propria porta com OTEL_EXPORTER_PROMETHEUS_PORT (porta sorteada) + CSTK_OTEL_ENDPOINT (URL correspondente) — README.md documenta um wrapper 'claude()' de exemplo para ~/.zshrc que sorteia porta livre a cada lancamento. CSTK_OTEL_ENDPOINT tambem e requisito DURO da captura de consumo avulso (issue #162) — sem ela o hook opt-in fica inerte, mesmo provisionado."
   _setup_info "setup: [telemetry] este wizard NAO escreve nada disso por voce (FR-012) — a ativacao e sempre manual, fora do diretorio do projeto."
 }
 

--- a/docs/cstk-usage.md
+++ b/docs/cstk-usage.md
@@ -5,16 +5,22 @@
 > **Advanced track** — opt-in, complements [Knowledge memory](./cstk-recall.md).
 
 Tracks Claude Code token/cost consumption that happens **outside** any
-`agente-00c`/`feature-00c` execution — regular interactive sessions. Opt-in via
-the same native local telemetry configuration Claude Code already uses (no
-second toggle): a `PostToolUse` hook writes a local TSV sidecar per
-process/segment, throttled and silent by design (never blocks or slows down
-the session). `cstk usage` reads that sidecar plus the `loose_usage` table in
+`agente-00c`/`feature-00c` execution — regular interactive sessions. A
+`PostToolUse` hook writes a local TSV sidecar per process/segment, throttled
+and silent by design (never blocks or slows down the session). `cstk usage` reads that sidecar plus the `loose_usage` table in
 `knowledge.db` to report consumption by project/model, and to compare it
 against pipeline (orchestrator) consumption.
 
+Capture needs **two** things — installing the hook is not enough:
+
+1. the hook itself, opt-in and default OFF:
+   `cstk hooks install --with-loose-usage`;
+2. **`CSTK_OTEL_ENDPOINT` exported in the environment of the `claude`
+   process.** The hook gates hard on this variable and exits `0` silently
+   without it — see [Requirements](#requirements) below.
+
 ```bash
-# Enable the capture hook (opt-in, default OFF)
+# 1. Enable the capture hook (opt-in, default OFF)
 cstk hooks install --with-loose-usage
 
 # List loose consumption by project/model
@@ -46,9 +52,58 @@ cstk usage prune --older-than-days 30
   `loose_usage` rows. Open segments are never eligible. `--dry-run` reports
   the same selection without any side effect.
 
-**Requirements**: `sqlite3`, `jq`. Capture requires the hook to be installed
-(`cstk hooks install --with-loose-usage`, opt-in, default OFF — never bundled
-with the mandatory guard hooks).
+## Requirements
+
+`sqlite3`, `jq`, **plus both** of the following:
+
+- the hook installed: `cstk hooks install --with-loose-usage` (opt-in,
+  default OFF — never bundled with the mandatory guard hooks);
+- **`CSTK_OTEL_ENDPOINT` set and non-empty in the environment of the
+  `claude` process.**
+
+The second one is a hard requirement, not a convenience for multi-process
+setups. `posttooluse-loose-usage.sh` reads it as its very first step and
+exits `0` in silence when it is empty:
+
+```sh
+_PLU_ENDPOINT="${CSTK_OTEL_ENDPOINT:-}"
+[ -n "$_PLU_ENDPOINT" ] || exit 0
+```
+
+The variable is the hook's anchor of process identity, and it is gated on
+*deliberately*: `OTEL_METRICS_EXPORTER` and `OTEL_EXPORTER_PROMETHEUS_PORT`
+were observed **absent** in the hook subprocess's environment, so gating on
+those would capture nothing at all.
+
+Note the asymmetry with the per-wave (pipeline) path, which is why a
+half-configured setup is easy to miss: `otel-usage.sh` falls back to
+`http://127.0.0.1:9464/metrics` when `CSTK_OTEL_ENDPOINT` is unset, so the
+panel keeps showing per-wave cost normally — giving the impression that
+telemetry is fully configured — while loose capture stays inert.
+
+The supported way to set it is the `claude()` launcher wrapper (`cstk help
+telemetry` prints the ready-to-paste block; see the telemetry section of
+[README.md](../README.md)), which exports it at every launch. Exporting it by
+hand in your shell rc works too, as long as it reaches the `claude` process.
+
+### Checking whether capture is actually armed
+
+`guard-hooks-status.sh check --include-loose-usage` reports the gate as a
+5th TSV column (issue #162):
+
+```console
+$ guard-hooks-status.sh check --projeto-alvo-path . --include-loose-usage
+posttooluse-loose-usage.sh	present	registered	current	endpoint-unset
+```
+
+`endpoint-unset` means the hook is provisioned but would capture nothing.
+`cstk setup` reports the same condition as `loose usage: configured-inert`.
+
+The reading describes the environment of *that invocation*: if you run it
+from a plain terminal while the wrapper exports the variable only inside the
+`claude` process, `endpoint-unset` is honest about your terminal but not
+about the hook. Run it from inside the session (or from the same shell you
+launch `claude` from) for a direct reading.
 
 ## Data captured
 

--- a/docs/cstk-usage.pt-BR.md
+++ b/docs/cstk-usage.pt-BR.md
@@ -6,15 +6,21 @@
 
 Rastreia o consumo de tokens/custo do Claude Code que acontece **fora** de
 qualquer execução `agente-00c`/`feature-00c` — sessões interativas comuns.
-Opt-in via a mesma configuração nativa de telemetria local que o Claude Code
-já usa (sem um segundo toggle): um hook `PostToolUse` escreve um sidecar TSV
-local por processo/segmento, com throttle e silencioso por design (nunca
-bloqueia nem atrasa a sessão). O `cstk usage` lê esse sidecar mais a tabela
+Um hook `PostToolUse` escreve um sidecar TSV local por processo/segmento, com
+throttle e silencioso por design (nunca bloqueia nem atrasa a sessão). O `cstk usage` lê esse sidecar mais a tabela
 `loose_usage` do `knowledge.db` para reportar consumo por projeto/modelo, e
 para comparar com o consumo de pipeline (orquestrador).
 
+A captura exige **duas** coisas — instalar o hook não basta:
+
+1. o hook em si, opt-in e default DESLIGADO:
+   `cstk hooks install --with-loose-usage`;
+2. **`CSTK_OTEL_ENDPOINT` exportada no ambiente do processo `claude`.** O
+   hook gateia duro nessa variável e sai `0` mudo sem ela — ver
+   [Requisitos](#requisitos) abaixo.
+
 ```bash
-# Habilitar o hook de captura (opt-in, default DESLIGADO)
+# 1. Habilitar o hook de captura (opt-in, default DESLIGADO)
 cstk hooks install --with-loose-usage
 
 # Listar consumo avulso por projeto/modelo
@@ -46,9 +52,60 @@ cstk usage prune --older-than-days 30
   `loose_usage` correspondentes. Segmentos abertos nunca são elegíveis.
   `--dry-run` reporta a mesma seleção sem nenhum efeito colateral.
 
-**Requisitos**: `sqlite3`, `jq`. A captura exige o hook instalado
-(`cstk hooks install --with-loose-usage`, opt-in, default DESLIGADO — nunca
-empacotado junto dos guard hooks obrigatórios).
+## Requisitos
+
+`sqlite3`, `jq`, **mais as duas** condições abaixo:
+
+- o hook instalado: `cstk hooks install --with-loose-usage` (opt-in, default
+  DESLIGADO — nunca empacotado junto dos guard hooks obrigatórios);
+- **`CSTK_OTEL_ENDPOINT` setada e não-vazia no ambiente do processo
+  `claude`.**
+
+A segunda é requisito duro, não conveniência para cenário multi-processo. O
+`posttooluse-loose-usage.sh` a lê como primeiro passo e sai `0` em silêncio
+quando ela está vazia:
+
+```sh
+_PLU_ENDPOINT="${CSTK_OTEL_ENDPOINT:-}"
+[ -n "$_PLU_ENDPOINT" ] || exit 0
+```
+
+A variável é a âncora de identidade de processo do hook, e o gate é
+*deliberado*: `OTEL_METRICS_EXPORTER` e `OTEL_EXPORTER_PROMETHEUS_PORT`
+foram observadas **ausentes** no ambiente do subprocesso do hook, então
+gatear por elas capturaria zero.
+
+Vale notar a assimetria com o caminho de pipeline (custo por onda), que é o
+motivo de um setup pela metade passar despercebido: o `otel-usage.sh` cai no
+default `http://127.0.0.1:9464/metrics` quando `CSTK_OTEL_ENDPOINT` está
+ausente, então o painel continua mostrando custo por onda normalmente — o
+que dá a impressão de telemetria configurada — enquanto a captura avulsa
+fica inerte.
+
+A forma suportada de setá-la é o wrapper `claude()` de lançamento (`cstk
+help telemetry` imprime o bloco pronto; ver a seção de telemetria do
+[README.pt-BR.md](../README.pt-BR.md)), que a exporta a cada lançamento.
+Exportar à mão no rc do shell também funciona, desde que chegue ao processo
+`claude`.
+
+### Como conferir se a captura está de fato armada
+
+O `guard-hooks-status.sh check --include-loose-usage` reporta o gate numa
+5ª coluna TSV (issue #162):
+
+```console
+$ guard-hooks-status.sh check --projeto-alvo-path . --include-loose-usage
+posttooluse-loose-usage.sh	present	registered	current	endpoint-unset
+```
+
+`endpoint-unset` significa hook provisionado que capturaria nada. O `cstk
+setup` reporta a mesma condição como `loose usage: configured-inert`.
+
+A leitura descreve o ambiente *daquela invocação*: rodando de um terminal
+comum enquanto o wrapper exporta a variável só dentro do processo `claude`,
+`endpoint-unset` é honesto sobre o seu terminal, mas não sobre o hook. Rode
+de dentro da sessão (ou do mesmo shell de onde você lança o `claude`) para
+uma leitura direta.
 
 ## Dados capturados
 

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
@@ -65,14 +65,35 @@
 #         (inclui stale e divergent).
 #
 #       --include-loose-usage (feature cstk-setup, FASE 2.1, FR-002/FR-008):
-#         extensao ADITIVA — acrescenta uma 4a linha TSV para
-#         posttooluse-loose-usage.sh (mesmo formato de 4 colunas; NUNCA
-#         ganha a 5a coluna mesmo com --verify-registration — ver abaixo).
+#         extensao ADITIVA — acrescenta uma 4a LINHA TSV para
+#         posttooluse-loose-usage.sh, com 5 COLUNAS (issue #162):
+#             <arquivo>\t<present|missing>\t<registered|unregistered>\t
+#             <current|stale|unknown>\t<endpoint-set|endpoint-unset>
 #         NAO altera o exit code (hook opt-in, ausencia nunca e anomalia).
 #         Sem a flag, saida byte-a-byte identica a atual. Runtime instalado
 #         anterior a esta extensao rejeita a flag em _gh_die_usage com
 #         exit 2 — o consumidor MUST tratar como
 #         loose_usage_status=indeterminate, nunca como falha da area.
+#
+#         5a coluna = GATE (issue #162). Semantica DIFERENTE da 5a coluna
+#         de --verify-registration (que NUNCA e emitida para esta linha):
+#         aqui reporta apenas se `CSTK_OTEL_ENDPOINT` esta setado e
+#         nao-vazio no ambiente DESTA invocacao. Por que existe: o hook
+#         gateia duro nessa variavel (posttooluse-loose-usage.sh, Passo 1)
+#         e sai 0 mudo sem ela — present+registered+current descrevia um
+#         hook que capturava ZERO, sem nenhuma superficie para enxergar
+#         isso. Mesma classe do caso que motivou a 3a coluna (hook stale
+#         reportado como "3/3 ativos" com tool_calls zerado por 15 ondas).
+#
+#         LIMITE DA OBSERVACAO (nao e veredito, e por isso os tokens sao
+#         `endpoint-set`/`endpoint-unset` e nao `armed`/`inert`): o
+#         ambiente que decide o gate e o do processo `claude` que hospeda
+#         o hook, NAO necessariamente o desta invocacao. Rodado de um
+#         terminal comum enquanto o wrapper `claude()` exporta a variavel
+#         so dentro do processo, o resultado honesto e `endpoint-unset`
+#         para ESTE ambiente — e o stderr diz exatamente isso. Rodado de
+#         dentro da sessao (Bash tool do orquestrador, `cstk setup` no
+#         mesmo shell), o ambiente e o mesmo e a leitura e direta.
 #
 #       --verify-registration (feature cstk-setup, FASE 2.2, FR-016):
 #         extensao ADITIVA — acrescenta uma 5a coluna TSV
@@ -529,11 +550,28 @@ _gh_cmd_check() {
       _lst_reg="unregistered"
     fi
     _lst_fresh=$(_gh_freshness "$_pap" "$_lh")
-    if [ "$_verify_reg" = 1 ]; then
-      _lst_verify=$(_gh_verify_registration "$_pap" "$_lh")
-      printf '%s\t%s\t%s\t%s\t%s\n' "$_lh" "$_lst_file" "$_lst_reg" "$_lst_fresh" "$_lst_verify"
+    # 5a coluna: GATE de ambiente (issue #162). Observacao pura sobre o
+    # ambiente DESTA invocacao — nunca o veredito "o hook captura/nao
+    # captura", que depende do ambiente do processo `claude`. Ver o bloco
+    # LIMITE DA OBSERVACAO no cabecalho.
+    if [ -n "${CSTK_OTEL_ENDPOINT:-}" ]; then
+      _lst_gate="endpoint-set"
     else
-      printf '%s\t%s\t%s\t%s\n' "$_lh" "$_lst_file" "$_lst_reg" "$_lst_fresh"
+      _lst_gate="endpoint-unset"
+    fi
+    # --verify-registration NUNCA emite a coluna canonical/divergent para
+    # esta linha (contrato original preservado): a 5a posicao aqui e, e
+    # continua sendo, a dimensao de gate.
+    printf '%s\t%s\t%s\t%s\t%s\n' "$_lh" "$_lst_file" "$_lst_reg" "$_lst_fresh" "$_lst_gate"
+
+    # Diagnostico: so quando o hook de fato RODARIA (present+registered) e
+    # ainda assim capturaria zero. Hook ausente/nao registrado ja e opt-in
+    # nao exercido — nada a dizer.
+    if [ "$_quiet" = 0 ] && [ "$_lst_file" = "present" ] && [ "$_lst_reg" = "registered" ] \
+       && [ "$_lst_gate" = "endpoint-unset" ]; then
+      _gh_err "posttooluse-loose-usage.sh esta present+registered, mas CSTK_OTEL_ENDPOINT esta AUSENTE no ambiente desta invocacao — o hook gateia nessa variavel (Passo 1) e sai 0 mudo, entao a captura de consumo avulso fica INERTE e 'cstk usage' responde 'nao medido'."
+      _gh_err "  Remediacao: exportar CSTK_OTEL_ENDPOINT no ambiente do processo 'claude' — o wrapper 'claude()' de 'cstk help telemetry' (README.md, secao de telemetria) faz isso a cada lancamento."
+      _gh_err "  Se o wrapper JA estiver instalado, esta leitura pode ser um falso alarme: o ambiente que conta e o do processo 'claude', nao o deste terminal."
     fi
   fi
 
@@ -639,9 +677,13 @@ USO:
 
 check     TSV <hook>\t<present|missing>\t<registered|unregistered>\t<current|stale|unknown>;
           exit 0 se os 3 ativos E atuais, 1 caso contrario.
-          --include-loose-usage acrescenta 4a linha (posttooluse-loose-usage.sh),
-          nao afeta o exit. --verify-registration acrescenta 5a coluna
-          (canonical|divergent|indeterminate); "divergent" muda exit p/ 1.
+          --include-loose-usage acrescenta 4a linha (posttooluse-loose-usage.sh)
+          com 5a coluna de GATE (endpoint-set|endpoint-unset: CSTK_OTEL_ENDPOINT
+          setado no ambiente DESTA invocacao? sem ele o hook sai 0 mudo e a
+          captura fica inerte — issue #162); nao afeta o exit.
+          --verify-registration acrescenta 5a coluna
+          (canonical|divergent|indeterminate) aos 3 hooks obrigatorios — nunca
+          a linha de loose-usage; "divergent" muda exit p/ 1.
           Invoque cada flag SEPARADA da chamada baseline (nunca combinadas).
 tick-mode "hook" ou "manual" — o orquestrador so ticka na mao em "manual".
           "manual" tambem quando a copia do hook e cega a backend (pre

--- a/tests/cstk/test_setup.sh
+++ b/tests/cstk/test_setup.sh
@@ -425,6 +425,102 @@ STUB
   }
 }
 
+# ==== 5a coluna de gate na linha de loose-usage (issue #162) ====
+#
+# O hook opt-in gateia em CSTK_OTEL_ENDPOINT e sai 0 mudo sem ela: provisionado
+# porem inerte. `configured` para esse caso era dizer "ok" a um caminho que
+# grava zero — dai `configured-inert`. Runtime antigo (4 colunas, sem gate)
+# devolve $5 vazio e MUST preservar `configured`, nunca inventar `-inert`.
+
+# _stub_ghs_loose DIR GATE_TOKEN -> stub com a linha loose present/registered
+# e a 5a coluna sendo GATE_TOKEN (string vazia = runtime antigo, 4 colunas).
+_stub_ghs_loose() {
+  _sgl_dir=$1
+  _sgl_gate=$2
+  mkdir -p "$_sgl_dir"
+  if [ -n "$_sgl_gate" ]; then
+    _sgl_loose_line="posttooluse-loose-usage.sh\\tpresent\\tregistered\\tcurrent\\t$_sgl_gate\\n"
+  else
+    _sgl_loose_line="posttooluse-loose-usage.sh\\tpresent\\tregistered\\tcurrent\\n"
+  fi
+  cat > "$_sgl_dir/guard-hooks-status.sh" <<STUB
+#!/bin/sh
+case "\$*" in
+  *--verify-registration*)
+    printf 'pretooluse-bash-guard.sh\tpresent\tregistered\tcurrent\tcanonical\n'
+    printf 'posttooluse-tool-call-tick.sh\tpresent\tregistered\tcurrent\tcanonical\n'
+    printf 'posttooluse-agent-usage.sh\tpresent\tregistered\tcurrent\tcanonical\n'
+    exit 0 ;;
+  *--include-loose-usage*)
+    printf 'pretooluse-bash-guard.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-tool-call-tick.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-agent-usage.sh\tpresent\tregistered\tcurrent\n'
+    printf '$_sgl_loose_line'
+    exit 0 ;;
+  *)
+    printf 'pretooluse-bash-guard.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-tool-call-tick.sh\tpresent\tregistered\tcurrent\n'
+    printf 'posttooluse-agent-usage.sh\tpresent\tregistered\tcurrent\n'
+    exit 0 ;;
+esac
+STUB
+  chmod +x "$_sgl_dir/guard-hooks-status.sh"
+}
+
+# _run_setup_loose NAME GATE_TOKEN -> roda `cstk setup --dry-run --verbose`
+# com o stub acima; deixa a saida combinada em $_CAPTURED_STDOUT/_STDERR.
+_run_setup_loose() {
+  _rsl_repo="$TMPDIR_TEST/repo-$1"
+  _make_repo "$_rsl_repo"
+  _rsl_home="$TMPDIR_TEST/home-$1"
+  mkdir -p "$_rsl_home"
+  _stub_ghs_loose "$TMPDIR_TEST/stubbin-$1" "$2"
+  capture env PATH="$TMPDIR_TEST/stubbin-$1:$PATH" HOME="$_rsl_home" CSTK_LIB="$CSTK_LIB" \
+    sh "$CSTK" setup --project-path "$_rsl_repo" --dry-run --verbose
+}
+
+scenario_loose_gate_inert_reportado() {
+  _run_setup_loose loose-inert endpoint-unset
+  if ! printf '%s\n%s\n' "$_CAPTURED_STDOUT" "$_CAPTURED_STDERR" | grep -q 'configured-inert'; then
+    _fail "scenario_loose_gate_inert_reportado" \
+      "esperava loose_usage_status=configured-inert; obtido: $_CAPTURED_STDOUT $_CAPTURED_STDERR"
+    return 1
+  fi
+  if ! printf '%s\n%s\n' "$_CAPTURED_STDOUT" "$_CAPTURED_STDERR" | grep -q 'CSTK_OTEL_ENDPOINT'; then
+    _fail "scenario_loose_gate_inert_reportado" \
+      "esperava explicacao citando CSTK_OTEL_ENDPOINT"
+    return 1
+  fi
+  return 0
+}
+
+scenario_loose_gate_armed_segue_configured() {
+  _run_setup_loose loose-armed endpoint-set
+  if ! printf '%s\n%s\n' "$_CAPTURED_STDOUT" "$_CAPTURED_STDERR" | grep -q 'loose usage.*: configured$'; then
+    _fail "scenario_loose_gate_armed_segue_configured" \
+      "esperava loose_usage_status=configured; obtido: $_CAPTURED_STDOUT $_CAPTURED_STDERR"
+    return 1
+  fi
+  return 0
+}
+
+# Runtime antigo: 4 colunas, $5 vazio => preserva `configured` (o gate e
+# desconhecido, nao "ausente"); jamais fabrica `-inert`.
+scenario_loose_gate_runtime_antigo_preserva_configured() {
+  _run_setup_loose loose-old ''
+  if printf '%s\n%s\n' "$_CAPTURED_STDOUT" "$_CAPTURED_STDERR" | grep -q 'configured-inert'; then
+    _fail "scenario_loose_gate_runtime_antigo_preserva_configured" \
+      "runtime sem a coluna de gate nao pode virar configured-inert"
+    return 1
+  fi
+  if ! printf '%s\n%s\n' "$_CAPTURED_STDOUT" "$_CAPTURED_STDERR" | grep -q 'loose usage.*: configured$'; then
+    _fail "scenario_loose_gate_runtime_antigo_preserva_configured" \
+      "esperava configured; obtido: $_CAPTURED_STDOUT $_CAPTURED_STDERR"
+    return 1
+  fi
+  return 0
+}
+
 # ==== 3.2.4 status=configured -> zero chamadas de aplicacao (I1) ====
 
 scenario_hooks_second_run_zero_calls() {

--- a/tests/test_guard-hooks-status.sh
+++ b/tests/test_guard-hooks-status.sh
@@ -55,9 +55,24 @@ SCRIPT="$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-st
 # falha que a memoria do projeto ja registra para helpers resolvidos via
 # ~/.claude. Cenarios que QUEREM testar o caminho do plugin setam as vars
 # explicitamente (ver scenario_check_plugin_*).
+# CSTK_OTEL_ENDPOINT e pinada VAZIA por default (issue #162): a 5a coluna
+# de gate le o ambiente da invocacao, entao herdar a variavel do shell de
+# quem roda a suite tornaria os cenarios nao-deterministicos (verdes na
+# maquina sem wrapper `claude()`, vermelhos na maquina com ele).
 _ghs() {
   capture env HOME="$TMPDIR_TEST/.home-sem-plugin" CLAUDE_PLUGIN_ROOT='' \
     CSTK_HOOKS_CATALOG_DIR="${CSTK_HOOKS_CATALOG_DIR:-}" \
+    CSTK_OTEL_ENDPOINT='' \
+    sh "$SCRIPT" "$@"
+}
+
+# _ghs_endpoint URL ARGS... -> mesma invocacao com CSTK_OTEL_ENDPOINT setada.
+_ghs_endpoint() {
+  _ge_url=$1
+  shift
+  capture env HOME="$TMPDIR_TEST/.home-sem-plugin" CLAUDE_PLUGIN_ROOT='' \
+    CSTK_HOOKS_CATALOG_DIR="${CSTK_HOOKS_CATALOG_DIR:-}" \
+    CSTK_OTEL_ENDPOINT="$_ge_url" \
     sh "$SCRIPT" "$@"
 }
 
@@ -494,6 +509,12 @@ scenario_loose_usage_detection_current_runtime() {
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 (hook opt-in ausente nao afeta exit), obtido $_CAPTURED_EXIT"; return 1; }
   printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-loose-usage.sh	missing	unregistered	' \
     || { _fail "TSV" "esperado 4a linha posttooluse-loose-usage.sh missing/unregistered"; return 1; }
+  # 5a coluna = gate de ambiente (issue #162); _ghs pina a variavel vazia.
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-loose-usage.sh	missing	unregistered	unknown	endpoint-unset$' \
+    || { _fail "TSV" "esperado 5a coluna endpoint-unset na linha loose: $_CAPTURED_STDOUT"; return 1; }
+  # Hook ausente = opt-in nao exercido: NAO ha o que avisar sobre o gate.
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'CSTK_OTEL_ENDPOINT' \
+    && { _fail "stderr" "hook ausente nao deveria disparar aviso de gate"; return 1; }
   _n=$(printf '%s\n' "$_CAPTURED_STDOUT" | wc -l | tr -d ' ')
   [ "$_n" = 4 ] || { _fail "TSV" "esperado 4 linhas com --include-loose-usage, obtido $_n"; return 1; }
   return 0
@@ -543,6 +564,83 @@ scenario_loose_usage_detection_stale_runtime() {
   capture sh "$_old" check --projeto-alvo-path "$_p" --quiet
   [ "$_CAPTURED_EXIT" = 0 ] \
     || { _fail "exit" "baseline no runtime antigo deveria seguir exit 0, obtido $_CAPTURED_EXIT"; return 1; }
+  return 0
+}
+
+# ==== 5a coluna de GATE na linha de loose-usage (issue #162) ====
+#
+# Motivacao (issue #162): o hook gateia duro em CSTK_OTEL_ENDPOINT
+# (posttooluse-loose-usage.sh, Passo 1) e sai 0 mudo sem ela. Antes desta
+# coluna, present+registered+current descrevia um hook que capturava ZERO,
+# sem nenhuma superficie para o operador enxergar isso — a mesma classe de
+# falha silenciosa que motivou a 3a coluna (stale reportado como ativo).
+
+# _provision_loose PAP -> hook opt-in presente E registrado (alem dos 3).
+_provision_loose() {
+  _pl_p=$1
+  for _pl_h in $_HOOKS; do _put_hook "$_pl_p" "$_pl_h"; done
+  _put_hook "$_pl_p" posttooluse-loose-usage.sh
+  # shellcheck disable=SC2086
+  _register "$_pl_p" $_HOOKS posttooluse-loose-usage.sh
+}
+
+# Hook provisionado + variavel AUSENTE => endpoint-unset + aviso no stderr,
+# sem mexer no exit (opt-in nunca reprova a area).
+scenario_loose_gate_endpoint_unset_avisa() {
+  _p=$(_mkproj proj-loose-gate-unset)
+  _provision_loose "$_p"
+  _ghs check --projeto-alvo-path "$_p" --include-loose-usage
+  [ "$_CAPTURED_EXIT" = 0 ] \
+    || { _fail "exit" "gate inerte NAO pode mudar o exit (hook opt-in), obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-loose-usage.sh	present	registered	current	endpoint-unset$' \
+    || { _fail "TSV" "esperado endpoint-unset: $_CAPTURED_STDOUT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'CSTK_OTEL_ENDPOINT' \
+    || { _fail "stderr" "esperado aviso citando CSTK_OTEL_ENDPOINT: $_CAPTURED_STDERR"; return 1; }
+  # O aviso precisa dizer o que o operador perde, nao so o nome da variavel.
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'INERTE' \
+    || { _fail "stderr" "aviso deveria explicitar que a captura fica INERTE"; return 1; }
+  return 0
+}
+
+# Mesma provisao, variavel PRESENTE => endpoint-set e nenhum aviso.
+scenario_loose_gate_endpoint_set_silencioso() {
+  _p=$(_mkproj proj-loose-gate-set)
+  _provision_loose "$_p"
+  _ghs_endpoint 'http://127.0.0.1:41234/metrics' check --projeto-alvo-path "$_p" --include-loose-usage
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-loose-usage.sh	present	registered	current	endpoint-set$' \
+    || { _fail "TSV" "esperado endpoint-set: $_CAPTURED_STDOUT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'CSTK_OTEL_ENDPOINT' \
+    && { _fail "stderr" "com a variavel setada nao pode haver aviso de gate"; return 1; }
+  return 0
+}
+
+# --quiet suprime o aviso (contrato geral do subcomando), mas NUNCA a coluna:
+# o consumidor programatico (cli/lib/setup.sh) chama sempre com --quiet.
+scenario_loose_gate_quiet_preserva_coluna() {
+  _p=$(_mkproj proj-loose-gate-quiet)
+  _provision_loose "$_p"
+  _ghs check --projeto-alvo-path "$_p" --include-loose-usage --quiet
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '	endpoint-unset$' \
+    || { _fail "TSV" "--quiet nao pode suprimir a coluna de gate: $_CAPTURED_STDOUT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDERR" | grep -q 'CSTK_OTEL_ENDPOINT' \
+    && { _fail "stderr" "--quiet deveria suprimir o aviso"; return 1; }
+  return 0
+}
+
+# --verify-registration continua NAO emitindo canonical/divergent para a
+# linha de loose-usage: a 5a posicao dessa linha e, e segue sendo, o gate.
+scenario_loose_gate_nao_vira_canonical_com_verify() {
+  _p=$(_mkproj proj-loose-gate-verify)
+  for _h in $_HOOKS; do _put_hook "$_p" "$_h"; done
+  _put_hook "$_p" posttooluse-loose-usage.sh
+  # shellcheck disable=SC2086
+  _register_canonical "$_p" $_HOOKS posttooluse-loose-usage.sh
+  _ghs check --projeto-alvo-path "$_p" --include-loose-usage --verify-registration
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-loose-usage.sh	present	registered	current	endpoint-unset$' \
+    || { _fail "TSV" "linha loose deveria manter o gate na 5a coluna: $_CAPTURED_STDOUT"; return 1; }
+  printf '%s\n' "$_CAPTURED_STDOUT" | grep -q '^posttooluse-loose-usage.sh.*canonical' \
+    && { _fail "TSV" "linha loose nao pode ganhar canonical/divergent"; return 1; }
   return 0
 }
 


### PR DESCRIPTION
Fecha #162 e #163.

Ambas foram avaliadas como **relevantes e necessarias**: nenhuma quebra codigo,
mas as duas fazem o toolkit afirmar "ok" para um estado que nao e ok — a mesma
classe de falha silenciosa que motivou a 3a coluna do `guard-hooks-status.sh`
(hook stale reportado como "3/3 ativos" com `tool_calls` zerado por 15 ondas).

## #162 — captura de consumo avulso inerte reportada como `current`

Confirmado no codigo: `posttooluse-loose-usage.sh:56-57` gateia duro em
`CSTK_OTEL_ENDPOINT` e sai `0` mudo sem ela. O gate esta **correto** e nao foi
mexido (o contrato explica por que `OTEL_METRICS_EXPORTER` /
`OTEL_EXPORTER_PROMETHEUS_PORT` nao servem: observadas ausentes no subprocesso).
O que estava errado era tudo em volta.

Assimetria que fazia o setup pela metade passar despercebido — `otel-usage.sh`
cai no default `http://127.0.0.1:9464/metrics` e continua medindo custo por
onda, entao o painel dava a impressao de telemetria configurada.

- **Diagnostico**: a linha de `posttooluse-loose-usage.sh` ganhou 5a coluna de
  GATE (`endpoint-set` | `endpoint-unset`) + aviso em stderr quando o hook esta
  present+registered e ainda assim capturaria nada. Nao afeta exit code nem a
  saida sem a flag.
- **`cstk setup`**: novo valor `configured-inert`. Runtime antigo (4 colunas)
  preserva `configured` — o gate fica desconhecido, jamais fabricado.
- **Doc**: `docs/cstk-usage.md`/`.pt-BR.md` perderam o "no second toggle" e
  ganharam secao Requisitos com as DUAS condicoes, o porque do gate, a
  assimetria e como conferir. READMEs e `cstk help telemetry` passaram a tratar
  o wrapper `claude()` como requisito duro, nao conveniencia multi-processo.

Os tokens sao **observacao, nao veredito** (`endpoint-set`/`endpoint-unset`, nao
`armed`/`inert`): o ambiente que decide o gate e o do processo `claude`, nao
necessariamente o da invocacao do diagnostico. O stderr diz isso explicitamente.

**Achado extra**: o ramo sem `python3` do wrapper liga
`CLAUDE_CODE_ENABLE_TELEMETRY` + `OTEL_METRICS_EXPORTER` mas **nao** define
`CSTK_OTEL_ENDPOINT` — nessa maquina o custo por onda funciona e a captura
avulsa nao. Documentado em `cstk help telemetry`.

**Divergencia pre-existente corrigida junto**: o cabecalho do script ja afirmava
que essa linha "NUNCA ganha a 5a coluna mesmo com `--verify-registration`", mas
o codigo emitia `canonical`/`divergent` ali. Caminho na pratica morto (as duas
flags nunca sao combinadas — SEC-03, gateado por teste; o unico consumidor le so
as colunas 2..4), mas era o contrato mentindo sobre o codigo.

## #163 — dica de `.git/info/exclude` nao cobria o `.bak` do proprio comando

A dica passou a incluir `.claude/*.bak` e `.claude/*.bak-pre-dedup` (este ultimo
cobre o backup do dedup do `--remove-classic`, que o glob `.bak` nao casa),
corrigida nos tres sitios: `--help` de `cstk hooks install`, `README.md` e
`README.pt-BR.md`.

## Verificacao

Dogfooding das duas reproducoes das issues contra o codigo deste repo
(`CSTK_LIB` apontando para `cli/lib`):

- #163 com a dica **nova**: `git status --porcelain -uall` vazio e
  `git add -A --dry-run` vazio. Controle com a dica **antiga**, mesmo fluxo:
  `?? .claude/settings.local.json.bak` — a diferenca e o fix.
- #162 sem a variavel: `posttooluse-loose-usage.sh present registered current
  endpoint-unset` + os 3 avisos de stderr. Com a variavel setada: `endpoint-set`
  e stderr limpo. `cstk setup --dry-run --verbose` reporta `configured-inert` /
  `configured` nos dois casos.

Suite completa: **PASS 3440 · FAIL 0 · ERROR 0 · ORPHANS 0** (1282s).
7 cenarios novos (4 em `test_guard-hooks-status.sh`, 3 em `tests/cstk/test_setup.sh`).

O helper `_ghs` do teste passou a pinar `CSTK_OTEL_ENDPOINT` vazia — sem isso os
cenarios ficariam verdes na maquina sem wrapper e vermelhos na maquina com ele.

## Release 9.2.3

Bump dos manifestos de plugin incluido no PR (commit `chore(release)`), em
lockstep com a tag — `validate-plugin-manifests.sh --version 9.2.3 --strict`
sai `OK (0 aviso(s))`. Sem isso o `release.yml` bloqueia a tag (gate MP-5).

Toca as duas metades da instalacao: `guard-hooks-status.sh` e **catalogo**
(`cstk update` / `cstk install --from`), `cli/lib/*` e o binario sao **runtime**
(`cstk self-update --from`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2ZbtoboQFmYui46awPkZs