### PR TITLE
docs(readme): formiga-cortadeira no topo com a historia da capa O'Reilly

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,38 @@
 [![Docs Site](https://img.shields.io/badge/docs-jotjunior.github.io/cstk-blue?logo=readthedocs)](https://jotjunior.github.io/cstk/)
 [![Publish Site](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml/badge.svg?branch=main)](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml)
 
+```text
+                        ██   ██
+                      ██   ██     ██████╗ ███████╗████████╗██╗  ██╗
+   ▄██████▄   ▄████▄ ▄███████▄   ██╔════╝ ██╔════╝╚══██╔══╝██║ ██╔╝
+  ██████████▄▄██████ ████  ███   ██║      ███████╗   ██║   █████╔╝
+  ▀████████▀  ▀████▀ █████████   ██║      ╚════██║   ██║   ██╔═██╗
+    ▀▀▀▀▀▀    ▄████▄  ▀▀▀▀ ▀▀▀   ╚██████╗ ███████║   ██║   ██║  ██╗
+            ▄█▀▄█▀ ▀█▄            ╚═════╝ ╚══════╝   ╚═╝   ╚═╝  ╚═╝
+          ▄█▀ ▄█▀    ▀█▄
+```
+
+**Why the leaf-cutter ant?** We asked Claude: *if cstk had a definitive
+O'Reilly guide, which animal would be on the cover?* The answer, without
+hesitation:
+
+> The leaf-cutter ant. The cover animal has to tell the product's story, and
+> the leaf-cutter tells every chapter: it doesn't eat the leaf it cuts — it
+> orchestrates. The heavy lifting is done by the colony, in parallel waves,
+> each worker carrying a piece that fits its own context. If one falls along
+> the way, another resumes exactly where it left off, because the pheromone
+> trail is the shared memory of the work — their `knowledge.db`, an auditable
+> trace any of them can consult before deciding the next step. And model
+> routing comes for free: worker caste for the volume, soldiers for the heavy
+> stuff, a queen that only decides. Autonomy without a black box, with
+> provenance recorded on the ground.
+>
+> And in the colophon, that classic footnote about the animal: *"the
+> leaf-cutter ant thrives in any POSIX environment and considers logs without
+> provenance a threat to its habitat."*
+
+That's why the ant lives in the `cstk` CLI header.
+
 A set of tools to boost day-to-day development productivity with
 [Claude Code](https://claude.ai/code): **skills** and **hooks** for
 documentation, development, security and code quality.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -8,6 +8,38 @@
 [![Docs Site](https://img.shields.io/badge/docs-jotjunior.github.io/cstk-blue?logo=readthedocs)](https://jotjunior.github.io/cstk/)
 [![Publish Site](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml/badge.svg?branch=main)](https://github.com/JotJunior/cstk/actions/workflows/publish-site.yml)
 
+```text
+                        ██   ██
+                      ██   ██     ██████╗ ███████╗████████╗██╗  ██╗
+   ▄██████▄   ▄████▄ ▄███████▄   ██╔════╝ ██╔════╝╚══██╔══╝██║ ██╔╝
+  ██████████▄▄██████ ████  ███   ██║      ███████╗   ██║   █████╔╝
+  ▀████████▀  ▀████▀ █████████   ██║      ╚════██║   ██║   ██╔═██╗
+    ▀▀▀▀▀▀    ▄████▄  ▀▀▀▀ ▀▀▀   ╚██████╗ ███████║   ██║   ██║  ██╗
+            ▄█▀▄█▀ ▀█▄            ╚═════╝ ╚══════╝   ╚═╝   ╚═╝  ╚═╝
+          ▄█▀ ▄█▀    ▀█▄
+```
+
+**Por que a formiga-cortadeira?** Perguntamos ao Claude: *se o cstk tivesse
+um guia definitivo da O'Reilly, que animal acha que seria exibido na capa?* A
+resposta, sem hesitar:
+
+> A formiga-cortadeira. O animal da capa precisa contar a história do produto,
+> e a saúva conta cada capítulo: ela não come a folha que corta, ela
+> orquestra — o trabalho pesado quem faz é a colônia, em levas paralelas, cada
+> operária carregando um pedaço que cabe no próprio contexto. Se uma cai no
+> meio do caminho, outra retoma exatamente de onde parou, porque a trilha de
+> feromônio é a memória compartilhada do trabalho — o `knowledge.db` delas, um
+> rastro auditável que qualquer uma consegue consultar antes de decidir o
+> próximo passo. E ainda tem o roteamento de modelos de graça: casta operária
+> para o volume, soldado para o que é pesado, rainha que só decide. Autonomia
+> sem caixa-preta, com proveniência gravada no chão.
+>
+> E no colofão, aquela nota de rodapé clássica sobre o animal: *"a
+> formiga-cortadeira prospera em qualquer ambiente POSIX e considera logs sem
+> proveniência uma ameaça ao seu habitat."*
+
+É por isso que a formiga vive no cabeçalho do CLI `cstk`.
+
 Conjunto de ferramentas para aumentar a produtividade no desenvolvimento do dia a dia com
 o [Claude Code](https://claude.ai/code): **skills** e **hooks** para
 documentação, desenvolvimento, segurança e qualidade de código.


### PR DESCRIPTION
Adiciona a arte ASCII da formiga (a mesma do cabecalho do `cstk help`) no topo dos dois READMEs (EN + pt-BR), com a explicacao do motivo: a resposta do Claude a pergunta "se o cstk tivesse um guia definitivo da O'Reilly, que animal estaria na capa?" — a formiga-cortadeira, que nao come a folha que corta: orquestra a colonia em levas paralelas, com a trilha de feromonio como memoria compartilhada (knowledge.db) e castas como model-routing.

Docs-only; `test_doc-counts.sh` verde (a contagem de skills nao foi tocada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)