### PR TITLE
fix(guards): allowlist por salto de redirect, guarda de onda aberta no --force e docker compose no bash-guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,85 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [10.4.0] - 2026-09-01
+
+Tres guardas que davam a resposta errada em execucao real. A allowlist de
+hosts era conferida so na URL inicial e nunca no salto final do redirect — e a
+medicao mostrou que esse salto ja saia da lista havia tempo. O `--force` do
+lock lia "pid morto" como "lock orfao entre ondas", quando o dono do lock e um
+shell efemero do command pai e o subagente segue trabalhando. E o bash-guard
+bloqueava `docker compose exec ... npm install`, que e a forma canonica
+documentada nos `CLAUDE.md` de projeto-alvo com container.
+
+### Security
+
+- **`cli/lib/http.sh` revalida a allowlist a cada salto de redirect**
+  (issue #178). O `-L` do curl foi removido: a cadeia e caminhada
+  manualmente, um salto por vez, e cada URL — a inicial e cada `Location` —
+  passa por `trusted_host_check` ANTES da requisicao correspondente. Salto
+  fora da allowlist nao gera requisicao alguma aquele host (nao e "baixa e
+  descarta depois"). Junto: redirect para `file://` recusado (so a origem
+  inicial pode ser `file://`, FR-014), teto de 10 saltos, e `3xx` sem
+  `Location` utilizavel vira erro em vez de o corpo do redirect virar
+  payload. 6 cenarios novos em `tests/cstk/test_http.sh`, com stub de curl e
+  log de chamadas — o log e o que prova que a URL recusada nunca chegou a ser
+  requisitada.
+- **`release-assets.githubusercontent.com` entra na
+  `CSTK_TRUSTED_RELEASE_HOSTS`** — achado da correcao acima, medido e nao
+  suposto. A cadeia real de um asset de release deste repositorio, caminhada
+  com `curl -w '%{http_code} %{redirect_url}'` sem `-L`, e
+  `github.com` -> `github.com` -> `release-assets.githubusercontent.com`; a
+  entrada `objects.githubusercontent.com`, herdada da epoca em que era esse o
+  CDN, so parecia cobrir o caso porque ninguem conferia o salto final. Sem
+  esta adicao, a revalidacao recusaria todo `install`/`self-update`/`serve` a
+  partir de asset de release. Medicao registrada no cabecalho de
+  `cli/lib/trusted-hosts.sh`; `tests/cstk/test_trusted-hosts.sh` cobre os 5
+  hosts.
+
+### Added
+
+- **`state-lock.sh acquire --force-abandoned`**: override explicito e
+  auditado (`DIAG|warning|lock-force-abandoned-override`) da guarda de onda
+  aberta. E o caminho do `/feature-00c-abort` — derrubar onda viva e
+  exatamente o que o abort faz — e o da retomada deliberada de onda
+  abandonada, depois de reconciliar.
+
+### Fixed
+
+- **`acquire --force` nao readquire mais lock com onda em voo** (issue #182).
+  A liveness do pid do dono NAO e proxy da liveness da onda: quem faz o
+  `acquire` e um shell efemero do command pai, que morre assim que o Bash
+  retorna, enquanto o subagente orquestrador segue trabalhando — por isso
+  "dono morto" e o estado NORMAL durante uma onda. O `--force` passa a
+  consultar o estado antes de consumar e recusa com exit 3 quando a ultima
+  onda esta aberta (`lock-force-denied-wave-open`, nomeando onda e
+  `started_at`) ou quando o estado esta ilegivel
+  (`lock-force-denied-state-unreadable`, fail-closed — "nao consegui ler"
+  nunca vira "nao ha onda"). Estado ausente continua liberando. A guarda le
+  via `_state-read.sh`, entao vale nos dois backends; ha cenario sqlite com
+  checagem anti-mirror. LIMITE documentado no codigo, no `--help`, na
+  `SKILL.md` do runtime e na prosa: a guarda nao cobre a janela entre o spawn
+  do subagente e o `open_wave` da onda nova. 5 cenarios novos em
+  `tests/test_state-lock.sh`.
+- **Prosa dos commands do `feature-00c` deixou de induzir ao erro**
+  (issue #182): `feature-00c-resume.md` trocou "lock orfao (dono morto) e o
+  caso NORMAL entre ondas" pela condicao real — lock orfao COM a ultima onda
+  FECHADA — citando o motivo e listando a arvore de decisao na recusa
+  (`reconcile-wave` / abort / `--force-abandoned`); o item 7 de
+  `feature-00c.md` ganhou a nota de "nao force aqui".
+  `feature-00c-abort.md` passou a usar `--force-abandoned`, sem o que o
+  proprio abort teria quebrado com a guarda nova.
+- **`bash-guard.sh` reconhece o wrapper de container de tres palavras**
+  (issue #186): `_bg_pkg_violation` so aceitava `docker exec/run`, entao
+  `docker compose exec api npm install zod` — a forma documentada nos
+  `CLAUDE.md` de projeto-alvo com container — caia na blocklist, junto com o
+  legado `docker-compose exec`. Nao abre superficie nova (`docker compose
+  exec` alcanca o mesmo container que `docker exec`; `docker compose run` tem
+  o mesmo poder de montagem de `docker run`, ja liberado) e preserva a
+  propriedade segment-aware: `echo docker compose exec; npm install zod`
+  segue bloqueado. A mensagem do bloqueio passou a citar as duas formas.
+  6 cenarios novos em `tests/test_bash-guard.sh`.
+
 ## [10.3.0] - 2026-08-30
 
 O caminho de instalacao por plugin nativo entregava skills, commands, agents e
@@ -7839,6 +7918,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[10.4.0]: https://github.com/JotJunior/cstk/releases/tag/v10.4.0
 [10.3.0]: https://github.com/JotJunior/cstk/releases/tag/v10.3.0
 [10.2.1]: https://github.com/JotJunior/cstk/releases/tag/v10.2.1
 [10.2.0]: https://github.com/JotJunior/cstk/releases/tag/v10.2.0

--- a/cli/lib/http.sh
+++ b/cli/lib/http.sh
@@ -8,9 +8,27 @@
 #   -f   fail em 4xx/5xx (sem gerar output "normal")
 #   -s   silent (sem progress bar)
 #   -S   mostra mensagem em caso de erro
-#   -L   segue redirects (GitHub Releases redireciona para CDN)
 #
-# Timeouts conservadores:
+# Redirects SEM `-L` (issue #178): o `-L` seguia a cadeia inteira dentro do
+# curl, e a allowlist de hosts (cli/lib/trusted-hosts.sh) so era aplicada
+# pelo caller sobre a URL INICIAL. Um host confiavel que redirecionasse para
+# fora da allowlist nao era revalidado — funcionava por coincidencia da
+# configuracao do GitHub (objects.githubusercontent.com ja esta na lista),
+# nao por verificacao. Agora a cadeia e caminhada MANUALMENTE, um salto por
+# vez: cada URL (a inicial e cada `Location`) passa por trusted_host_check
+# ANTES da requisicao correspondente. Salto fora da allowlist => nenhuma
+# requisicao e feita a esse host (nao ha "baixa e descarta depois").
+#
+# Regras da caminhada:
+#   - a URL INICIAL pode ser file:// (fluxo de dev, FR-014 de trusted-hosts)
+#     ou https:// com host na allowlist;
+#   - saltos subsequentes MUST ser https:// na allowlist — um redirect para
+#     file:// e recusado (leria arquivo local passando por download);
+#   - teto de _HTTP_MAX_REDIRS saltos (curl default seria 50);
+#   - 3xx sem `Location` legivel => erro (nunca tratar o corpo do redirect
+#     como se fosse o payload).
+#
+# Timeouts conservadores (por SALTO):
 #   --connect-timeout 10   nao esperar mais de 10s para conectar
 #   --max-time 300         tarball de release nao deve demorar mais de 5min
 #
@@ -23,15 +41,50 @@
 #
 # Retornos:
 #   0  sucesso
-#   1  erro de rede, HTTP, curl ausente ou arg problema
+#   1  erro de rede, HTTP, curl ausente, host fora da allowlist ou arg problema
 #   2  uso incorreto (argumentos faltando)
 #
-# POSIX sh puro. Deps: curl, printf, command.
+# POSIX sh puro. Deps: curl, printf, command; cli/lib/trusted-hosts.sh.
 
 if [ -n "${_CSTK_HTTP_LOADED:-}" ]; then
   return 0 2>/dev/null
 fi
 _CSTK_HTTP_LOADED=1
+
+# Allowlist compartilhada (constante estatica, nao overridable via env).
+# Idempotente: trusted-hosts.sh tem guarda de carga propria.
+# shellcheck source=./trusted-hosts.sh
+. "${CSTK_LIB:?CSTK_LIB must be set (http.sh depende de trusted-hosts.sh)}/trusted-hosts.sh"
+
+# Teto de saltos de redirect aceitos numa unica transferencia.
+_HTTP_MAX_REDIRS=10
+
+# _http_map_error <curl_exit> <url> — imprime a mensagem de erro mapeada.
+_http_map_error() {
+  case "$1" in
+    6)  printf 'http: nao foi possivel resolver host de %s (offline?)\n' "$2" >&2 ;;
+    7)  printf 'http: falha ao conectar em %s\n' "$2" >&2 ;;
+    22) printf 'http: servidor retornou erro HTTP para %s\n' "$2" >&2 ;;
+    28) printf 'http: timeout ao baixar %s\n' "$2" >&2 ;;
+    *)  printf 'http: download falhou (curl exit %s): %s\n' "$1" "$2" >&2 ;;
+  esac
+}
+
+# _http_hop_allowed <url> <hop_n> — 0 se a URL pode ser requisitada neste
+# salto. Salto 0 (URL inicial) aceita file://; saltos >0 exigem https na
+# allowlist (um redirect NUNCA pode virar leitura de arquivo local).
+_http_hop_allowed() {
+  if [ "$2" -gt 0 ]; then
+    case "$1" in
+      file://*)
+        printf 'http: redirect para file:// recusado (salto %s): %s\n' "$2" "$1" >&2
+        return 1
+        ;;
+    esac
+  fi
+  trusted_host_check "$1" || return 1
+  return 0
+}
 
 http_download() {
   # POSIX sh NAO tem local vars — usamos prefixo _http_ para evitar colisao
@@ -46,20 +99,53 @@ http_download() {
     printf 'http: curl nao encontrado no PATH\n' >&2
     return 1
   fi
-  _http_ec=0
-  curl -fsSL --connect-timeout 10 --max-time 300 -o "$_http_dest" -- "$_http_url" 2>/dev/null || _http_ec=$?
-  if [ "$_http_ec" -eq 0 ]; then
-    return 0
-  fi
-  case "$_http_ec" in
-    6)  printf 'http: nao foi possivel resolver host de %s (offline?)\n' "$_http_url" >&2 ;;
-    7)  printf 'http: falha ao conectar em %s\n' "$_http_url" >&2 ;;
-    22) printf 'http: servidor retornou erro HTTP para %s\n' "$_http_url" >&2 ;;
-    28) printf 'http: timeout ao baixar %s\n' "$_http_url" >&2 ;;
-    *)  printf 'http: download falhou (curl exit %d): %s\n' "$_http_ec" "$_http_url" >&2 ;;
-  esac
-  [ -f "$_http_dest" ] && rm -f -- "$_http_dest"
-  return 1
+
+  _http_hop_url=$_http_url
+  _http_hop_n=0
+  while :; do
+    if ! _http_hop_allowed "$_http_hop_url" "$_http_hop_n"; then
+      if [ "$_http_hop_n" -gt 0 ]; then
+        printf 'http: cadeia de redirects abortada (origem: %s)\n' "$_http_url" >&2
+      fi
+      [ -f "$_http_dest" ] && rm -f -- "$_http_dest"
+      return 1
+    fi
+
+    # Sem -L: um salto por invocacao. `-w` devolve codigo HTTP + a proxima
+    # URL (curl ja resolve Location relativo para absoluto).
+    _http_ec=0
+    _http_meta=$(curl -fsS --connect-timeout 10 --max-time 300 \
+      -w '%{http_code} %{redirect_url}' \
+      -o "$_http_dest" -- "$_http_hop_url" 2>/dev/null) || _http_ec=$?
+    if [ "$_http_ec" -ne 0 ]; then
+      _http_map_error "$_http_ec" "$_http_hop_url"
+      [ -f "$_http_dest" ] && rm -f -- "$_http_dest"
+      return 1
+    fi
+
+    _http_code=${_http_meta%% *}
+    _http_next=${_http_meta#* }
+
+    if [ -z "$_http_next" ]; then
+      case "$_http_code" in
+        3??)
+          printf 'http: resposta %s sem Location utilizavel em %s\n' "$_http_code" "$_http_hop_url" >&2
+          [ -f "$_http_dest" ] && rm -f -- "$_http_dest"
+          return 1
+          ;;
+      esac
+      return 0
+    fi
+
+    _http_hop_n=$((_http_hop_n + 1))
+    if [ "$_http_hop_n" -gt "$_HTTP_MAX_REDIRS" ]; then
+      printf 'http: excedido o teto de %s redirects a partir de %s\n' \
+        "$_HTTP_MAX_REDIRS" "$_http_url" >&2
+      [ -f "$_http_dest" ] && rm -f -- "$_http_dest"
+      return 1
+    fi
+    _http_hop_url=$_http_next
+  done
 }
 
 http_check_url() {
@@ -71,5 +157,19 @@ http_check_url() {
     printf 'http: curl nao encontrado no PATH\n' >&2
     return 1
   fi
-  curl -fsSLI --connect-timeout 10 --max-time 30 -o /dev/null -- "$1" 2>/dev/null
+
+  # Mesma caminhada manual do http_download, sem corpo (-I / HEAD).
+  _http_cu_url=$1
+  _http_cu_hop=0
+  while :; do
+    _http_hop_allowed "$_http_cu_url" "$_http_cu_hop" || return 1
+    _http_cu_meta=$(curl -fsSI --connect-timeout 10 --max-time 30 \
+      -w '%{http_code} %{redirect_url}' \
+      -o /dev/null -- "$_http_cu_url" 2>/dev/null) || return 1
+    _http_cu_next=${_http_cu_meta#* }
+    [ -n "$_http_cu_next" ] || return 0
+    _http_cu_hop=$((_http_cu_hop + 1))
+    [ "$_http_cu_hop" -le "$_HTTP_MAX_REDIRS" ] || return 1
+    _http_cu_url=$_http_cu_next
+  done
 }

--- a/cli/lib/trusted-hosts.sh
+++ b/cli/lib/trusted-hosts.sh
@@ -42,9 +42,34 @@ fi
 _CSTK_TRUSTED_HOSTS_LOADED=1
 
 # Lista estatica de hosts confiaveis para download de releases do toolkit.
-# Fonte: cli/lib/serve.sh:31 (_SERVE_ALLOWED_HOSTS), ja em producao antes
-# desta feature. NAO overridable via env — ver nota acima.
-CSTK_TRUSTED_RELEASE_HOSTS="github.com codeload.github.com objects.githubusercontent.com api.github.com"
+# Fonte original: cli/lib/serve.sh:31 (_SERVE_ALLOWED_HOSTS), ja em producao
+# antes da feature enforced-guards. NAO overridable via env — ver nota acima.
+#
+# release-assets.githubusercontent.com (issue #178, 2026-09-01): host de
+# destino REAL dos assets de release do GitHub hoje. Medido, nao suposto —
+# a cadeia de uma release deste proprio repositorio foi caminhada salto a
+# salto (`curl -w '%{http_code} %{redirect_url}'`, sem -L):
+#
+#   hop1 302 github.com
+#   hop2 302 github.com
+#   hop3 200 release-assets.githubusercontent.com
+#
+# (a cadeia de `tarball_url` da API termina em codeload.github.com, ja
+# listado). Enquanto o download seguia redirects DENTRO do curl (-L) sem
+# revalidar host, esse salto final nunca era conferido e a entrada
+# `objects.githubusercontent.com` — herdada da epoca em que era esse o CDN —
+# dava a impressao de cobrir o caso. Com a revalidacao por salto de
+# cli/lib/http.sh, a lista precisa refletir o destino real, senao todo
+# `cstk install`/`self-update`/`serve` a partir de asset de release passa a
+# ser recusado. objects.githubusercontent.com permanece na lista (continua
+# servindo outros artefatos do GitHub).
+#
+# NOTA OPERACIONAL: se o GitHub mudar de host outra vez, o download passa a
+# ser recusado com o host novo nomeado no stderr (fail-closed deliberado, em
+# vez de confianca silenciosa). O caminho de recuperacao nao depende desta
+# lista: o bootstrap `curl -fsSL .../install.sh | sh` (cli/install.sh) baixa
+# com curl direto e permite instalar a release nova que corrija a allowlist.
+CSTK_TRUSTED_RELEASE_HOSTS="github.com codeload.github.com objects.githubusercontent.com release-assets.githubusercontent.com api.github.com"
 
 # trusted_host_check URL
 # Verifica que URL usa esquema https:// com host na allowlist, ou file://

--- a/docs/cstk-serve.md
+++ b/docs/cstk-serve.md
@@ -58,8 +58,11 @@ unreachable, image build failed, unreconcilable leftover container) ·
 `2` usage error (invalid port, unknown flag).
 
 **Security**: only URLs from `api.github.com`, `github.com`,
-`codeload.github.com`, and `objects.githubusercontent.com` are authorized for
-the download (SSRF allowlist). Integrity is **fail-closed by default**: a package
+`codeload.github.com`, `objects.githubusercontent.com`, and
+`release-assets.githubusercontent.com` are authorized for the download (SSRF
+allowlist). The allowlist is re-checked on **every redirect hop**, not just on
+the initial URL: the download walks the chain one hop at a time and refuses a
+`Location` pointing outside the list before issuing any request to it. Integrity is **fail-closed by default**: a package
 without `.sha256` blocks (`unverifiable-blocked`); explicit and audited bypass
 via `--allow-unverified`/`CSTK_SERVE_ALLOW_UNVERIFIED=1`; a checksum mismatch
 always blocks. Host `127.0.0.1` is the only fully supported one.

--- a/docs/cstk-serve.pt-BR.md
+++ b/docs/cstk-serve.pt-BR.md
@@ -58,8 +58,11 @@ inacessível, build da imagem falhou, container remanescente irreconciliável) �
 `2` erro de uso (porta inválida, flag desconhecida).
 
 **Segurança**: apenas URLs de `api.github.com`, `github.com`,
