### PR TITLE
fix(runtime): suggestions.sh preserva blocos de outras execucoes no md compartilhado

### DIFF
--- a/plugins/cstk/skills/agente-00c-runtime/scripts/suggestions.sh
+++ b/plugins/cstk/skills/agente-00c-runtime/scripts/suggestions.sh
@@ -11,8 +11,11 @@
 #
 # Sugestoes vivem em DOIS lugares:
 #   1. state.json `.suggestions[]` (ground truth, JSON estruturado)
-#   2. agente-00c-suggestions.md (export human-readable, regerado a cada
-#      register a partir do estado).
+#   2. agente-00c-suggestions.md (export human-readable). O arquivo e
+#      COMPARTILHADO entre execucoes no mesmo projeto-alvo (issue #197):
+#      cada register/mark-issue substitui apenas o bloco da PROPRIA
+#      execucao (cabecalho H1 com o execution.id) e preserva verbatim os
+#      blocos das demais — nunca reescreve o arquivo inteiro.
 #
 # Subcomandos:
 #   suggestions.sh register --state-dir DIR --suggestions-file FILE
@@ -88,6 +91,69 @@ _sg_validate_severidade() {
     informativa|aviso|impeditiva) return 0 ;;
     *) return 1 ;;
   esac
+}
+
+# _sg_exec_id FILE (documento materializado) — id da execucao corrente
+_sg_exec_id() {
+  jq -r '(.execution.id // .execucao.id)' "$1"
+}
+
+# _sg_merge_md OLD_MD NEW_SECTION_FILE EXEC_ID -> stdout
+# O suggestions.md e compartilhado entre execucoes (per-projeto). Blocos de
+# OUTRAS execucoes (delimitados pelo cabecalho H1 "# Sugestoes do
+# Agente-00C — <id>") sao preservados verbatim; apenas o bloco de EXEC_ID e
+# substituido in-place (ou anexado ao final se ausente). Issue #197.
+_sg_merge_md() {
+  _old=$1
+  _new=$2
+  _mid=$3
+  if [ ! -f "$_old" ]; then
+    cat -- "$_new"
+    return 0
+  fi
+  awk -v id="$_mid" -v newfile="$_new" '
+    function print_new(   l) {
+      while ((getline l < newfile) > 0) print l
+      close(newfile)
+      printed = 1
+    }
+    /^# Sugestoes do Agente-00C — / {
+      hid = $0
+      sub(/^# Sugestoes do Agente-00C — /, "", hid)
+      if (hid == id) {
+        if (!printed) print_new()
+        skip = 1
+        next
+      }
+      skip = 0
+    }
+    skip { next }
+    { print; last = $0 }
+    END {
+      if (!printed) {
+        if (NR > 0 && last != "") print ""
+        print_new()
+      }
+    }
+  ' "$_old"
+}
+
+# _sg_write_md STATE_FILE MD_PATH — regenera a secao da execucao corrente e
+# mescla no arquivo compartilhado com escrita atomica.
+_sg_write_md() {
+  _wsf=$1
+  _wmd=$2
+  _wid=$(_sg_exec_id "$_wsf")
+  if ! _sg_render_md "$_wsf" > "$_wmd.new.$$"; then
+    rm -f -- "$_wmd.new.$$" 2>/dev/null
+    _sg_die "render-md falhou" 1
+  fi
+  if ! _sg_merge_md "$_wmd" "$_wmd.new.$$" "$_wid" > "$_wmd.tmp.$$"; then
+    rm -f -- "$_wmd.new.$$" "$_wmd.tmp.$$" 2>/dev/null
+    _sg_die "merge md falhou" 1
+  fi
+  rm -f -- "$_wmd.new.$$" 2>/dev/null
+  mv -f -- "$_wmd.tmp.$$" "$_wmd"
 }
 
 # ---------- Subcomandos ----------
