### PR TITLE
fix: projeto-alvo fora da raiz da sessao — guarda inerte, ramo de opt-in cego e --live falso-positivo (#189 #190 #191)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,21 @@ prompt to read what the hook does. The answer here: it is a passive local
 counter with an empty-output/always-zero-exit contract, enforced by its test
 suite (`tests/test_posttooluse-tool-call-tick.sh`).
 
+**Hooks are effective only for the session's project root.** Claude Code
+loads hooks from the `.claude/settings.json` of the directory the session
+was started in, and the Bash guard anchors "is a 00c execution active?" on
+that root (cwd and its ancestors, never a sibling or child directory). An
+execution whose `--projeto`/`--projeto-alvo-path` points elsewhere — e.g. a
+`cstk session start` worktree driven from the main checkout — runs with the
+guard **inert** while every registration check reports green (measured:
+`tool_calls: 0` across 3 waves, issue #189). The four 00c
+commands now refuse that combination before taking the lock
+(`session-scope.sh check`, exit 4), `guard-hooks-status.sh check` prints an
+effectiveness warning, and the only way through is the explicit, audited
+bypass `--allow-target-outside-session` (or
+`CSTK_ALLOW_TARGET_OUTSIDE_SESSION=1`), logged to the target's
+`enforcement-log.jsonl` as `source: "session-scope"`.
+
 ### What the Bash guard blocks
 
 During an active autonomous execution, `bash-guard.sh` blocks (among others):
@@ -68,6 +83,18 @@ by `secrets-filter.sh` **before** being truncated and written.
   `github.com.evil.com` and `user@evil.com` lookalikes (CWE-290) do not
   match. `install`, `self-update` and `serve` all check the host **before**
   any download; plain `http://` is rejected.
+- **Known limitation — integrity, not provenance (issue #177, accepted
+  risk).** The asset + `.sha256` pair proves the bytes you received are the
+  bytes that were published; it does not prove *who* published them, since
+  both files are written by the same release actor. A compromised release
+  workflow produces an internally consistent pair and `cstk serve` reports
+  `verified`. Build-provenance attestation was evaluated and deliberately
+  **not** adopted: verifying it on the client requires `gh` or `cosign`, which
+  would either become a hard dependency of a bootstrap that today needs only
+  `curl`/`tar`/`sha256sum`, or be checked opportunistically — a decorative
+  verification that is worse than none. The risk is accepted and recorded
+  here so it does not become a silent assumption; revisit if a
+  POSIX-verifiable attestation format becomes available.
 - **Two delivery paths, comparable but distinct guarantees.** The classic
   path (`curl | sh` + `cstk install`) is protected by the checksum + host
   allowlist above, applied by cstk's own code. The native plugin path is
@@ -96,19 +123,30 @@ by `secrets-filter.sh` **before** being truncated and written.
 
 ## MCP state server confinement
 
-The optional `cstk mcp` layer runs one Docker container per execution:
+The optional `cstk mcp` layer runs the state server as a direct process of
+the Claude Code session (`mode=direct`, since v8.0.0 — no container is
+created any more; `cstk mcp gc` only cleans up containers left by
+pre-cutover sessions):
 
-- The container mounts **only** that execution's state dir, the runtime
-  scripts (read-only) and that execution's enforcement log — never another
-  execution's state, never `knowledge.db`.
+- Confinement is by **authorization, not by process**: the server inherits
+  the user's filesystem like any other process, but every mutation goes
+  through the POSIX helpers, which only touch the state dir resolved from
+  the token presented in that call. The earlier Docker mount confinement
+  was deliberately given up in that cutover and is recorded as a declared
+  regression, not claimed as parity (`docs/specs/mcp-direct-transport/`).
 - Every tool call must present the execution's capability token (≥128-bit
   CSPRNG, stored in the state dir). Missing/mismatched/terminal-execution
   tokens are rejected fail-closed (`SESSION_MISMATCH`) — there is no
-  fallback to "the most likely active execution".
+  fallback to "the most likely active execution". Tokens are resolved
+  **under the session's project root**, which is why an execution targeting
+  another directory cannot use the MCP tools at all (issues #190/#191); the
+  pre-flight and `cstk mcp status --live` now say so instead of reporting
+  green.
 - The Node→POSIX boundary uses `execFile` with argv arrays; no free-text
-  field ever reaches a shell.
-- Docker unavailable degrades to the plain Bash path with none of the above
-  — the MCP layer adds confinement, it is not the source of it.
+  field ever reaches a shell, and error messages never echo the token.
+- Server unavailable degrades to the plain Bash path with none of the above
+  — the MCP layer adds an authorization boundary, it is not the source of
+  the guards.
 
 ## Autonomous orchestrator blast radius
 

--- a/cli/lib/mcp.sh
+++ b/cli/lib/mcp.sh
@@ -48,8 +48,10 @@
 # mode=docker (legado), roda um health check DE VERDADE (`_mcp_docker_
 # healthcheck` abaixo) em vez de so ecoar o descritor — usado pelo command
 # pai em cada `-resume` para reverificar saude SEM reiniciar o container.
-# Para `mode=direct` (toda sessao criada apos o cutover), `--live` e no-op
-# (ST-3): o guard `mode = "docker"` simplesmente nunca casa.
+# Para `mode=direct` (toda sessao criada apos o cutover), `--live` foi no-op
+# ate a issue #191 (`active` com 100% das tools em SESSION_MISMATCH); agora
+# exercita a resolucao POR TOKEN sob a raiz da sessao — ver
+# _mcp_live_direct_probe (status active|unresolvable|unknown).
 #
 # `gc` (task 5.4, CHK064): detecta e remove containers gerenciados cujo
 # state-dir dono esta em estado terminal ou nao existe mais — ver comentario
@@ -495,11 +497,90 @@ _mcp_print_status_from_descriptor() {
     fi
   fi
 
+  # `--live` em mode=direct (issue #191): ate aqui o --live so inspecionava o
+  # descritor (caminho --state-dir), enquanto TODA chamada de tool resolve
+  # por token a partir da raiz da sessao hospedeira (caminho --project-path,
+  # `mcp-session.sh resolve`). Sao dois caminhos distintos; a sonda cobria
+  # so o primeiro e respondia `active` com 100% das tools em
+  # SESSION_MISMATCH. Agora exercita o MESMO caminho de autorizacao que
+  # uma tool: apresenta o session_id do descritor ao resolve sob a raiz
+  # da sessao (session-scope.sh resolve = pwd -P/CLAUDE_PROJECT_DIR, o
+  # mesmo sinal que mcp-launch.sh entrega ao servidor). Desfechos:
+  #   active        descritor ok E token resolve
+  #   unresolvable  descritor ok, token NAO resolve (reason cita a raiz)
+  #   unknown       sonda indisponivel (helper ausente/erro) — nunca
+  #                 promovido a active por omissao
+  # Restrito a mode=direct: `bash-fallback` e legado pre-cutover (sem
+  # servidor real por tras) e `docker` ja tem a sonda propria acima.
+  if [ "$_live" = "1" ] && [ "$_mode" = "direct" ]; then
+    _mcp_live_direct_probe "$_sid" "$_container" "$_mode"
+    return 0
+  fi
+
   printf 'status=active\n'
   printf 'reason=-\n'
   printf 'container=%s\n' "$_container"
   printf 'session_id=%s\n' "$_sid"
   printf 'mode=%s\n' "$_mode"
+}
+
+# _mcp_live_direct_probe SID CONTAINER MODE — sonda REAL de resolubilidade
+# do token (issue #191). Imprime o bloco de status completo; nunca falha
+# (consulta respondida, nao veredito). Delega a resolucao a
+# mcp-session.sh resolve (SEC-H3) e a raiz da sessao a session-scope.sh
+# — nenhuma das duas regras e reimplementada aqui.
+_mcp_live_direct_probe() {
+  _lp_sid=$1
+  _lp_container=$2
+  _lp_mode=$3
+
+  _lp_ms=$(_mcp_runtime_script_path mcp-session.sh) || _lp_ms=""
+  if [ -z "$_lp_ms" ] || [ -z "$_lp_sid" ] || [ "$_lp_sid" = "-" ]; then
+    printf 'status=unknown\n'
+    printf 'reason=probe-unavailable:mcp-session.sh-ausente-ou-session_id-vazio\n'
+    printf 'container=%s\n' "$_lp_container"
+    printf 'session_id=%s\n' "$_lp_sid"
+    printf 'mode=%s\n' "$_lp_mode"
+    return 0
+  fi
+
+  _lp_root=""
+  if _lp_ss=$(_mcp_runtime_script_path session-scope.sh); then
+    _lp_root=$(sh "$_lp_ss" resolve 2>/dev/null | sed -n 's/^session_root=//p')
+  fi
+  [ -n "$_lp_root" ] || _lp_root=$(pwd -P 2>/dev/null) || _lp_root=""
+  if [ -z "$_lp_root" ]; then
+    printf 'status=unknown\n'
+    printf 'reason=probe-unavailable:raiz-da-sessao-irresolvivel\n'
+    printf 'container=%s\n' "$_lp_container"
+    printf 'session_id=%s\n' "$_lp_sid"
+    printf 'mode=%s\n' "$_lp_mode"
+    return 0
+  fi
+
+  if sh "$_lp_ms" resolve --project-path "$_lp_root" --token "$_lp_sid" >/dev/null 2>&1; then
+    _lp_rc=0
+  else
+    _lp_rc=$?
+  fi
+  case "$_lp_rc" in
+    0)
+      printf 'status=active\n'
+      printf 'reason=-\n'
+      ;;
+    3)
+      printf 'status=unresolvable\n'
+      printf 'reason=token-unresolvable-under:%s\n' "$_lp_root"
+      ;;
+    *)
+      printf 'status=unknown\n'
+      printf 'reason=probe-failed:mcp-session.sh-exit-%s\n' "$_lp_rc"
+      ;;
+  esac
+  printf 'container=%s\n' "$_lp_container"
+  printf 'session_id=%s\n' "$_lp_sid"
+  printf 'mode=%s\n' "$_lp_mode"
+  return 0
 }
 
 # _mcp_gen_token -> imprime em stdout um token hex de 32 bytes (256 bits,

--- a/plugins/cstk/commands/agente-00c-resume.md
+++ b/plugins/cstk/commands/agente-00c-resume.md
@@ -1,6 +1,6 @@
 ---
 description: 'Retoma execucao 00C apos pausa por bloqueio humano ou schedule entre ondas. Valida hash de integridade (FR-029), aplica resposta a bloqueios pendentes, delega proxima onda ao agente-00c-orchestrator.'
-argument-hint: "[--projeto-alvo-path <path>] [--resposta-bloqueio <id>:<resposta>] [--init-aspectos <json-array>] [--init-aspectos-tecnicos <json-array>] [--init-aspectos-operacionais <json-array>]"
+argument-hint: "[--projeto-alvo-path <path>] [--resposta-bloqueio <id>:<resposta>] [--init-aspectos <json-array>] [--init-aspectos-tecnicos <json-array>] [--init-aspectos-operacionais <json-array>] [--allow-target-outside-session]"
 allowed-tools:
   - Agent
   - Read
@@ -37,8 +37,20 @@ Extrair:
   `drift.sh init --force`.
 - `--init-aspectos-tecnicos` opcional, JSON array 0..7 strings
 - `--init-aspectos-operacionais` opcional, JSON array 0..7 strings
