### PR TITLE
fix(roadmap-wave): lancar filha com descricao + short-name e sempre em split

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "9.2.3",
+      "version": "9.3.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "9.2.3",
+      "version": "9.3.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [9.3.0] - 2026-08-26
+
+Corrige o lancamento das sessoes-filha da leva paralela do roadmap. O
+`parallel-launch.sh emit` compunha `/feature-00c <SHORT>`, mas o contrato
+REAL do command sao DOIS posicionais — `"<descricao>" [<short-name>]`
+(`plugins/cstk/commands/feature-00c.md:113-115`). A filha lia o short-name
+como DESCRICAO e re-derivava um short-name novo pelo `specify`, que podia
+divergir da worktree/branch ja criada por `cstk session start <SHORT>` e do
+`feature=<short>` da notificacao de volta. Na mesma release, o wrapper tmux
+passa a ser SEMPRE `split-window` (pane irmao no window da coordenadora) em
+vez de `new-window`.
+
+### Changed
+
+- **BREAKING para quem consome a saida do `emit` (a prosa do proprio
+  toolkit): prompt da filha agora e `/feature-00c "<DESCRICAO>" <SHORT>`.**
+  O short-name POSICIONAL pina a feature — nada mais e re-derivado, e o
+  short-name lancado passa a ser o mesmo da worktree, da branch e do
+  `feature=<short>` da notificacao (novo INV-9 do contrato). A descricao
+  entra sempre entre aspas duplas, dentro de um envelope de aspas simples.
+- **Wrapper tmux: `split-window`, nunca `new-window`.** Cada filha abre
+  como pane irmao no MESMO window da coordenadora, mantendo a leva inteira
+  visivel de uma vez. Consequencia verificada em `tmux list-commands`
+  (3.5a): `split-window` **nao tem `-n`**, entao o `-n "<SHORT>"` saiu da
+  composicao e a identificacao da filha passa a ser exclusivamente
+  `claude --name "cstk-feature/<SHORT>"` + o `pane_id` devolvido por
+  `-P -F '#{pane_id}'`.
+- **Kill switch de uma filha: `tmux kill-pane -t <pane_id>`** (antes
+  `tmux kill-window`), atualizado em `agente-00c.md` §6.bis, `docs/
+  agente-00c.md` (+ pt-BR), contrato §8.bis e no ensaio
+  `tests/eval/rehearsal_roadmap-wave.sh`. `cstk session end <short>`
+  continua sendo a outra metade (nunca `git worktree remove` cru).
+
+### Added
+
+- **`emit --description TEXT`** — descricao explicita da feature, pareada
+  com o `--feature` IMEDIATAMENTE anterior; vence o roadmap. Sem um
+  `--feature` antes => exit `2`.
+- **`emit --roadmap PATH`** — de onde extrair o paragrafo `**Descricao**:`
+  da entrada `### N. <SHORT>` quando `--description` nao foi informado.
+  Default `<repo>/docs/roadmap.md`; `/roadmap-wave` repassa o proprio
+  `--roadmap` tambem ao `emit`. Arquivo ausente ou entrada sem o campo =>
+  fallback para o proprio short-name com aviso em stderr, NUNCA erro
+  (best-effort, mesma politica do aviso de sobreposicao do
+  `roadmap-frontier.sh`).
+- **Sanitizacao da descricao (novo §4.1a do contrato + INV-10)**: prosa de
+  roadmap e UNTRUSTED (`roadmap-prose-untrusted`) e `--description` pode vir
+  de texto arbitrario, entao a descricao vira uma unica linha, perde
+  caracteres de controle, aspa simples, aspa dupla, crase, `\`, `$`, `;`,
+  `&`, `|`, `<`, `>`, `!`, `#`, tem espacos colapsados/aparados e e truncada
+  a 300 chars ANTES de entrar na composicao. E a remocao das aspas que torna
+  seguro o envelope de aspas simples.
+- **Cobertura**: 10 cenarios novos em `tests/test_parallel-launch.sh`
+  (descricao vinda do roadmap, precedencia do `--description`, pareamento
+  com o `--feature` anterior, `--description` orfa => exit 2, fallback com
+  aviso, roadmap inexistente nao aborta, truncamento em 300, 2 adversariais
+  de injecao). O stub de `claude` do e2e `tests/test_e2e_roadmap_wave.sh`
+  agora EXIGE o formato novo (`exit 64` no formato antigo — regressao para
+  `/feature-00c <short>` quebra o e2e), e o cenario de tmux real valida pane
+  irmao + `kill-pane` + assert de que nenhum window novo e criado.
+
 ## [9.2.3] - 2026-08-26
 
 Fecha duas issues de **diagnostico e documentacao enganosos** — nenhuma das
@@ -7343,6 +7404,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[9.3.0]: https://github.com/JotJunior/cstk/releases/tag/v9.3.0
 [9.2.3]: https://github.com/JotJunior/cstk/releases/tag/v9.2.3
 [9.2.2]: https://github.com/JotJunior/cstk/releases/tag/v9.2.2
 [9.2.1]: https://github.com/JotJunior/cstk/releases/tag/v9.2.1

--- a/docs/agente-00c.md
+++ b/docs/agente-00c.md
@@ -223,10 +223,14 @@ from a `status` field in the roadmap — and offers a **parallel wave**:
    `~/.claude` and credentials) and, above the cap, which ones.
 3. `parallel-launch.sh emit --repo <repo> --feature <short> [...]` **only
    prints** the launch commands per feature — `cstk session start <short>` +
-   `tmux new-window ... claude --name ... "/feature-00c <short>"`, or the
-   degraded `cd ... && claude ...` form when `check-tmux` says tmux is
-   absent (exit 3). The parent runs them; the script never executes anything
-   and never touches `cli/lib/session.sh`.
+   `tmux split-window ... claude --name ... '/feature-00c "<description>"
+   <short>'`, or the degraded `cd ... && claude ...` form when `check-tmux`
+   says tmux is absent (exit 3). Children always open as sibling **panes**
+   in the coordinator's window (`split-window`, never `new-window`), and
+   the prompt always carries the description as the first positional
+   argument and the short-name as the second — the exact `/feature-00c`
+   contract. The parent runs them; the script never executes anything and
+   never touches `cli/lib/session.sh`.
 4. When a child execution reaches a terminal state (`concluida`, `abortada`
    or `aguardando_humano`) `feature-00c.md` §5.quater sends, best-effort via
    the Claude Code `SendMessage` tool, the opaque trigger
@@ -239,7 +243,7 @@ from a `status` field in the roadmap — and offers a **parallel wave**:
 
 Empirically verified (dec-037 of the feature): an idle Claude Code session
 (13 h idle) woke up on `SendMessage` and answered in ~30 s without human
-intervention. Kill switch: `tmux kill-window -t <pane>` + `cstk session end
+intervention. Kill switch: `tmux kill-pane -t <pane_id>` + `cstk session end
 <short>`. Manual verification path: `cstk session list`,
 `roadmap-status.sh --json`, `tmux list-panes -a` (§6.bis).
 

--- a/docs/agente-00c.pt-BR.md
+++ b/docs/agente-00c.pt-BR.md
@@ -224,10 +224,14 @@ pai (`agente-00c.md` §6.ter / resume §9.ter) computa a *fronteira* — entrada
    `$HOME`, `~/.claude` e credenciais) e, acima do teto, quais.
 3. `parallel-launch.sh emit --repo <repo> --feature <short> [...]` **só
    imprime** os comandos de lançamento por feature — `cstk session start
