### PR TITLE
fix(bridge): opt-in explicito de Host nao-loopback (CSTK_PANEL_ALLOWED_HOSTS)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [10.2.1] - 2026-08-30
+
+O guard de `Host` das rotas da Ponte recusava, sem escape, qualquer hostname
+fora de loopback — o que deixava `/api/v1/bridge/*` inteiramente inacessivel
+atras de proxy reverso, o deployment em que o `Host` repassado e o dominio
+publico e nunca seria loopback. Relatado em uso real (`HTTP 400`, "Host header
+rejeitado").
+
+### Fixed
+
+- **Opt-in explicito de `Host` nao-loopback: `CSTK_PANEL_ALLOWED_HOSTS`** (lista
+  separada por virgula, contrato §11.2). Vazia ou ausente ⇒ **so loopback**, o
+  mesmo comportamento de antes desta configuracao existir: zero regressao, e o
+  default nunca depende de o operador lembrar de fechar nada.
+  Comparacao por **igualdade exata, case-insensitive**, nunca substring nem
+  wildcard — mesma disciplina de `cli/lib/trusted-hosts.sh` e pelo mesmo motivo
+  (CWE-290): sem ela, `painel.exemplo.com.evil.com` casaria uma entrada
+  `painel.exemplo.com`. Dois testes cobrem a armadilha (sufixo e prefixo) e
+  foram verificados por mutacao — trocando a igualdade por `includes()`, ambos
+  reprovam.
+  A mitigacao de DNS rebinding sobrevive ao opt-in: o hostname que o atacante
+  faz resolver para loopback nao esta na lista do operador.
+  > O opt-in **nao adiciona autenticacao**. O painel nao tem authn/authz
+  > propria e faz bind fixo em `127.0.0.1` (FR-017); expor sem controle de
+  > acesso na frente (proxy com auth, VPN, mTLS) publica rotas de **escrita**:
+  > quem alcanca o dominio le a fila — que carrega contexto de execucao dos
+  > agentes — e responde intervencoes, destravando o agente de outra pessoa.
+- **Assimetria de desenho entre cliente e servidor.** O contrato ja previa
+  deployment nao-loopback do lado CLIENTE (§11.5, opt-in
+  `CSTK_PANEL_ALLOW_NONLOOPBACK`) mas nao do lado servidor, e a §11.2 diz
+  `SHOULD` enquanto o codigo implementava `MUST` incondicional. As duas pontas
+  agora tem a mesma forma de escape explicito.
+- **Mensagem de erro citava a secao errada do contrato**: dizia `§11.4`
+  (permissoes de arquivo do `bridge.db`) em vez de `§11.2` (guard de `Host`) —
+  mandava um debugger futuro para o lugar errado.
+
 ## [10.2.0] - 2026-08-30
 
 A Ponte humana: uma fila unica, cross-projeto, de tudo que qualquer sessao do
@@ -7750,6 +7786,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[10.2.1]: https://github.com/JotJunior/cstk/releases/tag/v10.2.1
 [10.2.0]: https://github.com/JotJunior/cstk/releases/tag/v10.2.0
 [10.1.0]: https://github.com/JotJunior/cstk/releases/tag/v10.1.0
 [10.0.0]: https://github.com/JotJunior/cstk/releases/tag/v10.0.0

--- a/docs/specs/human-bridge/contracts/panel-bridge-api.md
+++ b/docs/specs/human-bridge/contracts/panel-bridge-api.md
@@ -461,6 +461,30 @@ visite de responder intervencoes via `fetch` para `127.0.0.1`.
   futuro reabriria o vetor CSRF em silencio.
 - **SHOULD**: validar o header `Host` contra `127.0.0.1`/`localhost` no escopo
   `/bridge/*` (mitigacao de DNS rebinding).
+- **MUST**: hostname fora de loopback so passa quando listado no opt-in
+  explicito `CSTK_PANEL_ALLOWED_HOSTS` (lista separada por virgula). Vazio ou
+  ausente ⇒ so loopback — o default nunca depende de o operador lembrar de
+  fechar nada. A comparacao e por **igualdade exata, case-insensitive**
+  (DNS e case-insensitive), **NUNCA** substring nem wildcard
+  `[VERIFICADO: mesma disciplina de cli/lib/trusted-hosts.sh, cabecalho
+  "CWE-290 — authentication/allowlist bypass"]`: sem isso,
+  `painel.exemplo.com.evil.com` casaria uma entrada `painel.exemplo.com`.
+  A mitigacao de DNS rebinding sobrevive ao opt-in porque o hostname que o
+  atacante faz resolver para loopback nao esta na lista do operador.
+
+  **Motivo de existir** — e ele precisa sobreviver a refactor: o painel faz
+  bind fixo em `127.0.0.1` (FR-017) e **nao tem autenticacao propria**. Atras
+  de proxy reverso o `Host` repassado e o dominio publico, que nunca e
+  loopback; sem o opt-in, a Ponte inteira fica inacessivel nesse deployment
+  — que e legitimo e observado em uso real.
+
+  > **O opt-in NAO adiciona autenticacao.** Ele apenas para de recusar o
+  > `Host`. Setar `CSTK_PANEL_ALLOWED_HOSTS` sem um controle de acesso na
+  > frente (proxy com auth, VPN, mTLS) publica rotas de **escrita** sem
+  > authn/authz: qualquer um que alcance o dominio le a fila — que carrega
+  > contexto de execucao dos agentes — e **responde** intervencoes,
+  > destravando e direcionando o agente de outra pessoa. Ver §"Transporte
+  > nao-loopback: nao coberto" nas limitacoes declaradas.
 
 ### 11.3 `question` tambem passa por scrub — a assimetria atual e um vazamento
 

--- a/panel/apps/server/package.json
+++ b/panel/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/server",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "Back-end HTTP read-only — Fastify 5 + better-sqlite3 sobre knowledge.db",
   "main": "./dist/index.js",
   "scripts": {

--- a/panel/apps/server/src/config.ts
+++ b/panel/apps/server/src/config.ts
@@ -71,6 +71,23 @@ export interface ServerConfig {
    * sobe so a API e loga aviso (Principio II).
    */
   webDir: string;
+  /**
+   * Hostnames aceitos no header `Host` das rotas `/api/v1/bridge/*` ALEM dos
+   * loopback (contrato §11.2). Vazio por default: sem opt-in explicito, so
+   * loopback passa — comportamento identico ao de antes desta configuracao
+   * existir.
+   *
+   * Existe para o deployment atras de proxy reverso: o proxy repassa o `Host`
+   * original (ex.: `painel.exemplo.com`), que nao e loopback e seria recusado.
+   * O opt-in e do OPERADOR, nunca inferido — a mitigacao de DNS rebinding
+   * depende de o hostname do atacante NAO estar nesta lista.
+   *
+   * ATENCAO: o painel nao tem autenticacao propria e faz bind em 127.0.0.1
+   * (FR-017). Setar esta variavel NAO adiciona auth — pressupoe que quem expoe
+   * o painel colocou um controle de acesso na frente (proxy com auth, VPN,
+   * mTLS). Ver §11.2 do contrato.
+   */
+  bridgeAllowedHosts: ReadonlySet<string>;
 }
 
 function resolveDbPath(): string {
@@ -161,6 +178,29 @@ export function listConfiguredProjectPaths(): string[] {
   return Object.values(resolveProjectPathsMap());
 }
 
+/**
+ * Resolve a allowlist de `Host` das rotas de Ponte (contrato §11.2) a partir de
+ * `CSTK_PANEL_ALLOWED_HOSTS` (lista separada por virgula).
+ *
+ * Disciplina de comparacao — MESMA de `cli/lib/trusted-hosts.sh`
+ * (`trusted_host_check`), pelo mesmo motivo (CWE-290, allowlist bypass):
+ * igualdade EXATA, case-insensitive (DNS e case-insensitive), NUNCA substring
+ * nem wildcard. Sem isso, `painel.exemplo.com.evil.com` casaria com uma entrada
+ * `painel.exemplo.com` e o controle viraria decoracao.
+ *
+ * Entradas vazias sao descartadas; env ausente ou so-espacos ⇒ set vazio.
+ * Nunca lanca — env malformada degrada para "so loopback", que e o default
+ * seguro (Principio II).
+ */
+export function resolveBridgeAllowedHosts(): ReadonlySet<string> {
+  const raw = process.env['CSTK_PANEL_ALLOWED_HOSTS'] ?? '';
+  const entries = raw
+    .split(',')
+    .map((h) => h.trim().toLowerCase())
+    .filter((h) => h !== '');
+  return new Set(entries);
+}
+
 export function loadConfig(): ServerConfig {
   return {
     dbPath: resolveDbPath(),
@@ -169,5 +209,6 @@ export function loadConfig(): ServerConfig {
     corsOrigin: process.env['CORS_ORIGIN'] ?? 'http://localhost:5173',
     supportedSchemaVersions: resolveSchemaVersions(),
     webDir: resolveWebDir(),
+    bridgeAllowedHosts: resolveBridgeAllowedHosts(),
   };
 }

--- a/panel/apps/server/src/routes/bridge.ts
+++ b/panel/apps/server/src/routes/bridge.ts
@@ -61,7 +61,13 @@ declare module 'fastify' {
 const QUESTION_ID_PATTERN = /^[A-Za-z0-9_-]{22,64}$/;
 
 // ---------------------------------------------------------------------------
-// §11.4/§11.2 — defesa DNS-rebinding (SHOULD): Host aceito so em loopback.
+// §11.2 — defesa DNS-rebinding: Host aceito em loopback e, com opt-in
+// EXPLICITO do operador (`CSTK_PANEL_ALLOWED_HOSTS`), nos hostnames listados.
+//
+// O opt-in existe para o deployment atras de proxy reverso, onde o `Host`
+// repassado e o dominio publico e nunca seria loopback. Sem ele o default
+// permanece "so loopback" — a mitigacao vale porque o hostname que o atacante
+// faz resolver para 127.0.0.1 nao esta na lista do operador.
 // ---------------------------------------------------------------------------
 const LOOPBACK_HOSTNAMES: ReadonlySet<string> = new Set(['127.0.0.1', 'localhost', '[::1]', '::1']);
 
@@ -185,9 +191,14 @@ export async function bridgeRoutes(server: FastifyInstance): Promise<void> {
 
       const hostHeader = request.headers.host ?? '';
       if (hostHeader !== '') {
-        const hostname = extractHostname(hostHeader);
-        if (!LOOPBACK_HOSTNAMES.has(hostname)) {
-          return reply.status(400).send(bridgeErrorEnvelope('Host header rejeitado (contrato §11.4)'));
+        // DNS e case-insensitive: normalizar ANTES de comparar, senao
+        // `Painel.Exemplo.Com` falharia contra uma allowlist em minusculas.
+        // Comparacao por igualdade EXATA — nunca substring/wildcard (CWE-290).
+        const hostname = extractHostname(hostHeader).toLowerCase();
+        const allowed =
+          LOOPBACK_HOSTNAMES.has(hostname) || config.bridgeAllowedHosts.has(hostname);
+        if (!allowed) {
+          return reply.status(400).send(bridgeErrorEnvelope('Host header rejeitado (contrato §11.2)'));
         }
       }
 

--- a/panel/apps/server/test/routes/bridge.test.ts
+++ b/panel/apps/server/test/routes/bridge.test.ts
@@ -110,7 +110,7 @@ describe('POST /api/v1/bridge/interventions', () => {
     expect(res.statusCode).toBe(415);
   });
 
-  it('Host nao-loopback -> 400 (contrato §11.4)', async () => {
+  it('Host nao-loopback SEM allowlist -> 400 (contrato §11.2)', async () => {
     const res = await server.inject({
       method: 'POST',
       url: '/api/v1/bridge/interventions',
@@ -118,6 +118,83 @@ describe('POST /api/v1/bridge/interventions', () => {
       payload: createBody(),
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  /**
+   * Opt-in de Host nao-loopback (contrato §11.2).
+   *
+   * `bridgeRoutes` resolve a config no REGISTRO, entao a allowlist congela
+   * junto com o server. Estes casos montam instancia propria com a env ja
+   * setada — o `server` compartilhado do beforeAll nunca a enxergaria.
+   */
+  describe('allowlist de Host (CSTK_PANEL_ALLOWED_HOSTS, §11.2)', () => {
+    async function serverWithAllowlist(value: string): Promise<FastifyInstance> {
+      process.env['CSTK_PANEL_ALLOWED_HOSTS'] = value;
+      const s = Fastify({ logger: false });
+      await s.register(async (v1) => {
+        await v1.register(bridgeRoutes);
+      }, { prefix: '/api/v1' });
+      await s.ready();
+      return s;
+    }
+
+    async function statusForHost(s: FastifyInstance, host: string): Promise<number> {
+      const res = await s.inject({
+        method: 'POST',
+        url: '/api/v1/bridge/interventions',
+        headers: { 'content-type': 'application/json', host },
+        payload: createBody(),
+      });
+      return res.statusCode;
+    }
+
+    it('host allowlistado passa o guard (nao e mais 400)', async () => {
+      const s = await serverWithAllowlist('painel.exemplo.com');
+      expect(await statusForHost(s, 'painel.exemplo.com:443')).not.toBe(400);
+      await s.close();
+    });
+
+    it('loopback continua passando mesmo com allowlist setada', async () => {
+      const s = await serverWithAllowlist('painel.exemplo.com');
+      expect(await statusForHost(s, '127.0.0.1:5173')).not.toBe(400);
+      await s.close();
+    });
+
+    it('CWE-290: sufixo NAO casa — painel.exemplo.com.evil.com -> 400', async () => {
+      // A armadilha que torna allowlist por substring inutil. A comparacao e
+      // por igualdade exata; se um dia virar `endsWith`/`includes`, este teste
+      // quebra e deve quebrar.
+      const s = await serverWithAllowlist('painel.exemplo.com');
+      expect(await statusForHost(s, 'painel.exemplo.com.evil.com')).toBe(400);
+      await s.close();
+    });
+
+    it('CWE-290: prefixo NAO casa — evil-painel.exemplo.com -> 400', async () => {
+      const s = await serverWithAllowlist('painel.exemplo.com');
+      expect(await statusForHost(s, 'evil-painel.exemplo.com')).toBe(400);
+      await s.close();
+    });
+
+    it('DNS e case-insensitive: Painel.Exemplo.COM casa entrada minuscula', async () => {
+      const s = await serverWithAllowlist('painel.exemplo.com');
+      expect(await statusForHost(s, 'Painel.Exemplo.COM:443')).not.toBe(400);
+      await s.close();
+    });
+
+    it('lista com multiplos hosts e espacos: cada entrada vale', async () => {
+      const s = await serverWithAllowlist(' a.exemplo.com , b.exemplo.com ');
+      expect(await statusForHost(s, 'a.exemplo.com')).not.toBe(400);
+      expect(await statusForHost(s, 'b.exemplo.com')).not.toBe(400);
+      expect(await statusForHost(s, 'c.exemplo.com')).toBe(400);
+      await s.close();
+    });
+
+    it('env vazia/so-virgulas degrada para so-loopback (default seguro)', async () => {
+      const s = await serverWithAllowlist(' , , ');
+      expect(await statusForHost(s, 'painel.exemplo.com')).toBe(400);
+      expect(await statusForHost(s, '127.0.0.1:5173')).not.toBe(400);
+      await s.close();
+    });
   });
 
   it('bridge.db indisponivel (dir sem permissao) -> 200 + degraded=true, sem questionId', async () => {

--- a/panel/apps/web/package.json
+++ b/panel/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/web",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "Front-end SPA React 19 + Vite 5 — Dashboard de Observabilidade Read-Only",
   "private": true,
   "type": "module",

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cstk-panel",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cstk-panel",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -27,7 +27,7 @@
     },
     "apps/server": {
       "name": "@cstk-panel/server",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@fastify/cors": "^11.2.0",
@@ -47,7 +47,7 @@
     },
     "apps/web": {
       "name": "@cstk-panel/web",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@tanstack/react-query": "^5.40.0",
@@ -6591,7 +6591,7 @@
       "license": "MIT"
     },
     "node_modules/react-markdown": {
-      "version": "10.2.0",
+      "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
       "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
       "license": "MIT",
@@ -8431,7 +8431,7 @@
     },
     "packages/shared-types": {
       "name": "@cstk-panel/shared-types",
-      "version": "10.2.0",
+      "version": "10.2.1",
       "dependencies": {
         "zod": "^3.23.0"
       },

--- a/panel/package.json
+++ b/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cstk-panel",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "private": true,
   "description": "Dashboard de Observabilidade Read-Only para execucoes agente-00c/feature-00c",
   "workspaces": [

--- a/panel/packages/shared-types/package.json
+++ b/panel/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/shared-types",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "description": "DTOs, envelope padrao e schemas Zod compartilhados entre apps/server e apps/web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"


### PR DESCRIPTION
## Opt-in explícito de `Host` não-loopback no guard da Ponte (v10.2.1)

**Bug relatado em uso real**, na primeira operação da Ponte atrás de proxy reverso:

```
XHR GET https://<dominio>/api/v1/bridge/interventions  [HTTP/3 400]
{"error":"Host header rejeitado (contrato §11.4)"}
```

O guard recusava, sem escape, qualquer hostname fora de loopback — deixando `/api/v1/bridge/*` **inteiramente inacessível** nesse deployment, onde o `Host` repassado pelo proxy é o domínio público e nunca seria loopback.

### Causa raiz

Não era o guard estar errado; era ele não ter escape, e havia **assimetria de desenho**: o contrato já previa deployment não-loopback do lado **cliente** (§11.5, opt-in `CSTK_PANEL_ALLOW_NONLOOPBACK`) e não do lado servidor. Além disso a §11.2 diz `SHOULD` enquanto o código implementava `MUST` incondicional.

### Correção

`CSTK_PANEL_ALLOWED_HOSTS` (lista separada por vírgula). Vazia/ausente ⇒ **só loopback** — zero regressão, o default não depende de o operador lembrar de fechar nada.

Comparação por **igualdade exata, case-insensitive**, nunca substring nem wildcard — mesma disciplina de `cli/lib/trusted-hosts.sh` e pelo mesmo motivo (CWE-290). A mitigação de DNS rebinding sobrevive: o hostname que o atacante faz resolver para loopback não está na lista do operador.

Corrige também a mensagem, que citava §11.4 (permissões de arquivo do `bridge.db`) em vez de §11.2.

### ⚠️ O opt-in NÃO adiciona autenticação

O painel não tem authn/authz própria e faz bind fixo em `127.0.0.1` (FR-017). Setar a variável apenas para de recusar o `Host`. Expor sem controle de acesso na frente (proxy com auth, VPN, mTLS) publica rotas de **escrita**: quem alcança o domínio lê a fila — que carrega contexto de execução dos agentes — e responde intervenções, destravando e direcionando o agente de outra pessoa. Registrado em destaque no contrato.

### Testado

- Suíte completa do toolkit: `PASS: 3598  FAIL: 0  ERROR: 0  ORPHANS: 0`
- Painel: `967 passed | 48 skipped`; typecheck e build limpos; `readonly-check` 3/3 OK
- +7 cenários em `bridge.test.ts` (35 no arquivo), incluindo as duas armadilhas CWE-290
- **Verificação por mutação**: trocando a igualdade por `includes()`, os dois testes CWE-290 reprovam — eles guardam a propriedade de fato
- Ambos os lockstep em `--strict` (MP-5 e WL-1..WL-5) → exit 0

Único warning de lint (`mkdirSync` não usado em `bridge-degradation-isolation.test.ts`) **provado pré-existente**: rodei o lint na main com o diff stashed e já estava lá, em arquivo não tocado por este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuxG6wc6yZJ5TD4TLbarET
