### PR TITLE
fix(feature-00c): reabertura grava opt-in herdado como channel=inherited, nunca prose (#192)

### DIFF
--- a/docs/specs/feature-reopen/contracts/reopen-flow.md
+++ b/docs/specs/feature-reopen/contracts/reopen-flow.md
@@ -126,6 +126,37 @@ qualquer outro valor faz `init` sair `2`
 Nenhum `--force` e necessario nem existe: apos a rotacao a raiz do state-dir nao
 tem mais `state.json`/`state.db`, e as guardas das L411-418 nao disparam.
 
+### Passo 3'.bis — registro do opt-in herdado *(novo, issue #192)*
+
+A heranca de FR-022 precisa de representacao em `.optin_responses[]`
+(Invariante I-2 do `state-ondas.sh start` exige registro do campo
+`atomic_commit` antes da onda-001). O enum `channel` de
+`mcp-elicitation-optins` ganhou o valor `inherited` (data-model.md, regra
+R-4) exatamente para isto — `prose` afirmaria um dialogo que 3' acabou de
+pular, e a ausencia de registro faria o orquestrador re-perguntar via
+`collect_optins`.
+
+```sh
+# logo apos o init de 3', independentemente do ramo de opt-in
+_prev_rec = registro mais recente de atomic_commit em rounds/<label> (ou null)
+append em .optin_responses[]:
+  { field: "atomic_commit", channel: "inherited",
+    outcome: _prev_rec.outcome | "absent",
+    applied_value: "$_atomic_herdado", recorded_at: <agora>,
+    reason: null | "round anterior sem registro ...; valor herdado de .atomic_commit_enabled",
+    inherited_from: "<label>" }
+_optin_inherited=1
+```
+
+Consequencias normativas na reabertura:
+
+- o passo 3.ter do `feature-00c.md` (registro `prose` do ramo legado) NAO
+  roda;
+- a linha `MCP: ramo estruturado de opt-ins ativo` NAO e injetada no spawn
+  — o orquestrador nao chama `collect_optins`;
+- reabertura **herda**, retomada (`/feature-00c-resume`) **le**; nenhuma
+  das duas pergunta nem "confirma com default".
+
 ### Passo 3'' — ponteiro e Decisao *(novo)*
 
 ```sh

--- a/docs/specs/mcp-elicitation-optins/data-model.md
+++ b/docs/specs/mcp-elicitation-optins/data-model.md
@@ -64,11 +64,12 @@ top-level, **append-only**, uma entrada por campo por execucao.
 | Field | Type | Constraints | Notes |
 |-------|------|-------------|-------|
 | `field` | enum | `atomic_commit` \| `roadmap_mode` \| `delivery_tier` | Identifica o opt-in |
-| `channel` | enum | `structured` \| `prose` | Canal que produziu a resposta (FR-004) |
+| `channel` | enum | `structured` \| `prose` \| `inherited` | Canal que produziu a resposta (FR-004); `inherited` = reabertura (`/feature-00c --reopen`, issue #192): nenhum dialogo ocorreu, valor copiado do round anterior |
 | `outcome` | enum | `accepted` \| `declined` \| `absent` \| `timeout` \| `unavailable` \| `failed` | Ver tabela de desfechos abaixo |
 | `applied_value` | string | valor final gravado, serializado (`"true"`, `"false"`, token do tier) | Espelha o que foi escrito na camada 1 |
 | `recorded_at` | string | ISO 8601 UTC | Timestamp do registro |
-| `reason` | string \| null | opcional, saneado | Diagnostico curto em `failed`; `null` nos demais |
+| `reason` | string \| null | opcional, saneado | Diagnostico curto em `failed`; em `inherited` sem registro-fonte, explica que o valor veio de `.atomic_commit_enabled`; `null` nos demais |
+| `inherited_from` | string \| null | so em `channel: "inherited"` | Rotulo do round de origem (`rounds/<label>`, ex. `r01`); ausente/`null` nos demais canais |
 
 ### Primitiva de escrita e comportamento por backend
 
@@ -132,6 +133,19 @@ Consequencia pratica:
 vez** por campo por execucao. Se o registro mais recente ja tem
 `channel: "prose"`, o campo esta encerrado qualquer que seja o `outcome` —
 garante FR-007/SC-002 (nunca travar) mesmo se a prosa tambem falhar.
+
+**Regra R-4 (heranca em reabertura, issue #192)**: uma execucao criada por
+`/feature-00c --reopen` NAO coleta o opt-in — herda o valor do round
+anterior (feature-reopen FR-022). O command pai grava, logo apos o `init`,
+UM registro `channel: "inherited"` com `applied_value` = valor herdado,
+`outcome` copiado do registro mais recente do round anterior (ou `absent`
+com `reason` quando o round anterior nao tem registro — o evento de decisao
+nao e observavel, so o valor), e `inherited_from` = rotulo do round. Esse
+registro satisfaz a Invariante I-2 sem dialogo; `collect_optins` NAO e
+invocado pelo orquestrador (a linha do ramo estruturado nao e injetada no
+spawn) e, se for, devolve `reused` como para qualquer registro existente.
+`channel: "prose"` NUNCA e gravado numa reabertura: afirmaria um dialogo que
+nao ocorreu (Principio VI).
 
 ### Enum `outcome` — desfechos e origem do sinal
 

--- a/plugins/cstk/commands/feature-00c.md
+++ b/plugins/cstk/commands/feature-00c.md
@@ -580,7 +580,56 @@ fi
 ```
 
 Ausencia, leitura falha ou valor nao reconhecido ⇒ `_atomic="false"`
-(default seguro, FR-022, literal). Nenhum `--force` e necessario nem
+(default seguro, FR-022, literal).
+
+**3'.bis — registro do opt-in herdado em `.optin_responses[]` (issue #192)**.
+Logo apos o `state-rw.sh init` de 3', e independentemente de
+`_optin_branch`, grave o registro com `channel: "inherited"` — o unico
+canal que diz a verdade sobre uma reabertura: nenhum dialogo aconteceu
+(3' acabou de pular o prompt), entao `channel: "prose"` seria proveniencia
+fabricada (Principio VI), e sem registro algum o guard M4/I-2 recusa a
+onda-001 ou o orquestrador chama `collect_optins` e RE-PERGUNTA, contra a
+FR-022. `outcome` e `applied_value` sao copiados do registro mais recente
+do round anterior quando ele existe; sem registro (round anterior
+pre-`mcp-elicitation-optins`), o VALOR vem de `.atomic_commit_enabled`
+(ja em `_atomic`) e o `outcome` e `absent` com `reason` explicando — o
+evento de decisao nao e observavel, so o valor aplicado.
+
+```bash
+_now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+_prev_rec="null"
+if [ -n "$_label" ]; then
+  _prev_rec=$(state-rw.sh get --state-dir "$AGENTE_00C_STATE_DIR/rounds/$_label" \
+    --field '([.optin_responses // [] | .[] | select(.field == "atomic_commit")] | sort_by(.recorded_at) | last) // null' \
+    2>/dev/null) || _prev_rec="null"
+fi
+_cur=$(state-rw.sh get --state-dir "$AGENTE_00C_STATE_DIR" --field '.optin_responses // []')
+_cur=$(printf '%s' "$_cur" | jq -c \
+  --argjson prev "$_prev_rec" --arg v "$_atomic" --arg ts "$_now" --arg from "${_label:-}" \
+  '. + [{
+     field: "atomic_commit",
+     channel: "inherited",
+     outcome: (if $prev != null then $prev.outcome else "absent" end),
+     applied_value: $v,
+     recorded_at: $ts,
+     reason: (if $prev != null then null
+              else "round anterior sem registro em .optin_responses[]; valor herdado de .atomic_commit_enabled" end),
+     inherited_from: (if $from == "" then null else $from end)
+   }]')
+state-rw.sh set --state-dir "$AGENTE_00C_STATE_DIR" --field '.optin_responses' --value "$_cur"
+_optin_inherited="1"
+```
+
+Com `_optin_inherited="1"`: o passo 3.ter NAO roda (o registro ja existe e
+e o unico honesto) e a linha `MCP: ramo estruturado de opt-ins ativo` NAO
+e injetada no spawn (secao 4) — o orquestrador nao chama `collect_optins`;
+se chamasse, o servidor devolveria `reused` (qualquer registro do campo
+encerra a coleta, `collect_optins.ts:mostRecentByField`), mas a instrucao
+honesta e nao pedir. Nao ha "confirmar com default" nesta reabertura:
+reabertura herda (FR-022), retomada le (`/feature-00c-resume`), e nenhuma
+das duas pergunta.
+
+Nenhum `--force` e necessario nem
 existe: a raiz do state-dir esta sem `state.json`/`state.db` apos a
 rotacao (ou, no caso `_skip_rotate`, ja estava sem desde a rotacao
 anterior), entao as guardas de "state.json ja existe" do `init` nao
@@ -836,8 +885,12 @@ acima. Escopo `feature-00c` (dec-083): SOMENTE `atomic_commit` — nenhum
 outro campo de opt-in (os demais campos de `agente-00c` sao exclusivos
 dele, ver `scenario_ausente_em_feature_00c_commands`).
 
+Reabertura (`_optin_inherited = "1"`, passo 3'.bis, issue #192): pule este
+passo — o registro `channel: "inherited"` ja foi gravado e gravar `prose`
+aqui afirmaria um dialogo que nao aconteceu.
+
 ```bash
-if [ "$_optin_branch" = "legado" ]; then
+if [ "$_optin_branch" = "legado" ] && [ "${_optin_inherited:-}" != "1" ]; then
   _now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   _cur=$(state-rw.sh get --state-dir "$AGENTE_00C_STATE_DIR" --field '.optin_responses // []')
   [ "$_atomic" = "true" ] && _out="accepted" || _out="declined"
@@ -900,7 +953,9 @@ fi
 >   contrato de queda mid-onda (0 retries + 1 confirmacao via cstk mcp
 >   status --live) e comutacao para Bash no resto da onda.`
 > - **Ramo `_optin_branch = "estruturado"` (decisao de ramo acima, task
->   5.3.1/5.5.1 — mcp-elicitation-optins)**: acrescente TAMBEM, na mesma
+>   5.3.1/5.5.1 — mcp-elicitation-optins) E `_optin_inherited` vazio**
+>   (reabertura ja gravou `channel: "inherited"` em 3'.bis — issue #192 —
+>   e NAO pode re-perguntar): acrescente TAMBEM, na mesma
 >   injecao, a linha: `MCP: ramo estruturado de opt-ins ativo (dec-080).
 >   Chame mcp__cstk-state__collect_optins como o PRIMEIRO ato desta
 >   execucao, ANTES de qualquer state-ondas.sh start/open_wave da

--- a/plugins/cstk/mcp/state-server/test/collect_optins.test.ts
+++ b/plugins/cstk/mcp/state-server/test/collect_optins.test.ts
@@ -263,6 +263,29 @@ test("handleCollectOptins (3.4.2 allowlist): content com token fora do enum nunc
   assert.equal(atomic?.outcome, "failed");
 });
 
+test("handleCollectOptins (issue #192, regra R-4): registro channel=inherited (reabertura) => reused, elicitInput NAO chamado — nunca re-pergunta o opt-in herdado", async () => {
+  const input = parseOrThrow({ session_id: "synthetic-token-abc123" });
+  let called = false;
+  const server: ElicitationServer = {
+    getClientCapabilities: () => ({ elicitation: {} }),
+    elicitInput: async () => {
+      called = true;
+      throw new Error("nao deveria ser chamado — opt-in herdado do round anterior (FR-022)");
+    },
+  };
+  const deps = {
+    ...baseDeps(server),
+    stateRwHelperPath: join(FIXTURES_DIR, "fake-collect-optins-state-rw-inherited.sh"),
+  };
+
+  const response = await handleCollectOptins(input, deps);
+
+  assert.equal(called, false);
+  assert.equal(response.outcome, "accepted");
+  assert.deepEqual(response.result?.reused, ["atomic_commit"]);
+  assert.deepEqual(response.result?.fields, [{ field: "atomic_commit", outcome: "accepted", applied_value: "true" }]);
+});
+
 test("handleCollectOptins (cap M6, task 3.3.1): todos os campos aplicaveis ja registrados => reused, elicitInput NAO chamado", async () => {
   const input = parseOrThrow({ session_id: "synthetic-token-abc123" });
   let called = false;

--- a/plugins/cstk/mcp/state-server/test/fixtures/fake-collect-optins-state-rw-inherited.sh
+++ b/plugins/cstk/mcp/state-server/test/fixtures/fake-collect-optins-state-rw-inherited.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Fixture (issue #192): simula state-rw.sh get/set para `.optin_responses` com
+# registro `channel: "inherited"` (reabertura, feature-reopen FR-022) para
+# atomic_commit — qualquer registro do campo encerra a coleta (reused),
+# sem re-perguntar ao operador; o canal nao importa para o reuso.
+set -eu
+_cmd="${1:-}"
+shift || true
+case "$_cmd" in
+  get)
+    _field=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --field) _field="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    case "$_field" in
+      ".optin_responses // []")
+        printf '[{"field":"atomic_commit","channel":"inherited","outcome":"accepted","applied_value":"true","recorded_at":"2026-09-02T00:00:00.000Z","reason":null,"inherited_from":"r01"}]\n'
+        ;;
+      *) printf 'fake-collect-optins-state-rw-inherited: campo desconhecido: %s\n' "$_field" >&2; exit 1 ;;
+    esac
+    ;;
+  set)
+    exit 0
+    ;;
+  *)
+    printf 'fake-collect-optins-state-rw-inherited: subcomando desconhecido: %s\n' "$_cmd" >&2
+    exit 1
+    ;;
+esac

--- a/tests/test_command-spawn-optin-elicitation.sh
+++ b/tests/test_command-spawn-optin-elicitation.sh
@@ -343,6 +343,29 @@ scenario_persistencia_legado_optin_responses_feature() {
 #       estruturado no spawn, nunca o token; linha presente + tool ausente
 #       => devolve o turno em vez de "seguir para o passo 2/4".
 
+# ==== issue #192: reabertura grava channel=inherited, nunca prose ====
+
+scenario_reopen_grava_channel_inherited_e_nao_prose() {
+  _f="$REPO_ROOT/plugins/cstk/commands/feature-00c.md"
+  grep -Fq "3'.bis" "$_f" || { _fail "3'.bis" "feature-00c.md sem o passo 3'.bis (issue #192)"; return 1; }
+  grep -Fq 'channel: "inherited"' "$_f" || { _fail "inherited" "feature-00c.md nao grava channel inherited"; return 1; }
+  grep -Fq 'inherited_from:' "$_f" || { _fail "inherited_from" "registro herdado sem inherited_from"; return 1; }
+  grep -Fq '_optin_inherited="1"' "$_f" || { _fail "flag" "3'.bis nao seta _optin_inherited"; return 1; }
+  # 3.ter guardado pela flag: nunca grava prose numa reabertura
+  grep -Fq 'if [ "$_optin_branch" = "legado" ] && [ "${_optin_inherited:-}" != "1" ]; then' "$_f" \
+    || { _fail "3.ter" "3.ter nao esta guardado por _optin_inherited"; return 1; }
+  # linha do ramo estruturado condicionada a _optin_inherited vazio
+  grep -Fq 'E `_optin_inherited` vazio**' "$_f" \
+    || { _fail "spawn" "linha do ramo estruturado nao condicionada a _optin_inherited"; return 1; }
+}
+
+scenario_reopen_contrato_e_data_model_declaram_inherited() {
+  grep -Fq '`inherited`' "$REPO_ROOT/docs/specs/mcp-elicitation-optins/data-model.md" \
+    || { _fail "data-model" "enum channel sem inherited"; return 1; }
+  grep -Fq "Passo 3'.bis" "$REPO_ROOT/docs/specs/feature-reopen/contracts/reopen-flow.md" \
+    || { _fail "reopen-flow" "contrato sem o passo 3'.bis"; return 1; }
+}
+
 _scenario_gate_toolset_cmd() {
   # $1=arquivo $2=regex do prompt de prosa (ancora de ordem)
   _l_cand=$(_first_line_of "$1" '_optin_branch="candidato"')

--- a/tests/test_feature-00c-preflight.sh
+++ b/tests/test_feature-00c-preflight.sh
@@ -545,6 +545,77 @@ scenario_T28b_atomic_commit_ausencia_equivale_false() {
 }
 
 # ---------------------------------------------------------------------------
+# T-28c/T-28d — 3'.bis (issue #192): registro `channel: "inherited"` em
+# .optin_responses[] replica literal do bloco de feature-00c.md, com e sem
+# registro-fonte no round anterior; I-2 satisfeita sem dialogo.
+# ---------------------------------------------------------------------------
+_t28_inherit_block() {
+  # $1=HOME $2=SD $3=label $4=_atomic — replica o bloco 3'.bis do command
+  _ib_home=$1; _ib_sd=$2; _label=$3; _atomic=$4
+  _now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  _prev_rec="null"
+  if [ -n "$_label" ]; then
+    _prev_rec=$(env HOME="$_ib_home" "$RW" get --state-dir "$_ib_sd/rounds/$_label" \
+      --field '([.optin_responses // [] | .[] | select(.field == "atomic_commit")] | sort_by(.recorded_at) | last) // null' \
+      2>/dev/null) || _prev_rec="null"
+  fi
+  _cur=$(env HOME="$_ib_home" "$RW" get --state-dir "$_ib_sd" --field '.optin_responses // []')
+  _cur=$(printf '%s' "$_cur" | jq -c \
+    --argjson prev "$_prev_rec" --arg v "$_atomic" --arg ts "$_now" --arg from "${_label:-}" \
+    '. + [{
+       field: "atomic_commit",
+       channel: "inherited",
+       outcome: (if $prev != null then $prev.outcome else "absent" end),
+       applied_value: $v,
+       recorded_at: $ts,
+       reason: (if $prev != null then null
+                else "round anterior sem registro em .optin_responses[]; valor herdado de .atomic_commit_enabled" end),
+       inherited_from: (if $from == "" then null else $from end)
+     }]')
+  env HOME="$_ib_home" "$RW" set --state-dir "$_ib_sd" --field '.optin_responses' --value "$_cur" >/dev/null 2>&1
+}
+
+_t28_fixture() {
+  # $1=sufixo $2=optin_responses do round anterior (JSON) ou "" para nenhum
+  _home="$TMPDIR_TEST/home-$1"; mkdir -p "$_home/.claude/cstk"
+  printf 'state_backend=json\n' > "$_home/.claude/cstk/config"
+  _sd="$TMPDIR_TEST/$1/.claude/feature-00c-state/demo"; mkdir -p "$_sd/rounds/r01"
+  env HOME="$_home" "$RW" init --state-dir "$_sd/rounds/r01" --execucao-id "exec-$1-r1" \
+    --projeto-alvo-path "/tmp/proj-$1" --descricao "descricao de teste com tamanho suficiente" \
+    --key-aspects '["a","b","c"]' --atomic-commit true >/dev/null 2>&1 || return 2
+  if [ -n "$2" ]; then
+    env HOME="$_home" "$RW" set --state-dir "$_sd/rounds/r01" --field '.optin_responses' --value "$2" >/dev/null 2>&1 || return 2
+  fi
+  env HOME="$_home" "$RW" init --state-dir "$_sd" --execucao-id "exec-$1-r2" \
+    --projeto-alvo-path "/tmp/proj-$1" --descricao "descricao de teste com tamanho suficiente" \
+    --key-aspects '["a","b","c"]' --atomic-commit true >/dev/null 2>&1 || return 2
+}
+
+scenario_T28c_optin_herdado_copia_outcome_do_round_anterior() {
+  _t28_fixture t28c '[{"field":"atomic_commit","channel":"structured","outcome":"accepted","applied_value":"true","recorded_at":"2026-08-17T00:00:00Z","reason":null}]' \
+    || { _error "fixture" "init falhou"; return 2; }
+  _t28_inherit_block "$_home" "$_sd" r01 true
+  _rec=$(env HOME="$_home" "$RW" get --state-dir "$_sd" --field '.optin_responses[-1]' 2>/dev/null)
+  printf '%s' "$_rec" | jq -e '.channel == "inherited" and .outcome == "accepted" and .applied_value == "true" and .inherited_from == "r01" and .reason == null' >/dev/null \
+    || { _fail "T-28c" "registro inesperado: $_rec"; return 1; }
+  # nunca `prose`: nenhum dialogo aconteceu
+  printf '%s' "$_rec" | grep -q '"prose"' && { _fail "T-28c" "channel prose numa reabertura"; return 1; }
+  # I-2 satisfeita sem dialogo: onda-001 abre
+  capture env HOME="$_home" "$SCRIPTS_DIR/state-ondas.sh" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "T-28c" "I-2 recusou onda-001: $_CAPTURED_STDERR"; return 1; }
+  return 0
+}
+
+scenario_T28d_optin_herdado_sem_registro_fonte_outcome_absent_com_reason() {
+  _t28_fixture t28d "" || { _error "fixture" "init falhou"; return 2; }
+  _t28_inherit_block "$_home" "$_sd" r01 false
+  _rec=$(env HOME="$_home" "$RW" get --state-dir "$_sd" --field '.optin_responses[-1]' 2>/dev/null)
+  printf '%s' "$_rec" | jq -e '.channel == "inherited" and .outcome == "absent" and .applied_value == "false" and .inherited_from == "r01" and (.reason | test("herdado de .atomic_commit_enabled"))' >/dev/null \
+    || { _fail "T-28d" "registro inesperado: $_rec"; return 1; }
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # T-29 — spec arquivada restaurada; _archived/ permanece intacto (diff -r)
 # ---------------------------------------------------------------------------
 scenario_T29_spec_arquivada_restaurada_archived_intacto() {

--- a/tests/test_state-ondas.sh
+++ b/tests/test_state-ondas.sh
@@ -113,6 +113,18 @@ scenario_start_onda001_aceita_com_optin_feature00c() {
   assert_stdout_contains "onda-001" || return 1
 }
 
+scenario_start_onda001_aceita_com_optin_inherited_feature00c() {
+  # issue #192: reabertura grava channel=inherited (nenhum dialogo); a
+  # Invariante I-2 exige registro do campo, nao um canal especifico.
+  _sd="$TMPDIR_TEST/feature-00c-state/demo-feature/state"
+  _init_state "$_sd"
+  capture "$RW" set --state-dir "$_sd" --field '.optin_responses' \
+    --value '[{"field":"atomic_commit","channel":"inherited","outcome":"accepted","applied_value":"true","recorded_at":"2026-09-02T00:00:00Z","reason":null,"inherited_from":"r01"}]'
+  capture "$SCRIPT" start --state-dir "$_sd"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "start" "$_CAPTURED_STDERR"; return 1; }
+  assert_stdout_contains "onda-001" || return 1
+}
+
 scenario_start_onda001_recusada_agente00c_faltam_2_de_3_campos() {
   _sd="$TMPDIR_TEST/agente-00c-state"
   _init_state "$_sd"


### PR DESCRIPTION
## Resumo

Resolve **#192** pela direção 1 da issue: terceiro valor de canal, `inherited`.

`/feature-00c --reopen` herda o opt-in de atomic-commit do round anterior sem coletar (feature-reopen FR-022), mas o modelo de `.optin_responses[]` (`mcp-elicitation-optins`) só conhecia `structured | prose`, e a Invariante I-2 exige registro antes da onda-001. Resultado: o ramo legado gravava `channel: "prose"` para um diálogo que o §3' acabara de pular (proveniência fabricada — Princípio VI), e o ramo estruturado não gravava nada, então o orquestrador chamava `collect_optins` e **re-perguntava**. `reopen-flow.md` não mencionava opt-in em lugar nenhum.

## Mudanças

- **`feature-00c.md` §3'.bis (novo)**: logo após o `init` da reabertura, independentemente do ramo, grava `{channel: "inherited", applied_value: <herdado>, outcome: <do registro mais recente do round anterior | "absent" + reason>, inherited_from: "<label>"}` e seta `_optin_inherited=1`. O §3.ter (registro `prose` do ramo legado) e a linha `MCP: ramo estruturado de opt-ins ativo` no spawn ficam condicionados à flag — reabertura **herda**, retomada **lê**, nenhuma das duas pergunta nem "confirma com default".
- **`data-model.md`**: enum `channel` ganha `inherited`; campo opcional `inherited_from`; regra **R-4**.
- **`reopen-flow.md`**: passo 3'.bis — a interação entre as duas features passa a estar desenhada.
- **Servidor MCP**: zero mudança de código. `mostRecentByField` já devolve `reused` para qualquer registro do campo (o teste TS novo prova que um registro `inherited` nunca dispara `elicitInput`).

Sobre o `outcome` quando o round anterior não tem registro (round pré-`mcp-elicitation-optins`): só o **valor** é observável (`.atomic_commit_enabled`), não o evento de decisão — por isso `absent` com `reason` explicando, em vez de inferir `accepted`/`declined`.

## Testes

- `test_feature-00c-preflight.sh` T-28c/T-28d: bloco literal do 3'.bis contra state real, com e sem registro-fonte; I-2 abre a onda-001 sem diálogo.
- `test_state-ondas.sh`: I-2 aceita registro `inherited`.
- `test_command-spawn-optin-elicitation.sh` +2: prosa (3'.bis, guarda do 3.ter, linha do spawn, contratos).
- `collect_optins.test.ts` +1 (241/241, `tsc --noEmit` limpo).
- Todos os testes que leem os arquivos editados re-rodados verdes; `--check-coverage` zero órfãos.

## Pós-release

Só catálogo (`feature-00c.md`) → `cstk update`/`install`.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRMKihs78cyzc4vwVfjPdJ