-   <short>` + `tmux new-window ... claude --name ... "/feature-00c <short>"`,
-   ou a forma degradada `cd ... && claude ...` quando `check-tmux` diz que o
-   tmux está ausente (exit 3). Quem executa é o pai; o script nunca executa
-   nada e nunca toca `cli/lib/session.sh`.
+   <short>` + `tmux split-window ... claude --name ...
+   '/feature-00c "<descricao>" <short>'`, ou a forma degradada
+   `cd ... && claude ...` quando `check-tmux` diz que o tmux está ausente
+   (exit 3). As filhas abrem sempre como **panes** irmãos no window da
+   coordenadora (`split-window`, nunca `new-window`), e o prompt sempre
+   leva a descrição como primeiro posicional e o short-name como segundo —
+   o contrato exato de `/feature-00c`. Quem executa é o pai; o script nunca
+   executa nada e nunca toca `cli/lib/session.sh`.
 4. Quando uma execução-filha chega a estado terminal (`concluida`, `abortada`
    ou `aguardando_humano`), `feature-00c.md` §5.quater envia, best-effort via
    a tool `SendMessage` do Claude Code, o gatilho opaco
@@ -240,7 +244,7 @@ pai (`agente-00c.md` §6.ter / resume §9.ter) computa a *fronteira* — entrada
 
 Verificado empiricamente (dec-037 da feature): uma sessão Claude Code ociosa
 há 13 h acordou ao receber `SendMessage` e respondeu em ~30 s sem intervenção
-humana. Kill switch: `tmux kill-window -t <pane>` + `cstk session end
+humana. Kill switch: `tmux kill-pane -t <pane_id>` + `cstk session end
 <short>`. Via manual de verificação: `cstk session list`,
 `roadmap-status.sh --json`, `tmux list-panes -a` (§6.bis).
 

--- a/docs/specs/roadmap-parallel-launch/contracts/parallel-launch.md
+++ b/docs/specs/roadmap-parallel-launch/contracts/parallel-launch.md
@@ -81,8 +81,9 @@ roadmap.
 ## 4. `parallel-launch.sh` — uso proposto
 
 ```
-parallel-launch.sh emit  --repo PATH --feature SHORT [--feature SHORT ...]
-                         [--coordinator-name NAME]
+parallel-launch.sh emit  --repo PATH --feature SHORT [--description TEXT]
+                         [--feature SHORT [--description TEXT] ...]
+                         [--roadmap PATH] [--coordinator-name NAME]
 parallel-launch.sh check-tmux
 parallel-launch.sh -h | --help
 ```
@@ -102,9 +103,47 @@ assercao verificavel em vez de promessa.
 
 ```
 cstk session start <SHORT>
-tmux new-window -c "<WORKTREE>" -n "<SHORT>" -P -F '#{pane_id}' \
-  claude --name "<CHILD_NAME>" "/feature-00c <SHORT>"
+tmux split-window -c "<WORKTREE>" -P -F '#{pane_id}' \
+  claude --name "<CHILD_NAME>" '/feature-00c "<DESCRICAO>" <SHORT>'
 ```
+
+**Sempre `split-window`, nunca `new-window`** (revisao 2026-08-26): a
+sessao-filha entra como **pane irmao no window da coordenadora**, mantendo
+a leva inteira visivel de uma vez. Consequencias diretas, verificadas em
+`tmux list-commands` (tmux 3.5a): `split-window` **nao tem `-n`** (nao
+nomeia window), entao a identificacao da filha passa a ser exclusivamente
+`claude --name "<CHILD_NAME>"` + o `pane_id` devolvido por `-P -F
+'#{pane_id}'` — que e tambem o endereco do kill switch
+(`tmux kill-pane -t <pane_id>`, §8.bis). `split-window` exige contexto de
+sessao tmux (o pai roda dentro do tmux); quando nao ha, vale a forma
+degradada do fim de §4.2.
+
+**Prompt no formato REAL de `/feature-00c`** (revisao 2026-08-26): o
+primeiro posicional e a **DESCRICAO** e o segundo e o **short-name**
+(`plugins/cstk/commands/feature-00c.md:113-115` — **REAL**, lido no
+proprio command). A forma anterior (`"/feature-00c <SHORT>"`) fazia o
+command ler o short-name como descricao e re-derivar um short-name novo
+via `specify`, divergindo da worktree/branch criada por `cstk session
+start <SHORT>` e do `feature=<short>` da notificacao (contract §6).
+
+### 4.1a Origem e sanitizacao de `<DESCRICAO>`
+
+Precedencia (primeira fonte nao-vazia vence):
+
+| # | Fonte | Observacao |
+|---|---|---|
+| 1 | `--description TEXT` | pareia com o `--feature` IMEDIATAMENTE anterior; sem `--feature` antes => exit `2` |
+| 2 | `**Descricao**:` da entrada `### N. <SHORT>` em `--roadmap` | default do `--roadmap`: `<repo>/docs/roadmap.md` (`contracts/roadmap-artifact.md` §2); linhas de continuacao juntadas por espaco |
+| 3 | o proprio `<SHORT>` | fallback degradado, com aviso em stderr. Ausencia de descricao **NUNCA** e erro (best-effort) |
+
+**Sanitizacao obrigatoria** — a prosa do roadmap e UNTRUSTED (mesmo rotulo
+`roadmap-prose-untrusted` de `roadmap-frontier.sh` §6) e `--description`
+pode vir de texto arbitrario. Antes de entrar na composicao, a descricao
+**MUST**: virar uma unica linha (newline/CR/TAB => espaco), perder todo
+caractere de controle, perder aspa simples, aspa dupla, crase, `\`, `$`,
+`;`, `&`, `|`, `<`, `>`, `!`, `#`, ter espacos colapsados/aparados e ser
+truncada a **300 chars**. E a remocao das aspas que torna seguro o
+envelope de aspas simples `'/feature-00c "<DESCRICAO>" <SHORT>'`.
 
 **Regras de quoting (obrigatorias — gate `owasp-security`, finding MEDIUM
 "argument/command injection")**: `<WORKTREE>` e `<CHILD_NAME>` **MUST** ser
@@ -115,7 +154,7 @@ aspa. `<CHILD_NAME>` MUST ser validado por allowlist
 `^cstk-feature/[a-z][a-z0-9-]*$` antes de entrar na linha, e
 `--coordinator-name` por `^cstk-coord/[A-Za-z0-9._-]{1,64}$`.
 
-Note que o `shell-command` do `tmux new-window` e passado como **argv
+Note que o `shell-command` do `tmux split-window` e passado como **argv
 separado**, nao como string unica entre aspas simples: a forma
 `'claude --name <X> "..."'` (string unica) faria uma aspa simples em `<X>`
 escapar do literal. tmux aceita argv multiplo nessa posicao, o que remove a
@@ -131,9 +170,13 @@ Elementos **REAIS** (verificados, nao supostos):
   `exec claude` sem argumento algum — nao aceita prompt nem nome.
 - `claude [options] [command] [prompt]` e `-n, --name <name>` — saida real de
   `claude --help` (versao `2.1.234`), prompt e POSICIONAL.
-- `new-window [-abdkPS] [-c start-directory] ... [-n window-name] ... [shell-command]`
-  — saida real de `tmux list-commands` (tmux 3.5a). `-P -F '#{pane_id}'`
-  imprime o identificador do pane criado.
+- `split-window [-bdefhIPvZ] [-c start-directory] [-e environment] [-F format] [-l size] [-t target-pane][shell-command]`
+  — saida real de `tmux list-commands` (tmux 3.5a). Note a AUSENCIA de
+  `-n`: `split-window` nao nomeia window. `-P -F '#{pane_id}'` imprime o
+  identificador do pane criado.
+- `"<descricao-curta>" [<short-name>] [--projeto <path>] [--whitelist <urls>]`
+  — `argument-hint` real de `plugins/cstk/commands/feature-00c.md:3`, com
+  o parse dos dois posicionais em `:113-115`.
 
 ### 4.2 Defesa em profundidade no `emit`
 
@@ -184,7 +227,7 @@ Em ambiente **sem tmux** (`check-tmux` exit `3`), `emit` imprime a segunda
 linha em forma manual equivalente (FR-007 / US3):
 
 ```
-cd <WORKTREE> && claude --name <CHILD_NAME> "/feature-00c <SHORT>"
+cd "<WORKTREE>" && claude --name "<CHILD_NAME>" '/feature-00c "<DESCRICAO>" <SHORT>'
 ```
 
 Nunca aguardar por tmux, nunca falhar silenciosamente (SC-003).
