### PR TITLE
docs(human-bridge): contrato da tool ask_operator e spikes

### DIFF
--- a/docs/specs/human-bridge/contracts/mcp-tool-ask-operator.md
+++ b/docs/specs/human-bridge/contracts/mcp-tool-ask-operator.md
@@ -1,0 +1,365 @@
+# Contrato: tool MCP `ask_operator` (human-bridge, superficie 1)
+
+Tool MCP **bloqueante** que faz uma pergunta ao operador e espera a resposta
+chegar pelo painel (`cstk-panel`). Nao usa `elicitation/create` e nao usa hook.
+
+**Legenda de veracidade (Principio VI)**: `[MEDIDO]` = medido empiricamente
+nesta linha de trabalho (evidencia em [`../spikes/README.md`](../spikes/README.md));
+`[VERIFICADO]` = citacao literal de fonte no repo; `[PROPOSTA]` = desenho novo,
+ainda nao medido.
+
+---
+
+## 1. Identidade e escopo
+
+Nome MCP: `mcp__cstk-state__ask_operator`. Seria a **9a** `registerTool` de
+`mcp/state-server/src/index.ts` (hoje ha 8) `[VERIFICADO]`.
+
+Esta e a **superficie 1** da human-bridge: pergunta que o AGENTE faz, cuja
+resposta vem do painel. Fora do escopo deste contrato:
+
+| # | Superficie | Mecanismo | Por que nao esta aqui |
+|---|-----------|-----------|-----------------------|
+| 2 | Gate de `PreToolUse` (comando perigoso) | hook | Ja existe portador: `pretooluse-bash-guard.sh` |
+| 3 | Elicitation levantada por OUTRO servidor MCP | hook `Elicitation` | Nao passa pelo `cstk-state` |
+
+**Por que nao `elicitation/create`**: o cliente Claude Code nao suporta url
+mode, e form mode renderiza na TUI — que e o oposto do requisito. Detalhe e
+evidencia medida em [`../spikes/README.md`](../spikes/README.md).
+
+---
+
+## 2. Request
+
+| Campo | Tipo | Obrig. | Notas |
+|-------|------|--------|-------|
+| `session_id` | string | **sim** | Roteamento. Resolucao exclusivamente pelo id da PROPRIA chamada `[VERIFICADO: contracts/server-session-resolution.md A-1/A-4 da feature mcp-direct-transport]`. `execution_id` NAO serve — nao e unico entre projetos. |
+| `question` | string | **sim** | Texto exibido ao operador. |
+| `kind` | `"choice"` \| `"confirm"` \| `"text"` | **sim** | Enum fechado. |
+| `options` | array\<string\> | so em `choice` | Enum fechado das respostas aceitas. |
+| `default_value` | string | **sim** | Valor seguro aplicado em TODO desfecho != `answered`. Sem ele a tool vira trava. |
+| `timeout_ms` | number | nao | Clampado pelo servidor (§4). |
+
+---
+
+## 3. Response (envelope de tool)
+
+Mesma forma das tools existentes `[VERIFICADO: interface GetStatusResponse,
+mcp/state-server/src/tools/get_status.ts:56-62 — campos outcome/reason/stage/result]`.
+
+```
+{ outcome: "accepted" | "rejected",
+  reason:  string | null,
+  stage:   "precondition" | "delegation" | null,
+  result:  ResultAskOperator | null }
+```
+
+`ResultAskOperator` `[PROPOSTA]`:
+
+| Campo | Tipo | Descricao |
+|-------|------|-----------|
+| `channel` | `"panel"` | Ver invariante C-5. |
+| `outcome` | `answered`\|`declined`\|`timeout`\|`unavailable`\|`failed` | Ver §5. |
+| `applied_value` | string | Valor efetivamente gravado (token fechado). |
+| `question_id` | string | Correlator, gerado pelo servidor. |
+| `untrusted_text` | string \| null | SOMENTE em `kind:"text"`. Ver §6. |
+
+`rejected` e reservado a falha de pre-condicao:
+
+| `reason` (prefixo) | Quando |
+|--------------------|--------|
+| `SESSION_MISMATCH` | token ausente/divergente/execucao terminal `[VERIFICADO: fail-closed, session/resolve.ts:40-46, "NUNCA cai em fallback para 'a execucao ativa mais provavel'"]` |
+| `TOOL_CALL_LIMIT_EXCEEDED` | teto de chamadas do processo `[VERIFICADO: index.ts:209-218]` |
+
+---
+
+## 4. Politica de relogios
+
+Ha **tres** relogios independentes; o menor vence. Os dois do cliente sao hard
+wall-clock e **progress notifications NAO estendem**
+`[VERIFICADO: descricao literal do campo `timeout` por servidor no cliente —
+"Hard wall-clock limit per call; progress notifications do not extend it"]`.
+
+| Relogio | Onde | Valor |
+|---------|------|-------|
+| Teto do servidor | `MCP_ASK_TIMEOUT_MS` | default **240000** ms `[PROPOSTA]` |
+| Teto total do cliente | `timeout` por servidor no `.mcp.json` | **300000** ms `[PROPOSTA]` |
+| Ociosidade do cliente | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT` | default stdio **1800000** ms `[MEDIDO]` |
+
+Sem provisionamento nenhum, quem governa e a **ociosidade**: o teto total
+default e efetivamente sem teto e nunca morde `[MEDIDO: tool bloqueante
+dormindo 31,7 min abortou aos 1815s com "sent no response or progress for
+1815s; aborting"]`. A combinacao proposta cabe dentro dessa janela mesmo se
+ninguem provisionar nada — mas **provisione assim mesmo**: 30 min e default
+NAO DOCUMENTADO do cliente e pode mudar entre versoes sem aviso.
+
+### R-CLOCK-1 (obrigatoria) — ordem dos tetos
+
+`MCP_ASK_TIMEOUT_MS` MUST ser estritamente MENOR que o `timeout` por servidor
+do cliente.
+
+### R-CLOCK-2 (obrigatoria) — folga minima de 60000 ms
+
+A folga entre os dois MUST ser >= **60000** ms.
+
+**Motivo — e ele precisa sobreviver a refactor**: o watchdog de ociosidade do
+cliente tem granularidade de ~30s e so aborta no primeiro tique DEPOIS de
+estourar. `[MEDIDO em duas escalas: configurado 10000 ms => abortou aos 30s;
+default 1800000 ms => abortou aos 1815s]`. A mensagem de erro reporta o
+silencio DECORRIDO, nao o valor configurado — o que faz um debug ingenuo
+concluir o valor errado. Logo todo teto do cliente tem overshoot de ate ~30s.
+`60000 = 30000 de overshoot + 30000 de margem`. **Otimizar essa folga para um
+valor menor reintroduz o modo de falha da R-CLOCK-3.**
+
+### R-CLOCK-3 — por que a ordem importa
+
+Se o CLIENTE matar primeiro, a chamada vira **erro** no contexto do modelo, o
+servidor nunca chega a aplicar `default_value` nem a persistir, e a invariante
+C-1 e violada exatamente no caso que ela existe para cobrir. Com o servidor
+desistindo primeiro, ele aplica o default, grava, e devolve `accepted` — o
+modelo nunca ve erro.
+
+### R-CLOCK-4 — faixa DERIVADA, nunca fixada
+
+A faixa valida de `MCP_ASK_TIMEOUT_MS` e:
+
+```
+[ 5000 , client_timeout_ms - 60000 ]
+```
+
+Com `client_timeout_ms = 300000`, isso da **[5000, 240000]** — e o default
+240000 e o **topo** da faixa, o que e coerente por construcao.
+
+A faixa MUST ser **derivada** de `client_timeout_ms`, nunca escrita como
+constante literal. Motivo: uma faixa fixada permite configuracao ILEGAL pela
+letra do proprio contrato (um teto de servidor dentro da faixa mas com folga
+< 60000 viola a R-CLOCK-2), e qualquer mudanca futura no `timeout` do
+`.mcp.json` reintroduziria a inconsistencia silenciosamente.
+
+Valor fora da faixa cai no **default**, nao e clampado para a borda `[PROPOSTA;
+espelha o precedente VERIFICADO de parseElicitTimeoutMs, collect_optins.ts:196-205]`.
+
+### R-CLOCK-5 — validacao na subida, nao no leitor do contrato
+
+O servidor MUST validar a combinacao no boot e **recusar-se a subir** quando
+ela for ilegal, em vez de confiar em quem leu este documento.
+
+Para validar, o servidor precisa CONHECER `client_timeout_ms` — e ele nao tem
+como ler o `.mcp.json` de forma confiavel. Logo o valor e **declarado ao
+servidor pelo mesmo provisionamento que configura o cliente** `[PROPOSTA]`:
+
+```jsonc
+"cstk-state": {
+  "type": "stdio",
+  "command": "<launcher>",
+  "args": [],
+  "timeout": 300000,                                  // relogio do CLIENTE
+  "env": { "CSTK_CLIENT_TOOL_TIMEOUT_MS": "300000" }  // o MESMO valor, para o SERVIDOR
+}
+```
+
+Os dois campos MUST ser escritos juntos, a partir de **um unico valor-fonte**
+em `cli/lib/mcp.sh`, para que nao possam divergir.
+
+Degradacao quando `CSTK_CLIENT_TOOL_TIMEOUT_MS` esta ausente (servidor
+registrado a mao, ou `.mcp.json` de instalacao anterior): o servidor **NAO**
+recusa subir — ele assume o teto conservador `240000` e emite **1** linha de
+aviso em stderr. Recusar subir por ausencia de uma variavel opcional
+transformaria um upgrade em outage; recusar subir por combinacao explicitamente
+ilegal e o comportamento correto. A distincao e deliberada.
+
+### R-CLOCK-6 — `0` nao e solucao
+
+`CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=0` (desliga a ociosidade) MUST NOT ser
+documentado como remedio. Remove a unica defesa contra servidor travado — uma
+chamada fica pendurada para sempre e a sessao junto. E e desnecessario: o
+`timeout` por servidor da janela longa E limitada, com erro legivel quando
+estoura `[MEDIDO: "timeout":60000 sobrepos CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=10000
+hostil e a tool de 45s completou]`.
+
+---
+
+## 5. Mapeamento sinal -> desfecho
+
+| Sinal observado | `outcome` |
+|-----------------|-----------|
+| painel entrega resposta | `answered` |
+| painel entrega recusa explicita | `declined` |
+| teto do SERVIDOR estoura (excecao lancada) | `timeout` `[MEDIDO: McpError code -32001, "MCP error -32001: Request timed out"]` |
+| painel inalcancavel, detectado ANTES de esperar | `unavailable` |
+| qualquer outra excecao | `failed` + **1** linha em stderr |
+
+**Nao existe `absent` nesta superficie.** `absent` e o envelope `cancel` do
+protocolo de elicitation; aqui nao ha envelope — ou o painel responde, ou e
+`timeout`. Diferenca **deliberada** entre as superficies, registrada para nao
+ser lida como esquecimento.
+
+A discriminacao continua sendo pelo **mecanismo** (envelope retornado x
+excecao lancada), nunca por tempo decorrido `[VERIFICADO: research.md
+Decision 6 da feature mcp-elicitation-optins]`.
+
+---
+
+## 6. `kind:"text"` — conteudo UNTRUSTED
+
+`text` esta **na v1** (decisao do operador). Motivo de existir: sem ele a tela
+de validacao de dados so sabe **aprovar ou bloquear**, nao sabe **CORRIGIR** —
+e corrigir e o Principio VI virando acao em vez de parada.
+
+### R-TEXT-1 — rotulo ESTRUTURAL
+
+O texto livre volta em campo PROPRIO do envelope (`untrusted_text`), NUNCA
+embutido em `applied_value` e NUNCA como prefixo de string. Em `kind:"text"`,
+`applied_value` carrega o token de desfecho, nao o texto.
+
+*Motivo*: prefixo de string o modelo ignora ou reinterpreta; campo estrutural
+ele nao consegue confundir com o valor. Mesma disciplina do `recall --context`
+e do TextRaw do painel.
+
+### R-TEXT-2 — tamanho
+
+Teto de **2048 bytes UTF-8**, truncado por budget de bytes. Reusa o orcamento
+ja existente `[VERIFICADO: REASON_MAX_BYTES = 2048, audit/log.ts:66]` em vez
+de introduzir numero novo.
+
+### R-TEXT-3 — scrub na entrada
+
+`secrets-filter.sh scrub` aplicado **uma unica vez**, na entrada, antes de
+qualquer uso. E o valor **escrubado** que persiste, que volta no envelope e
+que alimenta a linha de log — nunca o cru, e nunca dois subprocessos de scrub
+`[VERIFICADO: mesma disciplina L1 do campo reason, collect_optins.ts:394-408]`.
+Strip de caracteres de controle + truncamento aplicados junto.
+
+> **A cobertura do filtro e o PISO, nao a garantia.** `secrets-filter.sh scrub`
+> tem lacunas conhecidas e MEDIDAS (2026-08-27, script do repo):
+> `printf 'password=hunter2' | scrub` devolve **`password=hunter2` em claro** —
+> a regra de atribuicao exige valor com **20+ caracteres**
+> `[VERIFICADO: secrets-filter.sh:164, quantificador `{20,}`]`, entao segredo
+> curto passa; e nao existe regra alguma para blocos PEM
+> (`-----BEGIN PRIVATE KEY-----` atravessa intacto)
+> `[VERIFICADO: zero ocorrencias de PEM/PRIVATE KEY no script]`.
+> Aplicar o scrub continua obrigatorio, mas o desenho **NAO PODE** tratar
+> "passou pelo scrub" como "nao contem segredo" — em `untrusted_text` o valor
+> vem de humano colando de sistema externo, que e exatamente o cenario que
+> motiva a regra. As demais defesas (teto de 2048 bytes, rotulo estrutural,
+> R-TEXT-4) nao sao redundancia: sao o que segura o que o filtro deixa passar.
+
+### R-TEXT-4 — VALOR sim, INSTRUCAO nao
+
+A fronteira nao e "vai ou nao vai ao artefato". E **valor versus instrucao**:
+
+| Uso | Permitido? |
+|-----|-----------|
+| virar **valor de um campo** num artefato (spec, plan, contrato, tasks) | **SIM** — e o caso de uso |
+| virar **instrucao**: concatenado em prompt de etapa seguinte, mensagem de commit, corpo de PR, ou qualquer texto que descreva o que fazer a seguir | **NAO** |
+
+O caminho permitido e seguro porque o texto foi digitado por um humano que o
+viu na tela, esta limitado a 2048 bytes (R-TEXT-2), ja passou por scrub
+(R-TEXT-3), e o artefato ainda atravessa os gates de review que ja existem.
+
+> Formulacao anterior desta regra ("nenhum consumidor pode concatena-lo (...)
+> ou em qualquer texto que o modelo va executar" + "se precisar ir para um
+> artefato, vai citado e rotulado") era **larga demais** e neutralizava o
+> proprio `kind:"text"`: uma correcao de `route.path` que nunca chega ao
+> artefato, ou chega "citada", nao corrige nada — reintroduzia o `text` que
+> relata mas nao conserta, que e a opcao que o operador rejeitou.
+
+### Motivo dos quatro requisitos
+
+**O risco nao e o operador ser hostil.** E que, na validacao de dados, a pessoa
+esta **colando valores vindos de sistemas externos** — que e precisamente onde
+conteudo injetado entra. O que impede isso de virar ataque nao e nunca usar o
+valor; e **nunca deixar o valor virar comando** (ASI09/LLM01).
+
+Requisito sem o porque e requisito que morre no primeiro refactor — por isso o
+motivo esta escrito aqui, e nao no commit.
+
+---
+
+## 7. Persistencia
+
+Array irmao top-level **`.operator_answers[]`**, append-only.
+
+**NUNCA** `.optin_responses[]`: aquele tem chave natural `(execution, field)`
+com enum fechado de 3 campos e e lido pela guarda que recusa abrir a onda-001
+`[VERIFICADO: Invariante I-2, state-ondas.sh:687-690]`. Polui-lo com perguntas
+arbitrarias quebra a guarda.
+
+Shape — os **mesmos 6 campos** de `StoredOptinResponse`
+`[VERIFICADO: collect_optins.ts:328-334]`, com `field` -> `question_id`:
+
+```
+{ question_id, channel, outcome, applied_value, recorded_at, reason }
+```
+
+`untrusted_text` persiste como campo adicional, ja escrubado, sujeito a
+R-TEXT-2.
+
+Primitiva de escrita: a generica ja existente, **sem script novo** —
+`state-rw.sh set --state-dir <SD> --field '.operator_answers' --value <json-array>`
+(le `.operator_answers // []`, concatena, reescreve). Sob backend SQLite cai no
+catch-all `execution.extra_fields`, reconciliado no `read` — mesmo precedente
+de `.suggestions` `[VERIFICADO]`. Logo **nenhuma** edicao em `_state-rw-db.sh`,
+e o Principio II segue PASS (nenhum script POSIX novo, nenhuma dep nova).
+
+Regras de leitura, **identicas** as de `.optin_responses[]` para nao criar um
+segundo dialeto:
+
+- **R-1 (precedencia)**: vence o registro de maior `recorded_at`.
+- **R-2 (terminalidade)**: `unavailable` e `failed` sao NAO-terminais (ninguem
+  chegou a ser perguntado de fato); `answered`, `declined` e `timeout` sao
+  terminais.
+
+Trilha de auditoria: **1** linha em `enforcement-log.jsonl` por resposta
+persistida, `source: "mcp-ask-operator"`, best-effort, **nunca lanca**
+`[VERIFICADO: mesmo contrato de appendOptinDecisionRecord, audit/log.ts]`.
+
+---
+
+## 8. Invariantes contratuais
+
+**C-1 (herdada, intacta)** — `declined`, `timeout`, `unavailable` e `failed`
+**NAO** sao erro de tool: retornam `outcome:"accepted"` com o desfecho dentro
+de `result`. Transformar degradacao em erro faria o orquestrador tratar como
+falha e potencialmente reter ou repetir.
+
+**C-4 (nova)** — `default_value` e aplicado em TODO desfecho != `answered`, e o
+registro e gravado ANTES do retorno. Nunca trava, nunca fica sem rastro.
+
+**C-5 (nova)** — `channel` = `panel` nesta superficie (resposta vem do painel
+direto, sem portador local). `panel-hook` fica **reservado** as superficies 2 e
+3, onde o portador e mesmo o hook. Dois valores, cada um dizendo a verdade
+sobre a procedencia. Reciclar `structured` faria o campo perder a unica funcao
+que tem.
+
+---
+
+## 9. Provisionamento e cobertura
+
+**Provisionamento**: `cli/lib/mcp.sh` monta o bloco `mcpServers.cstk-state`
+com payload **estatico** (`type`/`command`/`args`), hoje **sem** `timeout` e
+sem `env` `[VERIFICADO: cli/lib/mcp.sh:995-1005]`. Acrescentar ali o par
+`timeout` + `CSTK_CLIENT_TOOL_TIMEOUT_MS` (R-CLOCK-5) faz `cstk mcp install`
+entregar a janela correta sem exigir nada do operador.
+
+**Cobertura**: `tests/test_orchestrator-allowlist-guard.sh` verifica **presenca
+nominal** das tools obrigatorias numa lista `_required` — hoje ja com as 8
+`[VERIFICADO: scenario_allowlist_declara_as_8_tools_mcp, :317 e :323-330]`. Uma
+9a tool que nao entre na `_required` **e** nao seja declarada na frontmatter
+dos DOIS orquestradores passa despercebida pelo teste, ficando sem cobertura
+justamente na superficie nova.
+
+---
+
+## 10. Nao coberto (bloqueios declarados)
+
+- **Teto do clamp de `MCP_TOOL_TIMEOUT` no cliente**: NAO medido. Irrelevante
+  para este contrato — o `timeout` por servidor e o botao, e e explicito.
+- **Transporte nao-stdio (http/sse)**: os defaults de ociosidade sao outros
+  (300000 ms lido no binario do cliente, nao medido). Este contrato cobre
+  stdio, que e o transporte do `cstk-state`
+  `[VERIFICADO: mode=direct, execFile de node]`.
+- **Long-poll ponta-a-ponta contra o painel**: NAO exercitado. Os relogios
+  foram medidos com `sleep`, que do ponto de vista do cliente e equivalente,
+  mas o caminho painel<->servidor pertence ao `cstk-panel` e permanece sem
+  medicao nesta linha de trabalho.

--- a/docs/specs/human-bridge/spikes/README.md
+++ b/docs/specs/human-bridge/spikes/README.md
@@ -1,0 +1,139 @@
+# Spikes da human-bridge — por que URL mode foi descartado
+
+**TL;DR**: o desenho original da human-bridge era ancorado em `elicitation/create`
+com `mode:"url"` — o servidor mandaria o operador ao painel e fecharia com
+`notifications/elicitation/complete`. **Isso nao funciona**: o cliente Claude Code
+nao anuncia a capability `url`. Medido em 2026-08-27 contra claude-code **2.1.247**
+com `@modelcontextprotocol/sdk` **1.30.0**. Se alguem propuser URL mode de novo,
+leia este arquivo antes — o codigo de url mode EXISTE no cliente, o que torna a
+proposta plausivel a leitura e falsa na pratica.
+
+## O que foi medido
+
+### 1. URL mode: capability ausente, chamada morre no servidor
+
+Capabilities reais do cliente, lidas com `getClientCapabilities()` de dentro de um
+servidor MCP stdio real (`server-form-caps.mjs`):
+
+```json
+{"elicitation":{"form":{}},"roots":{"listChanged":true}}
+```
+
+So `form`. Nao ha sub-capability `url`. O proprio SDK gateia nisso — literal em
+`@modelcontextprotocol/sdk/dist/esm/server/index.js:340-345`:
+
+```js
+async elicitInput(params, options) {
+    const mode = (params.mode ?? 'form');
+    switch (mode) {
+        case 'url': {
+            if (!this._clientCapabilities?.elicitation?.url) {
+                throw new Error('Client does not support url elicitation.');
+```
+
+Resultado de `server-url-mode.mjs`, que emite `mode:"url"`:
+
+```
+SPIKE_RESULT={"kind":"throw","name":"Error","code":null,
+              "message":"Client does not support url elicitation."}
+```
+
+A chamada **nao chega a virar trafego de protocolo** — morre no servidor.
+Consequencia: `notifications/elicitation/complete` e o correlator `elicitationId`
+sao inalcancaveis por esse caminho.
+
+> **A armadilha que custou uma rodada**: o binario do cliente **contem** o handler
+> de url mode (discriminador `mode==="url"`, `waitingState:{actionLabel:"Skip
+> confirmation"}`, handler de `notifications/elicitation/complete`, log
+> `Ignoring completion notification for unknown elicitation:`). Ler essas strings
+> e concluir "o cliente suporta" foi **erro de metodo**: presenca de codigo nao e
+> capability negociada. Infraestrutura presente e desligada continua desligada.
+
+### 2. Hooks `Elicitation` / `ElicitationResult` existem e funcionam
+
+Sao a via viva para resolver uma elicitation **fora da TUI**. Em `claude -p`
+(headless, que sozinho responde `cancel` na hora) o hook resolveu sem UI nenhuma:
+
+```
+SPIKE_RESULT={"kind":"envelope","action":"accept","content":{"answer":"RESPOSTA-DO-HOOK"}}
+```
+
+- **Registro** (`.claude/settings.json`): `{"hooks":{"Elicitation":[{"matcher":
+  "<nome-do-servidor-mcp>","hooks":[{"type":"command","command":"<script>"}]}]}}`.
+  O `matcher` casa o **nome do servidor MCP**, nao a tool.
+- **Entrada** (stdin JSON): ver `hook-input.sample.json` — chaves reais capturadas.
+  Em form mode, `url` e `elicitation_id` sao **omitidos**; nao ha id de elicitation
+  de graca.
+- **Saida**: `{"hookSpecificOutput":{"hookEventName":"Elicitation","action":
+  "accept","content":{...}}}`. O parser ignora em silencio se o stdout nao comeca
+  com `{`, se `hookEventName` diverge, ou se falta `action`; `action:"decline"` e
+  `decision:"block"` viram erro bloqueante.
+
+Este caminho e a **superficie 3** da human-bridge (elicitations levantadas por
+outros servidores MCP). Nao e a fundacao — ver o contrato da superficie 1 em
+[`../contracts/mcp-tool-ask-operator.md`](../contracts/mcp-tool-ask-operator.md).
+
+### 3. Relogios de uma tool bloqueante comum (`server-blocking.mjs`)
+
+Uma tool que simplesmente **nao retorna** nao precisa de elicitation nem de hook.
+Dois relogios do cliente, com mensagens **distinguiveis**:
+
+| Relogio | Mensagem literal | Comportamento |
+|---------|------------------|---------------|
+| Teto total | `MCP server "spike-block" tool "spike_block" timed out after 8s` | timer real, dispara cravado no valor de `"timeout"` do `.mcp.json` |
+| Ociosidade | `... sent no response or progress for 30s; aborting. If this server is configured in your MCP settings, set a per-server "timeout" (ms) to allow longer silent runs for just this server; otherwise set CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT (ms) globally (0 disables).` | granularidade de ~30s |
+
+Medicoes:
+
+| # | Setup | Resultado |
+|---|-------|-----------|
+| M1 | `"timeout":8000`, tool dorme 30s | abortou em **8s**, mensagem `timed out after 8s` |
+| M2 | `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=10000`, tool dorme 90s | abortou aos **30s**, mensagem reportando **30s** (nao 10s) |
+| M3 | sem env var, tool dorme 30s | **completou** (`SPIKE_BLOCK_DONE after=30004ms`) |
+| M4 | `"timeout":60000` + `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=10000` (hostil), tool dorme 45s | **completou** — o `timeout` por servidor levanta OS DOIS relogios |
+| M5 | sem env var e sem `timeout`, tool dorme 31,7 min | abortou aos **1815s** (`for 1815s; aborting`); wall-clock da sessao 1824s |
+
+Conclusoes que viraram requisito no contrato:
+
+1. **Por default quem governa e a ociosidade** (M5 confirma 1800000 ms para stdio);
+   o teto total default e efetivamente sem teto e nunca morde.
+2. **O watchdog tem overshoot de ate ~30s** (M2 e M5: 30s quando configurado 10s;
+   1815s quando o teto e 1800s) e a mensagem imprime o silencio **decorrido**, nao
+   o valor configurado. Daqui sai a folga minima de 60000 ms da R-CLOCK-2.
+3. **O botao certo e o `timeout` por servidor no `.mcp.json`** (M4), nunca a env
+   var global.
+
+### 4. Relogio do servidor vence hook lento
+
+Servidor com `{timeout:20000}` (via `RequestOptions.timeout` do SDK) e hook dormindo
+25s: `MCP error -32001: Request timed out`, wall-clock 33s. Confirma que a
+discriminacao contratual sobrevive — envelope retornado => `absent`; excecao
+`-32001` => `timeout` — e que o teto do hook precisa ser menor que o do servidor.
+
+## Como reproduzir
+
+Estes arquivos sao **descartaveis** e nao fazem parte do toolkit: nao sao
+empacotados, nao tem teste, nao entram no `--check-coverage`. Para rodar, e preciso
+um `node_modules` com `@modelcontextprotocol/sdk` (o de `mcp/state-server/` serve):
+
+```sh
+SPIKE=$(mktemp -d)
+cp docs/specs/human-bridge/spikes/*.mjs "$SPIKE/"
+ln -s "$PWD/mcp/state-server/node_modules" "$SPIKE/node_modules"
+
+cat > "$SPIKE/mcp.json" <<JSON
+{"mcpServers":{"spike-block":{"type":"stdio","command":"node",
+ "args":["$SPIKE/server-blocking.mjs"]}}}
+JSON
+
+mkdir -p "$SPIKE/proj" && cd "$SPIKE/proj"
+claude -p 'Chame spike_block com sleep_ms=30000 uma unica vez.' \
+  --mcp-config "$SPIKE/mcp.json" --strict-mcp-config \
+  --allowedTools 'mcp__spike-block__spike_block'
+```
+
+Acrescente `"timeout": <ms>` na entrada do servidor para exercitar o teto total, e
+prefixe `CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT=<ms>` para exercitar a ociosidade.
+
+> Nota de ambiente: `timeout(1)` do GNU nao existe no macOS — use o timeout da
+> ferramenta que invoca, nao um wrapper de shell.

--- a/docs/specs/human-bridge/spikes/elicit-hook.sh
+++ b/docs/specs/human-bridge/spikes/elicit-hook.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Hook Elicitation: resolve a elicitation sem UI, devolvendo accept + content.
+# Registrar em .claude/settings.json:
+#   {"hooks":{"Elicitation":[{"matcher":"spike-url-elicit",
+#     "hooks":[{"type":"command","command":"<path deste script>"}]}]}}
+# O matcher casa o NOME DO SERVIDOR MCP, nao a tool.
+cat > /dev/null   # troque por `cat >> input.jsonl` para capturar o payload
+printf '{"hookSpecificOutput":{"hookEventName":"Elicitation","action":"accept","content":{"answer":"RESPOSTA-DO-HOOK"}}}\n'

--- a/docs/specs/human-bridge/spikes/hook-input.sample.json
+++ b/docs/specs/human-bridge/spikes/hook-input.sample.json
@@ -1,0 +1,20 @@
+{
+  "session_id": "<uuid da sessao>",
+  "transcript_path": "<path do transcript>",
+  "cwd": "<cwd do projeto>",
+  "prompt_id": "<uuid do prompt>",
+  "hook_event_name": "Elicitation",
+  "mcp_server_name": "spike-url-elicit",
+  "message": "qual a resposta?",
+  "mode": "form",
+  "requested_schema": {
+    "type": "object",
+    "properties": {
+      "answer": {
+        "type": "string",
+        "title": "answer",
+        "description": "resposta"
+      }
+    }
+  }
+}

--- a/docs/specs/human-bridge/spikes/server-blocking.mjs
+++ b/docs/specs/human-bridge/spikes/server-blocking.mjs
@@ -1,0 +1,13 @@
+// Tool MCP bloqueante comum — sem elicitation, sem hook. So nao retorna.
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+const server = new McpServer({ name: "spike-block", version: "0.0.1" }, { capabilities: { tools: {} } });
+server.registerTool("spike_block",
+  { title: "spike_block", description: "Bloqueia por sleep_ms e retorna.", inputSchema: { sleep_ms: z.number() } },
+  async ({ sleep_ms }) => {
+    const t0 = Date.now();
+    await new Promise((r) => setTimeout(r, sleep_ms));
+    return { content: [{ type: "text", text: `SPIKE_BLOCK_DONE after=${Date.now() - t0}ms` }] };
+  });
+await server.connect(new StdioServerTransport());

--- a/docs/specs/human-bridge/spikes/server-form-caps.mjs
+++ b/docs/specs/human-bridge/spikes/server-form-caps.mjs
@@ -1,0 +1,23 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+const server = new McpServer({ name: "spike-url-elicit", version: "0.0.1" }, { capabilities: { tools: {} } });
+
+server.registerTool("spike_probe",
+  { title: "spike_probe", description: "Reporta as capabilities do cliente e dispara uma elicitation form-mode.", inputSchema: { question: z.string() } },
+  async ({ question }) => {
+    const caps = server.server.getClientCapabilities() ?? null;
+    let out;
+    try {
+      const r = await server.server.elicitInput(
+        { message: question, requestedSchema: { type: "object", properties: { answer: { type: "string", title: "answer", description: "resposta" } } } },
+        { timeout: 20000 },
+      );
+      out = { kind: "envelope", action: r.action, content: r.content ?? null };
+    } catch (e) {
+      out = { kind: "throw", code: e?.code ?? null, message: String(e?.message ?? e) };
+    }
+    return { content: [{ type: "text", text: "SPIKE_CAPS=" + JSON.stringify(caps) + " SPIKE_RESULT=" + JSON.stringify(out) }] };
+  });
+
+await server.connect(new StdioServerTransport());

--- a/docs/specs/human-bridge/spikes/server-url-mode.mjs
+++ b/docs/specs/human-bridge/spikes/server-url-mode.mjs
@@ -1,0 +1,66 @@
+// Spike descartavel: servidor MCP minimo que emite elicitation em mode:"url"
+// e fecha com notifications/elicitation/complete. Nao toca estado nenhum.
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const log = (...a) => process.stderr.write("[spike] " + a.join(" ") + "\n");
+
+const server = new McpServer(
+  { name: "spike-url-elicit", version: "0.0.1" },
+  { capabilities: { tools: {} } },
+);
+
+const COMPLETE_AFTER_MS = Number(process.env.SPIKE_COMPLETE_AFTER_MS ?? "1500");
+const TIMEOUT_MS = Number(process.env.SPIKE_TIMEOUT_MS ?? "20000");
+
+server.registerTool(
+  "spike_ask_url",
+  {
+    title: "spike_ask_url",
+    description: "Dispara uma elicitation em mode:url e fecha com notifications/elicitation/complete.",
+    inputSchema: { question: z.string() },
+  },
+  async ({ question }) => {
+    const elicitationId = "spike-" + Date.now().toString(36);
+    log("capabilities:", JSON.stringify(server.server.getClientCapabilities() ?? null));
+
+    // Agenda o fechamento out-of-band (simula o painel entregando a resposta
+    // AO SERVIDOR, que so entao avisa o cliente que a elicitation fechou).
+    const t = setTimeout(async () => {
+      try {
+        await server.server.notification({
+          method: "notifications/elicitation/complete",
+          params: { elicitationId },
+        });
+        log("complete-notification: sent", elicitationId);
+      } catch (e) {
+        log("complete-notification: FAILED", String(e));
+      }
+    }, COMPLETE_AFTER_MS);
+
+    let out;
+    try {
+      const r = await server.server.elicitInput(
+        {
+          mode: "url",
+          message: question,
+          elicitationId,
+          url: "http://127.0.0.1:5173/ask/" + elicitationId,
+        },
+        { timeout: TIMEOUT_MS },
+      );
+      out = { kind: "envelope", action: r.action, content: r.content ?? null };
+      log("elicitInput RESOLVED:", JSON.stringify(out));
+    } catch (e) {
+      out = { kind: "throw", name: e?.constructor?.name ?? null, code: e?.code ?? null, message: String(e?.message ?? e) };
+      log("elicitInput THREW:", JSON.stringify(out));
+    } finally {
+      clearTimeout(t);
+    }
+    return { content: [{ type: "text", text: "SPIKE_RESULT=" + JSON.stringify({ elicitationId, ...out }) }] };
+  },
+);
+
+await server.connect(new StdioServerTransport());
+log("connected");


### PR DESCRIPTION
Superfície 1 da `human-bridge`: tool MCP **bloqueante** que pergunta ao operador e espera a resposta chegar pelo painel. Não usa `elicitation/create`, não usa hook.

## Contrato

Etiquetagem de veracidade por afirmação — `[MEDIDO]`, `[VERIFICADO]`, `[PROPOSTA]` — e uma seção explícita do que **não** cobre: o caminho painel↔servidor nunca foi exercitado ponta-a-ponta, e está atribuído ao `cstk-panel`.

Regras duras que o contrato fixa:

- o timeout do **servidor** é estritamente menor que o `timeout` por servidor do cliente, com folga mínima de 60s. Se o cliente matar primeiro, a chamada vira **erro** no contexto do modelo e o servidor nunca aplica o `default_value` nem persiste — violando a invariante "degradação nunca vira erro de tool" exatamente no caso que ela existe para cobrir. Os 60s vêm da granularidade de ~30s do watchdog de ociosidade, medida duas vezes em escalas diferentes;
- `default_value` obrigatório: nunca trava, nunca vira erro de tool;
- `kind:"text"` volta em campo próprio do envelope com rótulo UNTRUSTED, limite de 2048 B e scrub — e vale como **valor**, nunca como instrução.

## Por que os spikes ficam versionados

São a evidência de por que URL mode foi descartado: o cliente **não anuncia** a capability `url`. Medido contra claude-code 2.1.247 + SDK 1.30.0.

O código de url mode **existe** no binário do cliente, o que torna a proposta plausível à leitura e falsa na prática. Sem esse registro, alguém refaz o spike inteiro daqui a alguns meses — foi exatamente o erro que custou uma rodada nesta investigação.

## Gate

```
./tests/run.sh --check-coverage  →  Cobertura completa: zero orfaos.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014sQ4MSZ9tHncycftiQcg76