### PR TITLE
feat(panel): transcript de sessao renderiza markdown nas mensagens

### DIFF
--- a/panel/apps/web/src/components/MarkdownView.test.ts
+++ b/panel/apps/web/src/components/MarkdownView.test.ts
@@ -230,4 +230,33 @@ describe('Auditoria de fonte — ausencia de dangerouslySetInnerHTML (task 5.3.3
   it('hooks.ts (camada de dados useFeatureDocs/useFeatureDocContent) nao usa dangerouslySetInnerHTML', () => {
     expect(readSrc('lib/hooks.ts')).not.toMatch(USAGE_RE);
   });
+
+  it('SessionDetail.tsx (consumidor do transcript, texto de agente) nao usa dangerouslySetInnerHTML', () => {
+    expect(readSrc('screens/SessionDetail.tsx')).not.toMatch(USAGE_RE);
+  });
+});
+
+describe('MarkdownView — variante de densidade via className (transcript de sessao)', () => {
+  it('SOMA a classe extra a markdown-view, nunca substitui', () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownView, { content: '# oi', className: 'markdown-view--compact' }),
+    );
+    expect(html).toContain('class="markdown-view markdown-view--compact"');
+  });
+
+  it('sem className continua exatamente markdown-view (sem espaco sobrando)', () => {
+    const html = renderToStaticMarkup(createElement(MarkdownView, { content: '# oi' }));
+    expect(html).toContain('class="markdown-view"');
+  });
+
+  it('a variante NAO afrouxa a sanitizacao (HTML ativo segue inerte)', () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownView, {
+        content: '<script>alert(1)</script>\n\n[x](javascript:alert(1))',
+        className: 'markdown-view--compact',
+      }),
+    );
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('javascript:');
+  });
 });