@@ -172,14 +238,11 @@ _sg_cmd_register() {
       --field '.accumulated_metrics.global_skill_suggestions_total' --value "$_total"
   fi
 
-  # Regenera suggestions.md a partir do estado ATUALIZADO (re-materializa;
-  # sem secrets-filter — caller aplica se quiser)
+  # Regenera a secao desta execucao a partir do estado ATUALIZADO e mescla
+  # no arquivo compartilhado preservando blocos de outras execucoes
+  # (issue #197; sem secrets-filter — caller aplica se quiser)
   _sf_after=$(state_read_materialize "$_sd")
-  _sg_render_md "$_sf_after" > "$_sf_md.tmp.$$" || {
-    rm -f -- "$_sf_md.tmp.$$" 2>/dev/null
-    _sg_die "render-md falhou" 1
-  }
-  mv -f -- "$_sf_md.tmp.$$" "$_sf_md"
+  _sg_write_md "$_sf_after" "$_sf_md"
 
   printf '%s\n' "$_id"
 }
@@ -288,16 +351,11 @@ _sg_cmd_mark_issue() {
       --field '.accumulated_metrics.toolkit_issues_opened' --value "$_total"
   fi
 
-  # Regenera suggestions.md se path passado (a partir do estado atualizado)
+  # Regenera suggestions.md se path passado (a partir do estado atualizado;
+  # mescla preservando blocos de outras execucoes — issue #197)
   if [ -n "$_sf_md" ]; then
     _sf_after=$(state_read_materialize "$_sd")
-    if _sg_render_md "$_sf_after" > "$_sf_md.tmp.$$"; then
-      mv -f -- "$_sf_md.tmp.$$" "$_sf_md" \
-        || { rm -f -- "$_sf_md.tmp.$$" 2>/dev/null; _sg_die "mv md falhou" 1; }
-    else
-      rm -f -- "$_sf_md.tmp.$$" 2>/dev/null
-      _sg_die "render-md falhou" 1
-    fi
+    _sg_write_md "$_sf_after" "$_sf_md"
   fi
 }
 

--- a/tests/test_suggestions.sh
+++ b/tests/test_suggestions.sh
@@ -145,6 +145,71 @@ scenario_render_md_sem_sugestoes() {
   assert_stdout_contains "Nenhuma sugestao" || return 1
 }
 