@@ -347,7 +390,7 @@ FR-017/FR-018 — CHK101/CHK103):
   fluxo de oferta (§3).
 - O teto de concorrencia (FR-003, default 2) e tambem um limite de blast
   radius, nao so de rate-limit (FR-018).
-- MUST existir kill switch trivial: `tmux kill-window -t <pane_id>` +
+- MUST existir kill switch trivial: `tmux kill-pane -t <pane_id>` +
   `cstk session end <SHORT>` (ambos **REAIS**), documentados junto da via
   manual (§7). `cstk session end <SHORT>` tem um segundo papel, alem de
   kill switch: e o pre-requisito de recuperacao (FR-016) apos uma
@@ -374,3 +417,9 @@ FR-017/FR-018 — CHK101/CHK103):
   aspas e revalidado por allowlist no ponto de uso (§4.1, §4.2).
 - **INV-8**: notificacao recebida e gatilho opaco; nenhuma acao e derivada
   do seu conteudo sem reconfirmacao pela fronteira recalculada (§6, §8).
+- **INV-9**: o prompt da filha carrega SEMPRE descricao (1o posicional) +
+  short-name (2o posicional) — o short-name lancado e o mesmo da worktree,
+  da branch e do `feature=<short>` da notificacao, nunca re-derivado
+  (§4.1).
+- **INV-10**: texto de descricao (roadmap ou `--description`) e UNTRUSTED:
+  entra na composicao apenas sanitizado por §4.1a, jamais bruto.

--- a/docs/specs/roadmap-parallel-launch/quickstart.md
+++ b/docs/specs/roadmap-parallel-launch/quickstart.md
@@ -88,7 +88,7 @@ travamento aguardando confirmacao de entrega. Falha registrada em log local.
 
 **Expected**: exit `0`; para cada feature escolhida, saida contem os comandos
 completos e executaveis (`cstk session start <SHORT>` e
-`cd <worktree> && claude --name … "/feature-00c <SHORT>"`); zero prompt
+`cd "<worktree>" && claude --name … '/feature-00c "<DESCRICAO>" <SHORT>'`); zero prompt
 pendente, zero espera por recurso ausente, zero falha silenciosa.
 
 **Assercao de paridade (AC2 da US3)**: os comandos impressos aqui sao

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "9.2.3",
+  "version": "9.3.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "9.2.3",
+  "version": "9.3.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/commands/agente-00c.md
+++ b/plugins/cstk/commands/agente-00c.md
@@ -937,7 +937,7 @@ tmux list-panes -a                                 # panes vivos (so quando lanc
 
 Interpretacao: worktree presente + status `em-andamento` + nenhuma
 notificacao recebida => filha possivelmente morta abruptamente. Kill switch
-trivial se necessario: `tmux kill-window -t <pane_id>` + `cstk session end
+trivial se necessario: `tmux kill-pane -t <pane_id>` + `cstk session end
 <SHORT>`. Esta via manual funciona independentemente de o wake-up automatico
 ter disparado ou nao (FR-013) — nao depende do resultado do experimento da
 FASE 0.
@@ -1076,8 +1076,20 @@ uma sessao-filha — so a coordenadora interage com o operador e lanca.
    ~/.claude/skills/agente-00c-runtime/scripts/parallel-launch.sh emit \
      --repo <PAP> \
      --feature <short-1> --feature <short-2> \
+     [--description "<texto>"]  # opcional, pareado com o --feature anterior
+     [--roadmap <path>]         # default: <PAP>/docs/roadmap.md
      [--coordinator-name <NAME_DO_PASSO_7>]
    ```
+
+   O prompt da filha e SEMPRE `/feature-00c "<DESCRICAO>" <SHORT>` — o
+   formato REAL do command (descricao no 1o posicional, short-name no 2o).
+   O `emit` resolve a `<DESCRICAO>` sozinho: `--description` explicito
+   vence; senao le o paragrafo `**Descricao**:` da entrada em
+   `docs/roadmap.md`; sem nenhum dos dois, cai no proprio short-name e
+   avisa em stderr. NUNCA lance `/feature-00c <short>` na mao: o command
+   leria o short-name como DESCRICAO e o specify re-derivaria um
+   short-name possivelmente diferente do da worktree/branch ja criada por
+   `cstk session start <SHORT>` (e do `feature=<short>` da notificacao).
 
    `emit` recomputa a guarda anti-duplicidade (TOCTOU, FR-011) IMEDIATAMENTE
    antes de compor — pula (nao imprime) qualquer `--feature` ja com
@@ -1085,11 +1097,23 @@ uma sessao-filha — so a coordenadora interage com o operador e lanca.
    (`outcome=blocked-invalid-feature`); reporte essas exclusoes ao
    operador, nunca falhe silenciosamente. Para cada par de comandos
    emitido, execute na ordem: primeiro `cstk session start <SHORT>`,
-   depois a segunda linha — `tmux new-window ...` quando `check-tmux`
+   depois a segunda linha — `tmux split-window ...` quando `check-tmux`
    (mesmo helper, subcomando `check-tmux`) reporta tmux disponivel, ou a
-   forma degradada `cd <WORKTREE> && claude --name ... "/feature-00c
-   <SHORT>"` (FR-007/SC-003) impressa para o operador copiar/colar
-   quando nao ha tmux ou a execucao nao pode abrir pane automaticamente.
+   forma degradada `cd <WORKTREE> && claude --name ... '/feature-00c
+   "<DESCRICAO>" <SHORT>'` (FR-007/SC-003) impressa para o operador
+   copiar/colar quando nao ha tmux ou a execucao nao pode abrir pane
+   automaticamente.
+
+   **Sempre split, nunca janela nova**: cada filha entra como pane irmao
+   no MESMO window da coordenadora (`tmux split-window -c <WORKTREE> -P -F
+   '#{pane_id}'`), o que mantem a leva inteira visivel de uma vez.
+   `split-window` nao aceita `-n` (nao nomeia window) — a identificacao da
+   filha e `claude --name "cstk-feature/<SHORT>"` + o `pane_id` devolvido
+   pelo `-P -F`. Guarde esse `pane_id`: e o endereco do kill switch
+   (`tmux kill-pane -t <pane_id>`). Com 3+ features o layout pode ficar
+   apertado — `tmux select-layout tiled` reequilibra (opcional, nunca
+   automatico). Se o `split-window` falhar por nao haver sessao tmux ativa
+   (coordenadora fora do tmux), use a forma degradada acima.
 
 9. **Reportar o que foi de fato aberto** (short-names lancados,
    worktrees, pane ids do tmux ou os comandos manuais impressos) na

--- a/plugins/cstk/commands/roadmap-wave.md
+++ b/plugins/cstk/commands/roadmap-wave.md
@@ -35,7 +35,7 @@ $ARGUMENTS
 | Flag | Default se ausente | Destino |
 |---|---|---|
 | `--projeto-alvo-path <path>` | diretorio de trabalho corrente (`pwd`) | `<PAP>` — `roadmap-frontier.sh --exclude-active-from-repo` + `parallel-launch.sh emit --repo` |
-| `--roadmap <path>` | omitido (helper usa `docs/roadmap.md`) | `roadmap-frontier.sh --roadmap` (passthrough, so quando informado) |
+| `--roadmap <path>` | omitido (helpers usam `docs/roadmap.md`) | `roadmap-frontier.sh --roadmap` **e** `parallel-launch.sh emit --roadmap` (passthrough, so quando informado — o `emit` le dali a `**Descricao**:` que vai no prompt da filha) |
 | `--specs-dir <dir>` | omitido (helper usa `docs/specs`) | `roadmap-frontier.sh --specs-dir` (passthrough, so quando informado) |
 | `--max <N>` | omitido (`resolve-offer` aplica default `2`) | `resolve-offer --max` |
 | `--yes` | ausente | ver passo 2 — atalho de confirmacao ja obtida |

