### PR TITLE
chore(release): 10.6.2 — markdown no transcript de sessao do painel

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "10.6.1",
+      "version": "10.6.2",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "10.6.1",
+      "version": "10.6.2",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [10.6.2] - 2026-09-07
+
+Release do painel: o transcript de sessao passa a exibir as mensagens de
+agente como markdown renderizado (PR #199), com a mesma postura de
+sanitizacao do doc-viewer. Nenhuma mudanca em CLI, skills ou runtime 00c.
+
+### Changed
+
+- **Transcript de sessao renderiza markdown nas mensagens (painel).**
+  `SessionDetail.tsx` passa a renderizar entradas `kind === 'text'` via
+  `MarkdownView` com a nova variante de densidade `markdown-view--compact`
+  (`prototype.css`); resumos de `tool_use` e marcadores de `tool_result`
+  continuam literais via `TextBlockRaw` (`sessionEntryRendersMarkdown`,
+  exportada e testada sem DOM). `MarkdownView` ganha prop `className`
+  ADITIVA (somada a `markdown-view`, nunca substituta) — puramente visual:
+  a sanitizacao permanece fixa (`rehype-sanitize` + allowlist de esquema de
+  URL, sem `rehype-raw`), coberta por novos cenarios em
+  `MarkdownView.test.ts` (HTML ativo segue inerte sob a variante) e pela
+  auditoria de ausencia de `dangerouslySetInnerHTML` estendida a
+  `SessionDetail.tsx`.
+
 ## [10.6.1] - 2026-09-07
 
 Release cosmetica: o help geral do binario `cstk` ganha identidade visual.
@@ -8075,6 +8096,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[10.6.2]: https://github.com/JotJunior/cstk/releases/tag/v10.6.2
 [10.6.1]: https://github.com/JotJunior/cstk/releases/tag/v10.6.1
 [10.6.0]: https://github.com/JotJunior/cstk/releases/tag/v10.6.0
 [10.5.0]: https://github.com/JotJunior/cstk/releases/tag/v10.5.0

--- a/panel/apps/server/package.json
+++ b/panel/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/server",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "description": "Back-end HTTP read-only — Fastify 5 + better-sqlite3 sobre knowledge.db",
   "main": "./dist/index.js",
   "scripts": {

--- a/panel/apps/web/package.json
+++ b/panel/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/web",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "description": "Front-end SPA React 19 + Vite 5 — Dashboard de Observabilidade Read-Only",
   "private": true,
   "type": "module",

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cstk-panel",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cstk-panel",
-      "version": "10.6.1",
+      "version": "10.6.2",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -27,7 +27,7 @@
     },
     "apps/server": {
       "name": "@cstk-panel/server",
-      "version": "10.6.1",
+      "version": "10.6.2",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@fastify/cors": "^11.2.0",
@@ -47,7 +47,7 @@
     },
     "apps/web": {
       "name": "@cstk-panel/web",
-      "version": "10.6.1",
+      "version": "10.6.2",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@tanstack/react-query": "^5.40.0",
@@ -8431,7 +8431,7 @@
     },
     "packages/shared-types": {
       "name": "@cstk-panel/shared-types",
-      "version": "10.6.1",
+      "version": "10.6.2",
       "dependencies": {
         "zod": "^3.23.0"
       },

--- a/panel/package.json
+++ b/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cstk-panel",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "private": true,
   "description": "Dashboard de Observabilidade Read-Only para execucoes agente-00c/feature-00c",
   "workspaces": [

--- a/panel/packages/shared-types/package.json
+++ b/panel/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/shared-types",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "description": "DTOs, envelope padrao e schemas Zod compartilhados entre apps/server e apps/web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"


### PR DESCRIPTION
## Resumo

Release 10.6.2: changelog + bump de lockstep (manifestos de plugin e workspace npm do painel) para a feature do PR #199 (transcript de sessao renderiza markdown nas mensagens, variante `markdown-view--compact`).

## Gates validados localmente

- `./scripts/validate-plugin-manifests.sh --version 10.6.2 --strict` → OK
- `./scripts/validate-panel-workspace-lockstep.sh --version 10.6.2 --strict` → OK
- Painel: `npm test` 974 passed, lint/typecheck/build OK (validados no PR #199)
- Suite POSIX completa (`LC_ALL=C ./tests/run.sh`) rodando — merge só após verde
- `./tests/run.sh --check-coverage` → zero órfãos
- Checagem de refs do CHANGELOG (headers sem link) → vazio

🤖 Generated with [Claude Code](https://claude.com/claude-code)