+- `--allow-target-outside-session` opcional; capturar em `_scope_allow`
+  (`--allow-outside` quando presente). Bypass explicito e auditado da
+  validacao abaixo (issues #189/#190/#191).
 
 Defina `<SD> = <PAP>/.claude/agente-00c-state` para os comandos abaixo.
+
+Antes do lock, valide que `<PAP>` e a RAIZ DESTA SESSAO (mesma guarda da
+secao 2 do `/agente-00c`: hooks de guarda e servidor MCP so operam sob a
+raiz da sessao; retomar de outra raiz roda a onda SEM guarda enforced e
+com toda tool MCP em SESSION_MISMATCH):
+
+```
+session-scope.sh check --projeto-alvo-path <PAP> $_scope_allow || exit 3
+```
 
 ### 2. Adquirir lock
 
@@ -230,19 +242,26 @@ nesta retomada:
 ### 5.e. Verificar saude do servidor MCP (paridade FR-011, sem restart) — FASE 6 task 6.2.2
 
 Best-effort, puramente observacional: `status --live` roda um health
-check REAL quando `mode=docker` e a sessao nao esta `stopped`, mas NUNCA
-reinicia o container nem muta o descritor em disco
-(contracts/mcp-session-lifecycle.md "`cstk mcp status --live`"). Roda a
-cada retomada, ANTES do spawn (passo 6), independente do passo 5:
+check REAL — em `mode=docker` (legado), a sonda do container; em
+`mode=direct` (issue #191), apresenta o `session_id` do descritor a
+`mcp-session.sh resolve` sob a raiz da sessao, o MESMO caminho de
+autorizacao que toda tool percorre — e NUNCA reinicia nada nem muta o
+descritor em disco (contracts/mcp-session-lifecycle.md "`cstk mcp status
+--live`"). Roda a cada retomada, ANTES do spawn (passo 6), independente
+do passo 5, e o `status=` DEVE ser lido (nao descartado):
 
 ```bash
-cstk mcp status --state-dir <SD> --live >/dev/null 2>&1 || :
+_mcp_live=$(cstk mcp status --state-dir <SD> --live 2>/dev/null | sed -n 's/^status=//p') || :
 ```
 
-Se a sonda reportar `status=unavailable` (container caiu durante a
-pausa), nenhuma acao adicional AQUI — o proximo spawn segue via caminho
-Bash. Esta etapa cobre so a verificacao de saude, nao a comutacao
-mid-onda (protocolo da task 5.5).
+- `active` = sonda saudavel (descritor ok E token resolve).
+- `unresolvable` (mode=direct: token NAO resolve sob a raiz desta sessao —
+  `reason=token-unresolvable-under:<raiz>`), `unavailable` (container caiu
+  durante a pausa), `stopped`, `unknown` ou vazio = sonda NAO saudavel:
+  nenhuma acao adicional AQUI — o proximo spawn segue via caminho Bash.
+  Antes da #191 o mode=direct respondia `active` incondicionalmente. Esta
+  etapa cobre so a verificacao de saude, nao a comutacao mid-onda
+  (protocolo da task 5.5).
 
 **Injecao do token de capacidade (dec-043 / SEC-H3, generalizada FR-013)**:
 apos a sonda, leia o descritor e injete o token no contexto do spawn
@@ -260,8 +279,9 @@ _mcp_token=$(jq -r '.session_id // ""' "<SD>/mcp-server.json" 2>/dev/null) || _m
   `MCP: servidor de estado ativo; session_id=<token>. Prefira as tools
   mcp__cstk-state__* apresentando ESTE session_id; em erro de transporte,
   contrato de queda mid-onda e comutacao para Bash.`
-- Token vazio ou sonda unavailable ⇒ NAO mencione MCP no prompt (caminho
-  Bash, zero regressao). Token NUNCA ecoado em stdout/logs.
+- Token vazio ou sonda NAO saudavel (`_mcp_live` != `active`) ⇒
+  NAO mencione MCP no prompt (caminho Bash, zero regressao).
+  Token NUNCA ecoado em stdout/logs.
 
 **Idempotencia dos opt-ins em retomada (task 5.2.1 — mcp-elicitation-optins,
 FR-008/FR-011)**: este resume NUNCA re-pergunta opt-ins por prosa (ja

--- a/plugins/cstk/commands/agente-00c.md
+++ b/plugins/cstk/commands/agente-00c.md
@@ -1,6 +1,6 @@
 ---
 description: 'Inicia execucao do orquestrador autonomo agente-00C sobre um projeto-alvo. Cria state em <projeto-alvo>/.claude/agente-00c-state/ e delega pipeline SDD ao agente-00c-orchestrator.'
-argument-hint: "<descricao-curta> [--stack <stack-json>] [--whitelist <path>] [--projeto-alvo-path <path>] [--canonical-project <name>]"
+argument-hint: "<descricao-curta> [--stack <stack-json>] [--whitelist <path>] [--projeto-alvo-path <path>] [--canonical-project <name>] [--allow-target-outside-session]"
 allowed-tools:
   - Agent
   - Read
@@ -125,7 +125,10 @@ execucao nao-interativa e abortar inviabilizaria automacao"`.
 
 Extrair `descricao-curta` (primeiro posicional, minimo 10 chars),
 `--stack`, `--whitelist`, `--projeto-alvo-path` (default = cwd),
-`--canonical-project NAME` (opcional, capturar em `_canonical_flag`).
+`--canonical-project NAME` (opcional, capturar em `_canonical_flag`) e
+`--allow-target-outside-session` (opcional, capturar em `_scope_allow` =
+`--allow-outside` quando presente; bypass explicito e auditado da
+validacao de raiz da sessao na secao 2 — issues #189/#190/#191).
 
 `--canonical-project` fixa a identidade de projeto na knowledge.db/anti-eco
 com PRECEDENCIA sobre a deteccao de worktree (secao 2, `_canonical`). Uso:
@@ -174,6 +177,16 @@ ja preparado fora do script), apenas defensivo.
   fora das zonas proibidas (`/`, `/etc`, `/usr`, `/var`, `~/.claude`,
   `~/.ssh`, `~/.config`, `~/.aws`, `~/.docker`) — FR-024.
   Use `path-guard.sh validate-target --projeto-alvo-path <PAP>`.
+- `<PAP>` deve ser a RAIZ DESTA SESSAO (issues #189/#190/#191): o harness
+  carrega os hooks de guarda e o servidor MCP da raiz da sessao, e ambos
+  ancoram "ha execucao ativa?" nela — um PAP em outro diretorio roda a
+  execucao inteira com a guarda de Bash INERTE (tool_calls=0, medido) e
+  toda tool mcp__cstk-state__* em SESSION_MISMATCH, com todo diagnostico
+  reportando verde. Fail-closed ANTES de lock/state:
+  `session-scope.sh check --projeto-alvo-path <PAP> $_scope_allow || exit 3`
+  (exit 4 = recusado; repita o stderr ao operador — remediacao:
+  `cd <PAP> && claude`). Com bypass (`verdict=diverged-allowed`), o ramo
+  de opt-in cai obrigatoriamente em `legado` (secao 3, 6o check).
 - `descricao-curta` <= 500 chars; sanitizar antes de qualquer uso em
   commit message, issue ou path — FR-025.
   Use `sanitize.sh check-length --max 500`.
@@ -359,9 +372,13 @@ fi
 #   (c) a tool visivel no SEU toolset — unica prova real (cobre tambem
 #       sessao bootada antes do .mcp.json e servidor de projeto nao
 #       aprovado, que nenhum probe de disco enxerga).
+# `--projeto-alvo-path <PAP>` (issue #190, 6o check): o servidor MCP desta
+# sessao resolve tokens sob a RAIZ DA SESSAO, nao sob o PAP — alvo fora da
+# raiz (so possivel via bypass da secao 2) => `idle|projeto-alvo fora da
+# raiz da sessao ...` e o ramo cai em legado sem queimar a onda-001.
 _optin_preflight=""
 if [ "$_optin_branch" = "candidato" ]; then
-  _optin_preflight=$(mcp-launch.sh preflight 2>/dev/null) || :
+  _optin_preflight=$(mcp-launch.sh preflight --projeto-alvo-path "<PAP>" 2>/dev/null) || :
   case "$_optin_preflight" in
     ready\|*) : ;;                       # servidor real serviria as tools
     *)        _optin_branch="legado" ;;  # `idle|<motivo>` ou helper ausente

--- a/plugins/cstk/commands/feature-00c-resume.md
+++ b/plugins/cstk/commands/feature-00c-resume.md
@@ -29,6 +29,9 @@ $ARGUMENTS
 short_name           = primeiro argumento posicional (OBRIGATORIO, kebab-case)
 --resposta-bloqueio  = string OBRIGATORIA se status = aguardando_humano
 --projeto PATH       = default = cwd (caso operador esteja em diretorio diferente)
+--allow-target-outside-session = opcional; capturar em `_scope_allow`
+                       (`--allow-outside` quando presente). Bypass explicito e
+                       auditado do passo 2.bis (issues #189/#190/#191).
 ```
 
 ### 2. Localizar state dir
@@ -43,6 +46,13 @@ if [ ! -d "$AGENTE_00C_STATE_DIR" ]; then
   stderr "Verifique o short-name ou invoque /feature-00c novamente"
   exit 6
 fi
+
+# 2.bis. projeto-alvo sob a raiz DESTA sessao (issues #189/#190/#191) —
+# mesma guarda do pre-flight 1.bis do /feature-00c: hooks de guarda e
+# servidor MCP so operam sob a raiz da sessao; retomar de outra raiz roda
+# a onda SEM guarda enforced (tool_calls=0) e com toda tool MCP em
+# SESSION_MISMATCH. Fail-closed ANTES do lock; bypass explicito auditado.
+session-scope.sh check --projeto-alvo-path "$_proj" $_scope_allow || exit 3
 
 # Backend-agnostico (state-db-runtime-parity, v6.3): sob backend SQLite
 # NAO existe state.json — o estado transacional e state.db. Exigir
@@ -173,17 +183,25 @@ fi
 
 6.bis. verificar saude do servidor MCP (paridade FR-011, sem restart) —
    FASE 6 task 6.2.2. Best-effort, puramente observacional: `status --live`
-   roda um health check REAL quando mode=docker e a sessao nao esta
-   stopped, mas NUNCA reinicia o container nem muta o descritor em disco
-   (contracts/mcp-session-lifecycle.md "cstk mcp status --live"). Roda a
-   cada retomada, independente do passo 6:
+   roda um health check REAL — em mode=docker (legado), a sonda do
+   container; em mode=direct (issue #191), apresenta o `session_id` do
+   descritor a `mcp-session.sh resolve` sob a raiz da sessao, o MESMO
+   caminho de autorizacao que toda tool percorre — e NUNCA reinicia nada
+   nem muta o descritor em disco (contracts/mcp-session-lifecycle.md
+   "cstk mcp status --live"). Roda a cada retomada, independente do
+   passo 6, e o `status=` DEVE ser lido (nao descartado):
 
-     cstk mcp status --state-dir "$AGENTE_00C_STATE_DIR" --live >/dev/null 2>&1 || :
+     _mcp_live=$(cstk mcp status --state-dir "$AGENTE_00C_STATE_DIR" --live 2>/dev/null | sed -n 's/^status=//p') || :
 
-   Se a sonda reportar `status=unavailable` (container caiu durante a
-   pausa), nenhuma acao adicional AQUI — o proximo spawn segue via
-   caminho Bash. Esta etapa cobre so a verificacao de saude, nao a
-   comutacao mid-onda (essa e o protocolo da task 5.5).
+   - `active` = sonda saudavel (descritor ok E token resolve).
+   - `unresolvable` (mode=direct: descritor ok, token NAO resolve sob a raiz
+     desta sessao — `reason=token-unresolvable-under:<raiz>`), `unavailable`
+     (container caiu durante a pausa), `stopped`, `unknown` ou vazio = sonda
+     NAO saudavel: nenhuma acao adicional AQUI — o proximo spawn segue via
+     caminho Bash. Antes da #191 o mode=direct respondia `active`
+     incondicionalmente e instruia o orquestrador a usar tools que falhavam
+     100% das vezes. Esta etapa cobre so a verificacao de saude, nao a
+     comutacao mid-onda (essa e o protocolo da task 5.5).
 
    **Injecao do token de capacidade (dec-043 / SEC-H3, generalizada
    FR-013)**: apos a sonda, leia o descritor e injete o token no contexto
@@ -199,8 +217,9 @@ fi
      `MCP: servidor de estado ativo; session_id=<token>. Prefira as tools
      mcp__cstk-state__* apresentando ESTE session_id; em erro de
      transporte, contrato de queda mid-onda e comutacao para Bash.`
-   - Token vazio ou sonda unavailable ⇒ NAO mencione MCP no prompt
-     (caminho Bash, zero regressao). Token NUNCA ecoado em stdout/logs.
+   - Token vazio ou sonda NAO saudavel (`_mcp_live` != `active`) ⇒
+     NAO mencione MCP no prompt (caminho Bash, zero regressao).
+     Token NUNCA ecoado em stdout/logs.
 
    **Idempotencia dos opt-ins em retomada (task 5.4.1 — mcp-elicitation-optins,
    FR-008/FR-011)**: este resume NUNCA re-pergunta o opt-in de atomic-commit

--- a/plugins/cstk/commands/feature-00c.md
+++ b/plugins/cstk/commands/feature-00c.md
@@ -1,6 +1,6 @@
 ---
 description: 'Inicia execucao feature-00c sobre UMA feature individual em projeto com briefing+constitution ratificados. Cria state em .claude/feature-00c-state/<short-name>/ e delega pipeline SDD (specify→clarify→plan→checklist→create-tasks→execute-task→converge→review-task) ao agente-00c-feature-orchestrator.'
-argument-hint: '"<descricao-curta>" [<short-name>] [--projeto <path>] [--whitelist <urls>] [--canonical-project <name>]'
+argument-hint: '"<descricao-curta>" [<short-name>] [--projeto <path>] [--whitelist <urls>] [--canonical-project <name>] [--allow-target-outside-session]'
 allowed-tools:
   - Agent
   - Read
@@ -114,6 +114,13 @@ descricao_curta  = primeiro argumento (string em quotes, OBRIGATORIO, <=500 char
 short_name       = segundo argumento posicional opcional (kebab-case);
                    se omitido, derivar via specify
 --projeto PATH   = default = cwd
+--allow-target-outside-session = opcional; capturar em `_scope_allow`
+                   (`--allow-outside` quando presente, vazio caso contrario).
+                   Bypass EXPLICITO e AUDITADO do pre-flight 1.bis (issues
+                   #189/#190/#191): projeto-alvo fora da raiz da sessao =
+                   hooks de guarda inertes + tools MCP em SESSION_MISMATCH.
+                   Nunca use por rotina; o caminho certo e abrir a sessao
+                   no projeto-alvo (`cd <projeto> && claude`).
 --whitelist CSV  = URLs externas adicionais ao .env (opcional)
 --canonical-project NAME = opcional; capturar em `_canonical_flag`.
                    Identidade de projeto explicita para a knowledge.db/
@@ -163,6 +170,24 @@ Exporte: `AGENTE_00C_STATE_DIR=<projeto>/.claude/feature-00c-state/<short_name>`
 1. realpath do projeto:
    _proj=$(realpath "$PROJETO" 2>/dev/null) || abortar exit 1
    - rejeitar zonas proibidas via path-guard.sh validate-target
+
+1.bis. projeto-alvo sob a raiz DESTA sessao (issues #189/#190/#191):
+   session-scope.sh check --projeto-alvo-path "$_proj" $_scope_allow || exit 3
+   - fail-closed ANTES de lock/state: o harness carrega hooks (.claude/
+     settings.json) e o servidor MCP (.mcp.json) da RAIZ DA SESSAO, e ambos
+     ancoram "ha execucao ativa?" nessa raiz. Com `--projeto` apontando
+     para outro diretorio (caso real: worktree irma comandada do checkout
+     principal), guard-hooks-status responde 3/3 verde e a guarda de Bash
+     fica INERTE (tool_calls=0 em 3 ondas medidas) — e toda tool
+     mcp__cstk-state__* cai em SESSION_MISMATCH. O helper compara
+     `pwd -P`/CLAUDE_PROJECT_DIR com `$_proj` (igualdade estrita de paths
+     canonicos) e grava a decisao em <alvo>/.claude/enforcement-log.jsonl.
+   - exit 4 = recusado: repita a mensagem do stderr ao operador (remediacao:
+     `cd $_proj && claude`, ou `--allow-target-outside-session` consciente).
+   - exit 0 com `verdict=diverged-allowed` (bypass): siga, mas o ramo de
+     opt-in cai OBRIGATORIAMENTE em `legado` (secao 3, 6o check) — o bypass
+     nao faz a tool funcionar, so registra que o operador aceitou rodar SEM
+     guarda enforced.
 
 2. sanitizar descricao_curta:
    _desc=$(printf '%s' "$DESC" | sanitize.sh limit-length --max 500)
@@ -716,9 +741,15 @@ fi
 #   (c) a tool visivel no SEU toolset — unica prova real (cobre tambem
 #       sessao bootada antes do .mcp.json e servidor de projeto nao
 #       aprovado, que nenhum probe de disco enxerga).
+# `--projeto-alvo-path "$_proj"` (issue #190, 6o check): o servidor MCP
+# desta sessao resolve tokens SOB A RAIZ DA SESSAO (`mcp-session.sh:272`,
+# `_feat_root="$_project_path/.claude/feature-00c-state"`), nao sob o
+# projeto-alvo. Alvo fora da raiz (so possivel via bypass do 1.bis) =>
+# preflight responde `idle|projeto-alvo fora da raiz da sessao ...` e o
+# ramo cai em legado AQUI, sem queimar a onda-001 em SESSION_MISMATCH.
 _optin_preflight=""
 if [ "$_optin_branch" = "candidato" ]; then
-  _optin_preflight=$(mcp-launch.sh preflight 2>/dev/null) || :
+  _optin_preflight=$(mcp-launch.sh preflight --projeto-alvo-path "$_proj" 2>/dev/null) || :
   case "$_optin_preflight" in
     ready\|*) : ;;                       # servidor real serviria as tools
     *)        _optin_branch="legado" ;;  # `idle|<motivo>` ou helper ausente

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/guard-hooks-status.sh
@@ -47,6 +47,8 @@
 #
 # Subcomandos:
 #   guard-hooks-status.sh check --projeto-alvo-path PATH [--quiet]
+#       (issue #189: alvo fora da raiz da sessao => aviso ATENCAO em stderr
+#        via session-scope.sh verdict; TSV e exit inalterados)
 #       [--include-loose-usage] [--verify-registration]
 #       — stdout: uma linha TSV por hook (4 colunas; 5 com
 #         --verify-registration):
@@ -572,6 +574,24 @@ _gh_cmd_check() {
       _gh_err "posttooluse-loose-usage.sh esta present+registered, mas CSTK_OTEL_ENDPOINT esta AUSENTE no ambiente desta invocacao — o hook gateia nessa variavel (Passo 1) e sai 0 mudo, entao a captura de consumo avulso fica INERTE e 'cstk usage' responde 'nao medido'."
       _gh_err "  Remediacao: exportar CSTK_OTEL_ENDPOINT no ambiente do processo 'claude' — o wrapper 'claude()' de 'cstk help telemetry' (README.md, secao de telemetria) faz isso a cada lancamento."
       _gh_err "  Se o wrapper JA estiver instalado, esta leitura pode ser um falso alarme: o ambiente que conta e o do processo 'claude', nao o deste terminal."
+    fi
+  fi
+
+  # Efetividade (issue #189): `present registered current` responde sobre o
+  # PROJETO-ALVO; nenhuma das tres colunas responde "esses hooks vao disparar
+  # na sessao que conduz esta execucao?". O harness carrega hooks da RAIZ DA
+  # SESSAO e a guarda ancora "ha execucao ativa?" no cwd/ancestrais — com o
+  # alvo fora da raiz, 3/3 verde e guarda inerte (tool_calls=0 medido em 3
+  # ondas). Aviso em stderr (nao muda o TSV nem o exit: consumidores parseiam
+  # as 4 colunas; o gate real e session-scope.sh check no pre-flight dos
+  # commands). Forma PURA `verdict`: nunca grava enforcement-log daqui.
+  if [ "$_quiet" = 0 ] && [ -n "$_GH_RR_SELF_DIR" ] && [ -f "$_GH_RR_SELF_DIR/session-scope.sh" ]; then
+    if _ss_out=$(sh "$_GH_RR_SELF_DIR/session-scope.sh" verdict --projeto-alvo-path "$_pap" 2>/dev/null); then
+      :
+    elif [ "$?" -eq 4 ]; then
+      _ss_root=$(printf '%s\n' "$_ss_out" | sed -n 's/^session_root=//p')
+      _gh_err "ATENCAO: hooks registrados em $_pap NAO sao efetivos nesta sessao — raiz da sessao e ${_ss_root:-?}, e o harness so carrega hooks (e ancora a guarda) na raiz. Estado real: guarda de Bash INERTE, tool_calls=0 (issue #189)."
+      _gh_err "  Remediacao: abra a sessao no projeto-alvo (cd $_pap && claude). O pre-flight dos commands 00c recusa esta combinacao por default (session-scope.sh check)."
     fi
   fi
 

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/mcp-launch.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/mcp-launch.sh
@@ -67,7 +67,9 @@
 #
 # Uso:
 #   mcp-launch.sh              # entrypoint stdio (registrado no .mcp.json)
-#   mcp-launch.sh preflight    # diagnostico READ-ONLY (bugfix 8.3.1)
+#   mcp-launch.sh preflight [--projeto-alvo-path PATH]   # diagnostico READ-ONLY
+#       (bugfix 8.3.1; --projeto-alvo-path = 6o check da issue #190: alvo fora
+#        da raiz da sessao => `idle|projeto-alvo fora da raiz da sessao ...`)
 #
 # `preflight` (bugfix 8.3.1 — caso real: `/mcp` mostrava `cstk-state ·
 # connected · no tools` e o command pai, decidindo o ramo de opt-ins so pelo
@@ -110,11 +112,32 @@ _ml_die() {
 # "preflight" (diagnostico read-only). Qualquer outro argumento e uso
 # incorreto — o harness invoca SEM argumentos, entao nada quebra no boot.
 _ml_mode="serve"
+_ml_pf_target=""
 case "${1:-}" in
   "") ;;
-  preflight) _ml_mode="preflight" ;;
+  preflight)
+    _ml_mode="preflight"
+    shift
+    # `--projeto-alvo-path PATH` (issue #190): 6o check da decisao de ramo
+    # de opt-in. O servidor MCP desta sessao resolve tokens SOB A RAIZ DA
+    # SESSAO (`CSTK_MCP_PROJECT_PATH:-$(pwd)` abaixo); um projeto-alvo fora
+    # dela faz TODA chamada de tool cair em SESSION_MISMATCH mesmo com
+    # `.mcp.json` presente, `cstk mcp start` cunhando token e o entrypoint
+    # buildado — os cinco checks anteriores passavam verdes e a onda-001
+    # era queimada. A comparacao e delegada a session-scope.sh verdict
+    # (forma PURA: sem enforcement-log, sem bypass — o bypass do pre-flight
+    # nao faz a tool funcionar).
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --projeto-alvo-path)
+          [ "$#" -ge 2 ] || _ml_die "preflight: --projeto-alvo-path exige valor" 2
+          _ml_pf_target=$2; shift 2 ;;
+        *) _ml_die "preflight: argumento desconhecido: $1" 2 ;;
+      esac
+    done
+    ;;
   -h|--help)