+# ==== Arquivo compartilhado entre execucoes (issue #197) ====
+# O suggestions.md e per-projeto, compartilhado por execucoes distintas.
+# register/mark-issue devem substituir SO o bloco da propria execucao
+# (cabecalho H1 com o execution.id) e preservar verbatim os demais.
+
+_init_exec() {
+  # $1 = state-dir; $2 = execucao-id
+  _ie_home="$TMPDIR_TEST/home-json"
+  mkdir -p "$_ie_home"
+  capture env HOME="$_ie_home" "$RW" init --state-dir "$1" --execucao-id "$2" \
+    --projeto-alvo-path "/tmp/p" --descricao "POC suggestions shared md"
+}
+
+scenario_register_preserva_bloco_de_outra_execucao() {
+  _sda="$TMPDIR_TEST/state-a"; _sdb="$TMPDIR_TEST/state-b"
+  _md="$TMPDIR_TEST/shared-sug.md"
+  _init_exec "$_sda" "exec-a"
+  _init_exec "$_sdb" "exec-b"
+  _register_default "$_sda" "$_md" clarify aviso
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "register A" "$_CAPTURED_STDERR"; return 1; }
+  _register_default "$_sdb" "$_md" plan impeditiva
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "register B" "$_CAPTURED_STDERR"; return 1; }
+  grep -q "Agente-00C — exec-a" "$_md" \
+    || { _fail "issue #197" "bloco de exec-a destruido pelo register de exec-b"; return 1; }
+  grep -q "Agente-00C — exec-b" "$_md" \
+    || { _fail "bloco exec-b ausente" ""; return 1; }
+  grep -q "skill \`clarify\`" "$_md" || { _fail "sugestao de exec-a sumiu" ""; return 1; }
+  grep -q "skill \`plan\`" "$_md" || { _fail "sugestao de exec-b sumiu" ""; return 1; }
+}
+
+scenario_register_substitui_proprio_bloco_sem_duplicar() {
+  _sda="$TMPDIR_TEST/state-a"; _sdb="$TMPDIR_TEST/state-b"
+  _md="$TMPDIR_TEST/shared-sug.md"
+  _init_exec "$_sda" "exec-a"
+  _init_exec "$_sdb" "exec-b"
+  _register_default "$_sda" "$_md" clarify aviso
+  _register_default "$_sdb" "$_md" plan impeditiva
+  # 2o register de exec-a: substitui o proprio bloco IN-PLACE, sem duplicar
+  # cabecalho nem apagar o bloco de exec-b.
+  _register_default "$_sda" "$_md" specify informativa
+  _ca=$(grep -c "Agente-00C — exec-a" "$_md")
+  [ "$_ca" = "1" ] || { _fail "bloco exec-a duplicado" "esperado 1 cabecalho, obtido $_ca"; return 1; }
+  _cb=$(grep -c "Agente-00C — exec-b" "$_md")
+  [ "$_cb" = "1" ] || { _fail "bloco exec-b" "esperado 1 cabecalho, obtido $_cb"; return 1; }
+  grep -q "skill \`specify\`" "$_md" || { _fail "sug-002 de exec-a ausente" ""; return 1; }
+  grep -q "skill \`plan\`" "$_md" || { _fail "bloco exec-b perdeu conteudo" ""; return 1; }
+}
+
+scenario_mark_issue_preserva_bloco_de_outra_execucao() {
+  _sda="$TMPDIR_TEST/state-a"; _sdb="$TMPDIR_TEST/state-b"
+  _md="$TMPDIR_TEST/shared-sug.md"
+  _init_exec "$_sda" "exec-a"
+  _init_exec "$_sdb" "exec-b"
+  _register_default "$_sda" "$_md" clarify impeditiva
+  _register_default "$_sdb" "$_md" plan aviso
+  capture "$SCRIPT" mark-issue --state-dir "$_sda" --suggestions-file "$_md" \
+    --suggestion-id "sug-001" \
+    --issue "https://github.com/JotJunior/cstk/issues/197"
+  [ "$_CAPTURED_EXIT" = 0 ] || { _fail "mark-issue" "$_CAPTURED_STDERR"; return 1; }
+  grep -q "issues/197" "$_md" || { _fail "issue nao refletida no md" ""; return 1; }
+  grep -q "Agente-00C — exec-b" "$_md" \
+    || { _fail "issue #197" "mark-issue de exec-a destruiu bloco de exec-b"; return 1; }
+  grep -q "skill \`plan\`" "$_md" || { _fail "conteudo de exec-b sumiu" ""; return 1; }
+}
+
 # --- Back-compat: fixture pt-BR legada lida via reader-fallback (.en // .pt) ---
 # schema-en-migration §6: os readers (count/list/next-id/render-md) usam paths EN
 # com fallback pt-BR. Prova que um state.json legado (escrito antes da migracao,


### PR DESCRIPTION
Fixes #197.

## Problema

`suggestions.sh register` (e `mark-issue`) regenerava o `.md` compartilhado INTEIRO a partir do `.suggestions[]` do state-dir da propria execucao e sobrescrevia com `mv -f`. Como o arquivo e compartilhado por projeto entre execucoes (`agente-00c-suggestions.md`; `feature-00c-suggestions.md` documentada como "compartilhada per-projeto" em `_audit-paths.md`), a execucao B apagava silenciosamente os blocos da execucao A — perda de dados real observada em campo (issue #197).

## Correcao

- Novo `_sg_merge_md`: preserva verbatim todo bloco cujo cabecalho H1 (`# Sugestoes do Agente-00C — <execution.id>`) pertenca a OUTRA execucao; o bloco da execucao corrente e substituido in-place (ou anexado ao final se ausente).
- `_sg_write_md` centraliza o caminho de escrita (render da secao propria + merge + tmp/mv atomico), usado por `register` e `mark-issue`.
- `render-md` (stdout) inalterado: continua emitindo so a secao da execucao corrente.

## Testes

- 3 cenarios novos em `tests/test_suggestions.sh`: register preserva bloco de outra execucao; register repetido substitui o proprio bloco sem duplicar cabecalho; mark-issue preserva bloco alheio.
- Mutation check: os 3 cenarios FALHAM contra o script antigo (git stash) e passam com o fix.
- Suite completa: `./tests/run.sh` — 3681 PASS / 0 FAIL.
- shellcheck limpo nos 2 arquivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)