--- a/plugins/cstk/skills/agente-00c-runtime/SKILL.md
+++ b/plugins/cstk/skills/agente-00c-runtime/SKILL.md
@@ -223,11 +223,16 @@ Consumidos SOMENTE pelos commands pai (`agente-00c.md` §6.ter/§6.quater,
 `feature-00c.md` §5.quater) — o orquestrador-subagente nunca oferta, lanca
 nem notifica (nao tem `SendMessage`/`ListAgents`; FR-012).
 
-- **`parallel-launch.sh emit --repo PATH --feature SHORT [...]
-  [--coordinator-name NAME]`** compoe e **so imprime** os comandos de
-  lancamento por feature (`cstk session start <SHORT>` + `tmux new-window ...
-  claude --name ... "/feature-00c <SHORT>"`, ou `cd ... && claude ...`
-  quando `check-tmux` sai 3). NUNCA executa nada e NUNCA toca
+- **`parallel-launch.sh emit --repo PATH --feature SHORT [--description
+  TEXT] [--roadmap PATH] [--coordinator-name NAME]`** compoe e **so
+  imprime** os comandos de lancamento por feature (`cstk session start
+  <SHORT>` + `tmux split-window ... claude --name ... '/feature-00c
+  "<DESCRICAO>" <SHORT>'`, ou `cd ... && claude ...` quando `check-tmux`
+  sai 3). O wrapper tmux e SEMPRE `split-window` (pane irmao no window da
+  coordenadora), nunca `new-window`. A `<DESCRICAO>` vem de
+  `--description`, senao do `**Descricao**:` do roadmap, senao do proprio
+  short-name (aviso em stderr); e sempre sanitizada (sem aspas nem
+  metacaractere de shell) e truncada a 300 chars. NUNCA executa nada e NUNCA toca
   `cli/lib/session.sh` (que faz `exec claude` sem argumentos — por isso a
   composicao e externa). Revalida o short-name (`^[a-z][a-z0-9-]*$`,
   <=64), quoting + allowlist de `<WORKTREE>`/`<CHILD_NAME>`, recomputa a

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/parallel-launch.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/parallel-launch.sh
@@ -10,8 +10,9 @@
 #      docs/specs/roadmap-wave/contracts/roadmap-wave-command.md §3
 #
 # Uso:
-#   parallel-launch.sh emit --repo PATH --feature SHORT [--feature SHORT ...]
-#                            [--coordinator-name NAME]
+#   parallel-launch.sh emit --repo PATH --feature SHORT [--description TEXT]
+#                            [--feature SHORT [--description TEXT] ...]
+#                            [--roadmap PATH] [--coordinator-name NAME]
 #   parallel-launch.sh check-tmux
 #   parallel-launch.sh resolve-offer --source <operator|absent>
 #                                    [--confirm RAW] [--max RAW]
@@ -30,6 +31,11 @@
 # operador. Isso torna o caminho automatico (com tmux) e o degradado (sem
 # tmux) comparaveis byte a byte na parte `claude --name ... "..."` — mesma
 # composicao, so envolvida de forma diferente (§4, decisao de desenho).
+#
+# Wrapper tmux: SEMPRE `split-window` (pane irmao no window da
+# coordenadora), nunca `new-window`. O prompt da filha e sempre
+# `/feature-00c "<DESCRICAO>" <SHORT>` — formato REAL do command
+# (feature-00c.md:113-115), com o short-name POSICIONAL pinando a feature.
 # INALTERADO por este script: cli/lib/session.sh.
 #
 # --coordinator-name NAME: aceito e validado por allowlist
@@ -60,21 +66,24 @@ set -eu
 _PL_NAME="parallel-launch"
 _PL_DIR=$(cd "$(dirname "$0")" && pwd)
 
