### PR TITLE
docs(changelog): 9.5.0 — doctor le escopo de projeto + declaracao de cobertura

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "9.4.0",
+      "version": "9.5.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "9.4.0",
+      "version": "9.5.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [9.5.0] - 2026-08-27
+
+O `cstk doctor` era cego para o escopo de PROJETO: definicoes instaladas em
+`.claude/agents/` e `.claude/commands/` do projeto-alvo nunca eram comparadas
+contra o catalogo, e o relatorio saia `[OK]` sobre o que jamais foi conferido.
+Foi assim que uma copia local do `agente-00c-feature-orchestrator` (sem
+nenhuma tool MCP) sombreou por semanas o orquestrador do catalogo com o
+doctor reportando saude. Alem do fix, esta release estabelece a **declaracao
+de cobertura** como formato da classe: quem afirma saude diz tambem o que
+consultou, quanto achou e quanto de fato leu.
+
+### Added
+
+- **Secao `Shadowed Scope` no `cstk doctor`.** Le os registros de instalacao
+  de escopo de projeto (`.claude/agents/.cstk-manifest` e
+  `.claude/commands/.cstk-manifest` do CWD) e compara cada definicao contra o
+  conteudo que o catalogo instalado tem HOJE — nao contra o hash que o proprio
+  manifesto capturou no dia da instalacao (FR-002). Quatro veredictos
+  distinguiveis: `shadowed` (divergente do catalogo), `shadow-current`
+  (identico), `unmanaged-upstream` (sem correspondente no catalogo atual —
+  removido/renomeado upstream, FR-010) e `indeterminate` (registro nao
+  interpretavel). Nenhum deles e contabilizado como saudavel por ausencia de
+  comparacao possivel.
+- **Declaracao de cobertura (FR-006/007/008/009).** Toda inspecao passa a
+  emitir quais fontes foram declaradas, quantas foram encontradas e quantas
+  foram lidas com sucesso, mais, por fonte, `registros no arquivo: N
+  interpretados: M nao interpretados: K` com o estado (`[absent]`,
+  `[partial]`). Fonte lida so em parte marca o escopo como `[PARCIAL]`;
+  ausencia total de manifesto sai como `[SEM-FONTE] ... nada foi comparado`,
+  nunca como sucesso.
+- **Nova lib `cli/lib/manifest-coverage.sh`** (`manifest_count_data_lines`,
+  `manifest_count_recognized`, `manifest_within_cap`, `detect_schema_version`)
+  e `tests/cstk/test_manifest-coverage.sh` (37 cenarios); `test_doctor.sh`
+  passa a 47 cenarios.
+
+### Fixed
+
+- **Falso `[OK]` sobre escopo nunca comparado.** Uma definicao de projeto
+  divergente do catalogo era reportada como saudavel; agora aparece como
+  `shadowed`. Copia local SEM registro de instalacao continua sendo conteudo
+  legitimo nao-gerenciado e NAO e reportada como problema (FR-004/FR-005) —
+  o objetivo e eliminar o falso relato de saude, nunca desencorajar a copia
+  local. A secao e report-only: nao gateia o exit do `doctor`.
+- **Numerador da cobertura nao mede mais o proprio parser.** O denominador
+  conta linhas de dados do arquivo (`manifest_count_data_lines`) e o
+  numerador e incrementado pelo laco que de fato classifica, uma vez por
+  veredito produzido — nunca por uma segunda passada de validacao com o mesmo
+  criterio, que daria 100% de cobertura por construcao (research.md D6,
+  vigente). Alterar o classificador muda o numerador por construcao, e os
+  testes que forcam divergencia entre os dois contadores stubam o
+  classificador, nao o validador (`tests/cstk/test_doctor.sh:905` e `:1128`).
+
 ## [9.4.0] - 2026-08-27
 
 Fecha quatro issues de "o dado esta ao alcance e o mecanismo nao o usa":
@@ -7483,6 +7535,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[9.5.0]: https://github.com/JotJunior/cstk/releases/tag/v9.5.0
 [9.4.0]: https://github.com/JotJunior/cstk/releases/tag/v9.4.0
 [9.3.0]: https://github.com/JotJunior/cstk/releases/tag/v9.3.0
 [9.2.3]: https://github.com/JotJunior/cstk/releases/tag/v9.2.3

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "9.4.0",
+  "version": "9.5.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"


### PR DESCRIPTION
Changelog da 9.5.0 + bump dos manifestos de plugin (gate MP-5) em lockstep com a tag.

## O que entra na release

Feature `doctor-shadowed-scope` (PR #174, merge `6b5bfac`): o `cstk doctor`
passa a ler os registros de instalacao de escopo de PROJETO
(`.claude/agents/.cstk-manifest` e `.claude/commands/.cstk-manifest`) e a
comparar cada definicao contra o catalogo instalado HOJE, com 4 veredictos
distinguiveis (`shadowed`, `shadow-current`, `unmanaged-upstream`,
`indeterminate`). Alem do fix, emite a **declaracao de cobertura** (fontes
declaradas / encontradas / lidas, e por fonte `registros no arquivo` vs
`interpretados`), servindo de implementacao de referencia da feature-classe.

## O que foi testado

- Suite completa local: `LC_ALL=C ./tests/run.sh` -> `# PASS: 3556  FAIL: 0  ERROR: 0  ORPHANS: 0  TIME: 1760s`
- `./tests/run.sh --check-coverage` -> "Cobertura completa: zero orfaos."
- `./scripts/validate-plugin-manifests.sh --version 9.5.0 --strict` -> `OK (0 aviso(s))`, exit 0
- `cstk doctor` -> ok: 35, edited: 0, missing: 0 (drift zero)
- Checagem de headers de CHANGELOG sem link-ref -> saida vazia

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rr4T8S7SFFYKmM5ookrywf