--- a/panel/apps/web/src/components/MarkdownView.tsx
+++ b/panel/apps/web/src/components/MarkdownView.tsx
@@ -146,11 +146,19 @@ function PreOrMermaid({ node: _node, children, ...rest }: ComponentProps<'pre'> 
 export interface MarkdownViewProps {
   /** Markdown BRUTO de um artefato de documentacao — UNTRUSTED (Principio V). */
   content: string;
+  /**
+   * Classe CSS ADICIONAL (somada a `markdown-view`, nunca no lugar dela) —
+   * usada por variantes de densidade, como o transcript de sessao
+   * (`markdown-view--compact`). Puramente visual: nao ha caminho por onde
+   * uma classe altere a postura de seguranca (sanitize/urlTransform sao
+   * fixos abaixo).
+   */
+  className?: string;
 }
 
-export function MarkdownView({ content }: MarkdownViewProps) {
+export function MarkdownView({ content, className = '' }: MarkdownViewProps) {
   return (
-    <div className="markdown-view">
+    <div className={`markdown-view${className ? ' ' + className : ''}`}>
       <Markdown
         // remark-gfm habilita as EXTENSOES GFM exigidas por FR-006 (tabelas,
         // strikethrough, task lists, autolinks) — opera no nivel do PARSER de

--- a/panel/apps/web/src/screens/SessionDetail.test.ts
+++ b/panel/apps/web/src/screens/SessionDetail.test.ts
@@ -4,7 +4,7 @@
  * (`sessionDetailDegradedCopy`, `sessionEntryKey`) e testada em isolamento.
  */
 import { describe, it, expect } from 'vitest';
-import { sessionDetailDegradedCopy, sessionEntryKey } from './SessionDetail.js';
+import { sessionDetailDegradedCopy, sessionEntryKey, sessionEntryRendersMarkdown } from './SessionDetail.js';
 
 describe('sessionDetailDegradedCopy — cobre TODOS os reasons de GET /sessions/:id/tail (US3)', () => {
   it('cobre session-not-found', () => {
@@ -42,5 +42,19 @@ describe('sessionEntryKey', () => {
 
   it('cai para o indice quando uuid e null (linhas legadas sem uuid)', () => {
     expect(sessionEntryKey({ uuid: null }, 2)).toBe('entry-2');
+  });
+});
+
+describe('sessionEntryRendersMarkdown — so a mensagem vira markdown', () => {
+  it('renderiza markdown para kind=text (mensagem escrita em markdown)', () => {
+    expect(sessionEntryRendersMarkdown('text')).toBe(true);
+  });
+
+  it('mantem literal o resumo de tool_use (glob/comando nao pode virar enfase)', () => {
+    expect(sessionEntryRendersMarkdown('tool_use')).toBe(false);
+  });
+
+  it('mantem literal o marcador de tool_result', () => {
+    expect(sessionEntryRendersMarkdown('tool_result')).toBe(false);
   });
 });

--- a/panel/apps/web/src/screens/SessionDetail.tsx
+++ b/panel/apps/web/src/screens/SessionDetail.tsx
@@ -7,7 +7,11 @@
  * `live: false` ainda exibe conteudo normalmente.
  *
  * `entries[].text` e UNTRUSTED (FR-005, Principio V) — renderizado via
- * `TextBlockRaw`, NUNCA `dangerouslySetInnerHTML`.
+ * `MarkdownView` (mensagens) ou `TextBlockRaw` (resumo de ferramenta),
+ * NUNCA `dangerouslySetInnerHTML`. As duas rotas escapam/sanitizam: o
+ * markdown passa por `rehype-sanitize` + allowlist de esquema de URL, sem
+ * `rehype-raw` — HTML bruto embutido no texto do agente continua inerte
+ * (ver MarkdownView.tsx).
  *
  * Ref: contracts/sessions-api.md; tasks.md §6.3.2.
  */
@@ -15,7 +19,7 @@ import { useParams } from 'react-router-dom';
 import { useSessionTail } from '@/lib/hooks.js';
 import { useApiState } from '@/hooks/useApiState.js';
 import { LoadingState, EmptyState, ErrorState, DegradedBanner } from '@/states/index.js';
-import { FreshnessLabel, TextBlockRaw } from '@/components/index.js';
+import { FreshnessLabel, MarkdownView, TextBlockRaw } from '@/components/index.js';
 import { fmtRelative, fmtTimestamp } from '@/lib/format.js';
 import type { SessionTailEntryDTO, DegradedReason } from '@cstk-panel/shared-types';
 
@@ -57,6 +61,25 @@ export function sessionDetailDegradedCopy(reason: DegradedReason | string | null
 /** Chave estavel de uma linha do tail — `uuid` quando presente, senao o indice. */
 export function sessionEntryKey(entry: Pick<SessionTailEntryDTO, 'uuid'>, index: number): string {
   return entry.uuid ?? `entry-${index}`;
+}
+
+/**
+ * Decide se o `text` de uma entrada e renderizado como MARKDOWN.
+ *
+ * Somente `kind === 'text'`: e a unica origem cujo conteudo foi de fato
+ * ESCRITO em markdown (mensagem de usuario/assistente — tabelas, listas,
+ * `code`, **negrito**). As outras duas origens sao texto sintetico do
+ * proprio painel e continuam literais:
+ *
+ * - `tool_use`    — resumo de UMA linha do input (path, comando, query);
+ *                   markdown ali so distorceria (`*` de glob virando enfase,
+ *                   `_` sumindo no meio de identificador);
+ * - `tool_result` — marcador de tamanho colapsado, sem markdown algum.
+ *
+ * Exportada para teste unitario direto (sem DOM) — ver SessionDetail.test.ts.
+ */
+export function sessionEntryRendersMarkdown(kind: SessionTailEntryDTO['kind']): boolean {
+  return kind === 'text';
 }
 
 export function SessionDetail() {
@@ -174,7 +197,9 @@ export function SessionDetail() {
                 {entry.text !== '' && (
                   entry.kind === 'tool_result'
                     ? <div className="mono" style={{ fontSize: 11.5, color: 'var(--text-3)' }}>{entry.text}</div>
-                    : <TextBlockRaw value={entry.text} />
+                    : sessionEntryRendersMarkdown(entry.kind)
+                      ? <MarkdownView content={entry.text} className="markdown-view--compact" />
+                      : <TextBlockRaw value={entry.text} />
                 )}
                 {entry.textTruncated && (
                   <div style={{ fontSize: 10, color: 'var(--text-3)', marginTop: 4 }}>[texto truncado]</div>

--- a/panel/apps/web/src/styles/prototype.css
+++ b/panel/apps/web/src/styles/prototype.css
@@ -277,6 +277,31 @@
 .markdown-view hr { border: none; border-top: 1px solid var(--border); margin: 16px 0; }
 .markdown-view img { max-width: 100%; border-radius: var(--r-xs); }
 
+/* Variante compacta (transcript de sessao — SessionDetail.tsx). Mesma
+ * postura de seguranca do doc-viewer (so muda densidade): mensagens de
+ * agente sao curtas e empilhadas dezenas por tela, entao o espacamento
+ * generoso do doc-viewer viraria rolagem inutil. */
+.markdown-view--compact { font-size: 12.5px; line-height: 1.55; }
+.markdown-view--compact h1, .markdown-view--compact h2, .markdown-view--compact h3,
+.markdown-view--compact h4, .markdown-view--compact h5, .markdown-view--compact h6 {
+  margin: 12px 0 6px;
+}
+.markdown-view--compact h1 { font-size: 16px; }
+.markdown-view--compact h2 { font-size: 14.5px; }
+.markdown-view--compact h3 { font-size: 13px; }
+.markdown-view--compact h4, .markdown-view--compact h5, .markdown-view--compact h6 { font-size: 12.5px; }
+.markdown-view--compact p { margin: 0 0 8px; }
+.markdown-view--compact ul, .markdown-view--compact ol { margin: 0 0 8px; padding-left: 20px; }
+.markdown-view--compact li { margin: 2px 0; }
+.markdown-view--compact pre { margin: 0 0 8px; padding: 8px 10px; }
+.markdown-view--compact code { font-size: 11.5px; }
+.markdown-view--compact table { margin: 0 0 8px; font-size: 12px; }
+.markdown-view--compact th, .markdown-view--compact td { padding: 4px 8px; }
+.markdown-view--compact blockquote { margin: 0 0 8px; }
+.markdown-view--compact hr { margin: 12px 0; }
+/* Ultimo bloco nao empurra a borda inferior da entrada do transcript. */
+.markdown-view--compact > *:last-child { margin-bottom: 0; }
+
 /* Diagramas Mermaid (blocos ```mermaid — MermaidDiagram.tsx). O SVG gerado
  * ja vem com max-width/width responsivos (useMaxWidth default da lib);
  * overflow-x cobre diagramas mais largos que o card em telas estreitas. */


### PR DESCRIPTION
## Resumo

O transcript de sessao do painel (`SessionDetail`) passa a renderizar as mensagens (`kind === 'text'`) como **markdown** via `MarkdownView`, com uma variante de densidade compacta (`markdown-view--compact`). Resumos de `tool_use` e marcadores de `tool_result` continuam **literais** — markdown ali so distorceria (`*` de glob virando enfase, `_` sumindo em identificador).

## Postura de seguranca preservada

- Mesma rota de sanitizacao do doc-viewer: `rehype-sanitize` + allowlist de esquema de URL, **sem** `rehype-raw` — HTML ativo embutido no texto do agente segue inerte (coberto por teste: `<script>` e `javascript:` nao sobrevivem).
- `className` do `MarkdownView` e ADITIVA (soma a `markdown-view`, nunca substitui) e puramente visual — nao ha caminho por onde uma classe altere sanitize/urlTransform.
- Auditoria de ausencia de `dangerouslySetInnerHTML` estendida a `SessionDetail.tsx`.

## Mudancas

- `MarkdownView.tsx`: prop opcional `className` (variante de densidade)
- `SessionDetail.tsx`: `sessionEntryRendersMarkdown(kind)` decide markdown vs literal; exportada para teste unitario sem DOM
- `prototype.css`: bloco `.markdown-view--compact` (tipografia/margens densas para transcript)
- Testes: +3 em `MarkdownView.test.ts` (variante nao afrouxa sanitizacao), +3 em `SessionDetail.test.ts` (so `text` vira markdown), +1 auditoria de fonte

## Validacao

- `npm test` (panel): 974 passed / 48 skipped
- `npm run lint`: 0 erros (1 warning pre-existente fora do escopo)
- `npm run typecheck` e `npm run build`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)