### PR TITLE
fix: issues #168-#171 — telemetria nos lancadores, scrub, enum de eixo e gate de MUST

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "9.3.0",
+      "version": "9.4.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "9.3.0",
+      "version": "9.4.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,85 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [9.4.0] - 2026-08-27
+
+Fecha quatro issues de "o dado esta ao alcance e o mecanismo nao o usa":
+telemetria anulada pelos proprios lancadores do cstk (#168), segredo curto e
+bloco PEM passando pelo scrub (#169), eixo estrutural fora do enum aceito em
+silencio (#170) e o gate de convergencia lendo 0 de 13 regras MUST e
+reportando sucesso (#171).
+
+### Fixed
+
+- **#168 — lancadores do cstk anulavam a propria telemetria.** O opt-in que
+  `cstk install` oferece e uma FUNCAO de shell `claude()` no rc do operador.
+  Os lancadores chamavam o BINARIO via `exec claude`, e `exec` nunca resolve
+  funcao de shell — pior, rodam em `sh` nao-interativo, onde o rc sequer e
+  lido. Resultado medido: toda execucao iniciada por `cstk session start
+  --claude`, `cstk 00c` ou pela leva paralela do roadmap subia SEM
+  telemetria, com `otel_usage` null em todas as ondas e CUSTO/TOKENS como
+  `—` no painel, mesmo com os 4 hooks corretamente provisionados. Agora os
+  tres lancadores resolvem a porta e exportam as variaveis por conta
+  propria, sem depender de rc, shell ou tmux — e isso vale igual para quem
+  instala pelo plugin nativo, que nao provisiona wrapper nenhum. Nova lib
+  `cli/lib/telemetry-env.sh` (runtime do binario) para `session start
+  --claude` e `cstk 00c`; `parallel-launch.sh emit` prefixa a composicao com
+  `env CLAUDE_CODE_ENABLE_TELEMETRY=1 ... CSTK_OTEL_ENDPOINT=...` usando UMA
+  porta por filha. Escolha explicita do operador vence sempre:
+  `CSTK_TELEMETRY_AUTO=0` desliga, e `CSTK_OTEL_ENDPOINT` ou
+  `CLAUDE_CODE_ENABLE_TELEMETRY` ja definidos no ambiente inibem a injecao —
+  exceto na leva paralela, onde o endpoint do ambiente e o da COORDENADORA e
+  herda-lo colocaria a filha na porta da mae.
+- **#169 — `secrets-filter.sh scrub` deixava passar segredo curto e bloco
+  PEM.** `password=hunter2` (7 chars) escapava do limiar `{20,}` da regra
+  generica e saia em claro; bloco PEM inteiro nao tinha regra alguma (o
+  corpo base64 nao tem palavra-chave proxima). Nova regra de bloco PEM
+  (deteccao estrita RFC 7468 — marcador sozinho na linha, para uma mencao em
+  prosa nao engolir o arquivo) e nova regra de limiar `{4,}` restrita a
+  palavras-chave de ALTA confianca (`password`, `api_key`, `private_key`,
+  `client_secret`, `*_token`, ...). O `{20,}` original fica intacto para as
+  genericas (`key`, `token`, `auth`, `pwd`): baixar o limiar para todas
+  trocaria vazamento por ruido, e `PWD=/algum/caminho` num dump de ambiente
+  viraria `[REDACTED]`. O cabecalho do script passa a declarar que a
+  cobertura e PISO, nao garantia — "passou pelo scrub" nunca significa "nao
+  contem segredo".
+- **#170 — `bloqueios.sh register` aceitava `axis:` fora do enum.** O
+  register validava so o PREFIXO de `--chave-assunto`; o consumidor do
+  vinculo de consentimento (`report.sh`) casa contra o enum COMPLETO
+  iterando `structural-axis-map.txt`. `axis:<qualquer-coisa>` passava limpo
+  e nunca casava: bloqueio, resposta e decisao existiam sem nada os ligar de
+  forma verificavel — buraco silencioso na trilha de auditoria, nao falha.
+  Agora o sufixo de `axis:` e validado contra o mapa (exit 2, citando os
+  eixos validos lidos do proprio arquivo). `briefing-item:` segue com sufixo
+  aberto por desenho, e `list --chave-assunto` segue sem validar (e query,
+  nao registro).
+- **#171 — `converge` reportava sucesso lendo 0 de 13 regras MUST.**
+  `extract-must.sh` reconhecia UMA convencao de marcacao (`**MUST:**`).
+  Contra uma `constitution.md` em bullet (`- MUST:`), formato igualmente
+  valido, lia zero regras — e o unico principio emitido entrava pelo rotulo
+  `(NON-NEGOTIABLE)` do heading, sem nenhuma regra lida. O parser agora
+  aceita as formas em bullet (`- MUST:`, `- **MUST:**`, `* MUST NOT:`, com
+  indentacao opcional), exigindo os dois-pontos para nao capturar `MUST` em
+  prosa corrida.
+
+### Added
+
+- `extract-must.sh --constitution <f> --coverage` — relatorio honesto de
+  cobertura do gate (#171): fontes lidas, contagem INDEPENDENTE da palavra
+  `MUST`, linhas reconhecidas pelo parser, principios emitidos e quantos
+  vieram so do rotulo do heading. A contagem independente usa gramatica
+  deliberadamente diferente da do parser: se compartilhasse, a metrica seria
+  autoconfirmatoria e voltaria a reportar 100%. Emite aviso em stderr quando
+  o arquivo fala de `MUST` e o parser reconhece zero regras. A skill
+  `converge` passa a exigir as DUAS invocacoes e proibe reportar o gate como
+  satisfeito quando a cobertura e zero.
+- `CSTK_TELEMETRY_AUTO=0` — kill switch da injecao automatica de telemetria
+  nos lancadores (#168). Documentado em `cstk help telemetry`.
+- Gate de paridade estendido (`tests/cstk/test_cstk-main.sh`): o conjunto de
+  variaveis de telemetria precisa ser identico entre o snippet canonico e os
+  tres lancadores, e um `exec claude` cru reintroduzido em `session.sh` ou
+  `00c-bootstrap.sh` reprova a suite — a regressao de #168 nao volta calada.
+
 ## [9.3.0] - 2026-08-26
 
 Corrige o lancamento das sessoes-filha da leva paralela do roadmap. O
@@ -7404,6 +7483,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[9.4.0]: https://github.com/JotJunior/cstk/releases/tag/v9.4.0
 [9.3.0]: https://github.com/JotJunior/cstk/releases/tag/v9.3.0
 [9.2.3]: https://github.com/JotJunior/cstk/releases/tag/v9.2.3
 [9.2.2]: https://github.com/JotJunior/cstk/releases/tag/v9.2.2

--- a/README.md
+++ b/README.md
@@ -496,9 +496,19 @@ claude() {
 Zero per-session configuration: each `claude` you type gets an isolated
 exporter and an isolated measurement. As a bonus, the delta's
 "exactly-one-session-grew" guard only ever sees that process's sessions, so
-ambiguity discards (`null` from concurrent sessions) all but disappear. The
-wrapper only covers processes launched from your shell — anything launched
-outside it (IDE, desktop app) still uses the fixed default port.
+ambiguity discards (`null` from concurrent sessions) all but disappear.
+
+> **The wrapper only covers `claude` TYPED in your shell.** It is a shell
+> *function*, and `exec` never resolves one — so until v9.4.0 every session
+> started by `cstk session start --claude`, `cstk 00c` or the roadmap's
+> parallel wave ran with **no** telemetry at all, which is exactly what
+> issue #168 measured. Since v9.4.0 those three launchers set the variables
+> themselves (one drawn port per process), so they no longer depend on your
+> rc, your shell or tmux — and neither does the native-plugin install, which
+> provisions no wrapper. Turn that off with `CSTK_TELEMETRY_AUTO=0`; an
+> explicit `CSTK_OTEL_ENDPOINT` or `CLAUDE_CODE_ENABLE_TELEMETRY` already in
+> the environment also wins. Anything launched outside both paths (IDE,
+> desktop app) still uses the fixed default port.
 
 Quick diagnosis when the panel shows no cost for any wave: check who owns the
 port and whether its working directory is the project you're actually running:

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -500,8 +500,19 @@ Zero configuração por sessão: cada `claude` que você digita ganha um exporte
 isolado e uma medição isolada. De bônus, o guard "exatamente uma sessão
 cresceu" do delta passa a ver só as sessões daquele processo — os descartes
 por ambiguidade (`null` por sessões concorrentes) praticamente desaparecem.
-O wrapper só cobre processos lançados do seu shell — o que nascer por fora
-(IDE, app desktop) continua na porta default fixa.
+
+> **O wrapper só cobre o `claude` DIGITADO no seu shell.** Ele é uma *função*
+> de shell, e `exec` nunca resolve função — então, até a v9.4.0, toda sessão
+> iniciada por `cstk session start --claude`, `cstk 00c` ou pela leva
+> paralela do roadmap rodava com telemetria **nenhuma**, que é exatamente o
+> que a issue #168 mediu. Desde a v9.4.0 esses três lançadores ligam as
+> variáveis por conta própria (uma porta sorteada por processo), sem depender
+> do seu rc, do seu shell nem do tmux — e o mesmo vale para quem instala pelo
+> plugin nativo, que não provisiona wrapper algum. Desligue com
+> `CSTK_TELEMETRY_AUTO=0`; um `CSTK_OTEL_ENDPOINT` ou
+> `CLAUDE_CODE_ENABLE_TELEMETRY` já presente no ambiente também vence. O que
+> nascer fora dos dois caminhos (IDE, app desktop) continua na porta default
+> fixa.
 
 Diagnóstico rápido quando o painel não mostra custo em onda nenhuma: veja
 quem é o dono da porta e se o diretório de trabalho dele é mesmo o projeto

--- a/cli/cstk
+++ b/cli/cstk
@@ -285,8 +285,25 @@ voce lanca o claude):
     --projeto-alvo-path . --include-loose-usage
   # 5a coluna: endpoint-set (armado) | endpoint-unset (inerte)
 
+O wrapper cobre `claude` DIGITADO no terminal. Os lancadores do proprio
+cstk (`cstk session start --claude`, `cstk 00c`, e a leva paralela do
+roadmap via `parallel-launch.sh emit`) NAO passam por ele: `exec` nunca
+resolve funcao de shell, e esses scripts rodam em `sh` nao-interativo, onde
+o rc sequer e lido. Desde a issue #168 eles ligam a telemetria por conta
+propria — sorteando a porta e exportando as variaveis so no ambiente do
+processo `claude`, com a mesma semantica do snippet. Nada a configurar.
+
+  Desligar essa injecao automatica:  CSTK_TELEMETRY_AUTO=0
+  Ela tambem NAO acontece quando CSTK_OTEL_ENDPOINT ja esta no ambiente, ou
+  quando CLAUDE_CODE_ENABLE_TELEMETRY esta definido com valor != 1
+  (opt-out explicito do operador vence sempre).
+  Excecao deliberada: na leva paralela o CSTK_OTEL_ENDPOINT do ambiente NAO
+  e herdado — cada filha precisa da PROPRIA porta (o exporter vive dentro de
+  cada processo `claude`; duas filhas na mesma porta = uma nao mede).
+
 Snippet canonico: identico ao de cli/install.sh (telemetry_snippet) —
-teste de paridade em tests/cstk/test_cstk-main.sh gateia drift entre os dois.
+teste de paridade em tests/cstk/test_cstk-main.sh gateia drift entre os dois
+E entre eles e os lancadores (conjunto de variaveis).
 TELHELP
       exit "$CSTK_EXIT_OK"
       ;;

--- a/cli/lib/00c-bootstrap.sh
+++ b/cli/lib/00c-bootstrap.sh
@@ -182,7 +182,8 @@ FLUXO (5 passos):
   2. Criar dir + lock per-path (`<path>/.cstk-00c.lock/`)
   3. Prompts interativos: descricao, stack (JSON, opcional), whitelist
   4. Dry-run preview com confirmacao final
-  5. exec claude com /agente-00c <args> auto-submetido
+  5. exec claude com /agente-00c <args> auto-submetido (telemetria local
+     ligada — desative com CSTK_TELEMETRY_AUTO=0)
 
 PROMPTS [Y/n] aceitam:
   Y/y/yes/sim/s/S/Enter         para SIM
@@ -783,7 +784,7 @@ _00c_dry_run_preview() {
 # especiais; conteudo interno ja e escapado via _00c_escape_sq (`'` -> `'\''`).
 # Stack JSON (ex: `{"runtime":"go"}`) tem aspas DUPLAS internas, mas como o
 # wrapping e single-quote, isso passa intacto para o argv recebido por claude.
-# A invocacao usa `exec claude "$_00c_slash_command"` (sem eval) — o claude
+# A invocacao usa `telemetry_exec_claude "$_00c_slash_command"` (sem eval) — o claude
 # recebe a string inteira como argv[1].
 _00c_build_slash_command() {
   _bsc_desc_esc=$(_00c_escape_sq "$_00c_descricao")
@@ -830,7 +831,8 @@ _00c_confirm_final() {
 
 # ==== _00c_exec_claude (FR-016f) ====
 #
-# (1) cd para o path; (2) release lock explicito (Decision 14); (3) exec claude.
+# (1) cd para o path; (2) release lock explicito (Decision 14); (3) exec do
+# claude via telemetry_exec_claude (issue #168).
 _00c_exec_claude() {
   if ! cd -- "$_00c_resolved_path" 2>/dev/null; then
     log_error "00c: falha em cd para $_00c_resolved_path"
@@ -851,7 +853,15 @@ _00c_exec_claude() {
   # --projeto-alvo-path '...'`). O claude e responsavel por interpretar
   # essa string como slash command auto-submetida (research.md Decision 11).
   # Sem `eval`: as aspas dentro da string sao literais.
-  exec claude "$_00c_slash_command"
+  #
+  # issue #168: via telemetry_exec_claude — `exec claude` cru nao resolve a
+  # funcao `claude()` do wrapper de telemetria (e este script roda em sh
+  # nao-interativo, onde o rc nem e lido), entao TODA execucao 00c iniciada
+  # por `cstk 00c` rodava sem telemetria: otel_usage null em todas as ondas.
+  # Kill switch: CSTK_TELEMETRY_AUTO=0.
+  # shellcheck source=./telemetry-env.sh
+  . "${CSTK_LIB:?CSTK_LIB must be set}/telemetry-env.sh"
+  telemetry_exec_claude "$_00c_slash_command"
 
   # Se exec falhou (claude nao executou), propagar.
   log_error "00c: exec claude falhou (claude nao iniciou)"

--- a/cli/lib/session.sh
+++ b/cli/lib/session.sh
@@ -94,7 +94,8 @@ SUBCOMANDOS:
                      local; prompt se ha commits nao-mergeados, --force bypassa).
            --reuse:  forca reutilizar HEAD atual de branch ja mergeada.
            --claude: apos criar a sessao, entra no diretorio e inicia o
-                     Claude Code (exec claude). Combinavel com as demais.
+                     Claude Code (exec claude, com telemetria local ligada —
+                     desative com CSTK_TELEMETRY_AUTO=0). Combinavel com as demais.
 
   list     Lista sessoes ativas. Marcadores STATUS (combinaveis):
            CURRENT (worktree atual), * (dirty), STALE (path inexistente).
@@ -556,7 +557,15 @@ EOF
     return 1
   fi
   printf 'Iniciando Claude Code em %s...\n' "$_session_path"
-  exec claude
+  # issue #168: `exec claude` chama o BINARIO e nunca resolve a funcao
+  # `claude()` do wrapper de telemetria — e este script roda em sh
+  # nao-interativo, onde o rc nem e lido. Sem isto, TODA sessao aberta por
+  # `cstk session start --claude` roda sem telemetria e o painel mostra
+  # custo/tokens como "—". telemetry_exec_claude resolve a porta e liga as
+  # variaveis aqui, sem depender de rc, shell ou tmux.
+  # shellcheck source=./telemetry-env.sh
+  . "${CSTK_LIB:?CSTK_LIB must be set}/telemetry-env.sh"
+  telemetry_exec_claude
 }
 
 # ==== Subcomando: list ====

--- a/cli/lib/telemetry-env.sh
+++ b/cli/lib/telemetry-env.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# telemetry-env.sh — injecao das variaveis de telemetria OTel nos lancadores
+# do proprio cstk (issue #168).
+#
+# ---- O problema que esta lib existe para resolver ----
+# O opt-in de telemetria que `cstk install` oferece (e que `cstk help
+# telemetry` imprime) e uma FUNCAO DE SHELL `claude()` no rc do operador.
+# Os lancadores do proprio cstk chamam o BINARIO via `exec claude`, e `exec`
+# nunca resolve funcao de shell:
+#
+#   $ sh -c 'foo() { echo FUNCAO; }; exec foo'
+#   sh: exec: foo: not found
+#
+# Pior: esses lancadores rodam em `sh` NAO-INTERATIVO, onde o rc sequer e
+# lido — a funcao nem existe ali. Resultado medido (issue #168): toda sessao
+# iniciada por `cstk session start --claude`, `cstk 00c` ou pela leva
+# paralela do roadmap rodava SEM telemetria, e o painel mostrava CUSTO e
+# TOKENS·SUBAGENTES como "—" com os hooks todos corretamente provisionados.
+# O produto anulava, por construcao, um recurso que o produto instala.
+#
+# A correcao e nao depender da funcao: resolver a porta e exportar as
+# variaveis aqui, no proprio lancador, replicando o que o snippet canonico
+# de `cli/install.sh` (telemetry_snippet) faz. Isso vale igual para quem usa
+# o plugin nativo, que nao instala wrapper nenhum.
+#
+# ---- Fronteira ----
+# Esta lib e RUNTIME do binario (`cstk self-update`), nao catalogo. O
+# terceiro lancador — `parallel-launch.sh emit` — vive no catalogo e nao
+# pode carregar esta lib; ele replica a MESMA decisao no proprio arquivo, e
+# `tests/cstk/test_cstk-main.sh` gateia o drift entre os tres pontos + o
+# snippet canonico.
+#
+# ---- Precedencia (nunca sobrescreve escolha explicita do operador) ----
+#   1. CSTK_TELEMETRY_AUTO=0            -> nao injeta nada (kill switch)
+#   2. CSTK_OTEL_ENDPOINT ja definido   -> ja configurado, nao toca
+#   3. CLAUDE_CODE_ENABLE_TELEMETRY definido com valor != 1
+#                                       -> opt-out explicito, nao toca
+#   4. caso contrario                   -> injeta
+#
+# POSIX sh. Sem dependencia alem de python3 (mesma do snippet canonico).
+
+# telemetry_env_enabled -> exit 0 se a injecao deve acontecer.
+# Silencioso: quem chama decide se avisa.
+telemetry_env_enabled() {
+  case "${CSTK_TELEMETRY_AUTO:-1}" in
+    0|no|NO|off|OFF|false|FALSE) return 1 ;;
+  esac
+  [ -z "${CSTK_OTEL_ENDPOINT:-}" ] || return 1
+  case "${CLAUDE_CODE_ENABLE_TELEMETRY:-}" in
+    ''|1) ;;
+    *) return 1 ;;
+  esac
+  return 0
+}
+
+# telemetry_env_free_port -> imprime uma porta TCP livre em 127.0.0.1.
+# Silencioso + exit 1 quando nao consegue (python3 ausente, bind negado).
+#
+# Mesma tecnica do snippet canonico: bind em porta 0 (o kernel escolhe uma
+# livre), le o numero, fecha. Ha uma janela de corrida entre o close e o
+# bind do exporter dentro do processo `claude` — janela que o snippet
+# canonico ja tem e aceita; esta lib nao piora nem melhora esse ponto.
+telemetry_env_free_port() {
+  command -v python3 >/dev/null 2>&1 || return 1
+  _tefp_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null) || return 1
+  case "$_tefp_port" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  printf '%s' "$_tefp_port"
+}
+
+# telemetry_exec_claude ARGS... -> exec do binario `claude` com as variaveis
+# de telemetria ligadas SO no ambiente desse processo (nada e exportado para
+# o shell chamador — mesma propriedade do snippet canonico, que evita o
+# falso alarme "exporter-down" em terminal sem sessao ativa).
+#
+# NUNCA retorna em caso de sucesso (exec substitui o processo).
+#
+# Degradacao, em ordem:
+#   - injecao desabilitada (ver telemetry_env_enabled) -> exec limpo, mudo;
+#   - sem porta livre (python3 ausente) -> liga telemetria na porta default
+#     fixa 9464, exatamente como o ramo sem-python3 do snippet canonico, e
+#     AVISA que CSTK_OTEL_ENDPOINT ficou ausente. Isso mantem o custo por
+#     onda medindo (cai no default) mas deixa `cstk usage` respondendo
+#     "nao medido" — o hook de consumo avulso gateia nessa variavel.
+telemetry_exec_claude() {
+  if ! telemetry_env_enabled; then
+    exec claude "$@"
+  fi
+
+  if _tec_port=$(telemetry_env_free_port); then
+    CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+    OTEL_METRICS_EXPORTER=prometheus \
+    OTEL_EXPORTER_PROMETHEUS_PORT="$_tec_port" \
+    CSTK_OTEL_ENDPOINT="http://127.0.0.1:${_tec_port}/metrics" \
+    exec claude "$@"
+  fi
+
+  printf 'cstk: telemetria: python3 ausente — nao consegui sortear porta livre.\n' >&2
+  printf 'cstk: telemetria: subindo na porta default 9464 e SEM CSTK_OTEL_ENDPOINT;\n' >&2
+  printf 'cstk: telemetria: o custo por onda mede, mas `cstk usage` vai responder "nao medido".\n' >&2
+  printf 'cstk: telemetria: detalhes e alternativas: cstk help telemetry\n' >&2
+  CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+  OTEL_METRICS_EXPORTER=prometheus \
+  exec claude "$@"
+}

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "9.3.0",
+  "version": "9.4.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/commands/agente-00c.md
+++ b/plugins/cstk/commands/agente-00c.md
@@ -1104,6 +1104,20 @@ uma sessao-filha — so a coordenadora interage com o operador e lanca.
    copiar/colar quando nao ha tmux ou a execucao nao pode abrir pane
    automaticamente.
 
+   **Execute a linha emitida VERBATIM.** Desde a issue #168 a composicao
+   `claude ...` vem prefixada por `env CLAUDE_CODE_ENABLE_TELEMETRY=1
+   OTEL_METRICS_EXPORTER=prometheus OTEL_EXPORTER_PROMETHEUS_PORT=<porta>
+   CSTK_OTEL_ENDPOINT=http://127.0.0.1:<porta>/metrics` — uma porta
+   sorteada POR FILHA. Nao remova, nao reordene e nao reaproveite a porta
+   entre filhas: o exporter OTel vive DENTRO de cada processo `claude`, e
+   sem esse prefixo a filha roda sem telemetria (custo e tokens de
+   subagente aparecem como `—` no painel, com os hooks todos corretos).
+   O wrapper `claude()` do rc do operador NAO alcanca este caminho — e
+   funcao de shell, e o tmux executa por `sh -c` nao-interativo.
+   Se `parallel-launch.sh` avisar em stderr que nao conseguiu sortear
+   porta, a filha sobe sem telemetria: reporte ao operador em vez de
+   inventar uma porta.
+
    **Sempre split, nunca janela nova**: cada filha entra como pane irmao
    no MESMO window da coordenadora (`tmux split-window -c <WORKTREE> -P -F
    '#{pane_id}'`), o que mantem a leva inteira visivel de uma vez.

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/bloqueios.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/bloqueios.sh
@@ -18,6 +18,12 @@
 #         opcional; prefixo fechado {briefing-item:, axis:} + sufixo
 #         nao-vazio, senao exit 2. Ausente = subject_key NULL (comportamento
 #         atual). Usada para dedup de FR-008 (ver `list` abaixo).
+#       — Para `axis:`, o SUFIXO tambem e validado contra o enum fechado de
+#         references/structural-axis-map.txt (issue #170): eixo fora do mapa
+#         e exit 2 no register, em vez de ser aceito e nunca casar no vinculo
+#         de consentimento. `briefing-item:` nao tem enum equivalente (sufixo
+#         aberto por desenho) e segue so com a checagem de prefixo.
+#         `list --chave-assunto` NAO valida: e query, nao registro.
 #
 #   bloqueios.sh respond --state-dir DIR --block-id ID --resposta TEXT
 #       — Marca bloqueio como `respondido`, registra human_answer e
@@ -56,6 +62,53 @@ _BL_DIR=$(cd "$(dirname -- "$0")" && pwd)
 # Envelope diagnostico aditivo (openspec-hygiene FR-012/FR-015 — escopo-piloto).
 # shellcheck source=./_diag.sh
 . "$_BL_DIR/_diag.sh"
+
+# ---------- Enum fechado de eixo estrutural (issue #170) ----------
+# Ref: docs/specs/structural-decision-human-gate/data-model.md §Enum
+#      structural_axis
+#
+# O consumidor do vinculo de consentimento (report.sh:552, e o `--consentimento`
+# de state-decisions.sh) casa `subject_key == "axis:" + <eixo>` ITERANDO o
+# structural-axis-map.txt. Validar aqui so o PREFIXO deixava passar
+# `axis:<qualquer-coisa>`, que era aceito no register e NUNCA casava no
+# vinculo — bloqueio, resposta e decisao existiam sem nada os ligar de forma
+# verificavel (buraco silencioso na trilha de auditoria, nao falha).
+# Enum fechado no consumidor exige enum fechado no produtor.
+#
+# So vale para `axis:`. `briefing-item:` NAO tem enum equivalente (o sufixo e
+# um id de item do briefing, aberto por desenho) — validar os dois igualmente
+# quebraria esse caminho.
+_BL_AXIS_MAP="$_BL_DIR/../references/structural-axis-map.txt"
+
+# _bl_axis_valid TOKEN -> exit 0 se TOKEN existe no enum de
+# structural-axis-map.txt (linhas 'eixo|rotulo'; '#' e vazias ignoradas).
+# Mapa ausente/ilegivel => REJEITA (fail-closed, sem fail-safe): aceitar eixo
+# desconhecido e exatamente o que esta trava fecha. Espelha _sd_axis_valid
+# de state-decisions.sh; a fonte de verdade unica e o ARQUIVO do mapa.
+_bl_axis_valid() {
+  _bav_tok="$1"
+  [ -n "$_bav_tok" ] || return 1
+  [ -f "$_BL_AXIS_MAP" ] || return 1
+  while IFS='|' read -r _bav_eixo _bav_rot || [ -n "$_bav_eixo" ]; do
+    case "$_bav_eixo" in
+      ''|'#'*) continue ;;
+    esac
+    if [ "$_bav_eixo" = "$_bav_tok" ]; then
+      return 0
+    fi
+  done < "$_BL_AXIS_MAP"
+  return 1
+}
+
+# _bl_axis_list -> eixos validos separados por ', ' (para mensagem de erro).
+# Fonte: o proprio mapa — nunca uma lista hardcoded que possa driftar dele.
+_bl_axis_list() {
+  [ -f "$_BL_AXIS_MAP" ] || { printf '<mapa ausente: %s>' "$_BL_AXIS_MAP"; return 0; }
+  awk -F'|' '
+    /^[[:space:]]*$/ || /^#/ { next }
+    { printf "%s%s", (n++ ? ", " : ""), $1 }
+  ' "$_BL_AXIS_MAP"
+}
 
 # Backend dual (feature state-db-foundation, FASE 3 task 3.5): presenca de
 # <state-dir>/state.db seleciona SQLite; senao, backend JSON (comportamento
@@ -192,7 +245,16 @@ _bl_cmd_register() {
   # e sufixo nao-vazio. Ausente = subject_key NULL (comportamento atual).
   if [ -n "$_subj" ]; then
     case "$_subj" in
-      briefing-item:?*|axis:?*) ;;
+      briefing-item:?*) ;;
+      axis:?*)
+        # issue #170: sufixo de `axis:` precisa estar no enum fechado —
+        # senao a chave e aceita aqui e nunca casa no vinculo de
+        # consentimento (degradacao silenciosa da trilha de auditoria).
+        _bl_axis_suffix=${_subj#axis:}
+        if ! _bl_axis_valid "$_bl_axis_suffix"; then
+          _bl_die "register: --chave-assunto 'axis:$_bl_axis_suffix' fora do enum de structural-axis-map.txt (eixos validos: $(_bl_axis_list)) — chave fora do enum e aceita no registro mas NUNCA casa no vinculo de consentimento [eixo-invalido]" 2
+        fi
+        ;;
       *) _bl_die "register: --chave-assunto invalida (esperado prefixo briefing-item: ou axis: com sufixo nao-vazio, recebido '$_subj')" 2 ;;
     esac
   fi

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/parallel-launch.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/parallel-launch.sh
@@ -32,6 +32,12 @@
 # tmux) comparaveis byte a byte na parte `claude --name ... "..."` — mesma
 # composicao, so envolvida de forma diferente (§4, decisao de desenho).
 #
+# Telemetria (issue #168): a composicao `claude ...` e prefixada por
+# `env CLAUDE_CODE_ENABLE_TELEMETRY=1 ... CSTK_OTEL_ENDPOINT=...` com UMA
+# porta sorteada POR FILHA — sem isso a filha sobe sem telemetria (o wrapper
+# do rc e funcao de shell e nao alcanca `sh -c` nao-interativo do tmux).
+# Kill switch: CSTK_TELEMETRY_AUTO=0. Detalhe em _pl_otel_prefix.
+#
 # Wrapper tmux: SEMPRE `split-window` (pane irmao no window da
 # coordenadora), nunca `new-window`. O prompt da filha e sempre
 # `/feature-00c "<DESCRICAO>" <SHORT>` — formato REAL do command
@@ -84,7 +90,9 @@ Uso: parallel-launch.sh emit --repo PATH --feature SHORT [--description TEXT]
 
 `emit` compoe e IMPRIME (nunca executa) o par de comandos de lancamento de
 cada --feature: `cstk session start <SHORT>` + `tmux split-window ...` (ou a
-forma degradada `cd ... && claude ...` quando tmux esta ausente). Quem
+forma degradada `cd ... && env ... claude ...` quando tmux esta ausente). A
+composicao `claude ...` vem prefixada por `env` com as variaveis de
+telemetria local (porta por filha; desative com CSTK_TELEMETRY_AUTO=0). Quem
 executa e o chamador (command pai) — este script nunca invoca cli/lib/
 session.sh nem qualquer outro comando de efeito colateral.
 
@@ -393,6 +401,70 @@ _pl_flush_pending() {
   _pl_pending_desc=""
 }
 
+# ==== telemetria da filha (issue #168) ====
+#
+# O wrapper de telemetria que `cstk install` oferece e uma FUNCAO de shell
+# `claude()`. A linha emitida aqui e executada por `tmux split-window`, que
+# roda o comando por um `sh -c` NAO-INTERATIVO — o rc nem e lido, a funcao
+# nao existe, e a filha subia sem telemetria (otel_usage null em todas as
+# ondas dela). Prefixamos a composicao com `env VAR=... ` para nao depender
+# de rc, shell nem tmux. `env` (binario real) em vez do prefixo nu
+# `VAR=v cmd` porque tmux pode executar a lista de argumentos sem passar por
+# shell, e nesse caminho o prefixo nu seria tratado como nome de programa.
+#
+# DIFERENCA DELIBERADA em relacao a cli/lib/telemetry-env.sh: la, um
+# CSTK_OTEL_ENDPOINT ja presente no ambiente significa "ja configurado, nao
+# toca", porque o exec SUBSTITUI o processo corrente. Aqui nao: o ambiente
+# corrente e o da SESSAO COORDENADORA, e cada filha precisa da PROPRIA porta
+# (o exporter vive dentro de cada processo `claude`; duas filhas na mesma
+# porta = uma delas nao mede). Herdar o endpoint da coordenadora seria o bug
+# que `cstk setup` ja avisa em outro contexto.
+#
+# Sem porta sorteavel (python3 ausente) NAO caimos na porta default fixa
+# 9464 — ao contrario do lancador de processo unico: aqui ha N filhas por
+# construcao, e todas na mesma porta fixa e pior que nenhuma. Emite aviso e
+# segue sem telemetria.
+#
+# Kill switch: CSTK_TELEMETRY_AUTO=0.
+_PL_OTEL_OK=0
+
+# _pl_otel_check -> decide UMA vez por invocacao de `emit` se ha como ligar
+# telemetria, e avisa (uma unica linha) se nao ha. Precisa rodar FORA de
+# command substitution: `_pl_otel_prefix` e chamado dentro de `$( )`, que e
+# subshell — um flag setado la nao volta, e o aviso sairia uma vez por
+# filha.
+_pl_otel_check() {
+  _PL_OTEL_OK=0
+  case "${CSTK_TELEMETRY_AUTO:-1}" in
+    0|no|NO|off|OFF|false|FALSE) return 0 ;;
+  esac
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf '%s: telemetria: python3 ausente — nao ha como sortear porta livre; filha(s) lancada(s) SEM telemetria (custo/tokens ficarao "-" no painel). Ver: cstk help telemetry\n' \
+      "$_PL_NAME" >&2
+    return 0
+  fi
+  _PL_OTEL_OK=1
+}
+
+# _pl_otel_prefix -> imprime `env VAR=... ` (com espaco final) ou nada.
+# Uma porta NOVA por chamada (uma por filha).
+_pl_otel_prefix() {
+  [ "$_PL_OTEL_OK" = 1 ] || return 0
+  _plop_port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null) || _plop_port=""
+  case "$_plop_port" in
+    ''|*[!0-9]*) _plop_port="" ;;
+  esac
+  if [ -z "$_plop_port" ]; then
+    # python3 existe mas o bind falhou (raro). Avisa por filha afetada — o
+    # stderr do subshell chega ao chamador normalmente.
+    printf '%s: telemetria: falha ao sortear porta livre — esta filha sobe SEM telemetria.\n' \
+      "$_PL_NAME" >&2
+    return 0
+  fi
+  printf 'env CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_METRICS_EXPORTER=prometheus OTEL_EXPORTER_PROMETHEUS_PORT=%s CSTK_OTEL_ENDPOINT=http://127.0.0.1:%s/metrics ' \
+    "$_plop_port" "$_plop_port"
+}
+
 # ==== emit ====
 
 _pl_cmd_emit() {
@@ -441,6 +513,11 @@ _pl_cmd_emit() {
 
   [ -n "$_pl_repo" ] || { printf '%s: --repo obrigatorio\n' "$_PL_NAME" >&2; exit 2; }
   [ "$_pl_n_features" -ge 1 ] || { printf '%s: pelo menos um --feature obrigatorio\n' "$_PL_NAME" >&2; exit 2; }
+
+  # Decide uma unica vez se ha telemetria (e avisa, uma linha so, se nao ha).
+  # Depois da validacao de argumentos: erro de uso nao deve vir precedido de
+  # aviso de telemetria.
+  _pl_otel_check
 
   # Default do roadmap: <repo>/docs/roadmap.md (contract §4.1a). Ausente =>
   # nenhuma descricao vinda do roadmap, NUNCA erro. `--roadmap` explicito
@@ -525,7 +602,12 @@ _pl_cmd_emit() {
     # crase, `\`, `$` e demais metacaracteres (§4.1).
     _pl_desc=$(_pl_resolve_desc "$_pl_short" "$_pl_desc_raw")
     _pl_prompt=$(printf "'/feature-00c \"%s\" %s'" "$_pl_desc" "$_pl_short")
-    _pl_claude_argv=$(printf 'claude --name "%s" %s' "$_pl_child" "$_pl_prompt")
+    # Prefixo de telemetria: UMA porta por filha (issue #168). Fica FORA do
+    # trecho comparado byte a byte entre os dois caminhos (a comparacao
+    # comeca em `claude --name`), justamente porque a porta e por-filha e
+    # nao poderia ser identica entre duas invocacoes.
+    _pl_claude_argv=$(printf '%sclaude --name "%s" %s' \
+      "$(_pl_otel_prefix)" "$_pl_child" "$_pl_prompt")
 
     _pl_line1=$(printf 'cstk session start %s' "$_pl_short")
     if $_pl_have_tmux; then

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/secrets-filter.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/secrets-filter.sh
@@ -9,9 +9,14 @@
 # Le stdin, escreve stdout com substituicao de cada match por [REDACTED].
 # Aplica em ordem (cada padrao independente, nao excludente):
 #
-#   1. Tokens com palavra-chave proxima:
-#      `(token|key|secret|password|pwd|auth|api_key|access_key)\s*[:=]\s*"?[A-Za-z0-9_-]{20,}"?`
-#      → reduz falsos positivos (hashes git, UUIDs sem contexto NAO sao filtrados)
+#   0. Blocos PEM (`-----BEGIN X-----` ... `-----END X-----`, marcador
+#      sozinho na linha, RFC 7468) → `[REDACTED-PEM-BLOCK]`. O corpo base64
+#      nao tem palavra-chave proxima e escapava de todas as outras regras.
+#   1. Tokens com palavra-chave proxima, em DOIS limiares:
+#      a) generico, `{20,}`: `(token|key|secret|password|pwd|auth|api_key|access_key)\s*[:=]\s*"?[A-Za-z0-9_-]{20,}"?`
+#         → limiar alto reduz falso positivo em prosa (`key: valor`)
+#      b) alta confianca, `{4,}`: `(password|passwd|api_key|access_key|secret_key|private_key|client_secret|*_token|secret)`
+#         → palavras-chave que seguidas de `:`/`=` praticamente nunca sao prosa
 #   2. AWS access keys: `AKIA[A-Z0-9]{16,}`
 #   3. Bearer tokens: `Bearer\s+[A-Za-z0-9._-]+`
 #   4. Basic auth em URLs: `https?://[^:]+:[^@]+@`
@@ -43,6 +48,18 @@
 #   0 sucesso (scrub) ou nenhum secret encontrado (check)
 #   1 secret detectado em check
 #   2 uso incorreto
+#
+# --- Contrato de cobertura (issue #169) ---
+# A cobertura deste filtro e um PISO, NAO uma garantia de ausencia de
+# segredo. "Passou pelo scrub" != "nao contem segredo". Casos conhecidos que
+# CONTINUAM passando em claro:
+#   - segredo curto (<4 chars) sob qualquer palavra-chave;
+#   - segredo de 4..19 chars sob palavra-chave NAO listada na regra 1b
+#     (ex.: `key`, `token`, `auth`, `pwd`, ou um nome proprio de aplicacao);
+#   - segredo sem palavra-chave proxima e sem formato reconhecido
+#     (AKIA/Bearer/basic-auth/PEM) e ausente do `--env-file`.
+# Consumidores que precisem de garantia (e nao de reducao de risco) precisam
+# de controle proprio a montante — nunca tratar este scrub como suficiente.
 #
 # POSIX sh + sed/grep/awk.
 
@@ -147,6 +164,31 @@ _sf_apply_filters() {
   # Caso contrario, o regex generico de token mascararia AKIA/Bearer com
   # [REDACTED] genenrico e perderia o tipo do secret.
 
+  # 0. Blocos PEM (chave privada, certificado, etc). Vem PRIMEIRO porque o
+  #    corpo base64 nao tem palavra-chave proxima e escaparia de todas as
+  #    demais regras (issue #169). Deteccao estrita por RFC 7468: a linha de
+  #    encapsulamento precisa estar SOZINHA na linha (so espacos ao redor) —
+  #    assim uma mencao em prosa/doc (`... o marcador `-----BEGIN X-----` ...`)
+  #    NAO engole o restante do arquivo. Bloco sem `-----END-----` e suprimido
+  #    ate EOF (fail-closed: melhor perder relatorio que vazar chave).
+  #    Guarda `grep -Eq` antes do awk: sem ela o awk rodaria em TODO input e
+  #    normalizaria a ausencia de newline final (`print` sempre a adiciona),
+  #    quebrando a comparacao byte a byte de que `check` depende (input limpo
+  #    sem newline final passaria a acusar secret).
+  if grep -Eq '^[[:space:]]*-----BEGIN [A-Z0-9][A-Z0-9 ]*-----[[:space:]]*$' "$_t1"; then
+    awk '
+      /^[[:space:]]*-----BEGIN [A-Z0-9][A-Z0-9 ]*-----[[:space:]]*$/ && !inpem {
+        inpem = 1; print "[REDACTED-PEM-BLOCK]"; next
+      }
+      inpem && /^[[:space:]]*-----END [A-Z0-9][A-Z0-9 ]*-----[[:space:]]*$/ {
+        inpem = 0; next
+      }
+      inpem { next }
+      { print }
+    ' "$_t1" > "$_t2"
+    mv "$_t2" "$_t1"; _t2=$(mktemp)
+  fi
+
   # 1. AWS access keys (formato unico)
   sed -E 's/AKIA[A-Z0-9]{16,}/[REDACTED-AWS-KEY]/g' "$_t1" > "$_t2"
   mv "$_t2" "$_t1"; _t2=$(mktemp)
@@ -162,6 +204,28 @@ _sf_apply_filters() {
   # 4. Tokens genericos com palavra-chave proxima (proximidade reduz falsos
   #    positivos). Regex: (KEY) WS* [:=] WS* "?" [A-Za-z0-9...]{20,} "?".
   if sed -E -e 's/((token|key|secret|password|pwd|auth|api_?key|access_?key)[[:space:]]*[:=][[:space:]]*"?)[A-Za-z0-9_=+\/-]{20,}("?)/\1[REDACTED]\3/Ig' \
+    "$_t1" > "$_t2" 2>/dev/null; then
+    mv "$_t2" "$_t1"
+    _t2=$(mktemp)
+  fi
+
+  # 4b. Mesma forma da regra 4, porem com limiar de 4 chars, restrita a
+  #     palavras-chave de ALTA confianca — aquelas cuja ocorrencia seguida de
+  #     `:`/`=` praticamente nunca e prosa (issue #169: `password=hunter2`,
+  #     7 chars, escapava do `{20,}` da regra 4 e saia em claro).
+  #
+  #     Por que uma lista SEPARADA em vez de baixar o `{20,}` da regra 4: o
+  #     limiar alto existe para nao redigir prosa comum (`key: valor`,
+  #     `auth: bearer`) — baixa-lo para todas as palavras-chave trocaria
+  #     vazamento por ruido, e ruido num filtro de seguranca leva a ignorar a
+  #     saida dele. Ficam DE FORA de propósito (seguem so na regra 4, {20,}):
+  #       - `key`, `token`, `auth`, `secret` generico em prosa;
+  #       - `pwd`  — `PWD=/algum/caminho` num dump de ambiente viraria
+  #         `[REDACTED]` e destruiria diagnostico legitimo do enforcement-log.
+  #
+  #     Cobertura e PISO, nao garantia: um segredo curto sob palavra-chave
+  #     nao listada continua passando. Ver comentario de contrato no topo.
+  if sed -E -e 's/((password|passwd|api_?key|apikey|access_?key|secret_?key|private_?key|client_?secret|auth_?token|access_?token|refresh_?token|secret)[[:space:]]*[:=][[:space:]]*"?)[A-Za-z0-9_=+\/-]{4,}("?)/\1[REDACTED]\3/Ig' \
     "$_t1" > "$_t2" 2>/dev/null; then
     mv "$_t2" "$_t1"
     _t2=$(mktemp)

--- a/plugins/cstk/skills/converge/SKILL.md
+++ b/plugins/cstk/skills/converge/SKILL.md
@@ -173,7 +173,22 @@ scripts/extract-must.sh --constitution "$CONSTITUTION"
 # exit: 0 sucesso | 1 constitution ausente (CRITICAL por MUST fica
 #       indisponivel; demais severidades SEGUEM se aplicando — nao aborte a
 #       skill so por isso) | 2 erro de uso
+
+scripts/extract-must.sh --constitution "$CONSTITUTION" --coverage
+# stdout: relatorio de cobertura (fontes lidas, contagem INDEPENDENTE da
+#         palavra MUST, linhas reconhecidas pelo parser, principios emitidos,
+#         quantos vieram so do rotulo do heading)
 ```
+
+**Rode as DUAS invocações** (issue #171). A segunda é o que separa "conferi
+tudo e passou" de "conferi uma fração e passou": o modo default responde
+*quais* princípios são MUST, nunca *quanto* do arquivo foi lido. Se
+`linhas de regra MUST reconhecidas pelo parser: 0` com ocorrências > 0, a
+constitution usa uma convenção de marcação que o parser não cobre — **não
+reporte o gate como satisfeito**: registre o número real no relatório da
+ETAPA 7 e trate a verificação de MUST como indisponível (mesmo tratamento do
+`exit 1` acima), nunca como aprovada. O relatório da ETAPA 7 deve citar as
+quatro linhas do `--coverage` verbatim, não uma paráfrase de sucesso.
 
 Cada linha de `extract-intent.sh` é um candidato a `Gap` a avaliar na ETAPA 4.
 A lista de `extract-must.sh` é o inventário de princípios usado na ETAPA 5
@@ -442,8 +457,11 @@ Todos POSIX sh puro, zero dependência obrigatória (`realpath` com fallback
   `docs/constitution.md` → aborta, teto 20 níveis).
 - `extract-intent.sh --tasks <tasks.md> [--plan <plan.md>]` — extração
   determinística de paths + origem (§ETAPA 3).
-- `extract-must.sh --constitution <constitution.md>` — princípios
-  `MUST`/`NON-NEGOTIABLE` (§ETAPA 3).
+- `extract-must.sh --constitution <constitution.md> [--coverage]` —
+  princípios `MUST`/`NON-NEGOTIABLE` (§ETAPA 3). Reconhece `**MUST:**` e as
+  formas em bullet (`- MUST:`, `- **MUST:**`, `* MUST NOT:`). `--coverage`
+  reporta quanto do arquivo o parser de fato leu — obrigatório junto com a
+  invocação default (issue #171).
 - `severity.sh --type <t> --priority <p> --must-violated <bool>` — função
   pura de severidade (§5.3).
 - `converge-tasks.sh {next-phase|existing-keys|append-phase|gap-key}` —

--- a/plugins/cstk/skills/converge/scripts/extract-must.sh
+++ b/plugins/cstk/skills/converge/scripts/extract-must.sh
@@ -8,10 +8,14 @@
 #
 # USO:
 #   extract-must.sh --constitution <constitution.md>
+#   extract-must.sh --constitution <constitution.md> --coverage
 #
 # Saida (stdout), TSV, uma linha por PRINCIPIO (nao por bullet individual)
 # marcado MUST/NON-NEGOTIABLE:
 #   <identificador>\t<titulo>
+#
+# Com --coverage, em vez do TSV imprime o relatorio de cobertura (ver
+# §"Relatorio de cobertura" abaixo).
 #
 # EXIT:
 #   0  sucesso (0+ linhas)
@@ -51,7 +55,7 @@
 #       `constitution` (SKILL.md) para o principio-base obrigatorio e
 #       usada em todo principio NON-NEGOTIABLE deste repo; OU
 #   (b) o corpo do principio (ate o proximo "### " ou EOF) contem uma linha
-#       "**MUST:**" — cobre o caso de um principio com regras MUST reais
+#       de regra MUST — cobre o caso de um principio com regras MUST reais
 #       mas cujo HEADING nao leva o sufixo "(NON-NEGOTIABLE)" (ex.:
 #       Principio III deste repo: "Formato Canonico de Skill..." tem bloco
 #       "**MUST:**" mas o proprio Decision Framework da constituicao NAO o
@@ -63,6 +67,39 @@
 # nao tem sufixo NON-NEGOTIABLE) NAO satisfazem (a) nem (b) e sao excluidos
 # corretamente.
 #
+# --- Convencoes de marcacao de linha MUST reconhecidas (issue #171) ---
+# ANTES desta correcao o sinal (b) casava UMA unica convencao — a linha
+# comecando literalmente em "**MUST:**". Contra uma constitution.md que use
+# bullet ("- MUST: ..."), formato igualmente valido e produzido por outros
+# projetos, o parser lia ZERO regras e o `converge` reportava sucesso como
+# se tivesse conferido tudo. Caso medido: 13 regras `- MUST:` no arquivo,
+# 0 reconhecidas; o unico principio emitido casou pela via (a) — rotulo de
+# heading — sem nenhuma regra lida.
+#
+# A regra agora aceita, com indentacao opcional e marcador de bullet
+# opcional (`-`, `*`, `+`), com ou sem negrito:
+#     **MUST:**   |   - MUST:   |   - **MUST:**   |   MUST:   |   * MUST NOT:
+# Exigir os dois-pontos e deliberado: mantem "MUST" em prosa corrida fora do
+# sinal (b), que e o que dava ao limiar original sua razao de existir.
+#
+# --- Relatorio de cobertura (--coverage, issue #171) ---
+# O modo default responde "quais principios sao MUST", nunca "quanto do
+# arquivo eu de fato li". Um gate que le uma fracao e reporta sucesso e pior
+# que gate ausente, porque produz confianca. `--coverage` imprime:
+#
+#   fontes declaradas: <path>
+#   ocorrencias da palavra MUST no arquivo (contagem independente): N
+#   linhas de regra MUST reconhecidas pelo parser: M
+#   principios emitidos: P
+#   principios emitidos so por rotulo de heading (sem regra MUST lida): Q
+#
+# A 2a linha usa gramatica DELIBERADAMENTE diferente da do parser — conta a
+# palavra `MUST` isolada (word boundary), sem nenhuma nocao de bullet,
+# negrito ou dois-pontos. Se compartilhasse a gramatica do parser, a metrica
+# seria autoconfirmatoria e voltaria a reportar 100%. Por ser independente,
+# ela e um limite SUPERIOR grosseiro (conta MUST em prosa tambem): N > M nao
+# prova lacuna, mas N >> M com M == 0 e exatamente o sintoma de #171.
+#
 # POSIX sh + awk (ferramentas POSIX canonicas, Constitution II). Zero eval
 # sobre conteudo lido (SEC-1). Todas as variaveis quotadas. Sem Bash-isms.
 
@@ -72,10 +109,14 @@ _EM_NAME="extract-must"
 
 _em_usage() {
   cat <<'USAGE' >&2
-Uso: extract-must.sh --constitution <constitution.md>
+Uso: extract-must.sh --constitution <constitution.md> [--coverage]
 
 Saida: TSV "<identificador>\t<titulo>" em stdout, uma linha por principio
 MUST/NON-NEGOTIABLE (nao por bullet individual).
+
+--coverage: em vez do TSV, imprime o relatorio de cobertura (fontes lidas,
+contagem independente de MUST, linhas reconhecidas pelo parser, principios
+emitidos e quantos vieram so do rotulo do heading).
 Exit: 0 sucesso | 1 --constitution ausente | 2 erro de uso
 USAGE
 }
@@ -88,6 +129,7 @@ _em_die_usage() {
 # ---------- Parse de flags ----------
 
 _CONST=""
+_COVERAGE=0
 
 if [ "$#" -eq 0 ]; then
   _em_usage
@@ -100,6 +142,10 @@ while [ "$#" -gt 0 ]; do
       [ "$#" -ge 2 ] || _em_die_usage "--constitution requer valor"
       _CONST=$2
       shift 2
+      ;;
+    --coverage)
+      _COVERAGE=1
+      shift
       ;;
     -h | --help)
       _em_usage
@@ -124,7 +170,61 @@ fi
 # visto no corpo dele ate aqui), depois comeca a acumular o novo. O ultimo
 # principio do arquivo e resolvido no bloco END.
 
-awk '
+# Regra de linha MUST, compartilhada pelo modo default e pelo --coverage
+# (uma unica definicao — duas copias driftariam e a metrica de cobertura
+# mediria um parser diferente do que roda).
+_EM_MUST_RE='^[[:space:]]*([-*+][[:space:]]+)?[*]*MUST([[:space:]]+NOT)?[*]*[[:space:]]*:'
+
+if [ "$_COVERAGE" = 1 ]; then
+  # Contagem INDEPENDENTE: a palavra MUST isolada, sem nocao de bullet,
+  # negrito ou dois-pontos. Gramatica de proposito diferente da do parser —
+  # se compartilhasse, a metrica seria autoconfirmatoria.
+  _em_words=$(grep -cE '(^|[^A-Za-z])MUST([^A-Za-z]|$)' "$_CONST" || :)
+  # Contagem do PARSER: a mesma regex que o modo default usa (uma definicao
+  # so — duas copias mediriam um parser diferente do que roda).
+  _em_lines=$(grep -cE "$_EM_MUST_RE" "$_CONST" || :)
+
+  # Classificacao de cada principio emitido: `with-must` (alguma regra MUST
+  # foi de fato lida no corpo) x `heading-only` (entrou so pelo rotulo
+  # "(NON-NEGOTIABLE)" do heading, sem nenhuma regra lida). Um unico passo —
+  # os dois numeros derivam da MESMA saida.
+  _em_classes=$(awk -v must_re="$_EM_MUST_RE" '
+    function flush() {
+      if (pending != "" && (pending_nonneg || pending_hasmust)) {
+        print pending_hasmust ? "with-must" : "heading-only"
+      }
+    }
+    /^### / {
+      flush()
+      raw = $0; sub(/^### /, "", raw)
+      pending = raw
+      pending_nonneg = (raw ~ /\(NON-NEGOTIABLE\)$/)
+      pending_hasmust = 0
+      next
+    }
+    $0 ~ must_re { pending_hasmust = 1; next }
+    END { flush() }
+  ' "$_CONST")
+
+  _em_emitted=$(printf '%s' "$_em_classes" | grep -c . || :)
+  _em_heading_only=$(printf '%s' "$_em_classes" | grep -c '^heading-only' || :)
+
+  printf 'fontes declaradas: %s\n' "$_CONST"
+  printf 'ocorrencias da palavra MUST no arquivo (contagem independente): %s\n' "$_em_words"
+  printf 'linhas de regra MUST reconhecidas pelo parser: %s\n' "$_em_lines"
+  printf 'principios emitidos: %s\n' "$_em_emitted"
+  printf 'principios emitidos so por rotulo de heading (sem regra MUST lida): %s\n' "$_em_heading_only"
+
+  # Sintoma exato de #171: o arquivo fala de MUST e o parser nao reconheceu
+  # NENHUMA regra. Nesse estado o resultado do gate nao cobre as regras do
+  # arquivo — dizer isso alto e o ponto do relatorio.
+  if [ "$_em_words" -gt 0 ] && [ "$_em_lines" -eq 0 ]; then
+    printf '%s: AVISO: o arquivo contem a palavra MUST mas NENHUMA linha de regra foi reconhecida — convencao de marcacao provavelmente nao suportada; o resultado NAO cobre as regras MUST deste arquivo.\n' "$_EM_NAME" >&2
+  fi
+  exit 0
+fi
+
+awk -v must_re="$_EM_MUST_RE" '
   function flush() {
     if (pending != "" && (pending_nonneg || pending_hasmust)) {
       printf "%s\t%s\n", pending_id, pending_title
@@ -159,7 +259,7 @@ awk '
     next
   }
 
-  /^\*\*MUST:\*\*/ {
+  $0 ~ must_re {
     pending_hasmust = 1
     next
   }

--- a/tests/cstk/test_cstk-main.sh
+++ b/tests/cstk/test_cstk-main.sh
@@ -217,4 +217,58 @@ scenario_help_telemetry_snippet_parity_with_install() {
   [ "$_a" = "$_b" ] || { _fail "parity" "snippet de telemetria divergiu entre cli/install.sh e cli/cstk"; return 1; }
 }
 
+# ==== issue #168: paridade do conjunto de variaveis entre os lancadores ====
+#
+# O snippet canonico (wrapper `claude()` do rc) e os TRES lancadores do
+# proprio cstk precisam ligar o MESMO conjunto de variaveis. Sem este gate,
+# adicionar uma variavel ao snippet e esquecer os lancadores reproduz
+# exatamente a issue #168: telemetria ativa para quem digita `claude` no
+# terminal, e inerte para tudo que o cstk lanca.
+
+# _telemetry_vars_of FILE -> nomes de variaveis de telemetria citados em
+# FILE, um por linha, ordenados e sem repeticao.
+_telemetry_vars_of() {
+  grep -oE '(CLAUDE_CODE_ENABLE_TELEMETRY|OTEL_METRICS_EXPORTER|OTEL_EXPORTER_PROMETHEUS_PORT|CSTK_OTEL_ENDPOINT)=' "$1" \
+    | sed 's/=$//' | sort -u
+}
+
+scenario_telemetry_vars_parity_snippet_vs_lancadores() {
+  _snip="$TMPDIR_TEST/snippet.txt"
+  awk '/^# >>> cstk telemetry >>>$/,/^# <<< cstk telemetry <<<$/' "$REPO_ROOT/cli/install.sh" > "$_snip"
+  [ -s "$_snip" ] || { _fail "extract" "snippet ausente de cli/install.sh"; return 1; }
+
+  _esperado=$(_telemetry_vars_of "$_snip")
+  [ -n "$_esperado" ] || { _fail "extract" "nenhuma variavel de telemetria no snippet"; return 1; }
+
+  # Lancador 1+2 (runtime do binario): cli/lib/telemetry-env.sh.
+  _lib=$(_telemetry_vars_of "$REPO_ROOT/cli/lib/telemetry-env.sh")
+  [ "$_lib" = "$_esperado" ] || {
+    _fail "parity" "cli/lib/telemetry-env.sh diverge do snippet: [$_lib] vs [$_esperado]"; return 1; }
+
+  # Lancador 3 (catalogo): parallel-launch.sh emit.
+  _pl=$(_telemetry_vars_of "$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/scripts/parallel-launch.sh")
+  [ "$_pl" = "$_esperado" ] || {
+    _fail "parity" "parallel-launch.sh diverge do snippet: [$_pl] vs [$_esperado]"; return 1; }
+}
+
+scenario_lancadores_nao_usam_exec_claude_cru() {
+  # `exec claude` nunca resolve a funcao `claude()` do rc (e estes scripts
+  # rodam em sh nao-interativo, onde o rc nem e lido). Qualquer reintroducao
+  # de `exec claude` cru nos lancadores e a regressao da issue #168.
+  for _f in cli/lib/session.sh cli/lib/00c-bootstrap.sh; do
+    _hits=$(grep -nE '^[[:space:]]*exec[[:space:]]+claude([[:space:]]|$)' "$REPO_ROOT/$_f" || :)
+    [ -z "$_hits" ] || { _fail "regressao #168" "$_f voltou a usar 'exec claude' cru: $_hits"; return 1; }
+  done
+  # O unico `exec claude` legitimo vive dentro da propria lib de telemetria.
+  grep -qE '^[[:space:]]*exec claude' "$REPO_ROOT/cli/lib/telemetry-env.sh" || {
+    _fail "estrutura" "cli/lib/telemetry-env.sh deveria conter o exec claude"; return 1; }
+}
+
+scenario_lancadores_expoem_kill_switch() {
+  for _f in cli/lib/telemetry-env.sh plugins/cstk/skills/agente-00c-runtime/scripts/parallel-launch.sh; do
+    grep -q 'CSTK_TELEMETRY_AUTO' "$REPO_ROOT/$_f" || {
+      _fail "kill switch" "$_f nao honra CSTK_TELEMETRY_AUTO"; return 1; }
+  done
+}
+
 run_all_scenarios

--- a/tests/cstk/test_telemetry-env.sh
+++ b/tests/cstk/test_telemetry-env.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# test_telemetry-env.sh — cobre cli/lib/telemetry-env.sh (issue #168).
+#
+# Contrato:
+#   telemetry_env_enabled   exit 0 = injetar; 1 = nao injetar
+#   telemetry_env_free_port stdout porta livre; exit 1 se nao conseguiu
+#   telemetry_exec_claude   exec do binario `claude` com as variaveis
+#                           ligadas SO no ambiente daquele processo
+#
+# Estrategia: source direto da lib + stub de `claude` no PATH que imprime as
+# variaveis recebidas. Sem rede, sem Claude Code real.
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+CSTK_LIB="$REPO_ROOT/cli/lib"
+export CSTK_LIB
+
+LIB="$CSTK_LIB/telemetry-env.sh"
+
+# _stub_claude_path -> diretorio com um `claude` falso que imprime, uma por
+# linha, as 4 variaveis de telemetria + os argumentos recebidos.
+_stub_claude_path() {
+  _dir="$TMPDIR_TEST/stubbin"
+  mkdir -p "$_dir"
+  cat > "$_dir/claude" <<'STUB'
+#!/bin/sh
+printf 'ENABLE=%s\n' "${CLAUDE_CODE_ENABLE_TELEMETRY:-<unset>}"
+printf 'EXPORTER=%s\n' "${OTEL_METRICS_EXPORTER:-<unset>}"
+printf 'PORT=%s\n' "${OTEL_EXPORTER_PROMETHEUS_PORT:-<unset>}"
+printf 'ENDPOINT=%s\n' "${CSTK_OTEL_ENDPOINT:-<unset>}"
+printf 'ARGV=%s\n' "$*"
+STUB
+  chmod +x "$_dir/claude"
+  printf '%s' "$_dir"
+}
+
+# ==== telemetry_env_enabled ====
+
+scenario_enabled_por_default() {
+  capture env -u CSTK_TELEMETRY_AUTO -u CSTK_OTEL_ENDPOINT -u CLAUDE_CODE_ENABLE_TELEMETRY \
+    sh -c ". \"$LIB\" && telemetry_env_enabled"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "default deveria injetar" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_kill_switch_desabilita() {
+  for _v in 0 no off false; do
+    capture env CSTK_TELEMETRY_AUTO="$_v" sh -c ". \"$LIB\" && telemetry_env_enabled"
+    [ "$_CAPTURED_EXIT" = 1 ] || { _fail "CSTK_TELEMETRY_AUTO=$_v deveria desabilitar" "exit=$_CAPTURED_EXIT"; return 1; }
+  done
+}
+
+scenario_endpoint_ja_definido_nao_e_tocado() {
+  # Ja configurado (wrapper do rc, config do operador) -> nao mexe.
+  capture env CSTK_OTEL_ENDPOINT="http://127.0.0.1:9999/metrics" \
+    sh -c ". \"$LIB\" && telemetry_env_enabled"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "endpoint ja definido deveria inibir" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_optout_explicito_de_telemetria_respeitado() {
+  # CLAUDE_CODE_ENABLE_TELEMETRY definido com valor != 1 = opt-out explicito.
+  capture env CLAUDE_CODE_ENABLE_TELEMETRY=0 \
+    sh -c ". \"$LIB\" && telemetry_env_enabled"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "opt-out explicito nao respeitado" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_enable_igual_1_nao_inibe() {
+  # =1 sem endpoint: ainda falta o endpoint, entao segue injetando.
+  capture env -u CSTK_OTEL_ENDPOINT CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+    sh -c ". \"$LIB\" && telemetry_env_enabled"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "=1 sem endpoint deveria injetar" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+# ==== telemetry_env_free_port ====
+
+scenario_free_port_retorna_inteiro() {
+  command -v python3 >/dev/null 2>&1 || { _fail "pre-requisito ausente" "python3"; return 2; }
+  capture sh -c ". \"$LIB\" && telemetry_env_free_port"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "free_port falhou" "$_CAPTURED_STDERR"; return 1; }
+  case "$_CAPTURED_STDOUT" in
+    ''|*[!0-9]*) _fail "porta nao numerica" "[$_CAPTURED_STDOUT]"; return 1 ;;
+  esac
+}
+
+scenario_free_port_sem_python3_falha_mudo() {
+  _shim="$TMPDIR_TEST/nopy"
+  mkdir -p "$_shim"
+  for _c in sh env printf; do
+    _p=$(command -v "$_c" 2>/dev/null) || continue
+    [ -e "$_shim/$_c" ] || ln -s "$_p" "$_shim/$_c" 2>/dev/null || :
+  done
+  capture env PATH="$_shim" sh -c ". \"$LIB\" && telemetry_env_free_port"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "sem python3 deveria sair 1" "exit=$_CAPTURED_EXIT"; return 1; }
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "deveria ser mudo em stdout" "[$_CAPTURED_STDOUT]"; return 1; }
+}
+
+# ==== telemetry_exec_claude ====
+
+scenario_exec_liga_as_quatro_variaveis() {
+  # O caso central da issue #168: `exec claude` cru nao alcanca a funcao
+  # `claude()` do rc, entao a sessao subia sem NENHUMA variavel.
+  command -v python3 >/dev/null 2>&1 || { _fail "pre-requisito ausente" "python3"; return 2; }
+  _stub=$(_stub_claude_path)
+  capture env -u CSTK_OTEL_ENDPOINT -u CLAUDE_CODE_ENABLE_TELEMETRY PATH="$_stub:$PATH" \
+    sh -c ". \"$LIB\" && telemetry_exec_claude"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exec falhou" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "ENABLE=1" || return 1
+  assert_stdout_contains "EXPORTER=prometheus" || return 1
+  assert_stdout_match "PORT=[0-9]+" || return 1
+  assert_stdout_match "ENDPOINT=http://127\.0\.0\.1:[0-9]+/metrics" || return 1
+}
+
+scenario_exec_porta_e_endpoint_sao_coerentes() {
+  command -v python3 >/dev/null 2>&1 || { _fail "pre-requisito ausente" "python3"; return 2; }
+  _stub=$(_stub_claude_path)
+  capture env -u CSTK_OTEL_ENDPOINT -u CLAUDE_CODE_ENABLE_TELEMETRY PATH="$_stub:$PATH" \
+    sh -c ". \"$LIB\" && telemetry_exec_claude"
+  _porta=$(printf '%s\n' "$_CAPTURED_STDOUT" | sed -n 's/^PORT=//p')
+  _end=$(printf '%s\n' "$_CAPTURED_STDOUT" | sed -n 's/^ENDPOINT=//p')
+  [ "$_end" = "http://127.0.0.1:${_porta}/metrics" ] || {
+    _fail "endpoint nao casa com a porta" "porta=$_porta endpoint=$_end"; return 1; }
+}
+
+scenario_exec_repassa_argumentos_intactos() {
+  # `cstk 00c` passa a slash command inteira como argv[1] — nao pode ser
+  # quebrada em palavras pela injecao.
+  _stub=$(_stub_claude_path)
+  capture env PATH="$_stub:$PATH" \
+    sh -c ". \"$LIB\" && telemetry_exec_claude \"/agente-00c 'desc com espaco' --projeto-alvo-path '/tmp/p'\""
+  assert_stdout_contains "ARGV=/agente-00c 'desc com espaco' --projeto-alvo-path '/tmp/p'" || return 1
+}
+
+scenario_exec_kill_switch_nao_injeta_nada() {
+  _stub=$(_stub_claude_path)
+  capture env -u CSTK_OTEL_ENDPOINT -u CLAUDE_CODE_ENABLE_TELEMETRY CSTK_TELEMETRY_AUTO=0 PATH="$_stub:$PATH" \
+    sh -c ". \"$LIB\" && telemetry_exec_claude"
+  assert_stdout_contains "ENABLE=<unset>" || return 1
+  assert_stdout_contains "ENDPOINT=<unset>" || return 1
+}
+
+scenario_exec_preserva_endpoint_preexistente() {
+  _stub=$(_stub_claude_path)
+  capture env PATH="$_stub:$PATH" CSTK_OTEL_ENDPOINT="http://127.0.0.1:9999/metrics" \
+    sh -c ". \"$LIB\" && telemetry_exec_claude"
+  assert_stdout_contains "ENDPOINT=http://127.0.0.1:9999/metrics" || return 1
+}
+
+scenario_exec_sem_python3_cai_na_porta_default_e_avisa() {
+  # Processo UNICO: cair na 9464 (default do exporter) mantem o custo por
+  # onda medindo — ao contrario da leva paralela, onde N filhas na mesma
+  # porta fixa seria pior que nada. Precisa avisar que o endpoint faltou.
+  _stub=$(_stub_claude_path)
+  _shim="$TMPDIR_TEST/nopy2"
+  mkdir -p "$_shim"
+  for _c in sh env printf chmod ln mkdir cat rm; do
+    _p=$(command -v "$_c" 2>/dev/null) || continue
+    [ -e "$_shim/$_c" ] || ln -s "$_p" "$_shim/$_c" 2>/dev/null || :
+  done
+  ln -s "$_stub/claude" "$_shim/claude" 2>/dev/null || :
+  capture env -u CSTK_OTEL_ENDPOINT -u CLAUDE_CODE_ENABLE_TELEMETRY PATH="$_shim" \
+    sh -c ". \"$LIB\" && telemetry_exec_claude"
+  assert_stdout_contains "ENABLE=1" || return 1
+  assert_stdout_contains "EXPORTER=prometheus" || return 1
+  assert_stdout_contains "ENDPOINT=<unset>" || return 1
+  assert_stderr_contains "cstk help telemetry" || return 1
+}
+
+run_all_scenarios

--- a/tests/test_bloqueios.sh
+++ b/tests/test_bloqueios.sh
@@ -836,4 +836,80 @@ scenario_sdhg_sqlite_list_chave_assunto_banco_legado_sem_coluna_nao_falha() {
 
 fi # sqlite3 disponivel
 
+# ==== issue #170: sufixo de axis: validado contra o enum fechado ====
+
+scenario_register_axis_fora_do_enum_falha_alto() {
+  # Regressao issue #170: `axis:<qualquer-coisa>` passava o register limpo e
+  # NUNCA casava no vinculo de consentimento (report.sh itera o mapa) —
+  # bloqueio, resposta e decisao existiam sem nada os ligar. Degradava em
+  # silencio em vez de falhar.
+  _sd="$TMPDIR_TEST/state"
+  _setup_with_decisao "$_sd" || { _error "fixture" ""; return 2; }
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --decisao-id "dec-001" \
+    --pergunta "Pergunta longa o suficiente para passar (>=20 chars)" \
+    --contexto-para-resposta "ctx" \
+    --chave-assunto "axis:exposicao-transcript-sem-scrub"
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "axis fora do enum deveria sair 2" "exit=$_CAPTURED_EXIT stdout=$_CAPTURED_STDOUT"; return 1; }
+  assert_stderr_contains "eixo-invalido" || return 1
+  # Nada foi gravado.
+  capture "$RW" get --state-dir "$_sd" --field '.accumulated_metrics.human_blocks_total'
+  assert_stdout_contains "0" || return 1
+}
+
+scenario_register_axis_erro_lista_eixos_do_mapa() {
+  # A mensagem cita os eixos validos LENDO o mapa (nunca lista hardcoded).
+  _sd="$TMPDIR_TEST/state"
+  _setup_with_decisao "$_sd" || { _error "fixture" ""; return 2; }
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --decisao-id "dec-001" \
+    --pergunta "Pergunta longa o suficiente para passar (>=20 chars)" \
+    --contexto-para-resposta "ctx" \
+    --chave-assunto "axis:eixo-que-nao-existe"
+  assert_stderr_contains "linguagem-runtime" || return 1
+  assert_stderr_contains "tier-entrega" || return 1
+}
+
+scenario_register_todos_os_eixos_do_mapa_sao_aceitos() {
+  # Paridade produtor-consumidor: TODO eixo do mapa passa no register.
+  _sd="$TMPDIR_TEST/state"
+  _setup_with_decisao "$_sd" || { _error "fixture" ""; return 2; }
+  _map="$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/references/structural-axis-map.txt"
+  [ -f "$_map" ] || { _error "mapa ausente: $_map" ""; return 2; }
+  _n=0
+  while IFS='|' read -r _eixo _rot; do
+    case "$_eixo" in ''|\#*) continue ;; esac
+    capture "$SCRIPT" register --state-dir "$_sd" \
+      --decisao-id "dec-001" \
+      --pergunta "Pergunta longa o suficiente para passar (>=20 chars)" \
+      --contexto-para-resposta "ctx" \
+      --chave-assunto "axis:$_eixo"
+    [ "$_CAPTURED_EXIT" = 0 ] || { _fail "eixo do mapa rejeitado: $_eixo" "$_CAPTURED_STDERR"; return 1; }
+    _n=$((_n + 1))
+  done < "$_map"
+  [ "$_n" -ge 6 ] || { _fail "mapa com menos eixos que o esperado" "n=$_n"; return 1; }
+}
+
+scenario_register_briefing_item_sufixo_segue_aberto() {
+  # `briefing-item:` NAO tem enum fechado (sufixo e id de item do briefing) —
+  # a trava de #170 vale so para `axis:`.
+  _sd="$TMPDIR_TEST/state"
+  _setup_with_decisao "$_sd" || { _error "fixture" ""; return 2; }
+  capture "$SCRIPT" register --state-dir "$_sd" \
+    --decisao-id "dec-001" \
+    --pergunta "Pergunta longa o suficiente para passar (>=20 chars)" \
+    --contexto-para-resposta "ctx" \
+    --chave-assunto "briefing-item:um-item-qualquer-do-briefing-abc123"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "briefing-item deveria seguir aberto" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_list_chave_assunto_nao_valida_enum() {
+  # `list --chave-assunto` e QUERY, nao registro: filtrar por chave fora do
+  # enum precisa seguir valido (retorna vazio), nunca virar erro.
+  _sd="$TMPDIR_TEST/state"
+  _setup_with_decisao "$_sd" || { _error "fixture" ""; return 2; }
+  capture "$SCRIPT" list --state-dir "$_sd" --chave-assunto "axis:nao-existe-no-mapa"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "list nao deve validar enum" "exit=$_CAPTURED_EXIT $_CAPTURED_STDERR"; return 1; }
+}
+
 run_all_scenarios

--- a/tests/test_extract-must.sh
+++ b/tests/test_extract-must.sh
@@ -214,4 +214,122 @@ EOF
   fi
 }
 
+# ---------- issue #171: convencao de MUST em bullet ----------
+
+scenario_must_em_bullet_simples() {
+  # Regressao issue #171: `- MUST:` era ignorado; um principio SEM sufixo
+  # (NON-NEGOTIABLE) e com regras MUST em bullet nao era emitido de forma
+  # alguma, e o gate reportava sucesso.
+  _write_const <<'EOF'
+### I. Primeiro (NON-NEGOTIABLE)
+- MUST: regra a.
+### II. Segundo
+- MUST: regra b.
+- MUST: regra c.
+EOF
+  capture "$SCRIPT" --constitution "$TMPDIR_TEST/constitution.md"
+  assert_stdout_contains "II	Segundo" || return 1
+}
+
+scenario_must_bullet_variantes_de_marcacao() {
+  # `- MUST:`, `* MUST:`, `+ MUST:`, `- **MUST:**`, `MUST:` cru, `MUST NOT:`,
+  # e indentacao — todas sao regra MUST.
+  for _mark in "- MUST:" "* MUST:" "+ MUST:" "- **MUST:**" "MUST:" "- MUST NOT:" "  - MUST:"; do
+    printf '### I. Sem sufixo\n%s regra.\n' "$_mark" > "$TMPDIR_TEST/constitution.md"
+    capture "$SCRIPT" --constitution "$TMPDIR_TEST/constitution.md"
+    assert_stdout_contains "Sem sufixo" || { _fail "marcacao nao reconhecida: $_mark" "$_CAPTURED_STDOUT"; return 1; }
+  done
+}
+
+scenario_must_em_prosa_corrida_nao_conta() {
+  # Exigir os dois-pontos e deliberado: `MUST` em prosa nao vira sinal.
+  _write_const <<'EOF'
+### I. Sem sufixo
+Este principio diz que o time MUST agir com cuidado.
+EOF
+  capture "$SCRIPT" --constitution "$TMPDIR_TEST/constitution.md"
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "prosa com MUST virou principio" "$_CAPTURED_STDOUT"; return 1; }
+}
+
+scenario_should_bullet_continua_excluido() {
+  _write_const <<'EOF'
+### I. Sem sufixo
+- SHOULD: recomendacao.
+EOF
+  capture "$SCRIPT" --constitution "$TMPDIR_TEST/constitution.md"
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "SHOULD virou MUST" "$_CAPTURED_STDOUT"; return 1; }
+}
+
+# ---------- issue #171: relatorio de cobertura ----------
+
+scenario_coverage_reporta_numeros_reais() {
+  _write_const <<'EOF'
+### I. Primeiro (NON-NEGOTIABLE)
+- MUST: regra a.
+- MUST: regra b.
+### II. Segundo
+- MUST: regra c.
+EOF
+  capture "$SCRIPT" --constitution "$TMPDIR_TEST/constitution.md" --coverage
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "coverage exit" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "ocorrencias da palavra MUST no arquivo (contagem independente): 3" || return 1
+  assert_stdout_contains "linhas de regra MUST reconhecidas pelo parser: 3" || return 1
+  assert_stdout_contains "principios emitidos: 2" || return 1
+}
+
+scenario_coverage_expoe_principio_so_por_rotulo_de_heading() {
+  # O caso exato de #171: o principio entra pelo rotulo (NON-NEGOTIABLE) do
+  # heading, sem NENHUMA regra lida. O relatorio precisa dizer isso.
+  _write_const <<'EOF'
+### I. Primeiro (NON-NEGOTIABLE)
+Texto sem marcacao de regra.
+EOF
+  capture "$SCRIPT" --constitution "$TMPDIR_TEST/constitution.md" --coverage
+  assert_stdout_contains "principios emitidos: 1" || return 1
+  assert_stdout_contains "principios emitidos so por rotulo de heading (sem regra MUST lida): 1" || return 1
+}
+
+scenario_coverage_avisa_quando_convencao_nao_e_reconhecida() {
+  # Sintoma de #171: arquivo fala de MUST, parser reconhece 0 regras.
+  _write_const <<'EOF'
+### I. Primeiro
+- MUST — regra sem dois-pontos.
+EOF
+  capture "$SCRIPT" --constitution "$TMPDIR_TEST/constitution.md" --coverage
+  assert_stdout_contains "linhas de regra MUST reconhecidas pelo parser: 0" || return 1
+  assert_stderr_contains "NAO cobre as regras MUST deste arquivo" || return 1
+}
+
+scenario_coverage_contagem_independente_nao_ecoa_o_parser() {
+  # A 2a linha usa gramatica diferente da do parser: um arquivo onde o
+  # parser le 0 e a contagem independente le >0 e o sinal util. Se as duas
+  # compartilhassem gramatica, ambas dariam 0 e a metrica seria inutil.
+  _write_const <<'EOF'
+### I. Primeiro
+Nota: o time MUST revisar. Outra linha: MUST ser auditado.
+EOF
+  capture "$SCRIPT" --constitution "$TMPDIR_TEST/constitution.md" --coverage
+  assert_stdout_contains "ocorrencias da palavra MUST no arquivo (contagem independente): 1" || return 1
+  assert_stdout_contains "linhas de regra MUST reconhecidas pelo parser: 0" || return 1
+}
+
+scenario_coverage_constitution_ausente_exit_1() {
+  capture "$SCRIPT" --constitution "$TMPDIR_TEST/nao-existe.md" --coverage
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "coverage com arquivo ausente" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_default_permanece_tsv_sem_coverage() {
+  # --coverage e ADITIVO: a saida default nao pode mudar de forma.
+  _write_const <<'EOF'
+### I. Primeiro (NON-NEGOTIABLE)
+**MUST:**
+- A.
+EOF
+  capture "$SCRIPT" --constitution "$TMPDIR_TEST/constitution.md"
+  assert_stdout_contains "I	Primeiro" || return 1
+  case "$_CAPTURED_STDOUT" in
+    *"fontes declaradas"*) _fail "default vazou relatorio de cobertura" "$_CAPTURED_STDOUT"; return 1 ;;
+  esac
+}
+
 run_all_scenarios

--- a/tests/test_parallel-launch.sh
+++ b/tests/test_parallel-launch.sh
@@ -43,8 +43,25 @@ _pl_path_without_tmux() {
   _shim="$TMPDIR_TEST/nobin"
   mkdir -p "$_shim"
   # Comandos externos usados por parallel-launch.sh (git/sed/awk/grep/date/
-  # dirname/basename/mkdir/cat/tr/cut) + os que o harness usa dentro de `capture`
-  # (mktemp/rm/sh/env). `tmux` NUNCA entra nesta lista.
+  # dirname/basename/mkdir/cat/tr/cut/python3) + os que o harness usa dentro de
+  # `capture` (mktemp/rm/sh/env). `tmux` NUNCA entra nesta lista.
+  #
+  # `python3` PRECISA entrar (issue #168): sem ele o shim escondia o sorteio
+  # de porta e os cenarios de composicao degradada passavam a exercitar,
+  # sem dizer, o caminho SEM telemetria — um falso-verde. A ausencia de
+  # python3 tem cenario proprio (_pl_path_without_tmux_nor_python3).
+  for _c in sh env git sed awk grep date dirname basename mkdir rm cat mktemp chmod ln find sort head tail tr wc cut python3; do
+    _p=$(command -v "$_c" 2>/dev/null) || continue
+    [ -e "$_shim/$_c" ] || ln -s "$_p" "$_shim/$_c" 2>/dev/null || :
+  done
+  printf '%s' "$_shim"
+}
+
+# _pl_path_without_tmux_nor_python3: como _pl_path_without_tmux, porem
+# tambem SEM python3 — exercita a degradacao de telemetria (issue #168).
+_pl_path_without_tmux_nor_python3() {
+  _shim="$TMPDIR_TEST/nobin-nopy"
+  mkdir -p "$_shim"
   for _c in sh env git sed awk grep date dirname basename mkdir rm cat mktemp chmod ln find sort head tail tr wc cut; do
     _p=$(command -v "$_c" 2>/dev/null) || continue
     [ -e "$_shim/$_c" ] || ln -s "$_p" "$_shim/$_c" 2>/dev/null || :
@@ -129,7 +146,8 @@ scenario_emit_composicao_degradada_sem_tmux() {
   assert_stdout_contains "cstk session start auth-basica" || return 1
   assert_stdout_not_contains "tmux new-window" || return 1
   assert_stdout_not_contains "tmux split-window" || return 1
-  assert_stdout_contains "cd \"$_repo-auth-basica\" && claude --name \"cstk-feature/auth-basica\" '/feature-00c \"auth-basica\" auth-basica'" || return 1
+  # issue #168: a composicao vem prefixada por `env ...` com a porta da filha.
+  assert_stdout_match "cd \"$_repo-auth-basica\" && env CLAUDE_CODE_ENABLE_TELEMETRY=1 [^ ]* OTEL_EXPORTER_PROMETHEUS_PORT=[0-9]+ [^ ]* claude --name \"cstk-feature/auth-basica\" '/feature-00c \"auth-basica\" auth-basica'" || return 1
 }
 
 scenario_emit_trecho_claude_identico_com_e_sem_tmux() {
@@ -634,6 +652,93 @@ scenario_resolve_offer_saida_e_sempre_duas_linhas_chave_valor() {
         || { _fail "linha 2 fora do formato max=<inteiro> (src=$_src confirm='$_c')" "obtido: $_CAPTURED_STDOUT"; return 1; }
     done
   done
+}
+
+# ==== issue #168: telemetria da filha ====
+
+scenario_emit_prefixa_telemetria_na_composicao() {
+  # O wrapper `claude()` do rc e funcao de shell e NAO alcanca o `sh -c`
+  # nao-interativo do tmux — sem o prefixo `env`, a filha sobe sem
+  # telemetria e o painel mostra custo/tokens como "-".
+  command -v python3 >/dev/null 2>&1 || { _fail "pre-requisito ausente" "python3"; return 2; }
+  _repo="$TMPDIR_TEST/repo-otel"
+  mkdir -p "$_repo"
+  capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "env CLAUDE_CODE_ENABLE_TELEMETRY=1" || return 1
+  assert_stdout_contains "OTEL_METRICS_EXPORTER=prometheus" || return 1
+  assert_stdout_match "OTEL_EXPORTER_PROMETHEUS_PORT=[0-9]+" || return 1
+  assert_stdout_match "CSTK_OTEL_ENDPOINT=http://127\.0\.0\.1:[0-9]+/metrics" || return 1
+  # O prefixo precede `claude`, nunca o substitui.
+  assert_stdout_match "/metrics claude --name" || return 1
+}
+
+scenario_emit_porta_distinta_por_filha() {
+  # O exporter OTel vive DENTRO de cada processo `claude`: duas filhas na
+  # mesma porta = uma delas nao mede.
+  command -v python3 >/dev/null 2>&1 || { _fail "pre-requisito ausente" "python3"; return 2; }
+  _repo="$TMPDIR_TEST/repo-portas"
+  mkdir -p "$_repo"
+  capture "$SCRIPT" emit --repo "$_repo" --feature primeira --feature segunda
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT"; return 1; }
+  _portas=$(printf '%s' "$_CAPTURED_STDOUT" | grep -oE 'OTEL_EXPORTER_PROMETHEUS_PORT=[0-9]+' | sort)
+  _total=$(printf '%s\n' "$_portas" | grep -c .)
+  _unicas=$(printf '%s\n' "$_portas" | sort -u | grep -c .)
+  [ "$_total" = 2 ] || { _fail "esperava 2 portas" "obtido $_total: $_portas"; return 1; }
+  [ "$_unicas" = 2 ] || { _fail "portas deveriam ser distintas por filha" "$_portas"; return 1; }
+}
+
+scenario_emit_nao_herda_endpoint_da_coordenadora() {
+  # Diferenca deliberada vs cli/lib/telemetry-env.sh: um CSTK_OTEL_ENDPOINT
+  # ja presente e o da SESSAO COORDENADORA. Herda-lo colocaria a filha na
+  # porta da mae. Cada filha precisa da propria.
+  command -v python3 >/dev/null 2>&1 || { _fail "pre-requisito ausente" "python3"; return 2; }
+  _repo="$TMPDIR_TEST/repo-herdado"
+  mkdir -p "$_repo"
+  capture env CSTK_OTEL_ENDPOINT="http://127.0.0.1:9999/metrics" \
+    CLAUDE_CODE_ENABLE_TELEMETRY=1 \
+    "$SCRIPT" emit --repo "$_repo" --feature auth-basica
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_match "CSTK_OTEL_ENDPOINT=http://127\.0\.0\.1:[0-9]+/metrics" || return 1
+  assert_stdout_not_contains "127.0.0.1:9999" || return 1
+}
+
+scenario_emit_kill_switch_desliga_telemetria() {
+  _repo="$TMPDIR_TEST/repo-killswitch"
+  mkdir -p "$_repo"
+  capture env CSTK_TELEMETRY_AUTO=0 "$SCRIPT" emit --repo "$_repo" --feature auth-basica
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT"; return 1; }
+  assert_stdout_not_contains "CLAUDE_CODE_ENABLE_TELEMETRY" || return 1
+  assert_stdout_contains "claude --name \"cstk-feature/auth-basica\"" || return 1
+}
+
+scenario_emit_sem_python3_avisa_e_segue_sem_telemetria() {
+  # N filhas por construcao: cair na porta default fixa 9464 seria pior que
+  # nada (so um processo pode usa-la). Avisa e segue sem telemetria.
+  _fake=$(_pl_path_without_tmux_nor_python3)
+  _repo="$TMPDIR_TEST/repo-nopy"
+  mkdir -p "$_repo"
+  _old_path=$PATH
+  PATH="$_fake"
+  capture "$SCRIPT" emit --repo "$_repo" --feature auth-basica
+  PATH=$_old_path
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "$_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_not_contains "CLAUDE_CODE_ENABLE_TELEMETRY" || return 1
+  assert_stdout_not_contains "9464" || return 1
+  assert_stderr_contains "SEM telemetria" || return 1
+  assert_stdout_contains "claude --name \"cstk-feature/auth-basica\"" || return 1
+}
+
+scenario_emit_aviso_de_telemetria_uma_vez_por_invocacao() {
+  _fake=$(_pl_path_without_tmux_nor_python3)
+  _repo="$TMPDIR_TEST/repo-nopy-multi"
+  mkdir -p "$_repo"
+  _old_path=$PATH
+  PATH="$_fake"
+  capture "$SCRIPT" emit --repo "$_repo" --feature primeira --feature segunda
+  PATH=$_old_path
+  _n=$(printf '%s' "$_CAPTURED_STDERR" | grep -c "SEM telemetria" || :)
+  [ "$_n" = 1 ] || { _fail "aviso deveria sair uma unica vez" "n=$_n"; return 1; }
 }
 
 run_all_scenarios

--- a/tests/test_secrets-filter.sh
+++ b/tests/test_secrets-filter.sh
@@ -201,4 +201,68 @@ scenario_scrub_env_valor_inicia_asterisco() {
   esac
 }
 
+# ==== issue #169: segredo curto (<20 chars) e bloco PEM ====
+
+scenario_scrub_segredo_curto_alta_confianca() {
+  # Regressao issue #169: `password=hunter2` (7 chars) escapava do `{20,}` da
+  # regra generica e saia EM CLARO. Regra 4b (limiar {4,}) fecha o caso.
+  capture sh -c "printf '%s' 'password=hunter2' | '$SCRIPT' scrub"
+  assert_stdout_contains "[REDACTED]" || return 1
+  case "$_CAPTURED_STDOUT" in
+    *hunter2*) _fail "segredo curto nao redacted" "$_CAPTURED_STDOUT"; return 1 ;;
+  esac
+}
+
+scenario_scrub_segredo_curto_variantes_de_palavra_chave() {
+  for _kw in password passwd api_key apikey access_key secret_key private_key client_secret auth_token access_token refresh_token secret; do
+    capture sh -c "printf '%s' '${_kw}: sk4tPr1v' | '$SCRIPT' scrub"
+    case "$_CAPTURED_STDOUT" in
+      *sk4tPr1v*) _fail "palavra-chave $_kw nao cobre segredo curto" "$_CAPTURED_STDOUT"; return 1 ;;
+    esac
+  done
+}
+
+scenario_scrub_curto_nao_redige_prosa_com_palavra_generica() {
+  # Contra-prova do trade-off: `key`/`auth`/`token` genericos NAO entram na
+  # regra 4b — continuam so no `{20,}` para nao redigir prosa comum.
+  capture sh -c "printf '%s' 'a key: valor comum de prosa' | '$SCRIPT' scrub"
+  assert_stdout_contains "key: valor" || return 1
+  capture sh -c "printf '%s' 'auth: bearer' | '$SCRIPT' scrub"
+  assert_stdout_contains "auth: bearer" || return 1
+}
+
+scenario_scrub_pwd_curto_preserva_diagnostico() {
+  # `pwd` fica DE FORA da regra 4b de proposito: `PWD=/algum/caminho` num
+  # dump de ambiente e diagnostico legitimo do enforcement-log.
+  capture sh -c "printf '%s' 'PWD=/tmp/lab' | '$SCRIPT' scrub"
+  assert_stdout_contains "PWD=/tmp/lab" || return 1
+}
+
+scenario_scrub_bloco_pem() {
+  # Regressao issue #169: bloco PEM inteiro saia EM CLARO (corpo base64 nao
+  # tem palavra-chave proxima, escapava de todas as regras).
+  capture sh -c "printf -- '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg\n-----END PRIVATE KEY-----\ndepois\n' | '$SCRIPT' scrub"
+  assert_stdout_contains "[REDACTED-PEM-BLOCK]" || return 1
+  assert_stdout_contains "depois" || return 1
+  case "$_CAPTURED_STDOUT" in
+    *MIIEvQIBADANBg*)   _fail "corpo PEM nao redacted" "$_CAPTURED_STDOUT"; return 1 ;;
+    *"BEGIN PRIVATE"*)  _fail "marcador PEM nao removido" "$_CAPTURED_STDOUT"; return 1 ;;
+  esac
+}
+
+scenario_scrub_bloco_pem_check_detecta() {
+  capture sh -c "printf -- '-----BEGIN RSA PRIVATE KEY-----\nZGVhZGJlZWY=\n-----END RSA PRIVATE KEY-----\n' | '$SCRIPT' check"
+  [ "$_CAPTURED_EXIT" -eq 1 ] || { _fail "check deveria detectar PEM" "exit=$_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_scrub_pem_mencionado_em_prosa_nao_engole_arquivo() {
+  # Deteccao estrita RFC 7468 (marcador SOZINHO na linha): uma mencao inline
+  # em doc/prosa nao pode suprimir o restante do arquivo.
+  capture sh -c "printf '%s\n%s\n' 'doc: o marcador \`-----BEGIN PRIVATE KEY-----\` deve ser escrubado' 'linha seguinte preservada' | '$SCRIPT' scrub"
+  assert_stdout_contains "linha seguinte preservada" || return 1
+  case "$_CAPTURED_STDOUT" in
+    *"[REDACTED-PEM-BLOCK]"*) _fail "mencao em prosa virou bloco PEM" "$_CAPTURED_STDOUT"; return 1 ;;
+  esac
+}
+
 run_all_scenarios


### PR DESCRIPTION
Fecha #168, #169, #170 e #171.

Fio comum das quatro: **o dado necessário estava ao alcance do mecanismo e ele não o usava** — e nenhuma delas falhava, todas degradavam em silêncio.

## #168 — os lançadores do cstk anulavam a própria telemetria

O opt-in que `cstk install` oferece é uma **função de shell** `claude()`. Os lançadores chamam o **binário** via `exec claude`, e `exec` nunca resolve função de shell — pior, rodam em `sh` não-interativo, onde o rc sequer é lido:

```console
$ sh -c 'foo() { echo FUNCAO; }; exec foo'
sh: exec: foo: not found
```

Resultado medido pelo autor da issue: toda execução iniciada por `cstk session start --claude`, `cstk 00c` ou pela leva paralela do roadmap subia **sem telemetria** — `otel_usage` null em todas as ondas, `CUSTO` e `TOKENS · SUBAGENTES` como `—` no painel, com os 4 hooks corretamente provisionados.

Foi pelo caminho **preferido** da issue (não depender da função):

- nova `cli/lib/telemetry-env.sh` (`telemetry_exec_claude`) para `session start --claude` e `cstk 00c`;
- `parallel-launch.sh emit` prefixa a composição com `env CLAUDE_CODE_ENABLE_TELEMETRY=1 … CSTK_OTEL_ENDPOINT=…`, com **uma porta por filha**.

Isso também cobre quem instala pelo plugin nativo, que não provisiona wrapper nenhum. Escolha explícita do operador vence sempre: `CSTK_TELEMETRY_AUTO=0` desliga, e `CSTK_OTEL_ENDPOINT`/`CLAUDE_CODE_ENABLE_TELEMETRY` já no ambiente inibem a injeção — **exceto** na leva paralela, onde o endpoint do ambiente é o da coordenadora e herdá-lo colocaria a filha na porta da mãe.

## #169 — `secrets-filter.sh scrub` deixava passar segredo curto e bloco PEM

`password=hunter2` (7 chars) escapava do limiar `{20,}`; bloco PEM não tinha regra alguma (o corpo base64 não tem palavra-chave próxima). Nova regra de PEM com detecção estrita RFC 7468 (marcador sozinho na linha, senão uma menção em doc engoliria o resto do arquivo) e novo limiar `{4,}` restrito a palavras-chave de alta confiança.

O `{20,}` original fica intacto para as genéricas (`key`, `token`, `auth`, `pwd`) — baixar o limiar para todas trocaria vazamento por ruído, e `PWD=/algum/caminho` num dump de ambiente viraria `[REDACTED]`. O cabeçalho do script passa a declarar que a cobertura é **piso, não garantia**, listando o que continua passando.

## #170 — `register` aceitava `axis:` fora do enum

O `register` validava só o **prefixo**; o consumidor do vínculo de consentimento (`report.sh:552`) casa contra o **enum completo** iterando `structural-axis-map.txt`. `axis:<qualquer-coisa>` passava limpo e nunca casava — bloqueio, resposta e decisão existiam sem nada os ligar de forma verificável. Agora o sufixo de `axis:` é validado contra o mapa (exit 2, citando os eixos válidos lidos do próprio arquivo). `briefing-item:` segue com sufixo aberto por desenho; `list --chave-assunto` segue sem validar (é query, não registro).

## #171 — `converge` reportava sucesso lendo 0 de 13 regras MUST

`extract-must.sh` reconhecia uma única convenção (`**MUST:**`). Contra uma `constitution.md` em bullet lia zero regras, e o único princípio emitido entrava pelo rótulo `(NON-NEGOTIABLE)` do heading, sem nenhuma regra lida.

Além do fix mínimo (formas em bullet), adicionei `--coverage`: relatório honesto de quanto do arquivo o parser de fato leu. A contagem independente usa gramática **deliberadamente diferente** da do parser — se compartilhasse, a métrica seria autoconfirmatória e voltaria a reportar 100%. A skill `converge` passa a exigir as duas invocações e proíbe reportar o gate como satisfeito com cobertura zero.

## Testes

Suite completa verde: **3494 cenários, 0 falhas, 0 órfãos** (`--fast` 2997 em 595s + `--slow` 497 em 459s).

Reproduzi cada issue contra o código antes de mexer, e verifiquei o fix depois:

| Issue | Antes | Depois |
|---|---|---|
| #168 | zero variáveis OTel no processo | `ENABLE=1 EXPORTER=prometheus PORT=63091 ENDPOINT=http://127.0.0.1:63091/metrics` (E2E com `claude` stub) |
| #169 | `password=hunter2` e bloco PEM em claro | `password=[REDACTED]`, `[REDACTED-PEM-BLOCK]` |
| #170 | `axis:exposicao-transcript-sem-scrub` → exit 0, persistido | exit 2, nada gravado |
| #171 | 1 princípio de 6, 0 de 13 regras | 6 de 6, 13 de 13 |

Cenários novos: `test_telemetry-env.sh` (13, arquivo novo), `test_parallel-launch.sh` (+6), `test_secrets-filter.sh` (+8), `test_bloqueios.sh` (+5), `test_extract-must.sh` (+9), `test_cstk-main.sh` (+3).

**Gates de regressão** em `test_cstk-main.sh`: o conjunto de variáveis de telemetria precisa ser idêntico entre o snippet canônico e os três lançadores, e um `exec claude` cru reintroduzido em `session.sh`/`00c-bootstrap.sh` reprova a suite — a regressão de #168 não volta calada.

## Notas de revisão

- **Um falso-verde encontrado no caminho:** o shim de PATH de `test_parallel-launch.sh` é allowlist e não tinha `python3`, então os cenários de composição degradada passaram a exercitar em silêncio o caminho *sem* telemetria. Adicionei `python3` à allowlist e criei um shim próprio para a degradação. As asserções novas foram mutation-testadas (remover o prefixo e remover uma variável do mapeamento — ambas reprovam como deviam).
- **`cstk 00c` exige TTY**, então esse lançador ficou coberto por teste unitário + gate estático, não por E2E. Dito explicitamente para não sugerir cobertura que não existe.
- **Não abri a feature guarda-chuva** que a #171 propõe: a própria issue ressalva que a classe alcançável por lint tem 2 membros e não 4. Segue como candidata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6bQXvRaxvRQux8Ambp1E3