+_PL_TAB=$(printf '\t')
+
 _PL_SHORT_RE='^[a-z][a-z0-9-]*$'
 _PL_CHILD_RE='^cstk-feature/[a-z][a-z0-9-]*$'
 _PL_COORD_RE='^cstk-coord/[A-Za-z0-9._-]{1,64}$'
 
 print_usage() {
   cat <<'EOF'
-Uso: parallel-launch.sh emit --repo PATH --feature SHORT [--feature SHORT ...]
-                              [--coordinator-name NAME]
+Uso: parallel-launch.sh emit --repo PATH --feature SHORT [--description TEXT]
+                              [--feature SHORT [--description TEXT] ...]
+                              [--roadmap PATH] [--coordinator-name NAME]
      parallel-launch.sh check-tmux
      parallel-launch.sh resolve-offer --source <operator|absent>
                                       [--confirm RAW] [--max RAW]
      parallel-launch.sh -h | --help
 
 `emit` compoe e IMPRIME (nunca executa) o par de comandos de lancamento de
-cada --feature: `cstk session start <SHORT>` + `tmux new-window ...` (ou a
+cada --feature: `cstk session start <SHORT>` + `tmux split-window ...` (ou a
 forma degradada `cd ... && claude ...` quando tmux esta ausente). Quem
 executa e o chamador (command pai) — este script nunca invoca cli/lib/
 session.sh nem qualquer outro comando de efeito colateral.
@@ -87,6 +96,16 @@ Opcoes de `emit`:
                            Revalidado contra ^[a-z][a-z0-9-]*$ (<=64 chars)
                            no momento do emit — defesa em profundidade
                            (exit 2 se nao casar).
+  --description TEXT      Descricao da feature imediatamente anterior
+                           (opcional). Vence o roadmap. Sanitizada
+                           (sem aspas nem metacaractere de shell) e
+                           truncada a 300 chars. Exit 2 se vier sem um
+                           --feature antes.
+  --roadmap PATH          Roadmap de onde extrair `**Descricao**:` quando
+                           --description nao foi informado. Default:
+                           <PATH-do---repo>/docs/roadmap.md. Ausente ou
+                           sem a entrada => fallback para o proprio
+                           short-name (aviso em stderr), NUNCA erro.
   --coordinator-name NAME Nome da sessao coordenadora (opcional), validado
                            contra ^cstk-coord/[A-Za-z0-9._-]{1,64}$ se
                            informado (exit 2 se mal-formado). Nao altera a
@@ -273,13 +292,118 @@ _pl_write_log() {
   return 0
 }
 
+# ==== Descricao da feature (contract §4.1a) ====
+#
+# O prompt da sessao-filha precisa casar o contrato REAL de /feature-00c
+# (plugins/cstk/commands/feature-00c.md:113-115): primeiro argumento
+# posicional = DESCRICAO (string em quotes), segundo = short-name
+# (opcional, kebab-case). Emitir so `/feature-00c <SHORT>` fazia o
+# short-name ser lido como descricao e o short-name REAL ser re-derivado
+# pelo specify — divergindo da worktree/branch ja criada por
+# `cstk session start <SHORT>` e do `feature=<short>` da notificacao.
+#
+# Fonte da descricao, em ordem de precedencia:
+#   1. --description TEXT (explicito, pareado com o --feature anterior)
+#   2. bloco `**Descricao**:` da entrada em docs/roadmap.md
+#      (contracts/roadmap-artifact.md §2)
+#   3. fallback = o proprio SHORT (degradado, com aviso em stderr)
+#
+# Conteudo do roadmap e UNTRUSTED (mesmo rotulo `roadmap-prose-untrusted`
+# ja usado por roadmap-frontier.sh §6): NUNCA entra bruto na composicao —
+# passa sempre por _pl_sanitize_desc.
+
+# _pl_sanitize_desc TEXT -> texto de uma linha, sem metacaractere de shell
+# nem aspa (de qualquer especie), colapsado e truncado a 300 chars.
+# A remocao de `'` e `"` e o que torna seguro o envelope
+# `'/feature-00c "<DESC>" <SHORT>'` da composicao (§4.1).
+_pl_sanitize_desc() {
+  printf '%s' "$1" \
+    | tr '\n\r\t' '   ' \
+    | tr -d '[:cntrl:]' \
+    | tr -d "\"\`\\\\\$;&|<>!#" \
+    | tr -d "'" \
+    | tr -s ' ' \
+    | sed 's/^ *//; s/ *$//' \
+    | cut -c1-300
+}
+
+# _pl_desc_from_roadmap ROADMAP SHORT -> texto do paragrafo
+# `**Descricao**:` da entrada `### N. SHORT` (linhas de continuacao
+# juntadas por espaco). Vazio se o arquivo, a entrada ou o campo nao
+# existirem — ausencia NUNCA e erro (best-effort, mesma politica do aviso
+# de sobreposicao de roadmap-frontier.sh).
+_pl_desc_from_roadmap() {
+  [ -f "$1" ] || return 0
+  awk -v target="$2" '
+    /^###[[:space:]]+[0-9]+\.[[:space:]]+/ {
+      hdr = $0
+      sub(/^###[[:space:]]+[0-9]+\.[[:space:]]+/, "", hdr)
+      sub(/[[:space:]]+$/, "", hdr)
+      inblock = (hdr == target)
+      collecting = 0
+      next
+    }
+    !inblock { next }
+    /^\*\*Descri[^*]*\*\*:/ {
+      line = $0
+      sub(/^\*\*Descri[^*]*\*\*:[[:space:]]*/, "", line)
+      out = line
+      collecting = 1
+      next
+    }
+    collecting {
+      if ($0 ~ /^[[:space:]]*$/ || $0 ~ /^[[:space:]]*[*-]/ || $0 ~ /^#/) {
+        collecting = 0
+        next
+      }
+      out = out " " $0
+    }
+    END { printf "%s", out }
+  ' "$1" 2>/dev/null || :
+}
+
+# _pl_resolve_desc SHORT EXPLICIT_DESC -> descricao final ja sanitizada.
+# Aplica a precedencia acima e avisa (stderr) quando cai no fallback.
+_pl_resolve_desc() {
+  _pl_rd_short=$1
+  _pl_rd_explicit=$2
+
+  _pl_rd_out=$(_pl_sanitize_desc "$_pl_rd_explicit")
+  if [ -z "$_pl_rd_out" ] && [ -n "$_pl_roadmap" ]; then
+    _pl_rd_out=$(_pl_sanitize_desc "$(_pl_desc_from_roadmap "$_pl_roadmap" "$_pl_rd_short")")
+  fi
+  if [ -z "$_pl_rd_out" ]; then
+    _pl_rd_out=$_pl_rd_short
+    printf '%s: descricao ausente para %s (nem --description nem **Descricao**: em %s) — usando o short-name como descricao\n' \
+      "$_PL_NAME" "$_pl_rd_short" "${_pl_roadmap:-<sem roadmap>}" >&2
+  fi
+  printf '%s' "$_pl_rd_out"
+}
+
+# _pl_flush_pending: fecha o par (--feature, --description) corrente na
+# lista `_pl_features`, uma entrada por linha no formato
+# `SHORT<TAB>DESC_BRUTA`. O TAB e separador seguro porque a descricao so
+# entra na composicao depois de _pl_sanitize_desc (que ja remove TAB).
+_pl_flush_pending() {
+  [ -n "$_pl_pending_short" ] || return 0
+  _pl_features=$(printf '%s%s\t%s\n' "$_pl_features" "$_pl_pending_short" "$_pl_pending_desc")
+  _pl_features="${_pl_features}
+"
+  _pl_pending_short=""
+  _pl_pending_desc=""
+}
+
 # ==== emit ====
 
 _pl_cmd_emit() {
   _pl_repo=""
   _pl_coordinator=""
+  _pl_roadmap=""
+  _pl_saw_roadmap=0
   _pl_features=""
   _pl_n_features=0
+  _pl_pending_short=""
+  _pl_pending_desc=""
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -288,10 +412,22 @@ _pl_cmd_emit() {
         _pl_repo=$2; shift 2 ;;
       --feature)
         [ $# -ge 2 ] || { printf '%s: --feature exige valor\n' "$_PL_NAME" >&2; exit 2; }
-        _pl_features="${_pl_features}${2}
-"
+        _pl_flush_pending
+        _pl_pending_short=$2
+        _pl_pending_desc=""
         _pl_n_features=$((_pl_n_features + 1))
         shift 2 ;;
+      --description)
+        [ $# -ge 2 ] || { printf '%s: --description exige valor\n' "$_PL_NAME" >&2; exit 2; }
+        [ -n "$_pl_pending_short" ] || {
+          printf '%s: --description exige um --feature imediatamente antes\n' "$_PL_NAME" >&2
+          exit 2
+        }
+        _pl_pending_desc=$2
+        shift 2 ;;
+      --roadmap)
+        [ $# -ge 2 ] || { printf '%s: --roadmap exige valor\n' "$_PL_NAME" >&2; exit 2; }
+        _pl_roadmap=$2; _pl_saw_roadmap=1; shift 2 ;;
       --coordinator-name)
         [ $# -ge 2 ] || { printf '%s: --coordinator-name exige valor\n' "$_PL_NAME" >&2; exit 2; }
         _pl_coordinator=$2; shift 2 ;;
@@ -301,8 +437,19 @@ _pl_cmd_emit() {
     esac
   done
 
+  _pl_flush_pending
+
   [ -n "$_pl_repo" ] || { printf '%s: --repo obrigatorio\n' "$_PL_NAME" >&2; exit 2; }
   [ "$_pl_n_features" -ge 1 ] || { printf '%s: pelo menos um --feature obrigatorio\n' "$_PL_NAME" >&2; exit 2; }
+
+  # Default do roadmap: <repo>/docs/roadmap.md (contract §4.1a). Ausente =>
+  # nenhuma descricao vinda do roadmap, NUNCA erro. `--roadmap` explicito
+  # com path inexistente tambem nao aborta (best-effort), so nao rende
+  # descricao.
+  if [ "$_pl_saw_roadmap" = 0 ]; then
+    _pl_roadmap="$_pl_repo/docs/roadmap.md"
+  fi
+  [ -f "$_pl_roadmap" ] || _pl_roadmap=""
 
   if [ -n "$_pl_coordinator" ] && ! _pl_valid_coordinator "$_pl_coordinator"; then
     printf '%s: --coordinator-name invalido (esperado ^cstk-coord/[A-Za-z0-9._-]{1,64}$): %s\n' \
@@ -328,8 +475,14 @@ _pl_cmd_emit() {
 
   IFS='
 '
-  for _pl_short in $_pl_features; do
+  for _pl_entry in $_pl_features; do
     unset IFS
+    [ -n "$_pl_entry" ] || continue
+    # TAB literal via variavel: em sh o padrao `\t` dentro de ${v%%...} e
+    # um `t` escapado, NAO um tab.
+    _pl_short=${_pl_entry%%"$_PL_TAB"*}
+    _pl_desc_raw=${_pl_entry#*"$_PL_TAB"}
+    [ "$_pl_desc_raw" != "$_pl_entry" ] || _pl_desc_raw=""
     [ -n "$_pl_short" ] || continue
 
     if ! _pl_valid_short "$_pl_short"; then
@@ -363,12 +516,26 @@ _pl_cmd_emit() {
     # Composicao compartilhada (byte a byte identica nos dois caminhos —
     # contract §4, decisao de desenho: US1 automatico e US3 degradado
     # comparaveis).
-    _pl_claude_argv=$(printf 'claude --name "%s" "/feature-00c %s"' "$_pl_child" "$_pl_short")
+    # Prompt da filha no formato REAL de /feature-00c: "<DESCRICAO>" <SHORT>
+    # (feature-00c.md:113-115). O short-name posicional PINA a feature —
+    # sem ele o specify re-derivaria um short-name possivelmente diferente
+    # da worktree/branch criada por `cstk session start <SHORT>`.
+    # Envelope em aspas SIMPLES para caber as aspas duplas da descricao;
+    # seguro porque _pl_sanitize_desc remove aspa simples, aspa dupla,
+    # crase, `\`, `$` e demais metacaracteres (§4.1).
+    _pl_desc=$(_pl_resolve_desc "$_pl_short" "$_pl_desc_raw")
+    _pl_prompt=$(printf "'/feature-00c \"%s\" %s'" "$_pl_desc" "$_pl_short")
+    _pl_claude_argv=$(printf 'claude --name "%s" %s' "$_pl_child" "$_pl_prompt")
 
     _pl_line1=$(printf 'cstk session start %s' "$_pl_short")
     if $_pl_have_tmux; then
-      _pl_line2=$(printf 'tmux new-window -c "%s" -n "%s" -P -F '"'"'#{pane_id}'"'"' \\\n  %s' \
-        "$_pl_worktree" "$_pl_short" "$_pl_claude_argv")
+      # SEMPRE split-window (nunca new-window): a leva paralela fica no
+      # MESMO window da coordenadora, em panes irmaos. `split-window` nao
+      # tem `-n` (nao nomeia window) — a identificacao da filha continua
+      # sendo `claude --name "<CHILD_NAME>"` + o pane_id devolvido por
+      # `-P -F '#{pane_id}'`.
+      _pl_line2=$(printf 'tmux split-window -c "%s" -P -F '"'"'#{pane_id}'"'"' \\\n  %s' \
+        "$_pl_worktree" "$_pl_claude_argv")
     else
       _pl_line2=$(printf 'cd "%s" && %s' "$_pl_worktree" "$_pl_claude_argv")
     fi

--- a/tests/eval/rehearsal_roadmap-wave.sh
+++ b/tests/eval/rehearsal_roadmap-wave.sh
@@ -166,7 +166,7 @@ RUNBOOK (operador no comando; cada passo abaixo e manual de proposito):
  5. Bookend final (mecanico, exit 0/1):
         $0 verify --dir $_DIR
 
-Kill switch de uma filha: tmux kill-window -t <janela> +
+Kill switch de uma filha: tmux kill-pane -t <pane_id> +
 cstk session end <short>.
 EOF
 }

--- a/tests/test_command-spawn-parallel-launch.sh
+++ b/tests/test_command-spawn-parallel-launch.sh
@@ -186,7 +186,7 @@ scenario_emit_nunca_executa_documentado() {
 
 scenario_degradacao_sem_tmux_documentada() {
   # FR-007/SC-003: forma degradada exata do contrato §4.2.
-  assert_exit 0 grep -Fq 'cd <WORKTREE> && claude --name ... "/feature-00c' "$CMD_INIT_AGENTE" || return 1
+  assert_exit 0 grep -Fq "cd <WORKTREE> && claude --name ... '/feature-00c" "$CMD_INIT_AGENTE" || return 1
 }
 
 # ==== Guarda anti-duplicidade / TOCTOU (FR-011) ====

--- a/tests/test_e2e_roadmap_wave.sh
+++ b/tests/test_e2e_roadmap_wave.sh
@@ -130,7 +130,10 @@ EOF
 
   # stub `claude`: simula a sessao-filha /feature-00c dirigindo o runtime
   # REAL. Composicao invocante (contract §4.1, byte-identica tmux/degradado):
-  #   claude --name "cstk-feature/<short>" "/feature-00c <short>"
+  #   claude --name "cstk-feature/<short>" '/feature-00c "<DESCRICAO>" <short>'
+  # O short-name e o SEGUNDO posicional (o primeiro e a descricao) — o stub
+  # so aceita esse formato: se o emit regredir para `/feature-00c <short>`,
+  # o parse falha (exit 64) e o e2e quebra, que e o efeito desejado.
   cat > "$_STUB_BIN/claude" <<'EOF'
 #!/bin/sh
 set -eu
@@ -141,7 +144,18 @@ while [ $# -gt 0 ]; do
       [ $# -ge 2 ] || exit 64
       shift 2 ;;
     "/feature-00c "*)
-      short=${1#/feature-00c }
+      # prompt = /feature-00c "<DESCRICAO>" <short>
+      _rest=${1#/feature-00c }
+      case "$_rest" in
+        '"'*)
+          _rest=${_rest#\"}       # remove aspa inicial da descricao
+          desc=${_rest%%\"*}      # descricao (nao usada pelo stub)
+          _rest=${_rest#*\"}      # sobra: ` <short>`
+          short=${_rest# }
+          ;;
+        *) exit 64 ;;             # formato antigo (`/feature-00c <short>`)
+      esac
+      [ -n "${desc:-}" ] || exit 64
       shift ;;
     *) shift ;;
   esac
@@ -378,16 +392,17 @@ scenario_corrente_completa_leva_paralela() {
   assert_stdout_not_contains '"short_name":"feat-beta"' || return 1
 }
 
-# ==== Cenario 3: janela tmux REAL (condicional) ====
+# ==== Cenario 3: pane tmux REAL (condicional) ====
 #
-# Valida o caminho automatico (US1): a linha `tmux new-window ...` emitida
+# Valida o caminho automatico (US1): a linha `tmux split-window ...` emitida
 # e executada DENTRO de um servidor tmux privado (-L socket proprio,
 # -f /dev/null — nunca toca o servidor do operador), a filha roda o stub
 # de claude ate produzir o marker, e o kill switch documentado
-# (`tmux kill-window`) encerra a janela. Sem tmux no ambiente: PASS com
+# (`tmux kill-pane -t <pane_id>`) encerra o pane. A filha entra como pane
+# irmao no window ja existente — nenhum window novo e criado. Sem tmux no ambiente: PASS com
 # aviso (a composicao claude ja foi validada no cenario 2, que e
 # forma-agnostica por contrato).
-scenario_tmux_janela_real_e_kill_switch() {
+scenario_tmux_pane_real_e_kill_switch() {
   if ! command -v tmux >/dev/null 2>&1; then
     printf '  # tmux ausente — cenario condicional pulado (composicao coberta pelo cenario 2)\n'
     return 0
@@ -400,7 +415,8 @@ scenario_tmux_janela_real_e_kill_switch() {
   capture sh "$PLAUNCH" emit --repo "$_REPO" --feature feat-alpha
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "emit: exit $_CAPTURED_EXIT"; return 1; }
   _emit_out=$_CAPTURED_STDOUT
-  assert_stdout_contains 'tmux new-window' || return 1
+  assert_stdout_contains 'tmux split-window' || return 1
+  assert_stdout_not_contains 'tmux new-window' || return 1
   _l1=$(printf '%s\n' "$_emit_out" | grep '^cstk session start ')
   env PATH="$_STUB_BIN:$PATH" HOME="$E2E_HOME" sh -c "cd '$_REPO' && $_l1" >/dev/null 2>&1 \
     || { _fail "session-start" "session start feat-alpha falhou"; return 1; }
@@ -419,6 +435,10 @@ scenario_tmux_janela_real_e_kill_switch() {
     tmux -L "$_SOCK" -f /dev/null new-session -d -s boot /bin/sh \
     || { _fail "tmux" "nao consegui subir servidor tmux privado"; return 1; }
 
+  # Panes ANTES do split (a filha entra como pane irmao no MESMO window —
+  # `split-window`, nunca `new-window`).
+  _panes_before=$(tmux -L "$_SOCK" list-panes -t boot -F '#{pane_id}' 2>/dev/null)
+
   tmux -L "$_SOCK" send-keys -t boot "sh '$_PHYS/launch.sh'" Enter \
     || { _tmux_kill; _fail "tmux" "send-keys falhou"; return 1; }
 
@@ -428,17 +448,30 @@ scenario_tmux_janela_real_e_kill_switch() {
     return 1
   fi
 
-  # Janela nomeada com o short (linger mantem viva) + kill switch.
+  # Pane novo no MESMO window (linger mantem vivo) + kill switch por pane.
+  # `split-window` nao nomeia window (nao tem `-n`): a identificacao e o
+  # pane_id, que e justamente o que `-P -F '#{pane_id}'` devolve.
+  _panes_after=$(tmux -L "$_SOCK" list-panes -t boot -F '#{pane_id}' 2>/dev/null)
+  _pane_novo=$(printf '%s\n' "$_panes_after" | grep -vxF "$_panes_before" | head -1)
+  [ -n "$_pane_novo" ] || {
+    _tmux_kill
+    _fail "tmux" "nenhum pane novo no window boot (antes=[$_panes_before] depois=[$_panes_after])"
+    return 1
+  }
   _wins=$(tmux -L "$_SOCK" list-windows -t boot -F '#{window_name}' 2>/dev/null)
-  case "$_wins" in
-    *feat-alpha*) : ;;
-    *) _tmux_kill; _fail "tmux" "janela feat-alpha nao listada: [$_wins]"; return 1 ;;
-  esac
-  tmux -L "$_SOCK" kill-window -t "boot:feat-alpha" 2>/dev/null \
-    || { _tmux_kill; _fail "tmux" "kill-window falhou"; return 1; }
-  _wins=$(tmux -L "$_SOCK" list-windows -t boot -F '#{window_name}' 2>/dev/null)
-  case "$_wins" in
-    *feat-alpha*) _tmux_kill; _fail "tmux" "janela sobreviveu ao kill switch"; return 1 ;;
+  _n_wins=$(printf '%s\n' "$_wins" | grep -c . || :)
+  [ "$_n_wins" = 1 ] || {
+    _tmux_kill
+    _fail "tmux" "split-window nao deveria criar window nova: [$_wins]"
+    return 1
+  }
+  tmux -L "$_SOCK" kill-pane -t "$_pane_novo" 2>/dev/null \
+    || { _tmux_kill; _fail "tmux" "kill-pane falhou"; return 1; }
+  _panes_final=$(tmux -L "$_SOCK" list-panes -t boot -F '#{pane_id}' 2>/dev/null)
+  case "$(printf '\n%s\n.' "$_panes_final")" in
+    *"
+$_pane_novo
+"*) _tmux_kill; _fail "tmux" "pane sobreviveu ao kill switch"; return 1 ;;
   esac
   _tmux_kill
 

--- a/tests/test_parallel-launch.sh
+++ b/tests/test_parallel-launch.sh
@@ -43,9 +43,9 @@ _pl_path_without_tmux() {
   _shim="$TMPDIR_TEST/nobin"
   mkdir -p "$_shim"
   # Comandos externos usados por parallel-launch.sh (git/sed/awk/grep/date/
-  # dirname/basename/mkdir/cat) + os que o harness usa dentro de `capture`
+  # dirname/basename/mkdir/cat/tr/cut) + os que o harness usa dentro de `capture`
   # (mktemp/rm/sh/env). `tmux` NUNCA entra nesta lista.
-  for _c in sh env git sed awk grep date dirname basename mkdir rm cat mktemp chmod ln find sort head tail tr wc; do
+  for _c in sh env git sed awk grep date dirname basename mkdir rm cat mktemp chmod ln find sort head tail tr wc cut; do
     _p=$(command -v "$_c" 2>/dev/null) || continue
     [ -e "$_shim/$_c" ] || ln -s "$_p" "$_shim/$_c" 2>/dev/null || :
   done
@@ -95,8 +95,10 @@ scenario_emit_composicao_com_tmux() {
   capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
   assert_stdout_contains "cstk session start auth-basica" || return 1
-  assert_stdout_contains "tmux new-window -c \"$_repo-auth-basica\" -n \"auth-basica\" -P -F '#{pane_id}'" || return 1
-  assert_stdout_contains 'claude --name "cstk-feature/auth-basica" "/feature-00c auth-basica"' || return 1
+  assert_stdout_contains "tmux split-window -c \"$_repo-auth-basica\" -P -F '#{pane_id}'" || return 1
+  assert_stdout_contains "claude --name \"cstk-feature/auth-basica\" '/feature-00c \"auth-basica\" auth-basica'" || return 1
+  # nunca new-window: a leva paralela vive em panes do window da coordenadora
+  assert_stdout_not_contains "tmux new-window" || return 1
 }
 
 scenario_emit_multiplas_features_em_ordem() {
@@ -126,7 +128,8 @@ scenario_emit_composicao_degradada_sem_tmux() {
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
   assert_stdout_contains "cstk session start auth-basica" || return 1
   assert_stdout_not_contains "tmux new-window" || return 1
-  assert_stdout_contains "cd \"$_repo-auth-basica\" && claude --name \"cstk-feature/auth-basica\" \"/feature-00c auth-basica\"" || return 1
+  assert_stdout_not_contains "tmux split-window" || return 1
+  assert_stdout_contains "cd \"$_repo-auth-basica\" && claude --name \"cstk-feature/auth-basica\" '/feature-00c \"auth-basica\" auth-basica'" || return 1
 }
 
 scenario_emit_trecho_claude_identico_com_e_sem_tmux() {
@@ -303,6 +306,159 @@ scenario_enforcement_log_registra_blocked_invalid_feature() {
     || { _fail "outcome=blocked-invalid-feature ausente" "$(cat "$_log")"; return 1; }
 }
 
+# ==== emit: prompt no formato REAL de /feature-00c (descricao + short) ====
+#
+# Defeito corrigido: `/feature-00c <SHORT>` fazia o short-name ser lido
+# como DESCRICAO pelo command (feature-00c.md:113-115) e o short-name real
+# ser re-derivado pelo specify — divergindo da worktree/branch criada por
+# `cstk session start <SHORT>`.
+
+# Cria um roadmap minimo (contracts/roadmap-artifact.md §2) em REPO/docs.
+_pl_write_roadmap() {
+  mkdir -p "$1/docs"
+  cat >"$1/docs/roadmap.md" <<'EOF'
+# Roadmap: teste
+
+## Features
+
+### 1. auth-basica
+
+- **short-name**: `auth-basica`
+- **ordem**: 1
+- **depende-de**: -
+
+**Descricao**: Autenticacao por e-mail e senha, com sessao assinada
+e recuperacao por link expiravel.
+
+**Justificativa**: base das demais.
+
+### 2. perfil-usuario
+
+- **short-name**: `perfil-usuario`
+- **ordem**: 2
+- **depende-de**: `auth-basica`
+
+**Descricao**: Edicao de perfil com "aspas", $VAR, `crase`, ; e | para
+exercitar a sanitizacao.
+EOF
+}
+
+scenario_emit_prompt_traz_descricao_do_roadmap() {
+  _repo="$TMPDIR_TEST/repo-desc-roadmap"
+  mkdir -p "$_repo"
+  _pl_write_roadmap "$_repo"
+
+  capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains '/feature-00c "Autenticacao por e-mail e senha, com sessao assinada e recuperacao por link expiravel." auth-basica' || return 1
+}
+
+scenario_emit_prompt_pina_short_name_posicional() {
+  _repo="$TMPDIR_TEST/repo-desc-pin"
+  mkdir -p "$_repo"
+  _pl_write_roadmap "$_repo"
+
+  capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT"; return 1; }
+  # o short-name DEVE ser o ultimo token do prompt (2o posicional), nunca
+  # o unico argumento
+  assert_stdout_match "/feature-00c \"[^\"]+\" auth-basica'" || return 1
+  assert_stdout_not_contains "/feature-00c auth-basica" || return 1
+}
+
+scenario_emit_description_explicita_vence_roadmap() {
+  _repo="$TMPDIR_TEST/repo-desc-explicita"
+  mkdir -p "$_repo"
+  _pl_write_roadmap "$_repo"
+
+  capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica --description "Descricao vinda do operador"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains '/feature-00c "Descricao vinda do operador" auth-basica' || return 1
+  assert_stdout_not_contains "Autenticacao por e-mail" || return 1
+}
+
+scenario_emit_description_pareia_com_a_feature_anterior() {
+  _repo="$TMPDIR_TEST/repo-desc-pareia"
+  mkdir -p "$_repo"
+
+  capture "$SCRIPT" emit --repo "$_repo" \
+    --feature primeira --description "Desc da primeira" \
+    --feature segunda --description "Desc da segunda"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains '/feature-00c "Desc da primeira" primeira' || return 1
+  assert_stdout_contains '/feature-00c "Desc da segunda" segunda' || return 1
+}
+
+scenario_emit_description_sem_feature_antes_exit2() {
+  _repo="$TMPDIR_TEST/repo-desc-orfa"
+  mkdir -p "$_repo"
+
+  capture "$SCRIPT" emit --repo "$_repo" --description "orfa" --feature auth-basica
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "exit esperado 2 (--description sem --feature antes)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "--description" || return 1
+}
+
+scenario_emit_sem_roadmap_cai_no_short_name_com_aviso() {
+  _repo="$TMPDIR_TEST/repo-desc-ausente"
+  mkdir -p "$_repo"
+
+  capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0 (ausencia de descricao NAO e erro)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains '/feature-00c "auth-basica" auth-basica' || return 1
+  assert_stderr_contains "descricao ausente" || return 1
+}
+
+scenario_emit_roadmap_explicito_inexistente_nao_aborta() {
+  _repo="$TMPDIR_TEST/repo-desc-roadmap-inexistente"
+  mkdir -p "$_repo"
+
+  capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica --roadmap "$TMPDIR_TEST/nao-existe.md"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0 (roadmap inexistente e best-effort)" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains '/feature-00c "auth-basica" auth-basica' || return 1
+}
+
+scenario_adversarial_descricao_do_roadmap_sanitizada() {
+  _repo="$TMPDIR_TEST/repo-desc-adversarial"
+  mkdir -p "$_repo"
+  _pl_write_roadmap "$_repo"
+
+  capture "$SCRIPT" emit --repo "$_repo" --feature perfil-usuario
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT"; return 1; }
+  # nenhuma aspa (simples ou dupla), crase, $ ou metacaractere de shell
+  # pode sobreviver dentro do envelope '/feature-00c "..." <short>'
+  _prompt=$(printf '%s' "$_CAPTURED_STDOUT" | sed -n "s/.*'\\/feature-00c \"\\(.*\\)\" perfil-usuario'.*/\\1/p")
+  [ -n "$_prompt" ] || { _fail "prompt nao casou o envelope esperado" "$_CAPTURED_STDOUT"; return 1; }
+  case "$_prompt" in
+    *'"'*|*"'"*|*'`'*|*'$'*|*';'*|*'|'*|*'&'*|*'<'*|*'>'*|*"\\"*)
+      _fail "descricao do roadmap deveria estar sanitizada" "[$_prompt]"; return 1 ;;
+  esac
+}
+
+scenario_adversarial_descricao_explicita_com_injecao_sanitizada() {
+  _repo="$TMPDIR_TEST/repo-desc-inj"
+  mkdir -p "$_repo"
+
+  capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica \
+    --description "fecha'; rm -rf / #\$(whoami) \`id\`"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_not_contains "\$(whoami)" || return 1
+  assert_stdout_not_contains '`id`' || return 1
+  # o envelope de aspas simples permanece integro (fecha so no fim)
+  assert_stdout_match "claude --name \"cstk-feature/auth-basica\" '/feature-00c \"[^']*\" auth-basica'" || return 1
+}
+
+scenario_emit_descricao_truncada_em_300_chars() {
+  _repo="$TMPDIR_TEST/repo-desc-longa"
+  mkdir -p "$_repo"
+  _longa=$(printf 'a%.0s' $(seq 1 400))
+
+  capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica --description "$_longa"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0" "obtido $_CAPTURED_EXIT"; return 1; }
+  _prompt=$(printf '%s' "$_CAPTURED_STDOUT" | sed -n "s/.*'\\/feature-00c \"\\(.*\\)\" auth-basica'.*/\\1/p")
+  _len=$(printf '%s' "$_prompt" | wc -c | tr -d ' ')
+  [ "$_len" = 300 ] || { _fail "descricao deveria ser truncada a 300 chars" "obtido $_len"; return 1; }
+}
+
 # ==== testes adversariais de injecao (2.7) ====
 
 scenario_adversarial_nome_de_repo_com_espaco_e_aspa() {
@@ -314,8 +470,8 @@ scenario_adversarial_nome_de_repo_com_espaco_e_aspa() {
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit esperado 0 (repo com espaco/aspa e valor legitimo, nao ataque de sintaxe)" "obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
   # <WORKTREE> MUST estar entre aspas duplas (contract §4.1, INV-7) — a
   # aspa interna do nome do repo NAO deve fechar a aspa do -c prematuramente:
-  # a linha inteira continua sendo um UNICO argumento entre -c "..." e -n.
-  assert_stdout_match '\-c "[^"]*repo com espaco e .aspa.[^"]*-auth-basica" -n "auth-basica"' || return 1
+  # a linha inteira continua sendo um UNICO argumento entre -c "..." e -P.
+  assert_stdout_match '\-c "[^"]*repo com espaco e .aspa.[^"]*-auth-basica" -P -F' || return 1
 }
 
 scenario_adversarial_short_name_malicioso_rejeitado() {


### PR DESCRIPTION
## Problema

`parallel-launch.sh emit` compunha o prompt da sessao-filha como
`/feature-00c <SHORT>`. O contrato REAL do command sao DOIS posicionais —
`"<descricao>" [<short-name>]` (`plugins/cstk/commands/feature-00c.md:113-115`).
Resultado: a filha lia o short-name como DESCRICAO e re-derivava um short-name
novo pelo `specify`, que podia divergir da worktree/branch ja criada por
`cstk session start <SHORT>` e do `feature=<short>` da notificacao de volta.

## Mudancas

- **Prompt no formato real**: `/feature-00c "<DESCRICAO>" <SHORT>`. O
  short-name posicional PINA a feature (novo INV-9 do contrato).
- **`--description TEXT`** (pareado com o `--feature` imediatamente anterior,
  exit 2 se vier orfa) e **`--roadmap PATH`** (default `<repo>/docs/roadmap.md`,
  le o paragrafo `**Descricao**:` da entrada `### N. <SHORT>`). Sem nenhum dos
  dois: fallback para o proprio short-name com aviso em stderr — ausencia
  NUNCA e erro.
- **Sanitizacao (novo §4.1a + INV-10)**: prosa de roadmap e UNTRUSTED e
  `--description` pode vir de texto arbitrario. A descricao vira uma linha,
  perde controles, aspa simples/dupla, crase, `\`, `$`, `;`, `&`, `|`, `<`,
  `>`, `!`, `#`, colapsa espacos e trunca em 300 chars antes de entrar na
  composicao — e o que torna seguro o envelope de aspas simples.
- **`tmux split-window`, nunca `new-window`**: cada filha abre como pane irmao
  no MESMO window da coordenadora. `split-window` nao tem `-n` (verificado em
  `tmux list-commands`, 3.5a), entao o `-n "<SHORT>"` saiu e a identidade vira
  `claude --name "cstk-feature/<SHORT>"` + o `pane_id` do `-P -F`.
- **Kill switch**: `tmux kill-pane -t <pane_id>` (antes `kill-window`),
  atualizado em command, docs EN/pt-BR, contrato §8.bis e no ensaio.

## Testado

- `LC_ALL=C ./tests/run.sh` — **PASS 3450 · FAIL 0 · ERROR 0 · ORPHANS 0** (1009s)
- `./tests/run.sh --check-coverage` — zero orfaos
- `shellcheck -x` limpo nos 3 arquivos shell tocados
- 10 cenarios novos em `tests/test_parallel-launch.sh` (fonte da descricao,
  precedencia, pareamento, orfa, fallback, truncamento, 2 adversariais de
  injecao)
- `tests/test_e2e_roadmap_wave.sh`: o stub de `claude` agora EXIGE o formato
  novo (`exit 64` no antigo — regressao quebra o e2e) e o cenario de tmux REAL
  valida pane irmao + `kill-pane` + assert de que nenhum window novo e criado
- `./scripts/validate-plugin-manifests.sh --version 9.3.0 --strict` — OK (gate MP-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DumGWyMzPkWSF59yXSM86C