### PR TITLE
chore(release): 10.6.4 — archive do portfolio + corpus canonico

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,14 +9,14 @@
       "name": "cstk",
       "description": "Full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators and enforced guard hooks",
       "source": "./plugins/cstk",
-      "version": "10.6.3",
+      "version": "10.6.4",
       "category": "development"
     },
     {
       "name": "cstk-language-go",
       "description": "Go language profile: Go-specific skills and hooks for the cstk toolkit",
       "source": "./plugins/cstk-language-go",
-      "version": "10.6.3",
+      "version": "10.6.4",
       "category": "development"
     }
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ Todas as mudanças relevantes deste projeto são documentadas aqui.
 O formato segue [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) e
 este projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
+## [10.6.4] - 2026-09-11
+
+Housekeeping do portfolio de specs: 16 features concluidas arquivadas com
+merge no corpus canonico de living-specs, e a historia da capa no README.
+Sem mudanca de codigo, skill ou contrato.
+
+### Changed
+
+- **Archive de 16 features concluidas em `docs/specs/_archived/2026-09-09-*/`
+  (PR #204).** Cada uma passou pelo fluxo `delta-gate.sh` -> `delta-merge.sh`
+  -> `mv`; o merge criou 3 capabilities novas no corpus canonico
+  (`docs/specs/current/converge-must-coverage-fail-closed.md`,
+  `delivery-tier.md`, `roadmap-mode.md`) e atualizou `spec-corpus.md`.
+  9 specs tiveram o marcador `**Skip**` reunificado em linha unica (formato
+  exigido pelo parser do `delta-gate.sh`) e 2 specs released sem secao
+  `## Delta Requirements` (`atomic-commit-ensure-branch`,
+  `wave-close-advance`) ganharam Skip verificado contra o corpus.
+  `tests/test_command-spawn-delivery-tier.sh` e
+  `tests/test_command-spawn-optin-elicitation.sh` reapontados para os
+  contratos sob `_archived/`. Restam ativas: `mcp-elicitation-optins`,
+  `orchestrator-mcp-allowlist`, `panel-monorepo`.
+- **README: formiga-cortadeira no topo com a historia da capa O'Reilly
+  (PR #203).**
+
 ## [10.6.3] - 2026-09-08
 
 Bugfix de perda de dados no runtime 00c (issue #197, PR #201): o
@@ -8119,6 +8143,7 @@ Primeira versão publicada do toolkit.
 - README documentando estrutura, pipeline SDD sugerido e convenções de
   nomenclatura
 
+[10.6.4]: https://github.com/JotJunior/cstk/releases/tag/v10.6.4
 [10.6.3]: https://github.com/JotJunior/cstk/releases/tag/v10.6.3
 [10.6.2]: https://github.com/JotJunior/cstk/releases/tag/v10.6.2
 [10.6.1]: https://github.com/JotJunior/cstk/releases/tag/v10.6.1

--- a/panel/apps/server/package.json
+++ b/panel/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/server",
-  "version": "10.6.3",
+  "version": "10.6.4",
   "description": "Back-end HTTP read-only — Fastify 5 + better-sqlite3 sobre knowledge.db",
   "main": "./dist/index.js",
   "scripts": {

--- a/panel/apps/web/package.json
+++ b/panel/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/web",
-  "version": "10.6.3",
+  "version": "10.6.4",
   "description": "Front-end SPA React 19 + Vite 5 — Dashboard de Observabilidade Read-Only",
   "private": true,
   "type": "module",

--- a/panel/package-lock.json
+++ b/panel/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cstk-panel",
-  "version": "10.6.3",
+  "version": "10.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cstk-panel",
-      "version": "10.6.3",
+      "version": "10.6.4",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -27,7 +27,7 @@
     },
     "apps/server": {
       "name": "@cstk-panel/server",
-      "version": "10.6.3",
+      "version": "10.6.4",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@fastify/cors": "^11.2.0",
@@ -47,7 +47,7 @@
     },
     "apps/web": {
       "name": "@cstk-panel/web",
-      "version": "10.6.3",
+      "version": "10.6.4",
       "dependencies": {
         "@cstk-panel/shared-types": "*",
         "@tanstack/react-query": "^5.40.0",
@@ -8431,7 +8431,7 @@
     },
     "packages/shared-types": {
       "name": "@cstk-panel/shared-types",
-      "version": "10.6.3",
+      "version": "10.6.4",
       "dependencies": {
         "zod": "^3.23.0"
       },

--- a/panel/package.json
+++ b/panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cstk-panel",
-  "version": "10.6.3",
+  "version": "10.6.4",
   "private": true,
   "description": "Dashboard de Observabilidade Read-Only para execucoes agente-00c/feature-00c",
   "workspaces": [

--- a/panel/packages/shared-types/package.json
+++ b/panel/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cstk-panel/shared-types",
-  "version": "10.6.3",
+  "version": "10.6.4",
   "description": "DTOs, envelope padrao e schemas Zod compartilhados entre apps/server e apps/web",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/cstk-language-go/.claude-plugin/plugin.json
+++ b/plugins/cstk-language-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk-language-go",
   "description": "Go language profile for the cstk toolkit: Go-specific skills (add-entity, add-consumer, add-migration, add-test, review) and hooks",
-  "version": "10.6.3",
+  "version": "10.6.4",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"

--- a/plugins/cstk/.claude-plugin/plugin.json
+++ b/plugins/cstk/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cstk",
   "description": "Spec-Driven Development toolkit for Claude Code: full SDD pipeline (briefing -> review-features), autonomous 00c orchestrators with auditable state, enforced guard hooks and cross-feature knowledge base",
-  "version": "10.6.3",
+  "version": "10.6.4",
   "author": {
     "name": "JotJunior",
     "url": "https://github.com/JotJunior"


### PR DESCRIPTION
## Resumo

Release PATCH 10.6.4 — docs-only:

- Changelog 10.6.4: archive de 16 features concluidas (PR #204, com 3 capabilities novas no corpus canonico) + capa O'Reilly no README (PR #203).
- Bump de versao em lockstep: `.claude-plugin/marketplace.json` (2 entradas), 2x `plugin.json`, e os 4 manifests + `package-lock.json` do workspace do painel.

## Validacao

- Suite completa local: **3681 PASS / 0 FAIL / 0 ERROR** (1242s, `LC_ALL=C`).
- `./tests/run.sh --check-coverage`: zero orfaos.
- `./scripts/validate-plugin-manifests.sh --version 10.6.4 --strict`: OK (gate MP-5).
- `./scripts/validate-panel-workspace-lockstep.sh --version 10.6.4`: OK.
- Checagem de refs do CHANGELOG (headers sem link): vazia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCiTvcqhSHVP5TkKcCbukn