-    printf 'uso: %s.sh [preflight]\n' "$_ML_NAME"
+    printf 'uso: %s.sh [preflight [--projeto-alvo-path PATH]]\n' "$_ML_NAME"
     exit 0
     ;;
   *) _ml_die "argumento desconhecido: $1 (aceito: preflight)" 2 ;;
@@ -256,6 +279,20 @@ fi
 # read-only para as causas mais comuns (mesmos pre-requisitos que
 # mcp-build-lazy.sh exige, sem executa-los).
 if [ "$_ml_mode" = "preflight" ]; then
+  if [ -n "$_ml_pf_target" ]; then
+    _ml_ss="$_ml_script_dir/session-scope.sh"
+    [ -f "$_ml_ss" ] \
+      || _ml_unavailable "session-scope.sh ausente em $_ml_script_dir — impossivel provar que o projeto-alvo esta sob a raiz da sessao"
+    if _ml_ss_out=$(sh "$_ml_ss" verdict --projeto-alvo-path "$_ml_pf_target" 2>/dev/null); then
+      :
+    else
+      _ml_ss_rc=$?
+      _ml_ss_root=$(printf '%s\n' "$_ml_ss_out" | sed -n 's/^session_root=//p')
+      [ "$_ml_ss_rc" -eq 4 ] \
+        || _ml_unavailable "session-scope.sh verdict falhou (exit $_ml_ss_rc) para --projeto-alvo-path $_ml_pf_target"
+      _ml_unavailable "projeto-alvo fora da raiz da sessao — o servidor MCP desta sessao resolve tokens sob ${_ml_ss_root:-?} (issue #190); abra a sessao no projeto-alvo ou siga pelo ramo legado"
+    fi
+  fi
   _ml_pf_entry="$_ml_state_server_dir/dist/src/index.js"
   if [ ! -f "$_ml_pf_entry" ]; then
     _ml_pf_why="dist/src/index.js ausente em $_ml_state_server_dir — build lazy nao concluiu nesta maquina"

