### PR TITLE
chore(release): 10.6.3 — fix suggestions.sh md compartilhado (issue #197)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "10.6.2",
+      "version": "10.6.3",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "10.6.2",
+      "version": "10.6.3",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [10.6.3] - 2026-09-08
+
+Bugfix de perda de dados no runtime 00c (issue #197, PR #201): o
+`suggestions.md` compartilhado entre execucoes deixava de ser reescrito
+por inteiro a cada register — a segunda execucao no mesmo projeto-alvo
+apagava silenciosamente os blocos da primeira.
+
+### Fixed
+
+- **`suggestions.sh` preserva blocos de outras execucoes no md
+  compartilhado.** `register` e `mark-issue` regeravam o arquivo INTEIRO a
+  partir do `.suggestions[]` do state-dir da propria execucao e
+  sobrescreviam com `mv -f` — destrutivo num arquivo compartilhado por
+  projeto (`agente-00c-suggestions.md`; `feature-00c-suggestions.md` e
+  "compartilhada per-projeto" por decisao em `_audit-paths.md`). Novo
+  `_sg_merge_md` preserva verbatim todo bloco cujo cabecalho H1
+  (`# Sugestoes do Agente-00C — <execution.id>`) pertenca a outra
+  execucao e substitui in-place (ou anexa) apenas o bloco proprio;
+  `_sg_write_md` centraliza render + merge + escrita atomica (tmp + mv).
+  `render-md` em stdout segue emitindo so a secao da execucao corrente.
+  3 cenarios novos em `tests/test_suggestions.sh`, verificados por
+  mutacao (falham contra o script antigo). Fecha a issue #197.
+
 ## [10.6.2] - 2026-09-07
 
 Release do painel: o transcript de sessao passa a exibir as mensagens de
@@ -8096,6 +8119,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[10.6.3]: https://github.com/JotJunior/cstk/releases/tag/v10.6.3
 [10.6.2]: https://github.com/JotJunior/cstk/releases/tag/v10.6.2
 [10.6.1]: https://github.com/JotJunior/cstk/releases/tag/v10.6.1
 [10.6.0]: https://github.com/JotJunior/cstk/releases/tag/v10.6.0

--- a/panel/apps/server/package.json
+++ b/panel/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/server",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "description": "Back-end HTTP read-only — Fastify 5 + better-sqlite3 sobre knowledge.db",
   "main": "./dist/index.js",
   "scripts": {

--- a/panel/apps/web/package.json
+++ b/panel/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/web",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "description": "Front-end SPA React 19 + Vite 5 — Dashboard de Observabilidade Read-Only",
   "private": true,
   "type": "module",

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cstk-panel",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cstk-panel",
-      "version": "10.6.2",
+      "version": "10.6.3",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -27,7 +27,7 @@
     },
     "apps/server": {
       "name": "@cstk-panel/server",
-      "version": "10.6.2",
+      "version": "10.6.3",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@fastify/cors": "^11.2.0",
@@ -47,7 +47,7 @@
     },
     "apps/web": {
       "name": "@cstk-panel/web",
-      "version": "10.6.2",
+      "version": "10.6.3",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@tanstack/react-query": "^5.40.0",
@@ -8431,7 +8431,7 @@
     },
     "packages/shared-types": {
       "name": "@cstk-panel/shared-types",
-      "version": "10.6.2",
+      "version": "10.6.3",
       "dependencies": {
         "zod": "^3.23.0"
       },

--- a/panel/package.json
+++ b/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cstk-panel",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "private": true,
   "description": "Dashboard de Observabilidade Read-Only para execucoes agente-00c/feature-00c",
   "workspaces": [

--- a/panel/packages/shared-types/package.json
+++ b/panel/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/shared-types",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "description": "DTOs, envelope padrao e schemas Zod compartilhados entre apps/server e apps/web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "10.6.2",
+  "version": "10.6.3",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"


### PR DESCRIPTION
Release PATCH 10.6.3: changelog + lockstep de manifestos de plugin (MP-5) e workspace do painel (WL-1..WL-5) para o fix da issue #197 (PR #201, ja mergeado na main).

- CHANGELOG 10.6.3 (Fixed) + link ref no rodape (refs-check vazio).
- Bump 10.6.2 -> 10.6.3 nos 2 plugin.json + marketplace.json + 4 package.json do painel + package-lock.json (5 linhas pontuais, sem tocar dependencia homonima).
- Gates locais verdes: validate-plugin-manifests --strict e validate-panel-workspace-lockstep --strict com --version 10.6.3.
- Suite completa rodada pre-merge do PR #201 sobre o mesmo conteudo: 3681 PASS / 0 FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)