-`codeload.github.com` e `objects.githubusercontent.com` são autorizadas no
-download (SSRF allowlist). Integridade **fail-closed por padrão**: pacote sem
+`codeload.github.com`, `objects.githubusercontent.com` e
+`release-assets.githubusercontent.com` são autorizadas no download (SSRF
+allowlist). A allowlist é reconferida a **cada salto de redirect**, não só na
+URL inicial: o download caminha a cadeia um salto por vez e recusa um
+`Location` fora da lista antes de fazer qualquer requisição a ele. Integridade **fail-closed por padrão**: pacote sem
 `.sha256` bloqueia (`unverifiable-blocked`); bypass explícito e auditado via
 `--allow-unverified`/`CSTK_SERVE_ALLOW_UNVERIFIED=1`; divergência de checksum
 bloqueia sempre. Host `127.0.0.1` é o único com suporte completo.

--- a/panel/apps/server/package.json
+++ b/panel/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/server",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "description": "Back-end HTTP read-only — Fastify 5 + better-sqlite3 sobre knowledge.db",
   "main": "./dist/index.js",
   "scripts": {

--- a/panel/apps/web/package.json
+++ b/panel/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/web",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "description": "Front-end SPA React 19 + Vite 5 — Dashboard de Observabilidade Read-Only",
   "private": true,
   "type": "module",

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cstk-panel",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cstk-panel",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -27,7 +27,7 @@
     },
     "apps/server": {
       "name": "@cstk-panel/server",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@fastify/cors": "^11.2.0",
@@ -47,7 +47,7 @@
     },
     "apps/web": {
       "name": "@cstk-panel/web",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@tanstack/react-query": "^5.40.0",
@@ -8431,7 +8431,7 @@
     },
     "packages/shared-types": {
       "name": "@cstk-panel/shared-types",
-      "version": "10.3.0",
+      "version": "10.4.0",
       "dependencies": {
         "zod": "^3.23.0"
       },

--- a/panel/package.json
+++ b/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cstk-panel",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "private": true,
   "description": "Dashboard de Observabilidade Read-Only para execucoes agente-00c/feature-00c",
   "workspaces": [

--- a/panel/packages/shared-types/package.json
+++ b/panel/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/shared-types",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "description": "DTOs, envelope padrao e schemas Zod compartilhados entre apps/server e apps/web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/commands/feature-00c-abort.md
+++ b/plugins/cstk/commands/feature-00c-abort.md
@@ -92,8 +92,14 @@ if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
   fi
 fi
 
-# Force-acquire do lock (mesmo se PID encerrou graciosamente, normalize estado)
-state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR" --force
+# Force-acquire do lock (mesmo se PID encerrou graciosamente, normalize estado).
+# `--force-abandoned` (nao `--force`) porque derrubar onda VIVA e exatamente o
+# que o abort faz: o `--force` simples recusa quando ha onda aberta no estado
+# (issue #182 — o dono do lock e um shell efemero, "pid morto" nao prova onda
+# encerrada). O override fica auditado como
+# `DIAG|warning|lock-force-abandoned-override`. Pre-condicao contratual ja
+# cumprida acima: SIGTERM + grace period.
+state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR" --force-abandoned
 ```
 
 ### 5. Marcar status=abortada + finished_at + motivo

--- a/plugins/cstk/commands/feature-00c-resume.md
+++ b/plugins/cstk/commands/feature-00c-resume.md
@@ -70,18 +70,40 @@ fi
    com lock livre e prossegue com lock ocupado.
    state-lock.sh check --state-dir "$AGENTE_00C_STATE_DIR" || _lock_detido=1
 
-2. adquirir lock — lock ORFAO (dono morto) e o caso NORMAL entre ondas: o
-   processo que fez o `acquire` da onda anterior ja saiu. Quem distingue
-   vivo de morto e o `acquire --force`: readquire emitindo
-   `DIAG|warning|lock-force-acquired` quando o dono esta morto, e RECUSA
-   com exit 3 quando o dono esta VIVO.
+2. adquirir lock — quem fez o `acquire` e um shell EFEMERO deste command
+   pai, que morre assim que o Bash retorna; quem faz o trabalho da onda e o
+   SUBAGENTE orquestrador, que segue vivo depois disso. Logo **"dono morto"
+   NAO significa onda encerrada** — durante uma onda em pleno voo o dono do
+   lock aparece como morto. O discriminador real esta no ESTADO, nao no
+   pid: lock orfao **com a ultima onda FECHADA** e o caso normal entre
+   ondas. `acquire --force` aplica exatamente essa regra (issue #182):
+   readquire com `DIAG|warning|lock-force-acquired` quando o dono esta
+   morto E nao ha onda aberta; RECUSA com exit 3 quando o dono esta VIVO
+   (`lock-force-denied-owner-alive`), quando ha onda ABERTA
+   (`lock-force-denied-wave-open`) ou quando o estado nao pode ser lido
+   (`lock-force-denied-state-unreadable`, fail-closed).
    state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR" \
      || state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR" --force \
-     || { stderr "outra sessao ativa para $SHORT (dono do lock VIVO)"; exit 3; }
+     || { stderr "lock nao readquirido para $SHORT — ver o DIAG acima (dono VIVO, onda aberta ou estado ilegivel)"; exit 3; }
 
    > Preferivel a `--force`: o command pai libera o lock ANTES de agendar a
    > proxima onda (passo 5, Cleanup). Ai a retomada adquire limpo e o
    > `--force` nunca precisa disparar.
+   >
+   > **Recusa do `--force` NAO se resolve insistindo.** Identifique o caso:
+   > - onda aberta com trabalho reconciliavel => `reconcile-wave` fecha a
+   >   onda; depois disso o `--force` passa sozinho;
+   > - execucao que deve ser derrubada => `/feature-00c-abort` (que ja usa
+   >   o caminho `--force-abandoned`);
+   > - onda comprovadamente abandonada e JA reconciliada => repetir com
+   >   `--force-abandoned`, que e deliberado e fica auditado
+   >   (`DIAG|warning|lock-force-abandoned-override`).
+   >
+   > LIMITE CONHECIDO da guarda: ela nao cobre a janela entre o spawn do
+   > subagente e o `open_wave` da onda nova — nessa janela o estado ainda
+   > nao tem onda aberta, embora ja possa haver trabalho em disco. Antes de
+   > usar `--force-abandoned`, confira `git status --porcelain` e o mtime
+   > dos arquivos do escopo da feature.
 
 3. validar hash state.json contra .sha256 (FR-014)
    NOTA (backend SQLite): `sha256-verify` e no-op e sai 0 — a integridade

--- a/plugins/cstk/commands/feature-00c.md
+++ b/plugins/cstk/commands/feature-00c.md
@@ -243,6 +243,11 @@ Exporte: `AGENTE_00C_STATE_DIR=<projeto>/.claude/feature-00c-state/<short_name>`
    _lock="$AGENTE_00C_STATE_DIR/.lock"
    state-lock.sh acquire --state-dir "$AGENTE_00C_STATE_DIR"
    - se ocupado, stderr "outra sessao ativa para $SHORT"; exit 3
+   - NAO force aqui. O dono do lock e um shell efemero deste command (morre
+     assim que o Bash retorna) enquanto o subagente segue trabalhando —
+     `pid morto` NAO e sinal de lock stale (issue #182). Lock ocupado numa
+     invocacao NOVA significa execucao ativa ou nao reconciliada: retome
+     com `/feature-00c-resume` ou encerre com `/feature-00c-abort`.
 
 8. coleta de consumo: PEDIR instalacao ao operador (nunca instalar sozinho)
    guard-hooks-status.sh check --projeto-alvo-path "$_proj" || :

--- a/plugins/cstk/skills/agente-00c-runtime/SKILL.md
+++ b/plugins/cstk/skills/agente-00c-runtime/SKILL.md
@@ -206,6 +206,16 @@ nenhum leitor constroi o path `state.json` na mao:
   pre-condicao CONTRATUAL (SIGTERM + grace 60s) e do caller. Sem
   `--force`, lock ocupado segue exit 3. `check-execution-busy` le o estado
   pelos DOIS backends (FR-010).
+  **Guarda de onda aberta (issue #182)**: o dono do lock e um shell efemero
+  do command pai, nao o subagente que faz a onda — "pid morto" e o estado
+  NORMAL com onda em voo. Por isso o `--force` tambem consulta o estado
+  antes de consumar e RECUSA (exit 3) quando a ultima onda esta aberta
+  (`lock-force-denied-wave-open`) ou quando o estado esta ilegivel
+  (`lock-force-denied-state-unreadable`, fail-closed). O override explicito
+  e `--force-abandoned` (caminho do `/feature-00c-abort` e da retomada de
+  onda comprovadamente abandonada), auditado como
+  `DIAG|warning|lock-force-abandoned-override`. A guarda NAO cobre a janela
+  entre o spawn do subagente e o `open_wave` da onda nova.
 - **`report.sh generate|emit` exit 7**: estado ausente (nem `state.json`
   nem `state.db` legivel) retorna exit 7 contratual (FR-008, alinha o
   contrato de invocacao do feature-00c); exit 2 (uso) e exit 1 (falha

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/bash-guard.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/bash-guard.sh
@@ -20,6 +20,11 @@
 # Analise por SEGMENTO (split em `;|&`): o bypass historico de package
 # manager ("basta 'docker run' coexistir em qualquer trecho") foi fechado —
 # o prefixo docker exec/run precisa estar no MESMO segmento do install.
+# Prefixos aceitos como wrapper de container: `docker exec/run`,
+# `docker compose exec/run` e o legado `docker-compose exec/run` (issue
+# #186 — a forma de 3 palavras e a documentada nos CLAUDE.md de
+# projeto-alvo com container; o nivel de confianca dos quatro e o mesmo,
+# muda so a sintaxe).
 # Limitacao documentada: extracao de alvos de `rm` nao parseia quoting;
 # caminhos via variavel ($VAR/...) passam — o guard e defesa em
 # profundidade, nao sandbox.
@@ -75,11 +80,13 @@ _bg_check_blocklist_cmd() {
   fi
 
   # 2. Package managers no host — bloqueia a menos que o PROPRIO segmento
-  # comece com docker exec/run (`docker exec foo npm install` passa).
+  # comece com um wrapper de container: `docker exec/run`,
+  # `docker compose exec/run` ou `docker-compose exec/run`
+  # (`docker compose exec api npm install zod` passa).
   # Segment-aware: fecha o bypass em que a mera coexistencia de
   # "docker run" liberava o comando inteiro (`npm install x; docker run y`).
   if _bg_pkg_violation '(^|[[:space:]])(npm|pnpm|yarn|pip|pip3|gem|brew)[[:space:]]+(install|i|add|update|upgrade)\b'; then
-    _bg_emit_block "package-manager" "package install no host bloqueado (use 'docker exec/run' como wrapper no MESMO segmento)"
+    _bg_emit_block "package-manager" "package install no host bloqueado (use 'docker exec/run' ou 'docker compose exec/run' como wrapper no MESMO segmento)"
     return 1
   fi
   # `go install` / `cargo install`
@@ -174,11 +181,15 @@ _bg_segments() {
 }
 
 # _bg_pkg_violation ERE -> 0 (violacao) se ALGUM segmento casa o padrao de
-# install SEM comecar com docker exec/run.
+# install SEM comecar com um wrapper de container reconhecido.
+# Wrappers reconhecidos (issue #186): `docker exec/run`,
+# `docker compose exec/run` e o legado `docker-compose exec/run`. A ancora
+# `^` preserva a propriedade segment-aware — um `docker compose exec` em
+# OUTRO segmento nao libera o segmento que instala.
 _bg_pkg_violation() {
   _bg_segments \
     | grep -E "$1" 2>/dev/null \
-    | grep -Ev '^[[:space:]]*docker[[:space:]]+(exec|run)[[:space:]]' \
+    | grep -Ev '^[[:space:]]*docker([[:space:]]+compose|-compose)?[[:space:]]+(exec|run)[[:space:]]' \
     >/dev/null 2>&1
 }
 

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/state-lock.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/state-lock.sh
@@ -20,6 +20,27 @@
 #         detido emite diag_emit lock-force-acquired com pid antigo/novo.
 #         Pre-condicao CONTRATUAL (nao verificada aqui): SIGTERM + grace
 #         period antes (feature-00c-abort.md); nunca primeiro recurso.
+#         GUARDA DE ONDA ABERTA (issue #182): a liveness do pid NAO e proxy
+#         da liveness da onda. Quem adquire o lock no fluxo
+#         agente-00c/feature-00c e um shell EFEMERO do command pai, que
+#         morre assim que o Bash retorna — enquanto o subagente
+#         orquestrador segue trabalhando. Por isso "dono morto" e o estado
+#         NORMAL durante uma onda em voo, e nao autoriza sozinho a
+#         reaquisicao. Antes de consumar, o --force consulta o estado: se a
+#         ultima onda esta ABERTA (finished_at == null), recusa (exit 3,
+#         diag lock-force-denied-wave-open). Estado ilegivel (jq ausente,
+#         state.db corrompido) tambem recusa — fail-closed.
+#   state-lock.sh acquire --state-dir DIR --force-abandoned [--owner-pid N]
+#       — implica --force e passa por cima da guarda de onda aberta. E o
+#         caminho do /agente-00c-abort e /feature-00c-abort (derrubar onda
+#         viva e exatamente o que o abort faz) e da retomada deliberada de
+#         onda abandonada, DEPOIS de reconciliar. Emite
+#         diag lock-force-abandoned-override alem do lock-force-acquired.
+#         LIMITE CONHECIDO: a guarda nao cobre a janela entre o spawn do
+#         subagente e o `open_wave` da onda nova — nessa janela nao ha onda
+#         aberta no estado ainda, embora ja possa haver trabalho em disco
+#         (issue #182, comentario). Fechar essa janela exige marcar a
+#         intencao de spawn no estado, do lado do command pai.
 #   state-lock.sh release --state-dir DIR
 #       — remove <DIR>/.lock/ (idempotente; inclui o arquivo owner).
 #   state-lock.sh check --state-dir DIR
@@ -83,14 +104,19 @@ _sl_print_help() {
 state-lock.sh — lock anti-concorrencia do agente-00C.
 
 USO:
-  state-lock.sh <subcomando> --state-dir DIR [--force] [--owner-pid N]
+  state-lock.sh <subcomando> --state-dir DIR [--force|--force-abandoned]
+                             [--owner-pid N]
 
 SUBCOMANDOS:
   acquire                Cria <DIR>/.lock/ atomicamente e grava o dono
                          (.lock/owner: pid + acquired_at). Exit 3 se ja
                          detido. Com --force (fluxo de abort, FR-007a):
                          consuma so com dono morto ou lock legado sem
-                         owner (aviso); dono VIVO = recusa (exit 3).
+                         owner (aviso), E com a ultima onda FECHADA; onda
+                         aberta ou dono VIVO = recusa (exit 3).
+                         --force-abandoned implica --force e passa por
+                         cima da guarda de onda aberta (abort / retomada
+                         deliberada apos reconciliar).
                          --owner-pid sobrepoe o PID gravado (default PPID).
   release                Remove <DIR>/.lock/ (idempotente).
   check                  Exit 0 se acquirable, 3 se detido (reporta dono).
@@ -119,11 +145,13 @@ esac
 
 _SL_STATE_DIR=""
 _SL_FORCE=0
+_SL_FORCE_ABANDONED=0
 _SL_OWNER_PID=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --state-dir) _SL_STATE_DIR=$2; shift 2 ;;
     --force) _SL_FORCE=1; shift ;;
+    --force-abandoned) _SL_FORCE=1; _SL_FORCE_ABANDONED=1; shift ;;
     --owner-pid)
       [ "$#" -ge 2 ] || _sl_die_usage "--owner-pid exige valor"
       case "$2" in
@@ -135,7 +163,7 @@ while [ "$#" -gt 0 ]; do
 done
 [ -n "$_SL_STATE_DIR" ] || _sl_die_usage "--state-dir obrigatorio"
 if [ "$_SL_SUBCMD" != "acquire" ]; then
-  [ "$_SL_FORCE" = 0 ] || _sl_die_usage "--force so e valido com acquire"
+  [ "$_SL_FORCE" = 0 ] || _sl_die_usage "--force/--force-abandoned so e valido com acquire"
   [ -z "$_SL_OWNER_PID" ] || _sl_die_usage "--owner-pid so e valido com acquire"
 fi
 
@@ -179,10 +207,85 @@ _sl_report_owner() {
   fi
 }
 
+# Descreve a ultima onda ABERTA (finished_at == null) como "id|started_at",
+# ou string vazia quando nao ha nenhuma. Exit 2 = nao foi possivel VERIFICAR
+# (estado ilegivel) — o caller trata como recusa, nunca como "nao ha onda".
+# Estado ausente (state-dir recem-criado, lock antes do init) = sem ondas.
+_sl_open_wave() {
+  _sl_ow_file=""
+  _sl_ow_rc=0
+  _sl_ow_file=$(state_read_materialize "$_SL_STATE_DIR" 2>/dev/null) || _sl_ow_rc=$?
+  if [ "$_sl_ow_rc" -ne 0 ]; then
+    return 2
+  fi
+  if [ ! -f "$_sl_ow_file" ]; then
+    printf ''
+    return 0
+  fi
+  command -v jq >/dev/null 2>&1 || return 2
+  _sl_ow_out=$(jq -r '
+    (((.waves // .ondas) // [])
+     | map(select(((.finished_at // .finalizada_em) // null) == null))
+     | last) as $w
+    | if $w == null then ""
+      else (($w.id // $w.numero // "?") | tostring) + "|"
+           + ((($w.started_at // $w.inicio) // "?") | tostring)
+      end
+  ' "$_sl_ow_file" 2>/dev/null) || return 2
+  printf '%s' "$_sl_ow_out"
+}
+
+# Guarda do --force (issue #182): a liveness do PID do dono nao diz nada
+# sobre a liveness da ONDA — quem fez o acquire e um shell efemero do
+# command pai, morto ha muito enquanto o subagente orquestrador trabalha.
+# Recusa o force quando ha onda aberta, ou quando o estado nao pode ser
+# lido (fail-closed). --force-abandoned passa por cima, deliberadamente.
+_sl_guard_open_wave() {
+  if [ "$_SL_FORCE_ABANDONED" = 1 ]; then
+    diag_emit warning lock-force-abandoned-override \
+      "acquire --force-abandoned: guarda de onda aberta ignorada por escolha explicita em $_SL_LOCK" \
+      "confirme que a onda foi reconciliada (reconcile-wave) ou que este e o fluxo de abort" || :
+    return 0
+  fi
+
+  _sl_gow_rc=0
+  _sl_gow=$(_sl_open_wave) || _sl_gow_rc=$?
+
+  if [ "$_sl_gow_rc" -ne 0 ]; then
+    printf '%s: acquire --force RECUSADO: nao foi possivel verificar se ha onda aberta em %s\n' \
+      "$_SL_NAME" "$_SL_STATE_DIR" >&2
+    printf '       (estado ilegivel: jq ausente, state.db corrompido ou sqlite3 indisponivel)\n' >&2
+    printf '       repita com --force-abandoned se tiver certeza de que nao ha onda em voo.\n' >&2
+    diag_emit error lock-force-denied-state-unreadable \
+      "acquire --force: estado ilegivel em $_SL_STATE_DIR — impossivel verificar onda aberta" \
+      "corrija a leitura do estado (jq/sqlite3) ou use --force-abandoned apos confirmar que nao ha onda em voo" || :
+    exit 3
+  fi
+
+  if [ -n "$_sl_gow" ]; then
+    _sl_gow_id=${_sl_gow%%|*}
+    _sl_gow_ts=${_sl_gow#*|}
+    printf '%s: acquire --force RECUSADO: onda %s esta ABERTA (started_at=%s)\n' \
+      "$_SL_NAME" "$_sl_gow_id" "$_sl_gow_ts" >&2
+    printf '       o dono do lock e um shell efemero do command pai: "pid morto" NAO significa\n' >&2
+    printf '       onda encerrada. Forcar aqui coloca dois orquestradores no mesmo state.\n' >&2
+    printf '       Feche a onda antes (reconcile-wave), aborte a execucao (/agente-00c-abort ou\n' >&2
+    printf '       /feature-00c-abort), ou repita com --force-abandoned se a onda foi abandonada.\n' >&2
+    diag_emit error lock-force-denied-wave-open \
+      "acquire --force: onda $_sl_gow_id aberta desde $_sl_gow_ts em $_SL_STATE_DIR — force recusado" \
+      "feche a onda (reconcile-wave) ou aborte a execucao; --force-abandoned so apos confirmar abandono" || :
+    exit 3
+  fi
+  return 0
+}
+
 # Remove o lock detido e readquire na MESMA invocacao (caminho autorizado
 # do --force). Falha de remocao/mkdir => exit 1 com diagnostico (contract §2).
+# A guarda de onda aberta roda AQUI para cobrir os dois caminhos que chegam
+# ao force (dono morto e lock legado sem owner) — nenhum consuma sem passar.
 _sl_force_consummate() {
   _sl_fc_old=$1
+  _sl_guard_open_wave
   if ! rmdir -- "$_SL_LOCK" 2>/dev/null; then
     rm -rf -- "$_SL_LOCK" 2>/dev/null || :
   fi

--- a/tests/cstk/test_http.sh
+++ b/tests/cstk/test_http.sh
@@ -9,6 +9,12 @@
 # Estrategia de teste: usa file:// URLs (suportado por curl em qualquer build
 # minimamente normal), que funciona 100% offline. Evita dependencia em rede
 # e em servidores externos.
+#
+# Cadeia de redirects (issue #178): coberta com STUB de curl no PATH, que
+# devolve `%{http_code} %{redirect_url}` conforme um mapa declarado pelo
+# cenario e REGISTRA cada URL requisitada num log. O log e o que prova a
+# propriedade central: a URL fora da allowlist nunca chega a ser requisitada
+# (nao ha "baixa e descarta depois").
 
 TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
@@ -96,6 +102,127 @@ scenario_check_url_inexistente() {
     _fail "http_check_url inexistente" "exit esperado !=0, obtido $_CAPTURED_EXIT"
     return 1
   fi
+}
+
+# ==== Cadeia de redirects revalidada salto a salto (issue #178) ====
+
+# _make_curl_stub <mapa> — instala um stub de curl em $TMPDIR_TEST/bin.
+# O mapa e uma sequencia de linhas "<url-glob>|<http_code>|<redirect_url>".
+# Toda invocacao registra a URL pedida em $TMPDIR_TEST/curl-calls.log.
+_make_curl_stub() {
+  _stub_dir="$TMPDIR_TEST/bin"
+  mkdir -p "$_stub_dir"
+  printf '%s\n' "$1" > "$TMPDIR_TEST/curl-map"
+  : > "$TMPDIR_TEST/curl-calls.log"
+  cat > "$_stub_dir/curl" <<STUB
+#!/bin/sh
+# Stub curl: nao toca a rede; responde a partir de $TMPDIR_TEST/curl-map.
+_url=""
+_out=""
+_prev=""
+for _a in "\$@"; do
+  case "\$_prev" in
+    -o) _out="\$_a" ;;
+  esac
+  case "\$_a" in
+    https://*|file://*|http://*) _url="\$_a" ;;
+  esac
+  _prev="\$_a"
+done
+printf '%s\n' "\$_url" >> "$TMPDIR_TEST/curl-calls.log"
+while IFS='|' read -r _pat _code _next; do
+  [ -n "\$_pat" ] || continue
+  case "\$_url" in
+    \$_pat)
+      [ -n "\$_out" ] && printf 'corpo-de-%s\n' "\$_code" > "\$_out"
+      printf '%s %s' "\$_code" "\$_next"
+      exit 0
+      ;;
+  esac
+done < "$TMPDIR_TEST/curl-map"
+exit 22
+STUB
+  chmod +x "$_stub_dir/curl"
+  printf '%s' "$_stub_dir"
+}
+
+# Conta quantas vezes uma URL casando o glob foi requisitada pelo stub.
+_curl_calls_matching() {
+  _cnt=0
+  while IFS= read -r _line; do
+    # shellcheck disable=SC2254  # $1 e um GLOB deliberado aqui (o chamador
+    # passa 'https://evil.example.com/*'), nao um literal a ser citado.
+    case "$_line" in
+      $1) _cnt=$((_cnt + 1)) ;;
+    esac
+  done < "$TMPDIR_TEST/curl-calls.log"
+  printf '%s' "$_cnt"
+}
+
+scenario_download_redirect_dentro_da_allowlist_segue() {
+  # github.com -> github.com -> release-assets.githubusercontent.com (a
+  # cadeia real medida de um asset de release; ver cli/lib/trusted-hosts.sh).
+  _bin=$(_make_curl_stub 'https://github.com/JotJunior/cstk/releases/*|302|https://github.com/hop2
+https://github.com/hop2|302|https://release-assets.githubusercontent.com/blob
+https://release-assets.githubusercontent.com/*|200|')
+  _dest="$TMPDIR_TEST/asset.bin"
+  capture env PATH="$_bin:$PATH" sh -c ". $CSTK_LIB/http.sh && http_download https://github.com/JotJunior/cstk/releases/x.tar.gz $_dest"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "redirect allowlist exit" "esperado 0, obtido $_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"; return 1; }
+  grep -q 'corpo-de-200' "$_dest" || { _fail "redirect allowlist corpo" "destino nao tem o corpo do salto final"; return 1; }
+}
+
+scenario_download_redirect_fora_da_allowlist_recusado() {
+  # O salto final sai da allowlist: DEVE ser recusado ANTES da requisicao.
+  _bin=$(_make_curl_stub 'https://github.com/JotJunior/cstk/releases/*|302|https://evil.example.com/payload.tar.gz
+https://evil.example.com/*|200|')
+  _dest="$TMPDIR_TEST/evil.bin"
+  capture env PATH="$_bin:$PATH" sh -c ". $CSTK_LIB/http.sh && http_download https://github.com/JotJunior/cstk/releases/x.tar.gz $_dest"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "redirect fora allowlist exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "evil.example.com" || return 1
+  [ ! -f "$_dest" ] || { _fail "redirect fora allowlist destino" "arquivo do salto recusado persistiu"; return 1; }
+  # Propriedade central: nenhuma requisicao chegou ao host recusado.
+  [ "$(_curl_calls_matching 'https://evil.example.com/*')" = 0 ] \
+    || { _fail "redirect fora allowlist requisicao" "o stub foi chamado para o host fora da allowlist"; return 1; }
+}
+
+scenario_download_redirect_para_file_recusado() {
+  # file:// e isento apenas como origem INICIAL (fluxo de dev); como destino
+  # de redirect viraria leitura de arquivo local disfarcada de download.
+  _src="$TMPDIR_TEST/segredo.txt"
+  printf 'segredo\n' > "$_src"
+  _bin=$(_make_curl_stub "https://github.com/*|302|file://$_src
+file://*|200|")
+  _dest="$TMPDIR_TEST/via-file.bin"
+  capture env PATH="$_bin:$PATH" sh -c ". $CSTK_LIB/http.sh && http_download https://github.com/x.tar.gz $_dest"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "redirect file:// exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "file://" || return 1
+}
+
+scenario_download_teto_de_redirects() {
+  # Loop de redirects DENTRO da allowlist: o teto interrompe a caminhada.
+  _bin=$(_make_curl_stub 'https://github.com/*|302|https://github.com/loop')
+  _dest="$TMPDIR_TEST/loop.bin"
+  capture env PATH="$_bin:$PATH" sh -c ". $CSTK_LIB/http.sh && http_download https://github.com/start $_dest"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "teto redirects exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "redirects" || return 1
+}
+
+scenario_download_3xx_sem_location_e_erro() {
+  # Nunca tratar o corpo de um 3xx sem Location como se fosse o payload.
+  _bin=$(_make_curl_stub 'https://github.com/*|302|')
+  _dest="$TMPDIR_TEST/sem-location.bin"
+  capture env PATH="$_bin:$PATH" sh -c ". $CSTK_LIB/http.sh && http_download https://github.com/x.tar.gz $_dest"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "3xx sem location exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  [ ! -f "$_dest" ] || { _fail "3xx sem location destino" "corpo do redirect persistiu como payload"; return 1; }
+}
+
+scenario_download_host_inicial_fora_da_allowlist_nao_requisita() {
+  _bin=$(_make_curl_stub 'https://evil.example.com/*|200|')
+  _dest="$TMPDIR_TEST/inicial.bin"
+  capture env PATH="$_bin:$PATH" sh -c ". $CSTK_LIB/http.sh && http_download https://evil.example.com/x.tar.gz $_dest"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "host inicial fora allowlist exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  [ "$(_curl_calls_matching 'https://evil.example.com/*')" = 0 ] \
+    || { _fail "host inicial fora allowlist requisicao" "houve requisicao ao host recusado"; return 1; }
 }
 
 run_all_scenarios

--- a/tests/cstk/test_trusted-hosts.sh
+++ b/tests/cstk/test_trusted-hosts.sh
@@ -34,8 +34,12 @@ scenario_trusted_host_github_com_aceito() {
   fi
 }
 
-scenario_trusted_host_todos_os_4_aceitos() {
-  for _h in github.com codeload.github.com objects.githubusercontent.com api.github.com; do
+scenario_trusted_host_todos_os_5_aceitos() {
+  # release-assets.githubusercontent.com entrou na lista pela issue #178: e o
+  # host de destino real da cadeia de redirects de um asset de release
+  # (medido; ver o cabecalho de cli/lib/trusted-hosts.sh).
+  for _h in github.com codeload.github.com objects.githubusercontent.com \
+            release-assets.githubusercontent.com api.github.com; do
     capture sh -c ". \"$CSTK_LIB/trusted-hosts.sh\" && trusted_host_check 'https://$_h/path/to/asset.tar.gz'"
     if [ "$_CAPTURED_EXIT" != "0" ]; then
       _fail "host_${_h}_aceito" "esperado exit 0, obtido $_CAPTURED_EXIT"

--- a/tests/test_bash-guard.sh
+++ b/tests/test_bash-guard.sh
@@ -338,4 +338,44 @@ scenario_blocklist_docker_run_npm_mesmo_segmento_passa() {
   [ "$_CAPTURED_EXIT" = 0 ] || { _fail "docker run npm" "$_CAPTURED_STDERR"; return 1; }
 }
 
+# ==== Wrapper de container em 3 palavras (issue #186) ====
+# `docker compose exec` e a forma canonica documentada nos CLAUDE.md de
+# projeto-alvo com container; a ancora de 2 palavras a bloqueava.
+
+scenario_blocklist_docker_compose_exec_npm_passa() {
+  capture "$SCRIPT" check-blocklist --command "docker compose exec api npm install zod"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "docker compose exec npm" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_blocklist_docker_compose_hifen_exec_npm_passa() {
+  capture "$SCRIPT" check-blocklist --command "docker-compose exec api npm install zod"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "docker-compose exec npm" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_blocklist_docker_compose_run_npm_passa() {
+  capture "$SCRIPT" check-blocklist --command "docker compose run --rm api npm install zod"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "docker compose run npm" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_blocklist_docker_compose_exec_go_install_passa() {
+  # A mesma ampliacao vale para a regra go/cargo install (mesmo helper).
+  capture "$SCRIPT" check-blocklist --command "docker compose exec api go install ./cmd/x"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "docker compose exec go install" "$_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_blocklist_dockerfoo_exec_npm_bloqueado() {
+  # Negativo: prefixo parecido (nao e a palavra "docker") segue bloqueado.
+  capture "$SCRIPT" check-blocklist --command "dockerfoo exec api npm install zod"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "dockerfoo exec npm" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "package-manager" || return 1
+}
+
+scenario_blocklist_docker_compose_outro_segmento_bloqueado() {
+  # Negativo: segment-awareness preservada — `docker compose exec` em OUTRO
+  # segmento nao libera o segmento que instala.
+  capture "$SCRIPT" check-blocklist --command "echo docker compose exec; npm install zod"
+  [ "$_CAPTURED_EXIT" = 1 ] || { _fail "docker compose coexist" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stderr_contains "package-manager" || return 1
+}
+
 run_all_scenarios

--- a/tests/test_state-lock.sh
+++ b/tests/test_state-lock.sh
@@ -352,6 +352,111 @@ scenario_force_flag_invalida_fora_do_acquire() {
   [ "$_CAPTURED_EXIT" = 2 ] || { _fail "release --force" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
   capture "$SCRIPT" check --state-dir "$_sd" --owner-pid 123
   [ "$_CAPTURED_EXIT" = 2 ] || { _fail "check --owner-pid" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+  capture "$SCRIPT" release --state-dir "$_sd" --force-abandoned
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "release --force-abandoned" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+}
+
+# --- Guarda de onda aberta no --force (issue #182) ------------------------
+# O dono do lock e um shell EFEMERO do command pai: "pid morto" e o estado
+# NORMAL enquanto o subagente orquestrador trabalha. Quem distingue pausa
+# entre ondas de onda em voo e o estado, nao o pid.
+
+# Prepara state-dir com lock detido por pid morto + state.json com uma onda
+# no estado pedido ("aberta" | "fechada").
+_mk_lock_com_onda() {
+  _mlo_sd=$1
+  _mlo_estado=$2
+  mkdir -p "$_mlo_sd/.lock"
+  printf 'pid=%s\nacquired_at=2026-08-29T20:39:13Z\n' "$_MLO_DEAD_PID" > "$_mlo_sd/.lock/owner"
+  if [ "$_mlo_estado" = "aberta" ]; then
+    printf '{"waves":[{"id":"onda-009","started_at":"2026-08-29T20:40:29Z","finished_at":null}]}\n' \
+      > "$_mlo_sd/state.json"
+  else
+    printf '{"waves":[{"id":"onda-009","started_at":"2026-08-29T20:40:29Z","finished_at":"2026-08-29T21:00:00Z"}]}\n' \
+      > "$_mlo_sd/state.json"
+  fi
+}
+
+# PID comprovadamente morto, reaproveitado pelos cenarios abaixo.
+_MLO_DEAD_PID=""
+_mlo_dead_pid() {
+  if [ -z "$_MLO_DEAD_PID" ]; then
+    sh -c 'exit 0' &
+    _MLO_DEAD_PID=$!
+    wait "$_MLO_DEAD_PID" 2>/dev/null || :
+  fi
+}
+
+scenario_force_onda_aberta_recusa_exit_3() {
+  _mlo_dead_pid
+  _sd="$TMPDIR_TEST/force-wave-open"
+  _mk_lock_com_onda "$_sd" aberta
+  capture "$SCRIPT" acquire --state-dir "$_sd" --force
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "force com onda aberta" "esperado 3, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "DIAG|error|lock-force-denied-wave-open|" || return 1
+  assert_stderr_contains "onda-009" || return 1
+  # NAO pode ter consumado: owner antigo intacto.
+  case "$_CAPTURED_STDERR" in
+    *lock-force-acquired*) _fail "force consumou com onda aberta" "$_CAPTURED_STDERR"; return 1 ;;
+  esac
+  grep -q "^pid=$_MLO_DEAD_PID\$" "$_sd/.lock/owner" \
+    || { _fail "owner alterado apos recusa" "$(cat "$_sd/.lock/owner")"; return 1; }
+}
+
+scenario_force_onda_fechada_readquire() {
+  # Lock orfao COM a ultima onda fechada e o caso normal entre ondas.
+  _mlo_dead_pid
+  _sd="$TMPDIR_TEST/force-wave-closed"
+  _mk_lock_com_onda "$_sd" fechada
+  capture "$SCRIPT" acquire --state-dir "$_sd" --force
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "force com onda fechada" "esperado 0, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "DIAG|warning|lock-force-acquired|" || return 1
+}
+
+scenario_force_abandoned_passa_por_cima_de_onda_aberta() {
+  # Caminho do abort e da retomada deliberada de onda abandonada.
+  _mlo_dead_pid
+  _sd="$TMPDIR_TEST/force-wave-abandoned"
+  _mk_lock_com_onda "$_sd" aberta
+  capture "$SCRIPT" acquire --state-dir "$_sd" --force-abandoned
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "force-abandoned com onda aberta" "esperado 0, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "DIAG|warning|lock-force-abandoned-override|" || return 1
+  assert_stderr_contains "DIAG|warning|lock-force-acquired|" || return 1
+}
+
+scenario_force_estado_ilegivel_recusa_fail_closed() {
+  # Estado presente mas ilegivel: nao da para AFIRMAR que nao ha onda em
+  # voo => recusa (nunca tratar "nao consegui ler" como "nao ha onda").
+  _mlo_dead_pid
+  _sd="$TMPDIR_TEST/force-state-broken"
+  mkdir -p "$_sd/.lock"
+  printf 'pid=%s\nacquired_at=2026-08-29T20:39:13Z\n' "$_MLO_DEAD_PID" > "$_sd/.lock/owner"
+  printf '{"waves": [ISTO NAO E JSON\n' > "$_sd/state.json"
+  capture "$SCRIPT" acquire --state-dir "$_sd" --force
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "force com estado ilegivel" "esperado 3, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "DIAG|error|lock-force-denied-state-unreadable|" || return 1
+  # --force-abandoned continua sendo a saida explicita.
+  capture "$SCRIPT" acquire --state-dir "$_sd" --force-abandoned
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "force-abandoned com estado ilegivel" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_sqlite_force_onda_aberta_recusa() {
+  # Paridade de backend: a guarda le o estado via _state-read.sh, entao vale
+  # igual sob state.db (nenhum leitor novo de state.json direto).
+  _sqlite3_adequate || { printf "# skip: sqlite3 indisponivel\n"; return 0; }
+  _mlo_dead_pid
+  _sd="$TMPDIR_TEST/state-sqlite-force"
+  _init_sqlite "$_sd" || { _fail "fixture sqlite" "init nao gerou state.db"; return 1; }
+  _ondas="$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/scripts/state-ondas.sh"
+  capture "$_ondas" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "fixture onda sqlite" "$_CAPTURED_STDERR"; return 1; }
+  mkdir -p "$_sd/.lock"
+  printf 'pid=%s\nacquired_at=2026-08-29T20:39:13Z\n' "$_MLO_DEAD_PID" > "$_sd/.lock/owner"
+  capture "$SCRIPT" acquire --state-dir "$_sd" --force
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "force sqlite onda aberta" "esperado 3, obtido $_CAPTURED_EXIT; $_CAPTURED_STDERR"; return 1; }
+  assert_stderr_contains "DIAG|error|lock-force-denied-wave-open|" || return 1
+  # A materializacao nao pode deixar espelho no state-dir (FR-003).
+  [ ! -f "$_sd/state.json" ] || { _fail "anti-mirror" "state.json espelho criado no state-dir"; return 1; }
 }
 
 run_all_scenarios


### PR DESCRIPTION
Tres correcoes de guarda, todas reportadas a partir de execucao real. Uma quarta issue da mesma leva (#177, attestation de proveniencia) **nao** entra aqui — justificativa no fim.

Closes #178
Closes #182
Closes #186

---

## #178 — allowlist de hosts revalidada apenas antes do redirect

`cli/lib/http.sh` baixava com `curl -fsSL`. O `-L` seguia a cadeia inteira dentro do curl e a allowlist (`cli/lib/trusted-hosts.sh`) so era aplicada pelo caller, sobre a URL **inicial**.

Adotei a alternativa estrita citada na propria issue: **sem `-L`**, a cadeia e caminhada manualmente, um salto por vez, e cada URL (a inicial e cada `Location`) passa por `trusted_host_check` **antes** da requisicao correspondente. Salto fora da allowlist ⇒ nenhuma requisicao e feita aquele host — nao e "baixa e descarta depois". Junto:

- redirect para `file://` recusado (so a origem **inicial** pode ser `file://`, fluxo de dev);
- teto de 10 saltos;
- `3xx` sem `Location` utilizavel vira erro, em vez de o corpo do redirect virar payload.

### Achado no caminho: o CDN de release mudou

A premissa da issue ("o GitHub redireciona legitimamente para `objects.githubusercontent.com`, que ja esta na allowlist") esta desatualizada. Caminhei a cadeia real de um asset de release deste repositorio, salto a salto, com `curl -w '%{http_code} %{redirect_url}'` e sem `-L`:

```
hop1 302 github.com
hop2 302 github.com
hop3 200 release-assets.githubusercontent.com   <- fora da allowlist
```

(a cadeia de `tarball_url` da API termina em `codeload.github.com`, ja listado).

Enquanto ninguem conferia o salto final, a entrada `objects.githubusercontent.com` — herdada da epoca em que era esse o CDN — dava a impressao de cobrir o caso. Com a revalidacao ativa, `install`/`self-update`/`serve` a partir de asset de release passariam a ser **recusados**. Por isso `release-assets.githubusercontent.com` entra na `CSTK_TRUSTED_RELEASE_HOSTS`, com a medicao registrada no cabecalho do arquivo. Download real validado ponta a ponta apos a mudanca.

Nota operacional (tambem no codigo): se o GitHub mudar de host outra vez, o download e recusado com o host novo nomeado no stderr — fail-closed deliberado. O caminho de recuperacao nao depende desta lista: o bootstrap `curl -fsSL .../install.sh | sh` usa curl direto.

## #182 — `acquire --force` readquiria lock com onda ainda em voo

A liveness do pid do dono do lock **nao e proxy da liveness da onda**: quem faz o `acquire` e um shell efemero do command pai, que morre assim que o Bash retorna, enquanto o subagente orquestrador segue trabalhando. "Dono morto" era lido como "lock orfao entre ondas" e autorizava o `--force` sobre trabalho em voo.

`state-lock.sh acquire --force` agora consulta o estado antes de consumar:

| Situacao | Resultado |
|---|---|
| dono VIVO | recusa (`lock-force-denied-owner-alive`, inalterado) |
| dono morto + ultima onda **aberta** | **recusa** (`lock-force-denied-wave-open`, nomeia onda + `started_at`) |
| dono morto + ultima onda fechada | readquire (`lock-force-acquired`, inalterado) |
| estado ilegivel (jq/sqlite3/state corrompido) | **recusa** fail-closed (`lock-force-denied-state-unreadable`) |

"Nao consegui ler o estado" nunca vira "nao ha onda". O override explicito e `--force-abandoned`, auditado como `DIAG|warning|lock-force-abandoned-override`.

`feature-00c-abort.md` passou a usa-lo: derrubar onda viva e exatamente o que o abort faz, e com `--force` simples o abort teria quebrado. A prosa de `feature-00c-resume.md` (a premissa "dono morto = caso normal entre ondas") e o item 7 de `feature-00c.md` foram corrigidos, com a arvore de decisao na recusa (reconcile-wave / abort / `--force-abandoned`).

A guarda le o estado via `_state-read.sh`, entao vale igual nos dois backends — ha cenario sqlite cobrindo, com checagem anti-mirror (FR-003).

**Limite conhecido, documentado no codigo, no `--help` e na prosa**: a guarda nao cobre a janela entre o spawn do subagente e o `open_wave` da onda nova (o comentario da issue). Fechar essa janela e a opcao (a) do proprio relato — marcar a intencao de spawn do lado do pai — que muda o contrato de orquestracao e o baseline do `commit-mode`; e feature, nao patch. A opcao (b) (working tree suja como sinal) ficou de fora por ser ruidosa demais para virar guarda default.

## #186 — `docker compose exec` bloqueado pelo bash-guard

`_bg_pkg_violation` so reconhecia o wrapper de container de **duas** palavras, entao a forma canonica de tres — a documentada nos `CLAUDE.md` de projeto-alvo com container — caia na blocklist. Passa a aceitar tambem `docker compose exec/run` e `docker-compose exec/run`.

Nao abre superficie nova: `docker compose exec` alcanca o mesmo container que `docker exec`, e `docker compose run` tem o mesmo poder de montagem de `docker run`, ja liberado. A propriedade segment-aware e preservada — `echo docker compose exec; npm install zod` continua bloqueado.

## Cobertura

- `tests/test_bash-guard.sh`: +6 cenarios (3 formas de wrapper, `go install` sob wrapper, 2 negativos).
- `tests/cstk/test_http.sh`: +6 cenarios com stub de curl e **log de chamadas** — o log e o que prova a propriedade central (a URL recusada nunca chega a ser requisitada).
- `tests/cstk/test_trusted-hosts.sh`: loop dos hosts aceitos passa a cobrir os 5.
- `tests/test_state-lock.sh`: +5 cenarios (onda aberta recusa, onda fechada readquire, `--force-abandoned` passa por cima, estado ilegivel fail-closed, paridade sqlite).

**Mutation test** aplicado nas duas guardas novas: neutralizar `_http_hop_allowed` derruba 3 cenarios; neutralizar `_sl_guard_open_wave` derruba 4. Nenhum dos testes novos passa por acidente.

Suite completa: **3617 pass, 1 fail** — o flaky conhecido `test_00c-bootstrap.sh :: scenario_issue_2_sigint_propaga_exit_130`, reconfirmado passando isolado. `ORPHANS: 0`.

## Sincronizacao (GOTCHA das duas metades)

Este PR toca as duas metades da instalacao:

- **runtime** (`cli/lib/http.sh`, `cli/lib/trusted-hosts.sh`) ⇒ `cstk self-update --from <tarball>`
- **catalogo** (`bash-guard.sh`, `state-lock.sh`, commands, SKILL.md) ⇒ `cstk update` / `cstk install --from <tarball>`

Atualizar so uma reproduz o sintoma classico "funciona no repo mas nao na sessao".

## Por que #177 nao entra aqui

Emitir attestation e trivial (`actions/attest-build-provenance` + duas permissions no `release.yml`). **Verificar** e que e a decisao: exigiria `gh attestation verify` no cliente, e hoje o caminho de instalacao depende so de `curl`/`tar`/`sha256`. Ou o `gh` vira dependencia dura de `install`/`serve` (regressao de portabilidade), ou a verificacao e oportunista — exatamente o "fallback permissivo demais, verificacao decorativa" que a propria issue alerta. Isso e politica com spec, no padrao do `enforced-guards`, nao patch de drive-by. #177 fica aberta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRMKihs78cyzc4vwVfjPdJ