--- a/plugins/cstk/skills/agente-00c-runtime/scripts/session-scope.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/session-scope.sh
@@ -1,0 +1,274 @@
+#!/bin/sh
+# session-scope.sh — raiz da sessao do harness x projeto-alvo da execucao
+# (issues #189/#190/#191 — mesma raiz: projeto-alvo != raiz da sessao).
+#
+# PROBLEMA QUE FECHA
+# ------------------
+# Os tres hooks de guarda (`pretooluse-bash-guard.sh` e os dois de metrica)
+# e o servidor MCP `cstk-state` desta sessao sao carregados a partir da RAIZ
+# DO PROJETO DA SESSAO do Claude Code (o `.claude/settings.json` e o
+# `.mcp.json` lidos no boot). Ambos ancoram a pergunta "ha execucao ativa?"
+# nessa raiz: o hook resolve o escopo por cwd/ancestrais/`CLAUDE_PROJECT_DIR`
+# (nunca desce, nunca sai do `.git`), e o servidor MCP varre
+# `<raiz>/.claude/{agente-00c-state,feature-00c-state}` (`mcp-session.sh
+# resolve --project-path`). Quando `--projeto` de um command 00c aponta para
+# OUTRO diretorio (caso tipico: worktree irma criada por `cstk session
+# start`, comandada do checkout principal), todo diagnostico responde verde
+# — hooks `present registered current`, `cstk mcp start` cunha token,
+# `mcp-launch.sh preflight` = `ready` — e ainda assim a guarda fica inerte
+# (`tool_calls: 0`, medido em 3 ondas reais) e toda tool MCP devolve
+# `SESSION_MISMATCH`. Guarda advisory na pratica, reportada como enforced.
+#
+# Este helper e a UNICA implementacao da pergunta "o projeto-alvo esta sob a
+# raiz desta sessao?" — commands, `guard-hooks-status.sh`, `mcp-launch.sh
+# preflight` e `cstk mcp status --live` delegam a ela em vez de reimplementar
+# (mesma disciplina de `state-backend.sh resolve` / `bash-guard.sh check`).
+#
+# RAIZ DA SESSAO (`resolve`)
+# --------------------------
+#   1. `$CLAUDE_PROJECT_DIR` quando definido e diretorio — e o que o harness
+#      exporta para HOOKS (o proprio `pretooluse-bash-guard.sh` a usa como
+#      fronteira). NAO chega ao ambiente da tool Bash (medido: ausente em
+#      `env` dentro de um command), por isso o passo 2.
+#   2. `pwd -P` — o cwd da tool Bash nasce na raiz da sessao e os commands 00c
+#      nunca fazem `cd` persistente (so em subshell). E EXATAMENTE o mesmo
+#      sinal que `mcp-launch.sh` usa (`CSTK_MCP_PROJECT_PATH:-$(pwd)`) para o
+#      servidor MCP: se divergir daqui, diverge la.
+#   Nao existe override por env: uma env var que redirecionasse a raiz seria
+#   um bypass nao auditado (mesma razao pela qual o hook consulta
+#   `CLAUDE_PROJECT_DIR` por ultimo e so como fronteira). O bypass existe, e
+#   explicito e auditado (`--allow-outside`, abaixo).
+#
+# VEREDITO (`check`)
+# ------------------
+# Igualdade ESTRITA de caminhos canonicos (`cd && pwd -P` nos dois lados).
+# Subdiretorio NAO e "alinhado": o hook nunca desce a partir do cwd e o
+# servidor MCP so varre `<raiz>/.claude/` — um alvo abaixo da raiz e tao
+# inerte quanto um irmao.
+#
+#   aligned          raiz == alvo                              exit 0
+#   diverged         raiz != alvo, sem bypass (fail-closed)    exit 4
+#   diverged-allowed raiz != alvo, bypass explicito            exit 0
+#                    (`--allow-outside` ou
+#                    `CSTK_ALLOW_TARGET_OUTSIDE_SESSION=1`),
+#                    aviso de alta visibilidade em stderr
+#
+# Toda divergencia (recusada OU permitida) vira linha auditavel em
+# `<projeto-alvo>/.claude/enforcement-log.jsonl` (`source:"session-scope"`,
+# `outcome: refused|bypass-allowed`), mesmo arquivo e idioma do
+# `serve-integrity` (`--allow-unverified`). Best-effort: falha de escrita
+# nunca muda o veredito.
+#
+# USO
+# ---
+#   session-scope.sh resolve
+#       stdout: session_root=<path>
+#               source=claude-project-dir|cwd
+#   session-scope.sh verdict --projeto-alvo-path PATH
+#       Comparacao PURA (sem log, sem bypass): para consumidores que so
+#       diagnosticam (`mcp-launch.sh preflight`, `guard-hooks-status.sh
+#       check`, `cstk mcp status --live`) e nao devem gravar `refused`
+#       no enforcement-log nem honrar o bypass — a tool MCP e o hook nao
+#       passam a funcionar porque o operador aceitou o risco.
+#       stdout: session_root=<path>
+#               target_project_path=<path>
+#               verdict=aligned|diverged
+#       exit 0 aligned · 4 diverged
+#   session-scope.sh check --projeto-alvo-path PATH [--allow-outside] [--quiet]
+#       stdout: session_root=<path>
+#               target_project_path=<path>
+#               verdict=aligned|diverged|diverged-allowed
+#               reason=-|<texto>
+#       --quiet suprime o stdout (exit code e o log continuam).
+#
+# Exit codes: 0 ok/alinhado/permitido · 1 erro (path inexistente) · 2 uso
+# incorreto · 4 diverged (recusado).
+#
+# POSIX sh puro (sem jq): o projeto-alvo pode estar mal provisionado.
+
+set -eu
+
+_SS_NAME="session-scope"
+
+_ss_die() {
+  printf '%s: %s\n' "$_SS_NAME" "$1" >&2
+  exit "${2:-1}"
+}
+
+_ss_die_usage() {
+  printf '%s: %s\n' "$_SS_NAME" "$1" >&2
+  printf 'uso: session-scope.sh resolve | verdict --projeto-alvo-path PATH | check --projeto-alvo-path PATH [--allow-outside] [--quiet]\n' >&2
+  exit 2
+}
+
+# _ss_canon PATH -> caminho canonico (symlinks resolvidos) ou falha.
+_ss_canon() {
+  [ -d "$1" ] || return 1
+  (CDPATH='' cd -- "$1" 2>/dev/null && pwd -P)
+}
+
+# _ss_json_escape S — escape minimo para valor JSON (barra, aspas, newline).
+_ss_json_escape() {
+  printf '%s' "$1" | awk '
+    {
+      gsub(/\\/, "\\\\");
+      gsub(/"/, "\\\"");
+      out = out (NR > 1 ? "\\n" : "") $0
+    }
+    END { printf "%s", out }
+  '
+}
+
+# _ss_session_root -> imprime "<root>\t<source>"; falha se nada resolver.
+_ss_session_root() {
+  if [ -n "${CLAUDE_PROJECT_DIR:-}" ] && [ -d "${CLAUDE_PROJECT_DIR}" ]; then
+    if _r=$(_ss_canon "$CLAUDE_PROJECT_DIR"); then
+      printf '%s\tclaude-project-dir\n' "$_r"
+      return 0
+    fi
+  fi
+  _r=$(pwd -P 2>/dev/null) || return 1
+  printf '%s\tcwd\n' "$_r"
+}
+
+# _ss_write_log TARGET ROOT OUTCOME — linha no enforcement-log do alvo.
+_ss_write_log() {
+  _wl_target=$1
+  _wl_root=$2
+  _wl_outcome=$3
+  _wl_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || _wl_ts=""
+  _wl_line=$(printf '{"source":"session-scope","timestamp":"%s","outcome":"%s","session_root":"%s","target_project_path":"%s"}' \
+    "$(_ss_json_escape "$_wl_ts")" \
+    "$(_ss_json_escape "$_wl_outcome")" \
+    "$(_ss_json_escape "$_wl_root")" \
+    "$(_ss_json_escape "$_wl_target")")
+  mkdir -p "$_wl_target/.claude" 2>/dev/null || return 0
+  printf '%s\n' "$_wl_line" >>"$_wl_target/.claude/enforcement-log.jsonl" 2>/dev/null || :
+  return 0
+}
+
+_ss_cmd_resolve() {
+  [ "$#" -eq 0 ] || _ss_die_usage "resolve nao aceita argumentos"
+  _rs=$(_ss_session_root) || _ss_die "nao consegui resolver a raiz da sessao (pwd falhou)" 1
+  _rs_root=${_rs%	*}
+  _rs_src=${_rs#*	}
+  printf 'session_root=%s\n' "$_rs_root"
+  printf 'source=%s\n' "$_rs_src"
+}
+
+# _ss_compare TARGET -> define _SS_ROOT/_SS_TARGET (canonicos) e retorna
+# 0 (aligned) ou 4 (diverged). UNICA implementacao da comparacao — `verdict`
+# e `check` so a embrulham (o mutation test em tests/test_session-scope.sh
+# neutraliza exatamente esta linha).
+_ss_compare() {
+  _SS_TARGET=$(_ss_canon "$1") \
+    || _ss_die "--projeto-alvo-path nao existe ou nao e diretorio: $1" 1
+  _rs=$(_ss_session_root) || _ss_die "nao consegui resolver a raiz da sessao (pwd falhou)" 1
+  _SS_ROOT=${_rs%	*}
+  if [ "$_SS_ROOT" = "$_SS_TARGET" ]; then
+    return 0
+  fi
+  return 4
+}
+
+# _ss_parse_target ARGS... -> _SS_ARG_TARGET/_SS_ARG_ALLOW/_SS_ARG_QUIET
+_ss_parse_target() {
+  _SS_ARG_TARGET=""
+  _SS_ARG_ALLOW=""
+  _SS_ARG_QUIET=""
+  _pt_sub=$1; shift
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --projeto-alvo-path)
+        [ "$#" -ge 2 ] || _ss_die_usage "--projeto-alvo-path exige valor"
+        _SS_ARG_TARGET=$2; shift 2 ;;
+      --allow-outside)
+        [ "$_pt_sub" = "check" ] || _ss_die_usage "$_pt_sub: --allow-outside so existe em check"
+        _SS_ARG_ALLOW=1; shift ;;
+      --quiet)
+        [ "$_pt_sub" = "check" ] || _ss_die_usage "$_pt_sub: --quiet so existe em check"
+        _SS_ARG_QUIET=1; shift ;;
+      *) _ss_die_usage "$_pt_sub: flag desconhecida: $1" ;;
+    esac
+  done
+  [ -n "$_SS_ARG_TARGET" ] || _ss_die_usage "$_pt_sub: --projeto-alvo-path e obrigatorio"
+}
+
+_ss_cmd_verdict() {
+  _ss_parse_target verdict "$@"
+  if _ss_compare "$_SS_ARG_TARGET"; then _vd_verdict="aligned"; _vd_exit=0
+  else _vd_verdict="diverged"; _vd_exit=4
+  fi
+  printf 'session_root=%s\n' "$_SS_ROOT"
+  printf 'target_project_path=%s\n' "$_SS_TARGET"
+  printf 'verdict=%s\n' "$_vd_verdict"
+  exit "$_vd_exit"
+}
+
+_ss_cmd_check() {
+  _ss_parse_target check "$@"
+  _ck_allow=$_SS_ARG_ALLOW
+  [ "${CSTK_ALLOW_TARGET_OUTSIDE_SESSION:-}" = "1" ] && _ck_allow=1
+
+  if _ss_compare "$_SS_ARG_TARGET"; then
+    _ck_verdict="aligned"
+    _ck_reason="-"
+    _ck_exit=0
+  else
+    _ck_reason="projeto-alvo fora da raiz da sessao — hooks de guarda e servidor MCP desta sessao operam sob $_SS_ROOT"
+    if [ -n "$_ck_allow" ]; then
+      _ck_verdict="diverged-allowed"
+      _ck_exit=0
+      _ss_write_log "$_SS_TARGET" "$_SS_ROOT" "bypass-allowed"
+      printf '%s: AVISO -- prosseguindo com projeto-alvo FORA da raiz da sessao (bypass explicito): hooks de guarda registrados em %s NAO gateiam esta sessao e as tools mcp__cstk-state__* nao resolvem o token desta execucao\n' \
+        "$_SS_NAME" "$_SS_TARGET" >&2
+    else
+      _ck_verdict="diverged"
+      _ck_exit=4
+      _ss_write_log "$_SS_TARGET" "$_SS_ROOT" "refused"
+      printf '%s: recusado -- projeto-alvo %s fora da raiz da sessao %s\n' \
+        "$_SS_NAME" "$_SS_TARGET" "$_SS_ROOT" >&2
+      printf '%s: as guardas enforced (hooks) e o servidor MCP desta sessao so operam sob a raiz; abra a sessao no projeto-alvo (cd %s && claude) ou use --allow-outside / CSTK_ALLOW_TARGET_OUTSIDE_SESSION=1 conscientemente (auditado)\n' \
+        "$_SS_NAME" "$_SS_TARGET" >&2
+    fi
+  fi
+
+  if [ -z "$_SS_ARG_QUIET" ]; then
+    printf 'session_root=%s\n' "$_SS_ROOT"
+    printf 'target_project_path=%s\n' "$_SS_TARGET"
+    printf 'verdict=%s\n' "$_ck_verdict"
+    printf 'reason=%s\n' "$_ck_reason"
+  fi
+  exit "$_ck_exit"
+}
+
+# ---------- Dispatch ----------
+
+if [ "$#" -lt 1 ]; then
+  _ss_die_usage "subcomando ausente (resolve | verdict | check)"
+fi
+_ss_sub=$1
+shift
+case "$_ss_sub" in
+  resolve) _ss_cmd_resolve "$@" ;;
+  verdict) _ss_cmd_verdict "$@" ;;
+  check)   _ss_cmd_check "$@" ;;
+  -h|--help)
+    cat <<'HELP'
+Uso: session-scope.sh resolve
+     session-scope.sh verdict --projeto-alvo-path PATH   (puro: sem log, sem bypass)
+     session-scope.sh check --projeto-alvo-path PATH [--allow-outside] [--quiet]
+
+Compara a raiz da sessao do harness (CLAUDE_PROJECT_DIR ou pwd -P) com o
+projeto-alvo. Divergencia = hooks de guarda inertes + tools MCP em
+SESSION_MISMATCH para esta execucao (issues #189/#190/#191).
+
+Vereditos: aligned (exit 0) | diverged (exit 4, fail-closed) |
+diverged-allowed (exit 0; --allow-outside ou
+CSTK_ALLOW_TARGET_OUTSIDE_SESSION=1; aviso em stderr). Toda divergencia
+vira linha em <alvo>/.claude/enforcement-log.jsonl (source=session-scope).
+HELP
+    exit 0
+    ;;
+  *) _ss_die_usage "subcomando desconhecido: $_ss_sub" ;;
+esac

--- a/tests/cstk/test_mcp.sh
+++ b/tests/cstk/test_mcp.sh
@@ -260,6 +260,92 @@ scenario_status_state_dir_inexistente_exit_1() {
   [ "$_CAPTURED_EXIT" = 1 ] || { _fail "state-dir inexistente exit" "esperado 1, obtido $_CAPTURED_EXIT"; return 1; }
 }
 
+# ---------- status --live em mode=direct (issue #191: sonda REAL por token) ----------
+# Antes: --live era no-op em mode=direct e respondia `active` com 100% das
+# tools em SESSION_MISMATCH (descritor ok, mas token irresoluvel sob a raiz
+# da sessao hospedeira). Agora exercita `mcp-session.sh resolve
+# --project-path <raiz da sessao>` com o session_id do descritor.
+
+# _mk_live_direct_fixture -> ROOT (raiz da sessao) com execucao feature-00c
+# ativa + descritor mode=direct, e OTHER (outra raiz). Define _LD_ROOT,
+# _LD_OTHER, _LD_SD.
+_mk_live_direct_fixture() {
+  _LD_ROOT="$TMPDIR_TEST/session-root"
+  _LD_OTHER="$TMPDIR_TEST/other-root"
+  mkdir -p "$_LD_ROOT" "$_LD_OTHER"
+  _LD_ROOT=$(CDPATH='' cd -- "$_LD_ROOT" && pwd -P)
+  _LD_OTHER=$(CDPATH='' cd -- "$_LD_OTHER" && pwd -P)
+  _LD_SD="$_LD_ROOT/.claude/feature-00c-state/minha-feature"
+  _init_active_exec_at "$_LD_ROOT" "$_LD_SD"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "fixture" "init falhou: $_CAPTURED_STDERR"; return 1; }
+  _write_descriptor "$_LD_SD" "tok-live-direct-0123456789abcdef" "direct" ""
+}
+
+# _cstk_mcp_from CWD ARGS... -> `cstk mcp` com cwd controlado e
+# CLAUDE_PROJECT_DIR desligada (raiz da sessao = cwd, como na tool Bash).
+_cstk_mcp_from() {
+  _cmf_cwd=$1; shift
+  capture sh -c 'cd -- "$1" && _lib=$2 && _bin=$3 && shift 3 && unset CLAUDE_PROJECT_DIR && exec env CSTK_LIB="$_lib" sh "$_bin" mcp "$@"' \
+    _ "$_cmf_cwd" "$CSTK_LIB_DIR" "$CSTK_BIN" "$@"
+}
+
+scenario_status_live_direct_token_resolve_sob_raiz_da_sessao_active() {
+  _mk_live_direct_fixture || return 1
+  _cstk_mcp_from "$_LD_ROOT" status --state-dir "$_LD_SD" --live
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "live direct exit" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "status=active" || return 1
+  assert_stdout_contains "reason=-" || return 1
+  assert_stdout_contains "mode=direct" || return 1
+}
+
+scenario_status_live_direct_token_irresoluvel_fora_da_raiz_reporta_unresolvable() {
+  _mk_live_direct_fixture || return 1
+  _cstk_mcp_from "$_LD_OTHER" status --state-dir "$_LD_SD" --live
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "live direct exit" "consulta respondida nunca falha: $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "status=unresolvable" || return 1
+  assert_stdout_contains "reason=token-unresolvable-under:$_LD_OTHER" || return 1
+  assert_stdout_contains "session_id=tok-live-direct-0123456789abcdef" || return 1
+  assert_stdout_not_contains "status=active" || return 1
+  # observacional: descritor intacto
+  _stopped=$(jq -r '.stopped_at // ""' "$_LD_SD/mcp-server.json")
+  [ -z "$_stopped" ] || { _fail "descritor mutado" "$_stopped"; return 1; }
+}
+
+scenario_status_live_direct_sem_live_continua_so_descritor() {
+  # Sem --live o contrato antigo permanece: so o descritor, sem sonda.
+  _mk_live_direct_fixture || return 1
+  _cstk_mcp_from "$_LD_OTHER" status --state-dir "$_LD_SD"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "status exit" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "status=active" || return 1
+}
+
+scenario_status_live_direct_execucao_terminal_reporta_unresolvable() {
+  # Descritor sem stopped_at, mas execucao ja terminal no state: a sonda
+  # segue o status REAL (dec-060/dec-061), como uma tool faria.
+  _mk_live_direct_fixture || return 1
+  capture env HOME="$TMPDIR_TEST/home" "$STATE_RW" set --state-dir "$_LD_SD" \
+    --field '.execution.status' --value '"concluida"' \
+    --field '.execution.finished_at' --value '"2026-09-02T00:00:00Z"'
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "fixture" "set terminal falhou: $_CAPTURED_STDERR"; return 1; }
+  _cstk_mcp_from "$_LD_ROOT" status --state-dir "$_LD_SD" --live
+  assert_stdout_contains "status=unresolvable" || return 1
+}
+
+scenario_status_live_direct_helper_ausente_reporta_unknown_nunca_active() {
+  _mk_live_direct_fixture || return 1
+  # Copia isolada de cli/lib: `$CSTK_LIB/../../plugins/...` nao existe, HOME
+  # sandbox sem catalogo, PATH sem mcp-session.sh => sonda indisponivel.
+  # Nunca promove a active por omissao.
+  _iso="$TMPDIR_TEST/isolated/cli/lib"; mkdir -p "$_iso" "$TMPDIR_TEST/home-vazio"
+  cp "$CSTK_LIB_DIR"/*.sh "$_iso/"
+  capture sh -c 'cd -- "$1" && unset CLAUDE_PROJECT_DIR && exec env HOME="$2" CSTK_LIB="$3" sh "$4" mcp status --state-dir "$5" --live' \
+    _ "$_LD_ROOT" "$TMPDIR_TEST/home-vazio" "$_iso" "$CSTK_BIN" "$_LD_SD"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "live direct exit" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "status=unknown" || return 1
+  assert_stdout_contains "reason=probe-unavailable" || return 1
+  assert_stdout_not_contains "status=active" || return 1
+}
+
 # ---------- status --live (task 5.3.3, FR-010: reverifica saude sem reiniciar) ----------
 
 scenario_status_live_mode_docker_saudavel_permanece_active() {

--- a/tests/test_command-spawn-mcp-lifecycle.sh
+++ b/tests/test_command-spawn-mcp-lifecycle.sh
@@ -96,6 +96,54 @@ scenario_resume_feat_menciona_sem_restart() {
   assert_exit 0 grep -Eiq 'sem restart|sem reiniciar|nao reinicia' "$CMD_RES_FEAT" || return 1
 }
 
+# ==== issues #189/#190/#191: projeto-alvo != raiz da sessao ====
+# Os 4 commands recusam (fail-closed, bypass auditado) um projeto-alvo fora
+# da raiz da sessao ANTES do lock; os 2 inits passam o alvo ao preflight do
+# launcher (6o check); os 2 resumes LEEM o status= do --live (unresolvable
+# nao e saudavel).
+
+scenario_session_scope_check_nos_4_commands() {
+  for _f in "$CMD_INIT_AGENTE" "$CMD_INIT_FEAT" "$CMD_RES_AGENTE" "$CMD_RES_FEAT"; do
+    grep -Eq 'session-scope\.sh check --projeto-alvo-path .*\$_scope_allow \|\| exit 3' "$_f" \
+      || { _fail "session-scope" "$_f nao invoca session-scope.sh check ... \$_scope_allow || exit 3"; return 1; }
+    grep -Fq -- '--allow-target-outside-session' "$_f" \
+      || { _fail "bypass" "$_f nao documenta --allow-target-outside-session"; return 1; }
+  done
+}
+
+scenario_session_scope_check_precede_lock_nos_4_commands() {
+  for _f in "$CMD_INIT_AGENTE" "$CMD_INIT_FEAT" "$CMD_RES_AGENTE" "$CMD_RES_FEAT"; do
+    _l_ss=$(grep -n 'session-scope\.sh check --projeto-alvo-path' "$_f" | head -1 | cut -d: -f1)
+    _l_lock=$(grep -n 'state-lock\.sh acquire' "$_f" | head -1 | cut -d: -f1)
+    [ -n "$_l_ss" ] && [ -n "$_l_lock" ] \
+      || { _fail "ancora" "$_f: session-scope=$_l_ss lock=$_l_lock"; return 1; }
+    [ "$_l_ss" -lt "$_l_lock" ] \
+      || { _fail "ordem" "$_f: session-scope ($_l_ss) deve preceder o lock ($_l_lock)"; return 1; }
+  done
+}
+
+scenario_preflight_recebe_projeto_alvo_nos_2_inits() {
+  grep -Eq 'mcp-launch\.sh preflight --projeto-alvo-path "\$_proj"' "$CMD_INIT_FEAT" \
+    || { _fail "preflight" "feature-00c.md: preflight sem --projeto-alvo-path \"\$_proj\""; return 1; }
+  grep -Eq 'mcp-launch\.sh preflight --projeto-alvo-path "<PAP>"' "$CMD_INIT_AGENTE" \
+    || { _fail "preflight" "agente-00c.md: preflight sem --projeto-alvo-path \"<PAP>\""; return 1; }
+}
+
+scenario_resumes_leem_status_do_live_e_tratam_unresolvable() {
+  for _f in "$CMD_RES_AGENTE" "$CMD_RES_FEAT"; do
+    grep -Eq "_mcp_live=.*cstk mcp status .*--live.*sed -n 's/\^status=//p'" "$_f" \
+      || { _fail "live" "$_f nao le o status= do --live em _mcp_live"; return 1; }
+    grep -Fq 'unresolvable' "$_f" \
+      || { _fail "live" "$_f nao trata status=unresolvable"; return 1; }
+    grep -Fq '_mcp_live` != `active`' "$_f" \
+      || { _fail "live" "$_f: injecao do token deve exigir _mcp_live == active"; return 1; }
+    # o descarte antigo (>/dev/null ... || :) nao pode sobreviver
+    if grep -Eq 'cstk mcp status --state-dir [^|]*--live >/dev/null 2>&1 \|\| :' "$_f"; then
+      _fail "live" "$_f ainda descarta a saida do --live"; return 1
+    fi
+  done
+}
+
 # ==== 6.2.3: stop somente em estado terminal (concluida|abortada) ====
 
 scenario_init_agente_instrui_mcp_stop_terminal() {

--- a/tests/test_command-spawn-optin-elicitation.sh
+++ b/tests/test_command-spawn-optin-elicitation.sh
@@ -346,7 +346,9 @@ scenario_persistencia_legado_optin_responses_feature() {
 _scenario_gate_toolset_cmd() {
   # $1=arquivo $2=regex do prompt de prosa (ancora de ordem)
   _l_cand=$(_first_line_of "$1" '_optin_branch="candidato"')
-  _l_pf=$(_first_line_of "$1" 'mcp-launch\.sh preflight 2>/dev/null')
+  # issue #190: preflight recebe --projeto-alvo-path (6o check); a ancora
+  # aceita as duas formas para nao acoplar este teste ao valor do path.
+  _l_pf=$(_first_line_of "$1" 'mcp-launch\.sh preflight( --projeto-alvo-path [^ ]+)? 2>/dev/null')
   _l_ts=$(_first_line_of "$1" 'select:mcp__cstk-state__collect_optins')
   _l_prompt=$(_first_line_of "$1" "$2")
   [ -n "$_l_cand" ] && [ -n "$_l_pf" ] && [ -n "$_l_ts" ] && [ -n "$_l_prompt" ] \

--- a/tests/test_guard-hooks-status.sh
+++ b/tests/test_guard-hooks-status.sh
@@ -184,6 +184,57 @@ scenario_check_completo_exit0() {
   return 0
 }
 
+# ==== issue #189: efetividade — alvo fora da raiz da sessao ====
+# `present registered current` responde sobre o alvo; a sessao carrega hooks
+# da propria raiz. 3/3 verde + guarda inerte era o caso medido (tool_calls=0
+# em 3 ondas). O check avisa em stderr sem mudar TSV nem exit.
+
+# _ghs_from CWD ARGS... — check com cwd controlado (= raiz da sessao) e
+# CLAUDE_PROJECT_DIR desligada.
+_ghs_from() {
+  _gf_cwd=$1; shift
+  capture sh -c 'cd -- "$1" && shift && unset CLAUDE_PROJECT_DIR && exec env HOME="$TMPDIR_TEST/.home-sem-plugin" CLAUDE_PLUGIN_ROOT="" CSTK_OTEL_ENDPOINT="" sh "$@"' \
+    _ "$_gf_cwd" "$SCRIPT" "$@"
+}
+
+scenario_check_alvo_fora_da_raiz_da_sessao_avisa_inefetivo_sem_mudar_tsv() {
+  _p=$(_mkproj proj-worktree)
+  _fully_provisioned "$_p"
+  _root="$TMPDIR_TEST/session-root"; mkdir -p "$_root"
+  _ghs_from "$_root" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0 (TSV/exit inalterados), obtido $_CAPTURED_EXIT"; return 1; }
+  for _h in $_HOOKS; do
+    printf '%s\n' "$_CAPTURED_STDOUT" | grep -q "^$_h	present	registered	current$" \
+      || { _fail "TSV" "esperado '$_h present registered current' intacto"; return 1; }
+  done
+  assert_stderr_contains "NAO sao efetivos nesta sessao" || return 1
+  assert_stderr_contains "issue #189" || return 1
+  assert_stderr_contains "session-scope.sh check" || return 1
+  # forma PURA: o diagnostico nunca grava enforcement-log no alvo
+  [ ! -e "$_p/.claude/enforcement-log.jsonl" ] \
+    || { _fail "log" "check nao pode gravar enforcement-log"; return 1; }
+}
+
+scenario_check_alvo_na_raiz_da_sessao_nao_avisa_inefetivo() {
+  _p=$(_mkproj proj-raiz)
+  _fully_provisioned "$_p"
+  _ghs_from "$_p" check --projeto-alvo-path "$_p"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "exit" "esperado 0, obtido $_CAPTURED_EXIT"; return 1; }
+  case "$_CAPTURED_STDERR" in
+    *"NAO sao efetivos"*) _fail "stderr" "alinhado nao deve avisar: $_CAPTURED_STDERR"; return 1 ;;
+  esac
+}
+
+scenario_check_quiet_suprime_aviso_de_efetividade() {
+  _p=$(_mkproj proj-quiet)
+  _fully_provisioned "$_p"
+  _root="$TMPDIR_TEST/session-root"; mkdir -p "$_root"
+  _ghs_from "$_root" check --projeto-alvo-path "$_p" --quiet
+  case "$_CAPTURED_STDERR" in
+    *"NAO sao efetivos"*) _fail "stderr" "--quiet deveria suprimir o aviso"; return 1 ;;
+  esac
+}
+
 # ==== INV-3: projeto virgem (o caso real: 35 ondas, zero hooks) ====
 
 scenario_check_nenhum_hook_exit1() {

--- a/tests/test_mcp-launch.sh
+++ b/tests/test_mcp-launch.sh
@@ -286,6 +286,80 @@ scenario_preflight_ready_quando_dist_presente() {
   esac
 }
 
+# ---- preflight --projeto-alvo-path (issue #190: 6o check da decisao de ramo) ----
+
+# _run_preflight_target SSD TARGET — como _run_preflight, com cwd controlado
+# (= raiz da sessao simulada) e CLAUDE_PROJECT_DIR desligada.
+_run_preflight_target() {
+  _rpt_ssd=$1
+  _rpt_target=$2
+  _rpt_cwd=$3
+  _rpt_bin="$TMPDIR_TEST/bin-pf-target"
+  mkdir -p "$_rpt_bin"; _stub_node "$_rpt_bin" 22
+  capture sh -c 'cd -- "$1" && unset CLAUDE_PROJECT_DIR && exec env PATH="$2:$PATH" CSTK_MCP_STATE_SERVER_DIR="$3" "$4" preflight --projeto-alvo-path "$5" < /dev/null' \
+    _ "$_rpt_cwd" "$_rpt_bin" "$_rpt_ssd" "$SCRIPT" "$_rpt_target"
+}
+
+scenario_preflight_target_alinhado_continua_ready() {
+  _ssd="$TMPDIR_TEST/ssd-pf-target-ok"
+  _make_state_server_dir_with_dist "$_ssd"
+  _root="$TMPDIR_TEST/session-root"; mkdir -p "$_root"
+  _run_preflight_target "$_ssd" "$_root" "$_root"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "preflight target alinhado" "esperado 0, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "ready|$_ssd/dist/src/index.js" || return 1
+}
+
+scenario_preflight_target_fora_da_raiz_idle_exit_3_mesmo_com_dist() {
+  _ssd="$TMPDIR_TEST/ssd-pf-target-out"
+  _make_state_server_dir_with_dist "$_ssd"
+  _root="$TMPDIR_TEST/session-root"; mkdir -p "$_root"
+  _other="$TMPDIR_TEST/other-worktree"; mkdir -p "$_other"
+  _run_preflight_target "$_ssd" "$_other" "$_root"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "preflight target fora" "esperado 3, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "idle|projeto-alvo fora da raiz da sessao" || return 1
+  assert_stdout_contains "resolve tokens sob " || return 1
+  # forma PURA: diagnostico nunca grava enforcement-log no alvo
+  [ ! -e "$_other/.claude/enforcement-log.jsonl" ] \
+    || { _fail "log" "preflight nao pode gravar enforcement-log (forma pura)"; return 1; }
+}
+
+scenario_preflight_target_fora_ignora_bypass_de_env() {
+  # O bypass do pre-flight (CSTK_ALLOW_TARGET_OUTSIDE_SESSION) nao faz a
+  # tool funcionar: o preflight continua idle.
+  _ssd="$TMPDIR_TEST/ssd-pf-target-byp"
+  _make_state_server_dir_with_dist "$_ssd"
+  _root="$TMPDIR_TEST/session-root"; mkdir -p "$_root"
+  _other="$TMPDIR_TEST/other-worktree"; mkdir -p "$_other"
+  _bin="$TMPDIR_TEST/bin-pf-byp"; mkdir -p "$_bin"; _stub_node "$_bin" 22
+  capture sh -c 'cd -- "$1" && unset CLAUDE_PROJECT_DIR && CSTK_ALLOW_TARGET_OUTSIDE_SESSION=1 exec env PATH="$2:$PATH" CSTK_MCP_STATE_SERVER_DIR="$3" "$4" preflight --projeto-alvo-path "$5" < /dev/null' \
+    _ "$_root" "$_bin" "$_ssd" "$SCRIPT" "$_other"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "preflight bypass" "esperado 3, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "idle|projeto-alvo fora da raiz da sessao" || return 1
+}
+
+scenario_preflight_target_inexistente_idle_exit_3() {
+  _ssd="$TMPDIR_TEST/ssd-pf-target-404"
+  _make_state_server_dir_with_dist "$_ssd"
+  _root="$TMPDIR_TEST/session-root"; mkdir -p "$_root"
+  _run_preflight_target "$_ssd" "$TMPDIR_TEST/nao-existe" "$_root"
+  [ "$_CAPTURED_EXIT" = 3 ] || { _fail "preflight target 404" "esperado 3, obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "idle|session-scope.sh verdict falhou" || return 1
+}
+
+scenario_preflight_flag_desconhecida_exit_2() {
+  _ssd="$TMPDIR_TEST/ssd-pf-flag"
+  _make_state_server_dir_with_dist "$_ssd"
+  capture env CSTK_MCP_STATE_SERVER_DIR="$_ssd" "$SCRIPT" preflight --bogus < /dev/null
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "preflight flag" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+}
+
+scenario_preflight_projeto_alvo_path_sem_valor_exit_2() {
+  _ssd="$TMPDIR_TEST/ssd-pf-noval"
+  _make_state_server_dir_with_dist "$_ssd"
+  capture env CSTK_MCP_STATE_SERVER_DIR="$_ssd" "$SCRIPT" preflight --projeto-alvo-path < /dev/null
+  [ "$_CAPTURED_EXIT" = 2 ] || { _fail "preflight sem valor" "esperado 2, obtido $_CAPTURED_EXIT"; return 1; }
+}
+
 scenario_preflight_idle_state_server_ausente_exit_3() {
   _run_preflight "$TMPDIR_TEST/nao-existe-pf"
   [ "$_CAPTURED_EXIT" = 3 ] || { _fail "preflight idle exit" "esperado 3, obtido $_CAPTURED_EXIT: $_CAPTURED_STDERR"; return 1; }

--- a/tests/test_session-scope.sh
+++ b/tests/test_session-scope.sh
@@ -1,0 +1,303 @@
+#!/bin/sh
+# test_session-scope.sh — cobre
+# plugins/cstk/skills/agente-00c-runtime/scripts/session-scope.sh
+# (issues #189/#190/#191: projeto-alvo != raiz da sessao). Regra de ouro.
+#
+# Cobertura:
+#   resolve: CLAUDE_PROJECT_DIR (hook) vence; sem ela, pwd -P (tool Bash);
+#            CLAUDE_PROJECT_DIR inexistente e ignorada (cai em cwd)
+#   check:   aligned (mesmo path; symlink canonizado); diverged exit 4 +
+#            linha `refused` no enforcement-log do ALVO; subdiretorio da
+#            raiz NAO e alinhado; bypass por flag e por env => exit 0 +
+#            `bypass-allowed` + AVISO em stderr; --quiet; alvo inexistente
+#            exit 1; sem --projeto-alvo-path exit 2; falha de escrita do
+#            log nao muda veredito
+#   verdict: puro (sem log/stderr, ignora bypass, recusa --allow-outside)
+#   mutation: neutralizar a comparacao derruba os cenarios de divergencia
+#   -h/--help; subcomando desconhecido
+
+TESTS_ROOT="${TESTS_ROOT:-$(cd "$(dirname "$0")" && pwd)}"
+REPO_ROOT="${REPO_ROOT:-$(cd "$TESTS_ROOT/.." && pwd)}"
+
+. "$TESTS_ROOT/lib/harness.sh"
+
+SCRIPT="$REPO_ROOT/plugins/cstk/skills/agente-00c-runtime/scripts/session-scope.sh"
+
+# _expect_exit N -> confere o exit da ultima captura (assert_exit do harness
+# re-executa o comando; aqui a captura ja aconteceu com cwd controlado).
+_expect_exit() {
+  [ "$_CAPTURED_EXIT" = "$1" ] && return 0
+  _fail "exit" "esperado exit=$1, obtido exit=$_CAPTURED_EXIT; stderr=$_CAPTURED_STDERR"
+  return 1
+}
+
+# _canon PATH -> caminho canonico (macOS: /var -> /private/var).
+_canon() { (CDPATH='' cd -- "$1" && pwd -P); }
+
+# _mk_pair -> cria $ROOT (raiz da sessao) e $OTHER (alvo irmao) sob TMPDIR_TEST.
+_mk_pair() {
+  ROOT="$TMPDIR_TEST/session-root"
+  OTHER="$TMPDIR_TEST/other-worktree"
+  mkdir -p "$ROOT" "$OTHER"
+  ROOT=$(_canon "$ROOT")
+  OTHER=$(_canon "$OTHER")
+}
+
+# _run_in DIR CMD... -> executa com cwd=DIR e CLAUDE_PROJECT_DIR desligada.
+_run_in() {
+  _ri_dir=$1; shift
+  capture sh -c 'cd -- "$1" && shift && unset CLAUDE_PROJECT_DIR && exec "$@"' _ "$_ri_dir" "$@"
+}
+
+# ==== resolve ====
+
+scenario_resolve_usa_cwd_sem_claude_project_dir() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" resolve
+  _expect_exit 0 || return 1
+  assert_stdout_contains "session_root=$ROOT" || return 1
+  assert_stdout_contains "source=cwd" || return 1
+}
+
+scenario_resolve_claude_project_dir_vence_cwd() {
+  _mk_pair
+  capture sh -c 'cd -- "$1" && CLAUDE_PROJECT_DIR="$2" exec "$3" resolve' _ "$OTHER" "$ROOT" "$SCRIPT"
+  _expect_exit 0 || return 1
+  assert_stdout_contains "session_root=$ROOT" || return 1
+  assert_stdout_contains "source=claude-project-dir" || return 1
+}
+
+scenario_resolve_claude_project_dir_inexistente_cai_em_cwd() {
+  _mk_pair
+  capture sh -c 'cd -- "$1" && CLAUDE_PROJECT_DIR="$1/nao-existe" exec "$2" resolve' _ "$ROOT" "$SCRIPT"
+  _expect_exit 0 || return 1
+  assert_stdout_contains "session_root=$ROOT" || return 1
+  assert_stdout_contains "source=cwd" || return 1
+}
+
+scenario_resolve_recusa_argumentos() {
+  capture "$SCRIPT" resolve --foo
+  _expect_exit 2 || return 1
+}
+
+# ==== check: aligned ====
+
+scenario_check_aligned_mesmo_path_exit0_sem_log() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$ROOT"
+  _expect_exit 0 || return 1
+  assert_stdout_contains "verdict=aligned" || return 1
+  assert_stdout_contains "reason=-" || return 1
+  [ ! -e "$ROOT/.claude/enforcement-log.jsonl" ] \
+    || { _fail "log" "aligned nao deve gravar enforcement-log"; return 1; }
+}
+
+scenario_check_aligned_via_symlink_canonizado() {
+  _mk_pair
+  ln -s "$ROOT" "$TMPDIR_TEST/link-root"
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$TMPDIR_TEST/link-root"
+  _expect_exit 0 || return 1
+  assert_stdout_contains "verdict=aligned" || return 1
+  assert_stdout_contains "target_project_path=$ROOT" || return 1
+}
+
+# ==== check: diverged (fail-closed) ====
+
+scenario_check_diverged_irmao_exit4_reason_cita_raiz() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$OTHER"
+  _expect_exit 4 || return 1
+  assert_stdout_contains "verdict=diverged" || return 1
+  assert_stdout_contains "session_root=$ROOT" || return 1
+  assert_stdout_contains "target_project_path=$OTHER" || return 1
+  assert_stdout_contains "operam sob $ROOT" || return 1
+  assert_stderr_contains "recusado" || return 1
+  assert_stderr_contains "--allow-outside" || return 1
+}
+
+scenario_check_diverged_grava_refused_no_log_do_alvo() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$OTHER"
+  _expect_exit 4 || return 1
+  _log="$OTHER/.claude/enforcement-log.jsonl"
+  [ -f "$_log" ] || { _fail "log" "enforcement-log do ALVO nao criado: $_log"; return 1; }
+  [ ! -e "$ROOT/.claude/enforcement-log.jsonl" ] \
+    || { _fail "log" "log gravado na raiz da sessao, deveria ser no alvo"; return 1; }
+  _line=$(tail -n 1 "$_log")
+  case "$_line" in
+    *'"source":"session-scope"'*'"outcome":"refused"'*"\"session_root\":\"$ROOT\""*"\"target_project_path\":\"$OTHER\""*) ;;
+    *) _fail "log" "linha inesperada: $_line"; return 1 ;;
+  esac
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s\n' "$_line" | jq -e . >/dev/null 2>&1 \
+      || { _fail "log" "linha nao e JSON valido: $_line"; return 1; }
+  fi
+}
+
+scenario_check_subdiretorio_da_raiz_nao_e_alinhado() {
+  _mk_pair
+  mkdir -p "$ROOT/sub/projeto"
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$ROOT/sub/projeto"
+  _expect_exit 4 || return 1
+  assert_stdout_contains "verdict=diverged" || return 1
+}
+
+scenario_check_raiz_e_subdiretorio_do_alvo_nao_e_alinhado() {
+  _mk_pair
+  mkdir -p "$OTHER/nested"
+  _run_in "$OTHER/nested" "$SCRIPT" check --projeto-alvo-path "$OTHER"
+  _expect_exit 4 || return 1
+  assert_stdout_contains "verdict=diverged" || return 1
+}
+
+# ==== verdict: comparacao pura (sem log, sem bypass) ====
+
+scenario_verdict_diverged_exit4_sem_log_e_sem_stderr() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" verdict --projeto-alvo-path "$OTHER"
+  _expect_exit 4 || return 1
+  assert_stdout_contains "verdict=diverged" || return 1
+  assert_stdout_contains "session_root=$ROOT" || return 1
+  [ ! -e "$OTHER/.claude/enforcement-log.jsonl" ] \
+    || { _fail "log" "verdict e puro: nunca grava enforcement-log"; return 1; }
+  [ -z "$_CAPTURED_STDERR" ] || { _fail "stderr" "verdict nao avisa: $_CAPTURED_STDERR"; return 1; }
+}
+
+scenario_verdict_ignora_bypass_por_env() {
+  _mk_pair
+  capture sh -c 'cd -- "$1" && unset CLAUDE_PROJECT_DIR && CSTK_ALLOW_TARGET_OUTSIDE_SESSION=1 exec "$2" verdict --projeto-alvo-path "$3"' \
+    _ "$ROOT" "$SCRIPT" "$OTHER"
+  _expect_exit 4 || return 1
+  assert_stdout_contains "verdict=diverged" || return 1
+}
+
+scenario_verdict_recusa_allow_outside_exit2() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" verdict --projeto-alvo-path "$OTHER" --allow-outside
+  _expect_exit 2 || return 1
+}
+
+scenario_verdict_aligned_exit0() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" verdict --projeto-alvo-path "$ROOT"
+  _expect_exit 0 || return 1
+  assert_stdout_contains "verdict=aligned" || return 1
+}
+
+# ==== check: bypass explicito e auditado ====
+
+scenario_check_bypass_flag_exit0_aviso_e_log_bypass_allowed() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$OTHER" --allow-outside
+  _expect_exit 0 || return 1
+  assert_stdout_contains "verdict=diverged-allowed" || return 1
+  assert_stderr_contains "AVISO" || return 1
+  assert_stderr_contains "NAO gateiam" || return 1
+  _line=$(tail -n 1 "$OTHER/.claude/enforcement-log.jsonl")
+  case "$_line" in
+    *'"outcome":"bypass-allowed"'*) ;;
+    *) _fail "log" "esperado bypass-allowed: $_line"; return 1 ;;
+  esac
+}
+
+scenario_check_bypass_env_exit0() {
+  _mk_pair
+  capture sh -c 'cd -- "$1" && unset CLAUDE_PROJECT_DIR && CSTK_ALLOW_TARGET_OUTSIDE_SESSION=1 exec "$2" check --projeto-alvo-path "$3"' \
+    _ "$ROOT" "$SCRIPT" "$OTHER"
+  _expect_exit 0 || return 1
+  assert_stdout_contains "verdict=diverged-allowed" || return 1
+  assert_stderr_contains "AVISO" || return 1
+}
+
+scenario_check_env_diferente_de_1_nao_e_bypass() {
+  _mk_pair
+  capture sh -c 'cd -- "$1" && unset CLAUDE_PROJECT_DIR && CSTK_ALLOW_TARGET_OUTSIDE_SESSION=true exec "$2" check --projeto-alvo-path "$3"' \
+    _ "$ROOT" "$SCRIPT" "$OTHER"
+  _expect_exit 4 || return 1
+  assert_stdout_contains "verdict=diverged" || return 1
+}
+
+scenario_check_bypass_nao_se_aplica_quando_alinhado() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$ROOT" --allow-outside
+  _expect_exit 0 || return 1
+  assert_stdout_contains "verdict=aligned" || return 1
+  [ -z "$_CAPTURED_STDERR" ] || { _fail "stderr" "alinhado nao deve avisar: $_CAPTURED_STDERR"; return 1; }
+}
+
+# ==== check: --quiet, erros de uso ====
+
+scenario_check_quiet_suprime_stdout_mantem_exit_e_log() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$OTHER" --quiet
+  _expect_exit 4 || return 1
+  [ -z "$_CAPTURED_STDOUT" ] || { _fail "stdout" "--quiet deveria suprimir stdout: $_CAPTURED_STDOUT"; return 1; }
+  [ -f "$OTHER/.claude/enforcement-log.jsonl" ] || { _fail "log" "--quiet nao pode pular o log"; return 1; }
+}
+
+scenario_check_alvo_inexistente_exit1() {
+  _mk_pair
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$TMPDIR_TEST/nao-existe"
+  _expect_exit 1 || return 1
+  assert_stderr_contains "nao existe" || return 1
+}
+
+scenario_check_sem_projeto_alvo_path_exit2() {
+  capture "$SCRIPT" check
+  _expect_exit 2 || return 1
+  assert_stderr_contains "obrigatorio" || return 1
+}
+
+scenario_check_flag_desconhecida_exit2() {
+  _mk_pair
+  capture "$SCRIPT" check --projeto-alvo-path "$ROOT" --bogus
+  _expect_exit 2 || return 1
+}
+
+scenario_check_falha_de_escrita_do_log_nao_muda_veredito() {
+  _mk_pair
+  mkdir -p "$OTHER/.claude"
+  chmod 500 "$OTHER/.claude"
+  _run_in "$ROOT" "$SCRIPT" check --projeto-alvo-path "$OTHER"
+  chmod 700 "$OTHER/.claude"
+  _expect_exit 4 || return 1
+  assert_stdout_contains "verdict=diverged" || return 1
+}
+
+# ==== mutation test: a comparacao e o que sustenta a guarda ====
+
+scenario_mutation_comparacao_neutralizada_derruba_divergencia() {
+  _mk_pair
+  _mut="$TMPDIR_TEST/session-scope-mutant.sh"
+  sed 's/if \[ "\$_SS_ROOT" = "\$_SS_TARGET" \]; then/if :; then/' "$SCRIPT" >"$_mut"
+  grep -q 'if :; then' "$_mut" || { _fail "mutant" "sed nao encontrou a comparacao — teste stale"; return 1; }
+  chmod +x "$_mut"
+  _run_in "$ROOT" "$_mut" check --projeto-alvo-path "$OTHER"
+  # O mutante responde aligned onde o original responde diverged: prova que
+  # o cenario de divergencia depende da comparacao real, nao passa por
+  # construcao.
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "mutant" "mutante deveria passar (exit 0), obtido $_CAPTURED_EXIT"; return 1; }
+  assert_stdout_contains "verdict=aligned" || return 1
+}
+
+# ==== help / dispatch ====
+
+scenario_help_exit0() {
+  capture "$SCRIPT" --help
+  _expect_exit 0 || return 1
+  assert_stdout_contains "check --projeto-alvo-path PATH" || return 1
+  assert_stdout_contains "#189" || return 1
+}
+
+scenario_sem_subcomando_exit2() {
+  capture "$SCRIPT"
+  _expect_exit 2 || return 1
+}
+
+scenario_subcomando_desconhecido_exit2() {
+  capture "$SCRIPT" bogus
+  _expect_exit 2 || return 1
+  assert_stderr_contains "subcomando desconhecido" || return 1
+}
+
+run_all_scenarios


### PR DESCRIPTION
## Resumo

Resolve **#189**, **#190** e **#191** (mesma raiz: `--projeto` ≠ raiz da sessão do Claude Code) e registra o aceite consciente da **#177** em `SECURITY.md`.

O harness carrega os hooks de guarda (`.claude/settings.json`) e o servidor MCP (`.mcp.json`) da raiz da sessão, e ambos ancoram "há execução ativa?" nela. Com o alvo em outro diretório (caso real: worktree irmã comandada do checkout principal), `guard-hooks-status` respondia 3/3 verde, `cstk mcp start` cunhava token, `preflight` dizia `ready` e `--live` dizia `active` — e a guarda de Bash ficava inerte (`tool_calls=0` em 3 ondas) com 100% das tools em `SESSION_MISMATCH`.

## Mudanças

- **`session-scope.sh`** (novo, `agente-00c-runtime`): única implementação de "alvo == raiz da sessão". `resolve` (`CLAUDE_PROJECT_DIR` > `pwd -P`, sem override por env), `verdict` (puro: sem log, sem bypass — para diagnósticos) e `check` (fail-closed exit 4; bypass explícito `--allow-outside`/`CSTK_ALLOW_TARGET_OUTSIDE_SESSION=1`, auditado em `<alvo>/.claude/enforcement-log.jsonl` com `source=session-scope`, mesmo idioma do `--allow-unverified`).
- **#189** — os 4 commands 00c chamam `session-scope.sh check` **antes do lock** e ganham `--allow-target-outside-session`; `guard-hooks-status.sh check` emite ATENÇÃO de inefetividade em stderr (TSV/exit intactos).
- **#190** — `mcp-launch.sh preflight --projeto-alvo-path PATH` = 6º check determinístico da decisão de ramo (`idle|projeto-alvo fora da raiz da sessao — o servidor MCP desta sessao resolve tokens sob <raiz>`); os 2 inits passam o alvo → ramo `legado` sem queimar a onda-001.
- **#191** — `cstk mcp status --live` em `mode=direct` deixa de ser no-op: apresenta o `session_id` do descritor a `mcp-session.sh resolve` sob a raiz da sessão (mesmo caminho de autorização das tools) → `active` | `unresolvable` (`reason=token-unresolvable-under:<raiz>`) | `unknown` (sonda indisponível, nunca promovida a `active`). Os 2 resumes agora **leem** o `status=` antes de injetar o token no spawn.
- **`SECURITY.md`**: efetividade dos hooks por raiz de sessão (#189); "Known limitation — integrity, not provenance" para a #177 (risco aceito e por quê); §MCP atualizado para `mode=direct` (dizia "one Docker container per execution", falso desde v8.0.0).

Direção deliberada: o fix **não** faz o hook "seguir" o `--projeto` via env — o guard consulta `CLAUDE_PROJECT_DIR` por último e só como fronteira justamente para uma env var não redirecionar o escopo (vetor de bypass). A recusa no pre-flight respeita isso.

## Testes

- `tests/test_session-scope.sh` — 27 cenários (inclui mutation test: neutralizar a comparação derruba a divergência).
- `test_mcp-launch` +6, `test_guard-hooks-status` +3, `tests/cstk/test_mcp` +5, `test_command-spawn-mcp-lifecycle` +4 (prosa dos 4 commands).
- Suíte completa: verde (`--check-coverage` zero órfãos).

## Pós-release

Toca `cli/lib/mcp.sh` (runtime → `cstk self-update`) **e** catálogo (`session-scope.sh`, `mcp-launch.sh`, `guard-hooks-status.sh`, commands → `cstk update`/`install`). Atualizar só uma metade reproduz o "funciona no repo mas não na sessão".

Closes #189
Closes #190
Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRMKihs78cyzc4vwVfjPdJ